### PR TITLE
feat(react): add Avatar component

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@nexus/tailwind": "*",
+    "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/packages/react/src/components/ui/Avatar.stories.tsx
+++ b/packages/react/src/components/ui/Avatar.stories.tsx
@@ -1,0 +1,388 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+
+import { themeOnlyModes } from '@/storybook/modes';
+
+import { Avatar, AvatarFallback, AvatarImage } from './avatar';
+
+const meta: Meta<typeof Avatar> = {
+  title: 'Components/Avatar',
+  component: Avatar,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'],
+      description: 'The size of the avatar',
+    },
+    shape: {
+      control: 'select',
+      options: ['circle', 'rounded'],
+      description: 'The shape of the avatar',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Avatar>;
+
+// Sample image URL for stories
+const sampleImageUrl =
+  'https://images.unsplash.com/photo-1492633423870-43d1cd2775eb?w=128&h=128&fit=crop&crop=faces';
+
+// =============================================================================
+// Default Stories
+// =============================================================================
+
+export const Default: Story = {
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src={sampleImageUrl} alt="User avatar" />
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+export const WithFallback: Story = {
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src="/broken-image.jpg" alt="User avatar" />
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+export const FallbackOnly: Story = {
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarFallback>AB</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+// =============================================================================
+// Size Stories
+// =============================================================================
+
+export const Size2XS: Story = {
+  args: { size: '2xs' },
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src={sampleImageUrl} alt="User avatar" />
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+export const SizeXS: Story = {
+  args: { size: 'xs' },
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src={sampleImageUrl} alt="User avatar" />
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+export const SizeSM: Story = {
+  args: { size: 'sm' },
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src={sampleImageUrl} alt="User avatar" />
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+export const SizeMD: Story = {
+  args: { size: 'md' },
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src={sampleImageUrl} alt="User avatar" />
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+export const SizeLG: Story = {
+  args: { size: 'lg' },
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src={sampleImageUrl} alt="User avatar" />
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+export const SizeXL: Story = {
+  args: { size: 'xl' },
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src={sampleImageUrl} alt="User avatar" />
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+export const Size2XL: Story = {
+  args: { size: '2xl' },
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src={sampleImageUrl} alt="User avatar" />
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+export const Size3XL: Story = {
+  args: { size: '3xl' },
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src={sampleImageUrl} alt="User avatar" />
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+export const Size4XL: Story = {
+  args: { size: '4xl' },
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src={sampleImageUrl} alt="User avatar" />
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+// =============================================================================
+// Shape Stories
+// =============================================================================
+
+export const ShapeCircle: Story = {
+  args: { shape: 'circle', size: 'lg' },
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src={sampleImageUrl} alt="User avatar" />
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+export const ShapeRounded: Story = {
+  args: { shape: 'rounded', size: 'lg' },
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src={sampleImageUrl} alt="User avatar" />
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+// =============================================================================
+// Play Function Tests
+// =============================================================================
+
+export const WithDataAttributes: Story = {
+  args: { size: 'lg', shape: 'circle' },
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src={sampleImageUrl} alt="User avatar" />
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const avatar = canvas.getByRole('img').closest('[data-slot="avatar"]');
+
+    await expect(avatar).toHaveAttribute('data-slot', 'avatar');
+    await expect(avatar).toHaveAttribute('data-size', 'lg');
+    await expect(avatar).toHaveAttribute('data-shape', 'circle');
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+};
+
+export const FallbackDataAttributes: Story = {
+  render: () => (
+    <Avatar size="md" shape="rounded">
+      <AvatarFallback>AB</AvatarFallback>
+    </Avatar>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const fallback = canvas.getByText('AB');
+
+    await expect(fallback).toHaveAttribute('data-slot', 'avatar-fallback');
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+};
+
+export const ImageAccessibility: Story = {
+  render: () => (
+    <Avatar size="lg">
+      <AvatarImage src={sampleImageUrl} alt="John Doe's profile picture" />
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const image = canvas.getByRole('img');
+
+    await expect(image).toHaveAccessibleName("John Doe's profile picture");
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+};
+
+// =============================================================================
+// All Variants Grid
+// =============================================================================
+
+export const AllSizes: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-6">
+      <div>
+        <h3 className="nx:mb-3 nx:text-sm nx:font-medium nx:text-foreground">
+          Circle Shape - All Sizes
+        </h3>
+        <div className="nx:flex nx:items-end nx:gap-3">
+          {(['2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const).map(
+            (size) => (
+              <div key={size} className="nx:flex nx:flex-col nx:items-center nx:gap-1">
+                <Avatar size={size} shape="circle">
+                  <AvatarImage src={sampleImageUrl} alt="User avatar" />
+                  <AvatarFallback>JD</AvatarFallback>
+                </Avatar>
+                <span className="nx:text-xs nx:text-muted-foreground">{size}</span>
+              </div>
+            )
+          )}
+        </div>
+      </div>
+      <div>
+        <h3 className="nx:mb-3 nx:text-sm nx:font-medium nx:text-foreground">
+          Rounded Shape - All Sizes
+        </h3>
+        <div className="nx:flex nx:items-end nx:gap-3">
+          {(['2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const).map(
+            (size) => (
+              <div key={size} className="nx:flex nx:flex-col nx:items-center nx:gap-1">
+                <Avatar size={size} shape="rounded">
+                  <AvatarImage src={sampleImageUrl} alt="User avatar" />
+                  <AvatarFallback>JD</AvatarFallback>
+                </Avatar>
+                <span className="nx:text-xs nx:text-muted-foreground">{size}</span>
+              </div>
+            )
+          )}
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: 'padded',
+    chromatic: { modes: themeOnlyModes },
+  },
+};
+
+export const AllFallbacks: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-6">
+      <div>
+        <h3 className="nx:mb-3 nx:text-sm nx:font-medium nx:text-foreground">
+          Fallback - Circle Shape
+        </h3>
+        <div className="nx:flex nx:items-end nx:gap-3">
+          {(['2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const).map(
+            (size) => (
+              <div key={size} className="nx:flex nx:flex-col nx:items-center nx:gap-1">
+                <Avatar size={size} shape="circle">
+                  <AvatarFallback>JD</AvatarFallback>
+                </Avatar>
+                <span className="nx:text-xs nx:text-muted-foreground">{size}</span>
+              </div>
+            )
+          )}
+        </div>
+      </div>
+      <div>
+        <h3 className="nx:mb-3 nx:text-sm nx:font-medium nx:text-foreground">
+          Fallback - Rounded Shape
+        </h3>
+        <div className="nx:flex nx:items-end nx:gap-3">
+          {(['2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'] as const).map(
+            (size) => (
+              <div key={size} className="nx:flex nx:flex-col nx:items-center nx:gap-1">
+                <Avatar size={size} shape="rounded">
+                  <AvatarFallback>JD</AvatarFallback>
+                </Avatar>
+                <span className="nx:text-xs nx:text-muted-foreground">{size}</span>
+              </div>
+            )
+          )}
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: 'padded',
+    chromatic: { modes: themeOnlyModes },
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-8">
+      <div>
+        <h3 className="nx:mb-3 nx:text-sm nx:font-medium nx:text-foreground">
+          With Image
+        </h3>
+        <div className="nx:flex nx:gap-6">
+          <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
+            <Avatar size="xl" shape="circle">
+              <AvatarImage src={sampleImageUrl} alt="User avatar" />
+              <AvatarFallback>JD</AvatarFallback>
+            </Avatar>
+            <span className="nx:text-xs nx:text-muted-foreground">Circle</span>
+          </div>
+          <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
+            <Avatar size="xl" shape="rounded">
+              <AvatarImage src={sampleImageUrl} alt="User avatar" />
+              <AvatarFallback>JD</AvatarFallback>
+            </Avatar>
+            <span className="nx:text-xs nx:text-muted-foreground">Rounded</span>
+          </div>
+        </div>
+      </div>
+      <div>
+        <h3 className="nx:mb-3 nx:text-sm nx:font-medium nx:text-foreground">
+          With Fallback
+        </h3>
+        <div className="nx:flex nx:gap-6">
+          <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
+            <Avatar size="xl" shape="circle">
+              <AvatarFallback>JD</AvatarFallback>
+            </Avatar>
+            <span className="nx:text-xs nx:text-muted-foreground">Circle</span>
+          </div>
+          <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
+            <Avatar size="xl" shape="rounded">
+              <AvatarFallback>JD</AvatarFallback>
+            </Avatar>
+            <span className="nx:text-xs nx:text-muted-foreground">Rounded</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: 'padded',
+    chromatic: { modes: themeOnlyModes },
+  },
+};

--- a/packages/react/src/components/ui/avatar.tsx
+++ b/packages/react/src/components/ui/avatar.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+
+import * as AvatarPrimitive from '@radix-ui/react-avatar';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const avatarVariants = cva(
+  'nx:relative nx:flex nx:shrink-0 nx:overflow-hidden nx:bg-muted',
+  {
+    variants: {
+      size: {
+        '2xs': 'nx:size-5 nx:text-[8px]',
+        xs: 'nx:size-6 nx:text-[10px]',
+        sm: 'nx:size-8 nx:text-xs',
+        md: 'nx:size-10 nx:text-sm',
+        lg: 'nx:size-12 nx:text-base',
+        xl: 'nx:size-14 nx:text-lg',
+        '2xl': 'nx:size-16 nx:text-xl',
+        '3xl': 'nx:size-20 nx:text-2xl',
+        '4xl': 'nx:size-24 nx:text-3xl',
+      },
+      shape: {
+        circle: 'nx:rounded-full',
+        rounded: 'nx:rounded-md',
+      },
+    },
+    compoundVariants: [
+      // Larger sizes get larger border radius for rounded shape
+      { size: 'lg', shape: 'rounded', className: 'nx:rounded-lg' },
+      { size: 'xl', shape: 'rounded', className: 'nx:rounded-lg' },
+      { size: '2xl', shape: 'rounded', className: 'nx:rounded-xl' },
+      { size: '3xl', shape: 'rounded', className: 'nx:rounded-xl' },
+      { size: '4xl', shape: 'rounded', className: 'nx:rounded-2xl' },
+    ],
+    defaultVariants: {
+      size: 'md',
+      shape: 'circle',
+    },
+  }
+);
+
+interface AvatarProps
+  extends React.ComponentProps<typeof AvatarPrimitive.Root>,
+    VariantProps<typeof avatarVariants> {}
+
+/**
+ * Avatar component for displaying user profile images with fallback support.
+ * Built on Radix UI Avatar primitive for proper image loading states.
+ */
+function Avatar({ className, size, shape, ...props }: AvatarProps) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      data-size={size}
+      data-shape={shape}
+      className={cn(avatarVariants({ size, shape, className }))}
+      {...props}
+    />
+  );
+}
+
+type AvatarImageProps = React.ComponentProps<typeof AvatarPrimitive.Image>;
+
+/**
+ * Image element for Avatar. Renders only when image loads successfully.
+ */
+function AvatarImage({ className, ...props }: AvatarImageProps) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn('nx:aspect-square nx:size-full nx:object-cover', className)}
+      {...props}
+    />
+  );
+}
+
+interface AvatarFallbackProps
+  extends React.ComponentProps<typeof AvatarPrimitive.Fallback> {
+  /**
+   * Delay in milliseconds before showing the fallback.
+   * Useful to avoid fallback flash for cached images.
+   * @default 0
+   */
+  delayMs?: number;
+}
+
+/**
+ * Fallback content for Avatar when image fails to load or is not provided.
+ * Typically displays user initials or a placeholder icon.
+ */
+function AvatarFallback({
+  className,
+  delayMs,
+  ...props
+}: AvatarFallbackProps) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      delayMs={delayMs}
+      className={cn(
+        'nx:flex nx:size-full nx:items-center nx:justify-center nx:bg-muted nx:font-medium nx:text-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Avatar,
+  AvatarFallback,
+  type AvatarFallbackProps,
+  AvatarImage,
+  type AvatarImageProps,
+  type AvatarProps,
+  avatarVariants,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,4 +5,5 @@ import './index.css';
 export { cn } from '@/lib/utils';
 
 // Components
+export * from '@/components/ui/avatar';
 export * from '@/components/ui/button';

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,17 +630,57 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
   integrity sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==
 
+"@radix-ui/react-avatar@^1.1.11":
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-avatar/-/react-avatar-1.1.11.tgz#3e24b70d636a12e2806abb2b4ce4b15df395f9c9"
+  integrity sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==
+  dependencies:
+    "@radix-ui/react-context" "1.1.3"
+    "@radix-ui/react-primitive" "2.1.4"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-is-hydrated" "0.1.0"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+
 "@radix-ui/react-compose-refs@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz#a2c4c47af6337048ee78ff6dc0d090b390d2bb30"
   integrity sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==
 
-"@radix-ui/react-slot@^1.2.4":
+"@radix-ui/react-context@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.3.tgz#81286f643b310d040eaac13b18e223130861d839"
+  integrity sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==
+
+"@radix-ui/react-primitive@2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz#2626ea309ebd63bf5767d3e7fc4081f81b993df0"
+  integrity sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==
+  dependencies:
+    "@radix-ui/react-slot" "1.2.4"
+
+"@radix-ui/react-slot@1.2.4", "@radix-ui/react-slot@^1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.4.tgz#63c0ba05fdf90cc49076b94029c852d7bac1fb83"
   integrity sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.2"
+
+"@radix-ui/react-use-callback-ref@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz#62a4dba8b3255fdc5cc7787faeac1c6e4cc58d40"
+  integrity sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==
+
+"@radix-ui/react-use-is-hydrated@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz#544da73369517036c77659d7cdd019dc0f5ff9a0"
+  integrity sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==
+  dependencies:
+    use-sync-external-store "^1.5.0"
+
+"@radix-ui/react-use-layout-effect@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz#0c4230a9eed49d4589c967e2d9c0d9d60a23971e"
+  integrity sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==
 
 "@rolldown/pluginutils@1.0.0-beta.53":
   version "1.0.0-beta.53"


### PR DESCRIPTION
## Summary
- Adds `Avatar` component to @nexus/react
- Implements all variants from Figma design (9 sizes, 2 shapes)
- Built on Radix UI Avatar primitive for proper image loading states
- Includes compound variants for adaptive border radius on larger sizes
- Includes Storybook stories with interaction tests (20 stories, all passing)

## Linear Issue
Closes NEX-109

## Figma
- [Avatar Specifications](https://www.figma.com/design/O1McE1zDvvGEYIxLNYYGhW/nexus?node-id=4-3200&m=dev)
- [Avatar Sizes](https://www.figma.com/design/O1McE1zDvvGEYIxLNYYGhW/nexus?node-id=4-3303&m=dev)

## Component Features
| Feature | Details |
|---------|---------|
| Sizes | 2xs (20px), xs (24px), sm (32px), md (40px), lg (48px), xl (56px), 2xl (64px), 3xl (80px), 4xl (96px) |
| Shapes | circle (rounded-full), rounded (adaptive radius) |
| States | Image, Fallback (initials) |

## Quality Gates
- ✅ Lint passed
- ✅ TypeScript passed
- ✅ Tests passed (46 total, 20 Avatar stories)
- ✅ Build passed

## Test Plan
- [ ] Visual review in Storybook
- [ ] Verify Figma parity
- [ ] All tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)