### PR TITLE
feat(playground): Add icon library switcher and UI overhaul

### DIFF
--- a/apps/playground/CLAUDE.md
+++ b/apps/playground/CLAUDE.md
@@ -7,12 +7,15 @@ Theme demonstration app for previewing design token combinations dynamically.
 - Demo tool for showing clients theme variations
 - Test different color, typography, spacing, and style combinations
 - Preview light/dark mode switching in real-time
+- Preview components with different icon libraries (Tabler, Lucide, Phosphor)
 
 ## Tech Stack
 
 - **Vite** 7.x with React plugin
 - **React** 19 with TypeScript
 - **Tailwind CSS** 4.x with `nx:` prefix
+- **Zustand** 5.x for icon library state
+- **Icon Libraries**: @tabler/icons-react, lucide-react, @phosphor-icons/react
 - Native HTML elements (no @nexus/react dependency)
 
 ## Commands
@@ -44,7 +47,7 @@ apps/playground/
 │       └── shadow-variables.css     # --nx-shadow-* CSS variables
 └── src/
     ├── main.tsx          # React entry
-    ├── App.tsx           # Main layout
+    ├── App.tsx           # Main layout (two-column: content + sidebar)
     ├── App.css           # Imports styles/globals.css
     ├── styles/           # Build-time CSS (copied from core)
     │   ├── globals.css   # Tailwind entry with @theme block
@@ -53,9 +56,15 @@ apps/playground/
     │   └── borderwidth-utilities.css
     ├── hooks/
     │   └── useTheme.ts   # Theme state + CSS loading
+    ├── store/
+    │   └── iconStore.ts  # Zustand store for icon library selection
+    ├── lib/
+    │   └── icon-registry.ts # Icon mappings across libraries
     └── components/
-        ├── ThemeSwitcher.tsx    # Dropdown controls (2 rows: Colors + Tokens)
-        └── ComponentShowcase.tsx # Component preview sections
+        ├── ThemeSwitcher.tsx     # Sidebar with theme controls
+        ├── ComponentShowcase.tsx # Component preview sections
+        ├── IconShowcase.tsx      # Icon grid with library info
+        └── PlaygroundIcon.tsx    # Icon component using selected library
 ```
 
 ## How It Works
@@ -98,6 +107,14 @@ useEffect(() => loadCSS(`/themes/size-${theme.size}.css`, 'size'), [theme.size])
 | Radius | blunt, sharp, subtle, smooth, mellow | subtle |
 | Border Width | vega, lyra, maia, mira, nova | vega |
 
+### Icon Libraries
+
+| Library | Package | Icon Count | Default |
+|---------|---------|------------|---------|
+| Tabler | @tabler/icons-react | 5,800+ | ✓ |
+| Lucide | lucide-react | 1,500+ | |
+| Phosphor | @phosphor-icons/react | 9,000+ | |
+
 ## Setup
 
 ```bash
@@ -112,13 +129,73 @@ The showcase demonstrates all token categories:
 
 | Section | Tokens Used |
 |---------|-------------|
-| Typography | `text-display-*`, `text-headling-*`, `text-body-*`, `text-label-*`, `text-code-*` |
-| Shadows | `--shadow-2xs` to `--shadow-2xl`, `--shadow-inner`, `--shadow-focus-default` |
+| Typography | `text-display-*`, `text-heading-*`, `text-body-*`, `text-label-*`, `text-code-*` |
+| Semantic Colors | `bg-primary-*`, `bg-secondary-*`, `bg-error-*`, etc. |
+| Shadows | `shadow-2xs` to `shadow-2xl`, `shadow-inner`, `shadow-focus-default` |
 | Border Radius | `rounded-base`, `rounded-sm`, `rounded-md`, `rounded-lg`, `rounded-xl`, `rounded-2xl`, `rounded-3xl`, `rounded-full` |
-| Spacing | `--size-1` to `--size-16` |
-| Buttons | Semantic colors + `var(--md)` for radius |
-| Colors | `bg-primary-*`, `bg-secondary-*`, `bg-error-*`, etc. |
-| Status | `bg-success-surface`, `text-success-text`, etc. |
+| Spacing | `w-1` to `w-16` |
+| Icons | 14 internal DS icons from selected library |
+| Buttons | Semantic colors + `rounded-md` for radius |
+| Cards & Containers | `bg-container`, `bg-popover`, `bg-muted`, `bg-accent` |
+| Borders | `border-default`, `border-thick`, `border-border-*` colors |
+| Status Messages | `*-surface`, `*-text` for success/error/warning/info |
+
+## Icon Library Switching
+
+The playground allows previewing icons from different libraries to help teams decide which library to use.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  icon-registry.ts                                           │
+│  Maps 14 internal icon names → library-specific components  │
+│  e.g., "check" → IconCheck (Tabler) | Check (Lucide)        │
+├─────────────────────────────────────────────────────────────┤
+│  iconStore.ts (Zustand)                                     │
+│  Manages selected library state with selective subscriptions│
+├─────────────────────────────────────────────────────────────┤
+│  PlaygroundIcon component                                   │
+│  <PlaygroundIcon name="check" size={16} />                  │
+│  Renders icon from currently selected library               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Available Internal Icons
+
+14 icons are mapped across all three libraries:
+
+| Icon Name | Use Case |
+|-----------|----------|
+| loader | Loading states |
+| chevron-down/up/left/right | Dropdowns, navigation |
+| check | Success, selection |
+| x | Close, dismiss |
+| alert-circle | Error states |
+| alert-triangle | Warning states |
+| circle-check | Success confirmation |
+| info-circle | Information |
+| search | Search inputs |
+| eye / eye-off | Password visibility |
+
+### Using PlaygroundIcon
+
+```tsx
+import { PlaygroundIcon } from './components/PlaygroundIcon';
+
+// Basic usage
+<PlaygroundIcon name="check" size={16} />
+
+// With className
+<PlaygroundIcon name="loader" className="nx:animate-spin nx:text-primary-text" />
+```
+
+### Why Zustand?
+
+Zustand was chosen over React Context for:
+- **Selective subscriptions**: Components only re-render when their specific slice changes
+- **No provider wrapping**: Simpler component tree
+- **Future scalability**: Easy to add more playground state (e.g., component props)
 
 ## Adding Components
 
@@ -162,8 +239,22 @@ The playground needs `@theme` so Tailwind generates CSS variable references that
 
 Theme CSS files use `html { }` instead of `:root { }` to ensure they override Tailwind's `@theme`-generated `:root` rules via cascade order (same specificity, but loaded later).
 
+## UI Layout
+
+The playground uses a two-column layout:
+- **Main content** (left): Scrollable component showcase with sticky header
+- **Sidebar** (right): Fixed theme controls panel
+
+ThemeSwitcher sections:
+- **Appearance**: Light/dark toggle switch
+- **Colors**: Base and brand color dropdowns with color indicators
+- **Design Tokens**: Size, typography, shadow, radius, border width
+- **Icons**: Library selector with icon count
+- **Reset button**: Returns to default theme
+
 ## Notes
 
 - All CSS files are committed for standalone deployment
 - Playground has no direct code dependency on core package
 - CSS is copied via `yarn tokens:modular` from root (regenerate after token changes)
+- Icon libraries are playground-only dependencies (not part of @nexus/react)

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -6,11 +6,17 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@phosphor-icons/react": "^2.1.10",
+    "@tabler/icons-react": "^3.36.1",
+    "lucide-react": "^0.562.0",
     "react": "^19.2.3",
-    "react-dom": "^19.2.3"
+    "react-dom": "^19.2.3",
+    "zustand": "^5.0.9"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -7,18 +7,39 @@ export default function App() {
 
   return (
     <div className="nx:bg-background nx:text-foreground nx:min-h-screen">
-      <header className="nx:border-border-default nx:border-b nx:p-4">
-        <h1 className="nx:text-2xl nx:font-bold">Nexus Theme Playground</h1>
-        <p className="nx:text-muted-foreground nx:text-sm">
-          Dynamically switch between theme combinations
-        </p>
-      </header>
+      <div className="nx:flex">
+        {/* Main Content */}
+        <main className="nx:flex-1 nx:min-w-0">
+          {/* Header */}
+          <header className="nx:sticky nx:top-0 nx:z-10 nx:bg-background/95 nx:backdrop-blur nx:border-b nx:border-border-default">
+            <div className="nx:px-6 nx:py-4">
+              <div className="nx:flex nx:items-center nx:gap-3">
+                <div className="nx:w-8 nx:h-8 nx:rounded-lg nx:bg-primary-background nx:flex nx:items-center nx:justify-center">
+                  <span className="nx:text-primary-foreground nx:font-bold nx:text-sm">N</span>
+                </div>
+                <div>
+                  <h1 className="nx:text-lg nx:font-semibold nx:text-foreground">
+                    Nexus Theme Playground
+                  </h1>
+                  <p className="nx:text-xs nx:text-muted-foreground">
+                    Preview and customize your design system
+                  </p>
+                </div>
+              </div>
+            </div>
+          </header>
 
-      <ThemeSwitcher theme={theme} setTheme={setTheme} />
+          {/* Content */}
+          <ComponentShowcase />
+        </main>
 
-      <main>
-        <ComponentShowcase />
-      </main>
+        {/* Sidebar */}
+        <aside className="nx:border-border-default nx:w-80 nx:shrink-0 nx:border-l">
+          <div className="nx:sticky nx:top-0 nx:h-screen nx:overflow-hidden">
+            <ThemeSwitcher theme={theme} setTheme={setTheme} />
+          </div>
+        </aside>
+      </div>
     </div>
   );
 }

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -15,7 +15,9 @@ export default function App() {
             <div className="nx:px-6 nx:py-4">
               <div className="nx:flex nx:items-center nx:gap-3">
                 <div className="nx:w-8 nx:h-8 nx:rounded-lg nx:bg-primary-background nx:flex nx:items-center nx:justify-center">
-                  <span className="nx:text-primary-foreground nx:font-bold nx:text-sm">N</span>
+                  <span className="nx:text-primary-foreground nx:font-bold nx:text-sm">
+                    N
+                  </span>
                 </div>
                 <div>
                   <h1 className="nx:text-lg nx:font-semibold nx:text-foreground">

--- a/apps/playground/src/components/ComponentShowcase.tsx
+++ b/apps/playground/src/components/ComponentShowcase.tsx
@@ -1,302 +1,286 @@
+import { IconShowcase } from './IconShowcase';
+
+// Reusable section component
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="nx:bg-background nx:rounded-xl nx:border nx:border-border-default nx:overflow-hidden">
+      <div className="nx:px-5 nx:py-4 nx:border-b nx:border-border-default nx:bg-muted/30">
+        <h2 className="nx:text-base nx:font-semibold nx:text-foreground">{title}</h2>
+        {description && (
+          <p className="nx:text-sm nx:text-muted-foreground nx:mt-0.5">{description}</p>
+        )}
+      </div>
+      <div className="nx:p-5">{children}</div>
+    </section>
+  );
+}
+
 export function ComponentShowcase() {
   return (
-    <div className="nx:space-y-8 nx:p-8">
-      {/* Typography Section */}
-      <section>
-        <h2 className="nx:mb-4 nx:text-lg nx:font-semibold">Typography</h2>
-        <div className="nx:border-border-default nx:bg-container nx:space-y-4 nx:rounded-lg nx:border nx:p-4">
-          <div>
-            <span className="nx:text-muted-foreground nx:text-xs">
-              display-large
-            </span>
-            <p className="nx:text-display-large">Display Large</p>
-          </div>
-          <div>
-            <span className="nx:text-muted-foreground nx:text-xs">
-              display-medium
-            </span>
-            <p className="nx:text-display-medium">Display Medium</p>
-          </div>
-          <div>
-            <span className="nx:text-muted-foreground nx:text-xs">
-              heading-xlarge
-            </span>
-            <p className="nx:text-heading-xlarge">Heading XLarge</p>
-          </div>
-          <div>
-            <span className="nx:text-muted-foreground nx:text-xs">
-              heading-large
-            </span>
-            <p className="nx:text-heading-large">Heading Large</p>
-          </div>
-          <div>
-            <span className="nx:text-muted-foreground nx:text-xs">
-              heading-medium
-            </span>
-            <p className="nx:text-heading-medium">Heading Medium</p>
-          </div>
-          <div>
-            <span className="nx:text-muted-foreground nx:text-xs">
-              body-large
-            </span>
-            <p className="nx:text-body-large">
-              Body Large - The quick brown fox jumps over the lazy dog.
-            </p>
-          </div>
-          <div>
-            <span className="nx:text-muted-foreground nx:text-xs">
-              body-default
-            </span>
-            <p className="nx:text-body-default">
-              Body Default - The quick brown fox jumps over the lazy dog.
-            </p>
-          </div>
-          <div>
-            <span className="nx:text-muted-foreground nx:text-xs">
-              body-small
-            </span>
-            <p className="nx:text-body-small">
-              Body Small - The quick brown fox jumps over the lazy dog.
-            </p>
-          </div>
-          <div className="nx:flex nx:gap-6">
-            <div>
-              <span className="nx:text-muted-foreground nx:text-xs">
-                label-large
+    <div className="nx:bg-muted/30 nx:min-h-screen">
+      <div className="nx:p-6 nx:space-y-6">
+        {/* Typography Section */}
+        <Section title="Typography" description="Text styles and font scales">
+          <div className="nx:space-y-6">
+            {/* Display */}
+            <div className="nx:space-y-2">
+              <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+                Display
               </span>
-              <p className="nx:text-label-large">Label Large</p>
+              <div className="nx:space-y-1">
+                <p className="nx:text-display-large">Display Large</p>
+                <p className="nx:text-display-medium">Display Medium</p>
+              </div>
             </div>
-            <div>
-              <span className="nx:text-muted-foreground nx:text-xs">
-                label-default
+
+            {/* Headings */}
+            <div className="nx:space-y-2">
+              <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+                Headings
               </span>
-              <p className="nx:text-label-default">Label Default</p>
+              <div className="nx:space-y-1">
+                <p className="nx:text-heading-xlarge">Heading XLarge</p>
+                <p className="nx:text-heading-large">Heading Large</p>
+                <p className="nx:text-heading-medium">Heading Medium</p>
+              </div>
             </div>
-            <div>
-              <span className="nx:text-muted-foreground nx:text-xs">
-                label-small
+
+            {/* Body */}
+            <div className="nx:space-y-2">
+              <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+                Body
               </span>
-              <p className="nx:text-label-small">Label Small</p>
+              <div className="nx:space-y-2">
+                <p className="nx:text-body-large">
+                  Body Large - The quick brown fox jumps over the lazy dog.
+                </p>
+                <p className="nx:text-body-default">
+                  Body Default - The quick brown fox jumps over the lazy dog.
+                </p>
+                <p className="nx:text-body-small">
+                  Body Small - The quick brown fox jumps over the lazy dog.
+                </p>
+              </div>
             </div>
-            <div>
-              <span className="nx:text-muted-foreground nx:text-xs">
-                label-caps
-              </span>
-              <p className="nx:text-label-caps">Label Caps</p>
+
+            {/* Labels & Code */}
+            <div className="nx:grid nx:grid-cols-2 nx:gap-6">
+              <div className="nx:space-y-2">
+                <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+                  Labels
+                </span>
+                <div className="nx:flex nx:flex-wrap nx:gap-4">
+                  <span className="nx:text-label-large">Label Large</span>
+                  <span className="nx:text-label-default">Label Default</span>
+                  <span className="nx:text-label-small">Label Small</span>
+                  <span className="nx:text-label-caps">Label Caps</span>
+                </div>
+              </div>
+              <div className="nx:space-y-2">
+                <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+                  Code
+                </span>
+                <div className="nx:flex nx:flex-wrap nx:gap-4">
+                  <code className="nx:text-code-block nx:bg-muted nx:px-2 nx:py-1 nx:rounded">
+                    const x = 42;
+                  </code>
+                  <code className="nx:text-code-inline nx:bg-muted nx:px-1.5 nx:py-0.5 nx:rounded">
+                    inline
+                  </code>
+                </div>
+              </div>
             </div>
           </div>
-          <div className="nx:flex nx:gap-6">
-            <div>
-              <span className="nx:text-muted-foreground nx:text-xs">
-                code-block
-              </span>
-              <p className="nx:text-code-block">const x = 42;</p>
-            </div>
-            <div>
-              <span className="nx:text-muted-foreground nx:text-xs">
-                code-inline
-              </span>
-              <p className="nx:text-code-inline">inline code</p>
-            </div>
+        </Section>
+
+        {/* Colors Section */}
+        <Section title="Semantic Colors" description="Brand and status color palette">
+          <div className="nx:grid nx:grid-cols-2 nx:gap-4 nx:sm:grid-cols-3 nx:md:grid-cols-5">
+            <ColorSwatch name="Background" className="nx:bg-background" border />
+            <ColorSwatch name="Foreground" className="nx:bg-foreground" textDark />
+            <ColorSwatch name="Primary" className="nx:bg-primary-background" />
+            <ColorSwatch name="Secondary" className="nx:bg-secondary-background" />
+            <ColorSwatch name="Muted" className="nx:bg-muted" />
+            <ColorSwatch name="Accent" className="nx:bg-accent" />
+            <ColorSwatch name="Success" className="nx:bg-success-background" />
+            <ColorSwatch name="Error" className="nx:bg-error-background" />
+            <ColorSwatch name="Warning" className="nx:bg-warning-background" />
+            <ColorSwatch name="Info" className="nx:bg-information-background" />
           </div>
-        </div>
-      </section>
+        </Section>
 
-      {/* Shadows Section */}
-      <section>
-        <h2 className="nx:mb-4 nx:text-lg nx:font-semibold">Shadows</h2>
-        <div className="nx:grid nx:grid-cols-2 nx:gap-6 sm:nx:grid-cols-3 md:nx:grid-cols-4 lg:nx:grid-cols-5">
-          <ShadowBox name="2xs" shadowClass="nx:shadow-2xs" />
-          <ShadowBox name="xs" shadowClass="nx:shadow-xs" />
-          <ShadowBox name="sm" shadowClass="nx:shadow-sm" />
-          <ShadowBox name="base" shadowClass="nx:shadow-base" />
-          <ShadowBox name="lg" shadowClass="nx:shadow-lg" />
-          <ShadowBox name="xl" shadowClass="nx:shadow-xl" />
-          <ShadowBox name="2xl" shadowClass="nx:shadow-2xl" />
-          <ShadowBox name="inner" shadowClass="nx:shadow-inner" />
-          <ShadowBox name="focus" shadowClass="nx:shadow-focus-default" />
-        </div>
-      </section>
-
-      {/* Radius Section */}
-      <section>
-        <h2 className="nx:mb-4 nx:text-lg nx:font-semibold">Border Radius</h2>
-        <div className="nx:flex nx:flex-wrap nx:gap-4">
-          <RadiusBox name="base" className="nx:rounded-base" />
-          <RadiusBox name="sm" className="nx:rounded-sm" />
-          <RadiusBox name="md" className="nx:rounded-md" />
-          <RadiusBox name="lg" className="nx:rounded-lg" />
-          <RadiusBox name="xl" className="nx:rounded-xl" />
-          <RadiusBox name="2xl" className="nx:rounded-2xl" />
-          <RadiusBox name="3xl" className="nx:rounded-3xl" />
-          <RadiusBox name="full" className="nx:rounded-full" />
-        </div>
-      </section>
-
-      {/* Spacing Section */}
-      <section>
-        <h2 className="nx:mb-4 nx:text-lg nx:font-semibold">Spacing Scale</h2>
-        <div className="nx:space-y-2">
-          <SpacingBar name="w-1" className="nx:w-1" />
-          <SpacingBar name="w-2" className="nx:w-2" />
-          <SpacingBar name="w-3" className="nx:w-3" />
-          <SpacingBar name="w-4" className="nx:w-4" />
-          <SpacingBar name="w-5" className="nx:w-5" />
-          <SpacingBar name="w-6" className="nx:w-6" />
-          <SpacingBar name="w-8" className="nx:w-8" />
-          <SpacingBar name="w-10" className="nx:w-10" />
-          <SpacingBar name="w-12" className="nx:w-12" />
-          <SpacingBar name="w-16" className="nx:w-16" />
-        </div>
-      </section>
-
-      {/* Buttons Section */}
-      <section>
-        <h2 className="nx:mb-4 nx:text-lg nx:font-semibold">Buttons</h2>
-        <div className="nx:flex nx:flex-wrap nx:gap-3">
-          <button className="nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium hover:nx:opacity-90">
-            Primary
-          </button>
-          <button className="nx:bg-secondary-background nx:text-secondary-foreground nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium hover:nx:opacity-90">
-            Secondary
-          </button>
-          <button className="nx:border-border-default nx:bg-background hover:nx:bg-accent nx:rounded-md nx:border nx:px-4 nx:py-2 nx:text-sm nx:font-medium">
-            Outline
-          </button>
-          <button className="hover:nx:bg-accent nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium">
-            Ghost
-          </button>
-          <button className="nx:bg-error-background nx:text-error-foreground nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium hover:nx:opacity-90">
-            Destructive
-          </button>
-        </div>
-      </section>
-
-      {/* Color Swatches Section */}
-      <section>
-        <h2 className="nx:mb-4 nx:text-lg nx:font-semibold">Semantic Colors</h2>
-        <div className="nx:grid nx:grid-cols-2 nx:gap-3 sm:nx:grid-cols-3 md:nx:grid-cols-4">
-          <ColorSwatch name="Background" className="nx:bg-background" />
-          <ColorSwatch
-            name="Foreground"
-            className="nx:bg-foreground"
-            textDark
-          />
-          <ColorSwatch name="Primary" className="nx:bg-primary-background" />
-          <ColorSwatch
-            name="Secondary"
-            className="nx:bg-secondary-background"
-          />
-          <ColorSwatch name="Muted" className="nx:bg-muted" />
-          <ColorSwatch name="Accent" className="nx:bg-accent" />
-          <ColorSwatch name="Success" className="nx:bg-success-background" />
-          <ColorSwatch name="Error" className="nx:bg-error-background" />
-          <ColorSwatch name="Warning" className="nx:bg-warning-background" />
-          <ColorSwatch name="Info" className="nx:bg-information-background" />
-        </div>
-      </section>
-
-      {/* Cards Section */}
-      <section>
-        <h2 className="nx:mb-4 nx:text-lg nx:font-semibold">
-          Cards & Containers
-        </h2>
-        <div className="nx:grid nx:gap-4 md:nx:grid-cols-2">
-          <div className="nx:border-border-default nx:bg-container nx:rounded-lg nx:border nx:p-4">
-            <h3 className="nx:font-medium">Container</h3>
-            <p className="nx:text-muted-foreground nx:mt-1 nx:text-sm">
-              This is a container with default background
-            </p>
+        {/* Shadows Section */}
+        <Section title="Shadows" description="Elevation and depth">
+          <div className="nx:grid nx:grid-cols-3 nx:gap-4 nx:sm:grid-cols-4 nx:md:grid-cols-5">
+            <ShadowBox name="2xs" shadowClass="nx:shadow-2xs" />
+            <ShadowBox name="xs" shadowClass="nx:shadow-xs" />
+            <ShadowBox name="sm" shadowClass="nx:shadow-sm" />
+            <ShadowBox name="base" shadowClass="nx:shadow-base" />
+            <ShadowBox name="lg" shadowClass="nx:shadow-lg" />
+            <ShadowBox name="xl" shadowClass="nx:shadow-xl" />
+            <ShadowBox name="2xl" shadowClass="nx:shadow-2xl" />
+            <ShadowBox name="inner" shadowClass="nx:shadow-inner" />
+            <ShadowBox name="focus" shadowClass="nx:shadow-focus-default" />
           </div>
-          <div className="nx:border-border-default nx:bg-popover nx:rounded-lg nx:border nx:p-4">
-            <h3 className="nx:font-medium">Popover</h3>
-            <p className="nx:text-muted-foreground nx:mt-1 nx:text-sm">
-              This uses the popover background color
-            </p>
-          </div>
-          <div className="nx:bg-muted nx:rounded-lg nx:p-4">
-            <h3 className="nx:text-muted-foreground nx:font-medium">Muted</h3>
-            <p className="nx:text-muted-foreground nx:mt-1 nx:text-sm">
-              Muted background with muted foreground text
-            </p>
-          </div>
-          <div className="nx:bg-accent nx:rounded-lg nx:p-4">
-            <h3 className="nx:text-accent-foreground nx:font-medium">Accent</h3>
-            <p className="nx:text-accent-foreground nx:mt-1 nx:text-sm">
-              Accent background with accent foreground text
-            </p>
-          </div>
-        </div>
-      </section>
+        </Section>
 
-      {/* Borders Section */}
-      <section>
-        <h2 className="nx:mb-4 nx:text-lg nx:font-semibold">Borders</h2>
-        <div className="nx:space-y-4">
-          <div>
-            <span className="nx:text-muted-foreground nx:mb-2 nx:block nx:text-xs">
-              Border Width Utilities
-            </span>
+        {/* Radius Section */}
+        <Section title="Border Radius" description="Corner rounding styles">
+          <div className="nx:flex nx:flex-wrap nx:gap-4">
+            <RadiusBox name="base" className="nx:rounded-base" />
+            <RadiusBox name="sm" className="nx:rounded-sm" />
+            <RadiusBox name="md" className="nx:rounded-md" />
+            <RadiusBox name="lg" className="nx:rounded-lg" />
+            <RadiusBox name="xl" className="nx:rounded-xl" />
+            <RadiusBox name="2xl" className="nx:rounded-2xl" />
+            <RadiusBox name="3xl" className="nx:rounded-3xl" />
+            <RadiusBox name="full" className="nx:rounded-full" />
+          </div>
+        </Section>
+
+        {/* Spacing Section */}
+        <Section title="Spacing Scale" description="Consistent spacing units">
+          <div className="nx:space-y-2">
+            <SpacingBar name="1" className="nx:w-1" />
+            <SpacingBar name="2" className="nx:w-2" />
+            <SpacingBar name="3" className="nx:w-3" />
+            <SpacingBar name="4" className="nx:w-4" />
+            <SpacingBar name="5" className="nx:w-5" />
+            <SpacingBar name="6" className="nx:w-6" />
+            <SpacingBar name="8" className="nx:w-8" />
+            <SpacingBar name="10" className="nx:w-10" />
+            <SpacingBar name="12" className="nx:w-12" />
+            <SpacingBar name="16" className="nx:w-16" />
+          </div>
+        </Section>
+
+        {/* Icons Section */}
+        <IconShowcase />
+
+        {/* Buttons Section */}
+        <Section title="Buttons" description="Interactive button variants">
+          <div className="nx:space-y-4">
             <div className="nx:flex nx:flex-wrap nx:gap-3">
-              <div className="nx:border-border-default nx:border-default nx:rounded nx:px-4 nx:py-2">
-                border-default
-              </div>
-              <div className="nx:border-border-default nx:border-thick nx:rounded nx:px-4 nx:py-2">
-                border-thick
-              </div>
-            </div>
-          </div>
-          <div>
-            <span className="nx:text-muted-foreground nx:mb-2 nx:block nx:text-xs">
-              Border Colors
-            </span>
-            <div className="nx:flex nx:flex-wrap nx:gap-3">
-              <div className="nx:border-border-default nx:border-thick nx:rounded nx:px-4 nx:py-2">
-                Default
-              </div>
-              <div className="nx:border-border-primary nx:border-thick nx:rounded nx:px-4 nx:py-2">
+              <button className="nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium hover:nx:opacity-90 nx:transition-opacity">
                 Primary
+              </button>
+              <button className="nx:bg-secondary-background nx:text-secondary-foreground nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium hover:nx:opacity-90 nx:transition-opacity">
+                Secondary
+              </button>
+              <button className="nx:border nx:border-border-default nx:bg-background hover:nx:bg-accent nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium nx:transition-colors">
+                Outline
+              </button>
+              <button className="hover:nx:bg-accent nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium nx:transition-colors">
+                Ghost
+              </button>
+              <button className="nx:bg-error-background nx:text-error-foreground nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium hover:nx:opacity-90 nx:transition-opacity">
+                Destructive
+              </button>
+            </div>
+          </div>
+        </Section>
+
+        {/* Cards Section */}
+        <Section title="Cards & Containers" description="Surface styles and containers">
+          <div className="nx:grid nx:gap-4 nx:md:grid-cols-2">
+            <div className="nx:border nx:border-border-default nx:bg-container nx:rounded-lg nx:p-4">
+              <h3 className="nx:font-medium">Container</h3>
+              <p className="nx:text-muted-foreground nx:mt-1 nx:text-sm">
+                Default container background
+              </p>
+            </div>
+            <div className="nx:border nx:border-border-default nx:bg-popover nx:rounded-lg nx:p-4">
+              <h3 className="nx:font-medium">Popover</h3>
+              <p className="nx:text-muted-foreground nx:mt-1 nx:text-sm">Popover background color</p>
+            </div>
+            <div className="nx:bg-muted nx:rounded-lg nx:p-4">
+              <h3 className="nx:text-muted-foreground nx:font-medium">Muted</h3>
+              <p className="nx:text-muted-foreground nx:mt-1 nx:text-sm">
+                Muted background with muted foreground
+              </p>
+            </div>
+            <div className="nx:bg-accent nx:rounded-lg nx:p-4">
+              <h3 className="nx:text-accent-foreground nx:font-medium">Accent</h3>
+              <p className="nx:text-accent-foreground nx:mt-1 nx:text-sm">
+                Accent background with accent foreground
+              </p>
+            </div>
+          </div>
+        </Section>
+
+        {/* Borders Section */}
+        <Section title="Borders" description="Border widths and colors">
+          <div className="nx:space-y-4">
+            <div>
+              <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+                Width
+              </span>
+              <div className="nx:flex nx:flex-wrap nx:gap-3 nx:mt-2">
+                <div className="nx:border nx:border-border-default nx:border-default nx:rounded nx:px-4 nx:py-2 nx:text-sm">
+                  default
+                </div>
+                <div className="nx:border nx:border-border-default nx:border-thick nx:rounded nx:px-4 nx:py-2 nx:text-sm">
+                  thick
+                </div>
               </div>
-              <div className="nx:border-border-success nx:border-thick nx:rounded nx:px-4 nx:py-2">
-                Success
-              </div>
-              <div className="nx:border-border-error nx:border-thick nx:rounded nx:px-4 nx:py-2">
-                Error
-              </div>
-              <div className="nx:border-border-information nx:border-thick nx:rounded nx:px-4 nx:py-2">
-                Info
+            </div>
+            <div>
+              <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+                Colors
+              </span>
+              <div className="nx:flex nx:flex-wrap nx:gap-3 nx:mt-2">
+                <div className="nx:border-2 nx:border-border-default nx:rounded nx:px-4 nx:py-2 nx:text-sm">
+                  Default
+                </div>
+                <div className="nx:border-2 nx:border-border-primary nx:rounded nx:px-4 nx:py-2 nx:text-sm">
+                  Primary
+                </div>
+                <div className="nx:border-2 nx:border-border-success nx:rounded nx:px-4 nx:py-2 nx:text-sm">
+                  Success
+                </div>
+                <div className="nx:border-2 nx:border-border-error nx:rounded nx:px-4 nx:py-2 nx:text-sm">
+                  Error
+                </div>
+                <div className="nx:border-2 nx:border-border-information nx:rounded nx:px-4 nx:py-2 nx:text-sm">
+                  Info
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </section>
+        </Section>
 
-      {/* Status Colors Section */}
-      <section>
-        <h2 className="nx:mb-4 nx:text-lg nx:font-semibold">Status Colors</h2>
-        <div className="nx:grid nx:gap-4 md:nx:grid-cols-2">
-          <div className="nx:bg-success-surface nx:rounded-lg nx:p-4">
-            <span className="nx:text-success-text nx:text-sm nx:font-medium">
-              Success message
-            </span>
+        {/* Status Colors Section */}
+        <Section title="Status Messages" description="Feedback and alert styles">
+          <div className="nx:grid nx:gap-4 nx:md:grid-cols-2">
+            <div className="nx:bg-success-surface nx:rounded-lg nx:p-4 nx:flex nx:items-center nx:gap-3">
+              <div className="nx:w-2 nx:h-2 nx:rounded-full nx:bg-success-background" />
+              <span className="nx:text-success-text nx:text-sm nx:font-medium">
+                Success message
+              </span>
+            </div>
+            <div className="nx:bg-error-surface nx:rounded-lg nx:p-4 nx:flex nx:items-center nx:gap-3">
+              <div className="nx:w-2 nx:h-2 nx:rounded-full nx:bg-error-background" />
+              <span className="nx:text-error-text nx:text-sm nx:font-medium">Error message</span>
+            </div>
+            <div className="nx:bg-warning-surface nx:rounded-lg nx:p-4 nx:flex nx:items-center nx:gap-3">
+              <div className="nx:w-2 nx:h-2 nx:rounded-full nx:bg-warning-background" />
+              <span className="nx:text-warning-text nx:text-sm nx:font-medium">Warning message</span>
+            </div>
+            <div className="nx:bg-information-surface nx:rounded-lg nx:p-4 nx:flex nx:items-center nx:gap-3">
+              <div className="nx:w-2 nx:h-2 nx:rounded-full nx:bg-information-background" />
+              <span className="nx:text-information-text nx:text-sm nx:font-medium">Info message</span>
+            </div>
           </div>
-          <div className="nx:bg-error-surface nx:rounded-lg nx:p-4">
-            <span className="nx:text-error-text nx:text-sm nx:font-medium">
-              Error message
-            </span>
-          </div>
-          <div className="nx:bg-warning-surface nx:rounded-lg nx:p-4">
-            <span className="nx:text-warning-text nx:text-sm nx:font-medium">
-              Warning message
-            </span>
-          </div>
-          <div className="nx:bg-information-surface nx:rounded-lg nx:p-4">
-            <span className="nx:text-information-text nx:text-sm nx:font-medium">
-              Info message
-            </span>
-          </div>
-        </div>
-      </section>
+        </Section>
+      </div>
     </div>
   );
 }
@@ -305,17 +289,21 @@ function ColorSwatch({
   name,
   className,
   textDark = false,
+  border = false,
 }: {
   name: string;
   className: string;
   textDark?: boolean;
+  border?: boolean;
 }) {
   return (
     <div
-      className={`nx:border-border-default nx:flex nx:h-20 nx:items-end nx:rounded-lg nx:border nx:p-2 ${className}`}
+      className={`nx:flex nx:h-20 nx:items-end nx:rounded-lg nx:p-3 ${className} ${
+        border ? 'nx:border nx:border-border-default' : ''
+      }`}
     >
       <span
-        className={`nx:text-xs nx:font-medium ${textDark ? 'nx:text-background' : ''}`}
+        className={`nx:text-xs nx:font-medium ${textDark ? 'nx:text-background' : 'nx:text-inherit'}`}
       >
         {name}
       </span>
@@ -323,20 +311,12 @@ function ColorSwatch({
   );
 }
 
-function ShadowBox({
-  name,
-  shadowClass,
-}: {
-  name: string;
-  shadowClass: string;
-}) {
+function ShadowBox({ name, shadowClass }: { name: string; shadowClass: string }) {
   return (
     <div
-      className={`nx:bg-container nx:flex nx:h-20 nx:w-full nx:items-center nx:justify-center nx:rounded-lg ${shadowClass}`}
+      className={`nx:bg-background nx:flex nx:h-16 nx:w-full nx:items-center nx:justify-center nx:rounded-lg ${shadowClass}`}
     >
-      <span className="nx:text-muted-foreground nx:text-xs nx:font-medium">
-        {name}
-      </span>
+      <span className="nx:text-muted-foreground nx:text-xs nx:font-medium">{name}</span>
     </div>
   );
 }
@@ -344,7 +324,7 @@ function ShadowBox({
 function RadiusBox({ name, className }: { name: string; className: string }) {
   return (
     <div
-      className={`nx:border-primary-background nx:bg-container nx:flex nx:h-16 nx:w-16 nx:items-center nx:justify-center nx:border-2 ${className}`}
+      className={`nx:border-2 nx:border-primary-background nx:bg-muted nx:flex nx:h-14 nx:w-14 nx:items-center nx:justify-center ${className}`}
     >
       <span className="nx:text-xs nx:font-medium">{name}</span>
     </div>
@@ -354,10 +334,10 @@ function RadiusBox({ name, className }: { name: string; className: string }) {
 function SpacingBar({ name, className }: { name: string; className: string }) {
   return (
     <div className="nx:flex nx:items-center nx:gap-3">
-      <span className="nx:text-muted-foreground nx:w-12 nx:text-xs">
+      <span className="nx:text-muted-foreground nx:w-8 nx:text-xs nx:text-right nx:font-mono">
         {name}
       </span>
-      <div className={`nx:bg-primary-background nx:h-4 ${className}`} />
+      <div className={`nx:bg-primary-background nx:h-3 nx:rounded-sm ${className}`} />
     </div>
   );
 }

--- a/apps/playground/src/components/ComponentShowcase.tsx
+++ b/apps/playground/src/components/ComponentShowcase.tsx
@@ -13,9 +13,13 @@ function Section({
   return (
     <section className="nx:bg-background nx:rounded-xl nx:border nx:border-border-default nx:overflow-hidden">
       <div className="nx:px-5 nx:py-4 nx:border-b nx:border-border-default nx:bg-muted/30">
-        <h2 className="nx:text-base nx:font-semibold nx:text-foreground">{title}</h2>
+        <h2 className="nx:text-base nx:font-semibold nx:text-foreground">
+          {title}
+        </h2>
         {description && (
-          <p className="nx:text-sm nx:text-muted-foreground nx:mt-0.5">{description}</p>
+          <p className="nx:text-sm nx:text-muted-foreground nx:mt-0.5">
+            {description}
+          </p>
         )}
       </div>
       <div className="nx:p-5">{children}</div>
@@ -102,12 +106,26 @@ export function ComponentShowcase() {
         </Section>
 
         {/* Colors Section */}
-        <Section title="Semantic Colors" description="Brand and status color palette">
+        <Section
+          title="Semantic Colors"
+          description="Brand and status color palette"
+        >
           <div className="nx:grid nx:grid-cols-2 nx:gap-4 nx:sm:grid-cols-3 nx:md:grid-cols-5">
-            <ColorSwatch name="Background" className="nx:bg-background" border />
-            <ColorSwatch name="Foreground" className="nx:bg-foreground" textDark />
+            <ColorSwatch
+              name="Background"
+              className="nx:bg-background"
+              border
+            />
+            <ColorSwatch
+              name="Foreground"
+              className="nx:bg-foreground"
+              textDark
+            />
             <ColorSwatch name="Primary" className="nx:bg-primary-background" />
-            <ColorSwatch name="Secondary" className="nx:bg-secondary-background" />
+            <ColorSwatch
+              name="Secondary"
+              className="nx:bg-secondary-background"
+            />
             <ColorSwatch name="Muted" className="nx:bg-muted" />
             <ColorSwatch name="Accent" className="nx:bg-accent" />
             <ColorSwatch name="Success" className="nx:bg-success-background" />
@@ -189,7 +207,10 @@ export function ComponentShowcase() {
         </Section>
 
         {/* Cards Section */}
-        <Section title="Cards & Containers" description="Surface styles and containers">
+        <Section
+          title="Cards & Containers"
+          description="Surface styles and containers"
+        >
           <div className="nx:grid nx:gap-4 nx:md:grid-cols-2">
             <div className="nx:border nx:border-border-default nx:bg-container nx:rounded-lg nx:p-4">
               <h3 className="nx:font-medium">Container</h3>
@@ -199,7 +220,9 @@ export function ComponentShowcase() {
             </div>
             <div className="nx:border nx:border-border-default nx:bg-popover nx:rounded-lg nx:p-4">
               <h3 className="nx:font-medium">Popover</h3>
-              <p className="nx:text-muted-foreground nx:mt-1 nx:text-sm">Popover background color</p>
+              <p className="nx:text-muted-foreground nx:mt-1 nx:text-sm">
+                Popover background color
+              </p>
             </div>
             <div className="nx:bg-muted nx:rounded-lg nx:p-4">
               <h3 className="nx:text-muted-foreground nx:font-medium">Muted</h3>
@@ -208,7 +231,9 @@ export function ComponentShowcase() {
               </p>
             </div>
             <div className="nx:bg-accent nx:rounded-lg nx:p-4">
-              <h3 className="nx:text-accent-foreground nx:font-medium">Accent</h3>
+              <h3 className="nx:text-accent-foreground nx:font-medium">
+                Accent
+              </h3>
               <p className="nx:text-accent-foreground nx:mt-1 nx:text-sm">
                 Accent background with accent foreground
               </p>
@@ -258,7 +283,10 @@ export function ComponentShowcase() {
         </Section>
 
         {/* Status Colors Section */}
-        <Section title="Status Messages" description="Feedback and alert styles">
+        <Section
+          title="Status Messages"
+          description="Feedback and alert styles"
+        >
           <div className="nx:grid nx:gap-4 nx:md:grid-cols-2">
             <div className="nx:bg-success-surface nx:rounded-lg nx:p-4 nx:flex nx:items-center nx:gap-3">
               <div className="nx:w-2 nx:h-2 nx:rounded-full nx:bg-success-background" />
@@ -268,15 +296,21 @@ export function ComponentShowcase() {
             </div>
             <div className="nx:bg-error-surface nx:rounded-lg nx:p-4 nx:flex nx:items-center nx:gap-3">
               <div className="nx:w-2 nx:h-2 nx:rounded-full nx:bg-error-background" />
-              <span className="nx:text-error-text nx:text-sm nx:font-medium">Error message</span>
+              <span className="nx:text-error-text nx:text-sm nx:font-medium">
+                Error message
+              </span>
             </div>
             <div className="nx:bg-warning-surface nx:rounded-lg nx:p-4 nx:flex nx:items-center nx:gap-3">
               <div className="nx:w-2 nx:h-2 nx:rounded-full nx:bg-warning-background" />
-              <span className="nx:text-warning-text nx:text-sm nx:font-medium">Warning message</span>
+              <span className="nx:text-warning-text nx:text-sm nx:font-medium">
+                Warning message
+              </span>
             </div>
             <div className="nx:bg-information-surface nx:rounded-lg nx:p-4 nx:flex nx:items-center nx:gap-3">
               <div className="nx:w-2 nx:h-2 nx:rounded-full nx:bg-information-background" />
-              <span className="nx:text-information-text nx:text-sm nx:font-medium">Info message</span>
+              <span className="nx:text-information-text nx:text-sm nx:font-medium">
+                Info message
+              </span>
             </div>
           </div>
         </Section>
@@ -311,12 +345,20 @@ function ColorSwatch({
   );
 }
 
-function ShadowBox({ name, shadowClass }: { name: string; shadowClass: string }) {
+function ShadowBox({
+  name,
+  shadowClass,
+}: {
+  name: string;
+  shadowClass: string;
+}) {
   return (
     <div
       className={`nx:bg-background nx:flex nx:h-16 nx:w-full nx:items-center nx:justify-center nx:rounded-lg ${shadowClass}`}
     >
-      <span className="nx:text-muted-foreground nx:text-xs nx:font-medium">{name}</span>
+      <span className="nx:text-muted-foreground nx:text-xs nx:font-medium">
+        {name}
+      </span>
     </div>
   );
 }
@@ -337,7 +379,9 @@ function SpacingBar({ name, className }: { name: string; className: string }) {
       <span className="nx:text-muted-foreground nx:w-8 nx:text-xs nx:text-right nx:font-mono">
         {name}
       </span>
-      <div className={`nx:bg-primary-background nx:h-3 nx:rounded-sm ${className}`} />
+      <div
+        className={`nx:bg-primary-background nx:h-3 nx:rounded-sm ${className}`}
+      />
     </div>
   );
 }

--- a/apps/playground/src/components/IconShowcase.tsx
+++ b/apps/playground/src/components/IconShowcase.tsx
@@ -17,7 +17,9 @@ export function IconShowcase() {
       <div className="nx:px-5 nx:py-4 nx:border-b nx:border-border-default nx:bg-muted/30">
         <div className="nx:flex nx:items-center nx:justify-between">
           <div>
-            <h2 className="nx:text-base nx:font-semibold nx:text-foreground">Icons</h2>
+            <h2 className="nx:text-base nx:font-semibold nx:text-foreground">
+              Icons
+            </h2>
             <p className="nx:text-sm nx:text-muted-foreground nx:mt-0.5">
               Internal DS icons from{' '}
               <a
@@ -42,7 +44,11 @@ export function IconShowcase() {
               key={name}
               className="nx:bg-muted/50 nx:flex nx:flex-col nx:items-center nx:gap-2 nx:rounded-lg nx:p-3 hover:nx:bg-muted nx:transition-colors nx:cursor-default"
             >
-              <PlaygroundIcon name={name} size={20} className="nx:text-foreground" />
+              <PlaygroundIcon
+                name={name}
+                size={20}
+                className="nx:text-foreground"
+              />
               <span className="nx:text-muted-foreground nx:text-[10px] nx:text-center nx:leading-tight">
                 {name}
               </span>

--- a/apps/playground/src/components/IconShowcase.tsx
+++ b/apps/playground/src/components/IconShowcase.tsx
@@ -1,0 +1,55 @@
+import { iconLibraryMeta, iconNames, useIconStore } from '../store/iconStore';
+
+import { PlaygroundIcon } from './PlaygroundIcon';
+
+/**
+ * IconShowcase
+ *
+ * Displays all available DS internal icons in a grid.
+ * Icons automatically update when the library is switched.
+ */
+export function IconShowcase() {
+  const library = useIconStore((s) => s.library);
+  const meta = iconLibraryMeta[library];
+
+  return (
+    <section className="nx:bg-background nx:rounded-xl nx:border nx:border-border-default nx:overflow-hidden">
+      <div className="nx:px-5 nx:py-4 nx:border-b nx:border-border-default nx:bg-muted/30">
+        <div className="nx:flex nx:items-center nx:justify-between">
+          <div>
+            <h2 className="nx:text-base nx:font-semibold nx:text-foreground">Icons</h2>
+            <p className="nx:text-sm nx:text-muted-foreground nx:mt-0.5">
+              Internal DS icons from{' '}
+              <a
+                href={meta.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="nx:text-primary-text nx:underline hover:nx:no-underline"
+              >
+                {meta.label}
+              </a>
+            </p>
+          </div>
+          <span className="nx:text-xs nx:text-muted-foreground nx:bg-muted nx:px-2 nx:py-1 nx:rounded-full">
+            {meta.iconCount} available
+          </span>
+        </div>
+      </div>
+      <div className="nx:p-5">
+        <div className="nx:grid nx:grid-cols-4 nx:gap-3 nx:sm:grid-cols-5 nx:md:grid-cols-7">
+          {iconNames.map((name) => (
+            <div
+              key={name}
+              className="nx:bg-muted/50 nx:flex nx:flex-col nx:items-center nx:gap-2 nx:rounded-lg nx:p-3 hover:nx:bg-muted nx:transition-colors nx:cursor-default"
+            >
+              <PlaygroundIcon name={name} size={20} className="nx:text-foreground" />
+              <span className="nx:text-muted-foreground nx:text-[10px] nx:text-center nx:leading-tight">
+                {name}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/playground/src/components/PlaygroundIcon.tsx
+++ b/apps/playground/src/components/PlaygroundIcon.tsx
@@ -1,0 +1,33 @@
+import type { SVGProps } from 'react';
+
+import { type IconName,useIcon } from '../store/iconStore';
+
+/**
+ * PlaygroundIcon props
+ */
+interface PlaygroundIconProps extends SVGProps<SVGSVGElement> {
+  /** Icon name from the DS internal icon set */
+  name: IconName;
+  /** Icon size (width and height) */
+  size?: number | string;
+}
+
+/**
+ * PlaygroundIcon
+ *
+ * Renders an icon from the currently selected icon library.
+ * Automatically switches between Tabler, Lucide, and Phosphor based on store state.
+ *
+ * @example
+ * ```tsx
+ * <PlaygroundIcon name="check" size={16} />
+ * <PlaygroundIcon name="loader" className="nx:animate-spin" />
+ * ```
+ */
+export function PlaygroundIcon({ name, size = 24, ...props }: PlaygroundIconProps) {
+  const Icon = useIcon(name);
+
+  return <Icon width={size} height={size} {...props} />;
+}
+
+export type { IconName,PlaygroundIconProps };

--- a/apps/playground/src/components/PlaygroundIcon.tsx
+++ b/apps/playground/src/components/PlaygroundIcon.tsx
@@ -1,6 +1,6 @@
 import type { SVGProps } from 'react';
 
-import { type IconName,useIcon } from '../store/iconStore';
+import { type IconName, useIcon } from '../store/iconStore';
 
 /**
  * PlaygroundIcon props
@@ -24,10 +24,14 @@ interface PlaygroundIconProps extends SVGProps<SVGSVGElement> {
  * <PlaygroundIcon name="loader" className="nx:animate-spin" />
  * ```
  */
-export function PlaygroundIcon({ name, size = 24, ...props }: PlaygroundIconProps) {
+export function PlaygroundIcon({
+  name,
+  size = 24,
+  ...props
+}: PlaygroundIconProps) {
   const Icon = useIcon(name);
 
   return <Icon width={size} height={size} {...props} />;
 }
 
-export type { IconName,PlaygroundIconProps };
+export type { IconName, PlaygroundIconProps };

--- a/apps/playground/src/components/ThemeSwitcher.tsx
+++ b/apps/playground/src/components/ThemeSwitcher.tsx
@@ -1,22 +1,106 @@
 import type { ThemeConfig } from '../hooks/useTheme';
+import { type IconLibrary,iconLibraryMeta, useIconStore } from '../store/iconStore';
 
-// Color themes
-const BASES = ['slate', 'neutral', 'zinc', 'gray', 'stone'] as const;
-const BRANDS = ['blue', 'gray', 'neutral', 'slate'] as const;
+import { PlaygroundIcon } from './PlaygroundIcon';
 
-// Design token modes
-const SIZE_MODES = ['vega', 'lyra', 'maia', 'mira', 'nova'] as const;
-const TYPOGRAPHY_MODES = ['vega', 'lyra', 'maia', 'mira', 'nova'] as const;
-const SHADOW_MODES = ['vega', 'lyra', 'maia', 'mira', 'nova'] as const;
+// Theme options with metadata
+const BASES = [
+  { value: 'slate', label: 'Slate', color: '#64748b' },
+  { value: 'neutral', label: 'Neutral', color: '#737373' },
+  { value: 'zinc', label: 'Zinc', color: '#71717a' },
+  { value: 'gray', label: 'Gray', color: '#6b7280' },
+  { value: 'stone', label: 'Stone', color: '#78716c' },
+] as const;
+
+const BRANDS = [
+  { value: 'blue', label: 'Blue', color: '#3b82f6' },
+  { value: 'gray', label: 'Gray', color: '#6b7280' },
+  { value: 'neutral', label: 'Neutral', color: '#737373' },
+  { value: 'slate', label: 'Slate', color: '#64748b' },
+] as const;
+
+const TOKEN_MODES = ['vega', 'lyra', 'maia', 'mira', 'nova'] as const;
 const RADIUS_MODES = ['blunt', 'sharp', 'subtle', 'smooth', 'mellow'] as const;
-const BORDERWIDTH_MODES = ['vega', 'lyra', 'maia', 'mira', 'nova'] as const;
+const ICON_LIBRARIES = ['tabler', 'lucide', 'phosphor'] as const;
+
+const DEFAULT_THEME: ThemeConfig = {
+  base: 'slate',
+  brand: 'blue',
+  dark: false,
+  size: 'vega',
+  typography: 'vega',
+  shadow: 'vega',
+  radius: 'subtle',
+  borderWidth: 'vega',
+};
 
 type ThemeSwitcherProps = {
   theme: ThemeConfig;
   setTheme: React.Dispatch<React.SetStateAction<ThemeConfig>>;
 };
 
-function SelectControl({
+// Reusable components
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="nx:bg-background nx:rounded-lg nx:border nx:border-border-default nx:p-3">
+      <h3 className="nx:text-xs nx:font-semibold nx:uppercase nx:tracking-wide nx:text-muted-foreground nx:mb-3">
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+function ColorSelect({
+  id,
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  options: readonly { value: string; label: string; color: string }[];
+  onChange: (value: string) => void;
+}) {
+  const selected = options.find((o) => o.value === value);
+
+  return (
+    <div className="nx:flex nx:items-center nx:justify-between">
+      <label htmlFor={id} className="nx:text-sm nx:text-foreground">
+        {label}
+      </label>
+      <div className="nx:relative">
+        <select
+          id={id}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="nx:appearance-none nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:pl-7 nx:pr-8 nx:py-1.5 nx:text-sm nx:cursor-pointer hover:nx:bg-accent nx:transition-colors"
+        >
+          {options.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        {/* Color indicator */}
+        <div
+          className="nx:absolute nx:left-2 nx:top-1/2 nx:-translate-y-1/2 nx:w-3 nx:h-3 nx:rounded-full nx:border nx:border-border-default"
+          style={{ backgroundColor: selected?.color }}
+        />
+        {/* Chevron */}
+        <PlaygroundIcon
+          name="chevron-down"
+          size={14}
+          className="nx:absolute nx:right-2 nx:top-1/2 nx:-translate-y-1/2 nx:text-muted-foreground nx:pointer-events-none"
+        />
+      </div>
+    </div>
+  );
+}
+
+function TokenSelect({
   id,
   label,
   value,
@@ -30,96 +114,207 @@ function SelectControl({
   onChange: (value: string) => void;
 }) {
   return (
-    <div className="nx:flex nx:items-center nx:gap-2">
-      <label htmlFor={id} className="nx:text-sm nx:font-medium">
-        {label}:
+    <div className="nx:flex nx:items-center nx:justify-between">
+      <label htmlFor={id} className="nx:text-sm nx:text-foreground">
+        {label}
       </label>
-      <select
-        id={id}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="nx:border-border-default nx:bg-background nx:rounded nx:border nx:px-2 nx:py-1 nx:text-sm"
+      <div className="nx:relative">
+        <select
+          id={id}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="nx:appearance-none nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:pl-3 nx:pr-8 nx:py-1.5 nx:text-sm nx:cursor-pointer hover:nx:bg-accent nx:transition-colors nx:capitalize"
+        >
+          {options.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt.charAt(0).toUpperCase() + opt.slice(1)}
+            </option>
+          ))}
+        </select>
+        <PlaygroundIcon
+          name="chevron-down"
+          size={14}
+          className="nx:absolute nx:right-2 nx:top-1/2 nx:-translate-y-1/2 nx:text-muted-foreground nx:pointer-events-none"
+        />
+      </div>
+    </div>
+  );
+}
+
+function ToggleSwitch({
+  checked,
+  onChange,
+  labelLeft,
+  labelRight,
+}: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  labelLeft: string;
+  labelRight: string;
+}) {
+  return (
+    <div className="nx:flex nx:items-center nx:justify-center nx:gap-3">
+      <span
+        className={`nx:text-sm ${!checked ? 'nx:text-foreground nx:font-medium' : 'nx:text-muted-foreground'}`}
       >
-        {options.map((opt) => (
-          <option key={opt} value={opt}>
-            {opt.charAt(0).toUpperCase() + opt.slice(1)}
-          </option>
-        ))}
-      </select>
+        {labelLeft}
+      </span>
+      <button
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={`nx:relative nx:w-11 nx:h-6 nx:rounded-full nx:transition-colors nx:border nx:border-border-default ${
+          checked ? 'nx:bg-primary-background' : 'nx:bg-muted'
+        }`}
+      >
+        <span
+          className={`nx:absolute nx:top-px nx:left-px nx:w-5 nx:h-5 nx:rounded-full nx:bg-background nx:shadow-sm nx:transition-transform nx:border nx:border-border-default ${
+            checked ? 'nx:translate-x-5' : ''
+          }`}
+        />
+      </button>
+      <span
+        className={`nx:text-sm ${checked ? 'nx:text-foreground nx:font-medium' : 'nx:text-muted-foreground'}`}
+      >
+        {labelRight}
+      </span>
     </div>
   );
 }
 
 export function ThemeSwitcher({ theme, setTheme }: ThemeSwitcherProps) {
+  const iconLibrary = useIconStore((s) => s.library);
+  const setIconLibrary = useIconStore((s) => s.setLibrary);
+
+  const handleReset = () => {
+    setTheme(DEFAULT_THEME);
+    setIconLibrary('tabler');
+  };
+
   return (
-    <div className="nx:border-border-default nx:bg-muted nx:border-b nx:p-4">
-      {/* Color Themes Row */}
-      <div className="nx:mb-3 nx:flex nx:flex-wrap nx:items-center nx:gap-4">
-        <span className="nx:text-muted-foreground nx:text-xs nx:font-semibold nx:uppercase">
-          Colors
-        </span>
-        <SelectControl
-          id="base-select"
-          label="Base"
-          value={theme.base}
-          options={BASES}
-          onChange={(v) => setTheme((t) => ({ ...t, base: v }))}
-        />
-        <SelectControl
-          id="brand-select"
-          label="Brand"
-          value={theme.brand}
-          options={BRANDS}
-          onChange={(v) => setTheme((t) => ({ ...t, brand: v }))}
-        />
-        <button
-          onClick={() => setTheme((t) => ({ ...t, dark: !t.dark }))}
-          className="nx:border-border-default nx:bg-background hover:nx:bg-accent nx:rounded nx:border nx:px-3 nx:py-1 nx:text-sm"
-        >
-          {theme.dark ? 'Light' : 'Dark'}
-        </button>
+    <div className="nx:h-full nx:flex nx:flex-col nx:bg-muted/50">
+      {/* Header */}
+      <div className="nx:p-4 nx:border-b nx:border-border-default">
+        <h2 className="nx:text-base nx:font-semibold nx:text-foreground">Customize Theme</h2>
+        <p className="nx:text-xs nx:text-muted-foreground nx:mt-0.5">
+          Adjust colors, tokens, and icons
+        </p>
       </div>
 
-      {/* Design Tokens Row */}
-      <div className="nx:flex nx:flex-wrap nx:items-center nx:gap-4">
-        <span className="nx:text-muted-foreground nx:text-xs nx:font-semibold nx:uppercase">
-          Tokens
-        </span>
-        <SelectControl
-          id="size-select"
-          label="Size"
-          value={theme.size}
-          options={SIZE_MODES}
-          onChange={(v) => setTheme((t) => ({ ...t, size: v }))}
-        />
-        <SelectControl
-          id="typography-select"
-          label="Type"
-          value={theme.typography}
-          options={TYPOGRAPHY_MODES}
-          onChange={(v) => setTheme((t) => ({ ...t, typography: v }))}
-        />
-        <SelectControl
-          id="shadow-select"
-          label="Shadow"
-          value={theme.shadow}
-          options={SHADOW_MODES}
-          onChange={(v) => setTheme((t) => ({ ...t, shadow: v }))}
-        />
-        <SelectControl
-          id="radius-select"
-          label="Radius"
-          value={theme.radius}
-          options={RADIUS_MODES}
-          onChange={(v) => setTheme((t) => ({ ...t, radius: v }))}
-        />
-        <SelectControl
-          id="borderwidth-select"
-          label="Border"
-          value={theme.borderWidth}
-          options={BORDERWIDTH_MODES}
-          onChange={(v) => setTheme((t) => ({ ...t, borderWidth: v }))}
-        />
+      {/* Scrollable Content */}
+      <div className="nx:flex-1 nx:overflow-y-auto nx:p-4 nx:space-y-4">
+        {/* Appearance */}
+        <Section title="Appearance">
+          <ToggleSwitch
+            checked={theme.dark}
+            onChange={(dark) => setTheme((t) => ({ ...t, dark }))}
+            labelLeft="Light"
+            labelRight="Dark"
+          />
+        </Section>
+
+        {/* Colors */}
+        <Section title="Colors">
+          <div className="nx:space-y-3">
+            <ColorSelect
+              id="base-select"
+              label="Base"
+              value={theme.base}
+              options={BASES}
+              onChange={(v) => setTheme((t) => ({ ...t, base: v }))}
+            />
+            <ColorSelect
+              id="brand-select"
+              label="Brand"
+              value={theme.brand}
+              options={BRANDS}
+              onChange={(v) => setTheme((t) => ({ ...t, brand: v }))}
+            />
+          </div>
+        </Section>
+
+        {/* Design Tokens */}
+        <Section title="Design Tokens">
+          <div className="nx:space-y-3">
+            <TokenSelect
+              id="size-select"
+              label="Size"
+              value={theme.size}
+              options={TOKEN_MODES}
+              onChange={(v) => setTheme((t) => ({ ...t, size: v }))}
+            />
+            <TokenSelect
+              id="typography-select"
+              label="Typography"
+              value={theme.typography}
+              options={TOKEN_MODES}
+              onChange={(v) => setTheme((t) => ({ ...t, typography: v }))}
+            />
+            <TokenSelect
+              id="shadow-select"
+              label="Shadow"
+              value={theme.shadow}
+              options={TOKEN_MODES}
+              onChange={(v) => setTheme((t) => ({ ...t, shadow: v }))}
+            />
+            <TokenSelect
+              id="radius-select"
+              label="Radius"
+              value={theme.radius}
+              options={RADIUS_MODES}
+              onChange={(v) => setTheme((t) => ({ ...t, radius: v }))}
+            />
+            <TokenSelect
+              id="borderwidth-select"
+              label="Border Width"
+              value={theme.borderWidth}
+              options={TOKEN_MODES}
+              onChange={(v) => setTheme((t) => ({ ...t, borderWidth: v }))}
+            />
+          </div>
+        </Section>
+
+        {/* Icons */}
+        <Section title="Icons">
+          <div className="nx:flex nx:items-center nx:justify-between">
+            <label htmlFor="icon-library-select" className="nx:text-sm nx:text-foreground">
+              Library
+            </label>
+            <div className="nx:relative">
+              <select
+                id="icon-library-select"
+                value={iconLibrary}
+                onChange={(e) => setIconLibrary(e.target.value as IconLibrary)}
+                className="nx:appearance-none nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:pl-3 nx:pr-8 nx:py-1.5 nx:text-sm nx:cursor-pointer hover:nx:bg-accent nx:transition-colors"
+              >
+                {ICON_LIBRARIES.map((lib) => (
+                  <option key={lib} value={lib}>
+                    {iconLibraryMeta[lib].label}
+                  </option>
+                ))}
+              </select>
+              <PlaygroundIcon
+                name="chevron-down"
+                size={14}
+                className="nx:absolute nx:right-2 nx:top-1/2 nx:-translate-y-1/2 nx:text-muted-foreground nx:pointer-events-none"
+              />
+            </div>
+          </div>
+          <p className="nx:text-xs nx:text-muted-foreground nx:mt-2">
+            {iconLibraryMeta[iconLibrary].iconCount} icons available
+          </p>
+        </Section>
+      </div>
+
+      {/* Footer */}
+      <div className="nx:p-4 nx:border-t nx:border-border-default">
+        <button
+          onClick={handleReset}
+          className="nx:w-full nx:flex nx:items-center nx:justify-center nx:gap-2 nx:bg-background nx:border nx:border-border-default nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium hover:nx:bg-accent nx:transition-colors"
+        >
+          <PlaygroundIcon name="x" size={14} />
+          Reset to Default
+        </button>
       </div>
     </div>
   );

--- a/apps/playground/src/components/ThemeSwitcher.tsx
+++ b/apps/playground/src/components/ThemeSwitcher.tsx
@@ -1,5 +1,9 @@
 import type { ThemeConfig } from '../hooks/useTheme';
-import { type IconLibrary,iconLibraryMeta, useIconStore } from '../store/iconStore';
+import {
+  type IconLibrary,
+  iconLibraryMeta,
+  useIconStore,
+} from '../store/iconStore';
 
 import { PlaygroundIcon } from './PlaygroundIcon';
 
@@ -40,7 +44,13 @@ type ThemeSwitcherProps = {
 };
 
 // Reusable components
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
   return (
     <div className="nx:bg-background nx:rounded-lg nx:border nx:border-border-default nx:p-3">
       <h3 className="nx:text-xs nx:font-semibold nx:uppercase nx:tracking-wide nx:text-muted-foreground nx:mb-3">
@@ -195,7 +205,9 @@ export function ThemeSwitcher({ theme, setTheme }: ThemeSwitcherProps) {
     <div className="nx:h-full nx:flex nx:flex-col nx:bg-muted/50">
       {/* Header */}
       <div className="nx:p-4 nx:border-b nx:border-border-default">
-        <h2 className="nx:text-base nx:font-semibold nx:text-foreground">Customize Theme</h2>
+        <h2 className="nx:text-base nx:font-semibold nx:text-foreground">
+          Customize Theme
+        </h2>
         <p className="nx:text-xs nx:text-muted-foreground nx:mt-0.5">
           Adjust colors, tokens, and icons
         </p>
@@ -277,7 +289,10 @@ export function ThemeSwitcher({ theme, setTheme }: ThemeSwitcherProps) {
         {/* Icons */}
         <Section title="Icons">
           <div className="nx:flex nx:items-center nx:justify-between">
-            <label htmlFor="icon-library-select" className="nx:text-sm nx:text-foreground">
+            <label
+              htmlFor="icon-library-select"
+              className="nx:text-sm nx:text-foreground"
+            >
               Library
             </label>
             <div className="nx:relative">

--- a/apps/playground/src/lib/icon-registry.ts
+++ b/apps/playground/src/lib/icon-registry.ts
@@ -91,58 +91,63 @@ export type IconName =
 /**
  * Icon component type (compatible with all three libraries)
  */
-export type IconComponent = ComponentType<SVGProps<SVGSVGElement> & { size?: number | string }>;
+export type IconComponent = ComponentType<
+  SVGProps<SVGSVGElement> & { size?: number | string }
+>;
 
 /**
  * Icon registry mapping internal names to library-specific components
  */
-export const iconRegistry: Record<IconLibrary, Record<IconName, IconComponent>> = {
+export const iconRegistry: Record<
+  IconLibrary,
+  Record<IconName, IconComponent>
+> = {
   tabler: {
-    'loader': TablerLoader2,
+    loader: TablerLoader2,
     'chevron-down': TablerChevronDown,
     'chevron-left': TablerChevronLeft,
     'chevron-right': TablerChevronRight,
     'chevron-up': TablerChevronUp,
-    'check': TablerCheck,
-    'x': TablerX,
+    check: TablerCheck,
+    x: TablerX,
     'alert-circle': TablerAlertCircle,
     'alert-triangle': TablerAlertTriangle,
     'circle-check': TablerCircleCheck,
     'info-circle': TablerInfoCircle,
-    'search': TablerSearch,
-    'eye': TablerEye,
+    search: TablerSearch,
+    eye: TablerEye,
     'eye-off': TablerEyeOff,
   },
   lucide: {
-    'loader': LucideLoader2,
+    loader: LucideLoader2,
     'chevron-down': LucideChevronDown,
     'chevron-left': LucideChevronLeft,
     'chevron-right': LucideChevronRight,
     'chevron-up': LucideChevronUp,
-    'check': LucideCheck,
-    'x': LucideX,
+    check: LucideCheck,
+    x: LucideX,
     'alert-circle': LucideAlertCircle,
     'alert-triangle': LucideAlertTriangle,
     'circle-check': LucideCircleCheck,
     'info-circle': LucideInfoCircle,
-    'search': LucideSearch,
-    'eye': LucideEye,
+    search: LucideSearch,
+    eye: LucideEye,
     'eye-off': LucideEyeOff,
   },
   phosphor: {
-    'loader': PhosphorLoader2,
+    loader: PhosphorLoader2,
     'chevron-down': PhosphorChevronDown,
     'chevron-left': PhosphorChevronLeft,
     'chevron-right': PhosphorChevronRight,
     'chevron-up': PhosphorChevronUp,
-    'check': PhosphorCheck,
-    'x': PhosphorX,
+    check: PhosphorCheck,
+    x: PhosphorX,
     'alert-circle': PhosphorAlertCircle,
     'alert-triangle': PhosphorAlertTriangle,
     'circle-check': PhosphorCircleCheck,
     'info-circle': PhosphorInfoCircle,
-    'search': PhosphorSearch,
-    'eye': PhosphorEye,
+    search: PhosphorSearch,
+    eye: PhosphorEye,
     'eye-off': PhosphorEyeOff,
   },
 };
@@ -150,7 +155,10 @@ export const iconRegistry: Record<IconLibrary, Record<IconName, IconComponent>> 
 /**
  * Library metadata for UI display
  */
-export const iconLibraryMeta: Record<IconLibrary, { label: string; iconCount: string; url: string }> = {
+export const iconLibraryMeta: Record<
+  IconLibrary,
+  { label: string; iconCount: string; url: string }
+> = {
   tabler: {
     label: 'Tabler',
     iconCount: '5,700+',

--- a/apps/playground/src/lib/icon-registry.ts
+++ b/apps/playground/src/lib/icon-registry.ts
@@ -1,0 +1,183 @@
+/**
+ * Icon Registry
+ *
+ * Maps internal DS icon names to their equivalents in each supported library.
+ * This enables the playground to preview components with different icon libraries.
+ *
+ * Supported libraries:
+ * - Tabler (DS default): https://tabler.io/icons
+ * - Lucide (shadcn default): https://lucide.dev
+ * - Phosphor: https://phosphoricons.com
+ */
+
+// Tabler Icons
+import type { ComponentType, SVGProps } from 'react';
+
+// Phosphor Icons
+import {
+  CaretDown as PhosphorChevronDown,
+  CaretLeft as PhosphorChevronLeft,
+  CaretRight as PhosphorChevronRight,
+  CaretUp as PhosphorChevronUp,
+  Check as PhosphorCheck,
+  CheckCircle as PhosphorCircleCheck,
+  Eye as PhosphorEye,
+  EyeSlash as PhosphorEyeOff,
+  Info as PhosphorInfoCircle,
+  MagnifyingGlass as PhosphorSearch,
+  SpinnerGap as PhosphorLoader2,
+  Warning as PhosphorAlertTriangle,
+  WarningCircle as PhosphorAlertCircle,
+  X as PhosphorX,
+} from '@phosphor-icons/react';
+import {
+  IconAlertCircle as TablerAlertCircle,
+  IconAlertTriangle as TablerAlertTriangle,
+  IconCheck as TablerCheck,
+  IconChevronDown as TablerChevronDown,
+  IconChevronLeft as TablerChevronLeft,
+  IconChevronRight as TablerChevronRight,
+  IconChevronUp as TablerChevronUp,
+  IconCircleCheck as TablerCircleCheck,
+  IconEye as TablerEye,
+  IconEyeOff as TablerEyeOff,
+  IconInfoCircle as TablerInfoCircle,
+  IconLoader2 as TablerLoader2,
+  IconSearch as TablerSearch,
+  IconX as TablerX,
+} from '@tabler/icons-react';
+// Lucide Icons
+import {
+  AlertCircle as LucideAlertCircle,
+  AlertTriangle as LucideAlertTriangle,
+  Check as LucideCheck,
+  CheckCircle2 as LucideCircleCheck,
+  ChevronDown as LucideChevronDown,
+  ChevronLeft as LucideChevronLeft,
+  ChevronRight as LucideChevronRight,
+  ChevronUp as LucideChevronUp,
+  Eye as LucideEye,
+  EyeOff as LucideEyeOff,
+  Info as LucideInfoCircle,
+  Loader2 as LucideLoader2,
+  Search as LucideSearch,
+  X as LucideX,
+} from 'lucide-react';
+
+/**
+ * Supported icon library identifiers
+ */
+export type IconLibrary = 'tabler' | 'lucide' | 'phosphor';
+
+/**
+ * Internal icon names used by the DS
+ */
+export type IconName =
+  | 'loader'
+  | 'chevron-down'
+  | 'chevron-left'
+  | 'chevron-right'
+  | 'chevron-up'
+  | 'check'
+  | 'x'
+  | 'alert-circle'
+  | 'alert-triangle'
+  | 'circle-check'
+  | 'info-circle'
+  | 'search'
+  | 'eye'
+  | 'eye-off';
+
+/**
+ * Icon component type (compatible with all three libraries)
+ */
+export type IconComponent = ComponentType<SVGProps<SVGSVGElement> & { size?: number | string }>;
+
+/**
+ * Icon registry mapping internal names to library-specific components
+ */
+export const iconRegistry: Record<IconLibrary, Record<IconName, IconComponent>> = {
+  tabler: {
+    'loader': TablerLoader2,
+    'chevron-down': TablerChevronDown,
+    'chevron-left': TablerChevronLeft,
+    'chevron-right': TablerChevronRight,
+    'chevron-up': TablerChevronUp,
+    'check': TablerCheck,
+    'x': TablerX,
+    'alert-circle': TablerAlertCircle,
+    'alert-triangle': TablerAlertTriangle,
+    'circle-check': TablerCircleCheck,
+    'info-circle': TablerInfoCircle,
+    'search': TablerSearch,
+    'eye': TablerEye,
+    'eye-off': TablerEyeOff,
+  },
+  lucide: {
+    'loader': LucideLoader2,
+    'chevron-down': LucideChevronDown,
+    'chevron-left': LucideChevronLeft,
+    'chevron-right': LucideChevronRight,
+    'chevron-up': LucideChevronUp,
+    'check': LucideCheck,
+    'x': LucideX,
+    'alert-circle': LucideAlertCircle,
+    'alert-triangle': LucideAlertTriangle,
+    'circle-check': LucideCircleCheck,
+    'info-circle': LucideInfoCircle,
+    'search': LucideSearch,
+    'eye': LucideEye,
+    'eye-off': LucideEyeOff,
+  },
+  phosphor: {
+    'loader': PhosphorLoader2,
+    'chevron-down': PhosphorChevronDown,
+    'chevron-left': PhosphorChevronLeft,
+    'chevron-right': PhosphorChevronRight,
+    'chevron-up': PhosphorChevronUp,
+    'check': PhosphorCheck,
+    'x': PhosphorX,
+    'alert-circle': PhosphorAlertCircle,
+    'alert-triangle': PhosphorAlertTriangle,
+    'circle-check': PhosphorCircleCheck,
+    'info-circle': PhosphorInfoCircle,
+    'search': PhosphorSearch,
+    'eye': PhosphorEye,
+    'eye-off': PhosphorEyeOff,
+  },
+};
+
+/**
+ * Library metadata for UI display
+ */
+export const iconLibraryMeta: Record<IconLibrary, { label: string; iconCount: string; url: string }> = {
+  tabler: {
+    label: 'Tabler',
+    iconCount: '5,700+',
+    url: 'https://tabler.io/icons',
+  },
+  lucide: {
+    label: 'Lucide',
+    iconCount: '1,500+',
+    url: 'https://lucide.dev',
+  },
+  phosphor: {
+    label: 'Phosphor',
+    iconCount: '7,400+',
+    url: 'https://phosphoricons.com',
+  },
+};
+
+/**
+ * Get an icon component by name and library
+ */
+export function getIcon(name: IconName, library: IconLibrary): IconComponent {
+  return iconRegistry[library][name];
+}
+
+/**
+ * Get all icon names
+ */
+export function getAllIconNames(): IconName[] {
+  return Object.keys(iconRegistry.tabler) as IconName[];
+}

--- a/apps/playground/src/store/iconStore.ts
+++ b/apps/playground/src/store/iconStore.ts
@@ -81,4 +81,4 @@ export const iconNames = getAllIconNames();
 export { iconLibraryMeta };
 
 // Re-export types for convenience
-export type { IconComponent,IconLibrary, IconName };
+export type { IconComponent, IconLibrary, IconName };

--- a/apps/playground/src/store/iconStore.ts
+++ b/apps/playground/src/store/iconStore.ts
@@ -1,0 +1,84 @@
+import { create } from 'zustand';
+
+import {
+  getAllIconNames,
+  getIcon,
+  type IconComponent,
+  type IconLibrary,
+  iconLibraryMeta,
+  type IconName,
+} from '../lib/icon-registry';
+
+/**
+ * Icon store state
+ */
+interface IconState {
+  /** Current icon library */
+  library: IconLibrary;
+  /** Set the icon library */
+  setLibrary: (library: IconLibrary) => void;
+}
+
+/**
+ * Icon Store
+ *
+ * Zustand store for managing icon library state in the playground.
+ * Uses selective subscriptions to prevent unnecessary re-renders.
+ *
+ * @example
+ * ```tsx
+ * // Only re-renders when library changes
+ * const library = useIconStore((s) => s.library);
+ *
+ * // Only re-renders when setLibrary changes (never)
+ * const setLibrary = useIconStore((s) => s.setLibrary);
+ *
+ * // Get both (re-renders on library change)
+ * const { library, setLibrary } = useIconStore();
+ * ```
+ */
+export const useIconStore = create<IconState>((set) => ({
+  library: 'tabler',
+  setLibrary: (library) => set({ library }),
+}));
+
+/**
+ * Helper hook to get an icon component by name
+ *
+ * @example
+ * ```tsx
+ * const CheckIcon = useIcon('check');
+ * return <CheckIcon size={16} />;
+ * ```
+ */
+export function useIcon(name: IconName): IconComponent {
+  const library = useIconStore((s) => s.library);
+  return getIcon(name, library);
+}
+
+/**
+ * Helper hook to get the icon getter function
+ *
+ * @example
+ * ```tsx
+ * const getIconComponent = useIconGetter();
+ * const CheckIcon = getIconComponent('check');
+ * ```
+ */
+export function useIconGetter(): (name: IconName) => IconComponent {
+  const library = useIconStore((s) => s.library);
+  return (name: IconName) => getIcon(name, library);
+}
+
+/**
+ * Get all available icon names
+ */
+export const iconNames = getAllIconNames();
+
+/**
+ * Library metadata for UI display
+ */
+export { iconLibraryMeta };
+
+// Re-export types for convenience
+export type { IconComponent,IconLibrary, IconName };

--- a/packages/react/src/components/ui/Button.stories.tsx
+++ b/packages/react/src/components/ui/Button.stories.tsx
@@ -1,5 +1,5 @@
-import { IconRocket, IconStar } from '@tabler/icons-react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { IconRocket, IconStar } from '@tabler/icons-react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { themeOnlyModes } from '@/storybook/modes';

--- a/packages/react/src/lib/icons.ts
+++ b/packages/react/src/lib/icons.ts
@@ -25,4 +25,4 @@ export { IconCheck, IconX } from '@tabler/icons-react';
 export { IconAlertCircle, IconAlertTriangle, IconCircleCheck, IconInfoCircle } from '@tabler/icons-react';
 
 // Common UI
-export { IconSearch, IconEye, IconEyeOff } from '@tabler/icons-react';
+export { IconEye, IconEyeOff,IconSearch } from '@tabler/icons-react';

--- a/yarn.lock
+++ b/yarn.lock
@@ -625,6 +625,11 @@
   resolved "https://registry.yarnpkg.com/@neoconfetti/react/-/react-1.0.0.tgz#9a619d980a2285a829b1f8c78ca6484f0364a370"
   integrity sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==
 
+"@phosphor-icons/react@^2.1.10":
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@phosphor-icons/react/-/react-2.1.10.tgz#3a97ec5b7a4b8d53afeb29125bc17e74ed2daf92"
+  integrity sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA==
+
 "@polka/url@^1.0.0-next.24":
   version "1.0.0-next.29"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
@@ -3430,6 +3435,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lucide-react@^0.562.0:
+  version "0.562.0"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.562.0.tgz#217796c2f57624f012b484ea7f08505067c90d51"
+  integrity sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==
+
 lz-string@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
@@ -4977,3 +4987,8 @@ yocto-queue@^0.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.2.1.tgz#07f0388c7edbfd5f5a2466181cb4adf5b5dbd57b"
   integrity sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==
+
+zustand@^5.0.9:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.9.tgz#389dcd0309b9c545d7a461bd3c54955962847654"
+  integrity sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg==


### PR DESCRIPTION
## Summary

- Add icon library switcher to preview DS components with Tabler, Lucide, or Phosphor icons
- Complete UI overhaul with polished theme controls sidebar
- Add Zustand store for icon library state management
- Create icon registry mapping 14 internal DS icons across all three libraries

## Changes

### New Files
- `src/store/iconStore.ts` - Zustand store for icon library selection
- `src/lib/icon-registry.ts` - Icon mappings across Tabler, Lucide, Phosphor
- `src/components/PlaygroundIcon.tsx` - Icon component using selected library
- `src/components/IconShowcase.tsx` - Grid display of all available icons

### Modified Files
- `App.tsx` - Two-column layout with sticky sidebar
- `ThemeSwitcher.tsx` - Polished controls with toggle switch, color indicators, card sections
- `ComponentShowcase.tsx` - Card-style sections with better organization
- `package.json` - Added icon libraries, Zustand, lint/typecheck scripts
- `CLAUDE.md` - Updated documentation

### Dependencies Added
- `@tabler/icons-react` ^3.36.1
- `lucide-react` ^0.562.0
- `@phosphor-icons/react` ^2.1.10
- `zustand` ^5.0.9

## Test Plan

- [x] Run `yarn lint` - passes
- [x] Run `yarn typecheck` - passes
- [ ] Run `yarn playground` and verify:
  - Icon library switcher works in sidebar
  - Icons update when library is changed
  - All theme controls function correctly
  - Light/dark toggle works
  - Reset button restores defaults

## Screenshots

_Add screenshots of the new playground UI_

---

Closes NEX-139

🤖 Generated with [Claude Code](https://claude.com/claude-code)