### PR TITLE
feat(context-engine): add HTTP server with Hono API [NEX-146]

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
+. "$HOME/.nvm/nvm.sh"
+
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -32,9 +32,17 @@
     "playground": "cd apps/playground && yarn dev",
     "size-limit": "size-limit",
     "prepare": "husky",
-    "ce:db:up": "yarn workspace @context-engine/db docker:up",
-    "ce:db:down": "yarn workspace @context-engine/db docker:down",
-    "ce:db:logs": "yarn workspace @context-engine/db docker:logs"
+    "ce:docker:up": "docker compose -f packages/context-engine/docker-compose.yml up -d",
+    "ce:docker:down": "docker compose -f packages/context-engine/docker-compose.yml down",
+    "ce:docker:logs": "docker compose -f packages/context-engine/docker-compose.yml logs -f",
+    "ce:db:push": "yarn workspace @context-engine/db db:push",
+    "ce:db:generate": "yarn workspace @context-engine/db db:generate",
+    "ce:db:migrate": "yarn workspace @context-engine/db db:migrate",
+    "ce:db:studio": "yarn workspace @context-engine/db db:studio",
+    "ce:server:dev": "yarn workspace @context-engine/server dev",
+    "ce:server:start": "yarn workspace @context-engine/server start",
+    "ce:core:build": "yarn workspace @context-engine/core build",
+    "ce:core:dev": "yarn workspace @context-engine/core dev"
   },
   "size-limit": [
     {

--- a/packages/context-engine/core/package.json
+++ b/packages/context-engine/core/package.json
@@ -53,7 +53,7 @@
     "dev": "tsup --watch",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint src/ --ext .ts",
+    "lint": "eslint src/",
     "process:help": "tsx scripts/run-processor.ts --help",
     "extract": "tsx scripts/run-processor.ts --phase extract",
     "generate": "tsx scripts/run-processor.ts --phase generate",

--- a/packages/context-engine/core/scripts/run-processor.ts
+++ b/packages/context-engine/core/scripts/run-processor.ts
@@ -409,10 +409,8 @@ async function main(): Promise<void> {
   const totalTimeMs = performance.now() - startTime;
   printSummary(succeeded, failed, totalTimeMs);
 
-  // Exit with error if any failed
-  if (failed.length > 0) {
-    process.exit(1);
-  }
+  // Exit with appropriate code
+  process.exit(failed.length > 0 ? 1 : 0);
 }
 
 main().catch((error) => {

--- a/packages/context-engine/db/package.json
+++ b/packages/context-engine/db/package.json
@@ -17,6 +17,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "clean": "rm -rf dist",
+    "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/context-engine/db/src/index.ts
+++ b/packages/context-engine/db/src/index.ts
@@ -39,7 +39,10 @@ export {
   type FindManyOptions,
 } from './repositories/component-repository.js';
 export { EmbeddingRepository } from './repositories/embedding-repository.js';
-export { OrganizationRepository } from './repositories/organization-repository.js';
+export {
+  type FindManyOrganizationsOptions,
+  OrganizationRepository,
+} from './repositories/organization-repository.js';
 
 // =============================================================================
 // Embeddings

--- a/packages/context-engine/db/src/repositories/component-repository.ts
+++ b/packages/context-engine/db/src/repositories/component-repository.ts
@@ -98,11 +98,13 @@ export class ComponentRepository {
 
   /**
    * Find multiple components with optional filters
+   *
+   * @returns Object containing the paginated components and total count
    */
   async findMany(
     orgId: string,
     options: FindManyOptions = {}
-  ): Promise<Component[]> {
+  ): Promise<{ components: Component[]; total: number }> {
     const {
       where = {},
       limit = 50,
@@ -124,6 +126,14 @@ export class ComponentRepository {
       conditions.push(eq(components.embeddingStatus, where.embeddingStatus));
     }
 
+    // Count total matching records (without pagination)
+    const [countResult] = await this.db
+      .select({ count: count() })
+      .from(components)
+      .where(and(...conditions));
+
+    const total = countResult?.count ?? 0;
+
     // Order column
     const orderColumn = {
       name: components.name,
@@ -133,13 +143,16 @@ export class ComponentRepository {
 
     const orderFn = orderDir === 'desc' ? desc : asc;
 
-    return this.db
+    // Fetch paginated results
+    const componentsList = await this.db
       .select()
       .from(components)
       .where(and(...conditions))
       .orderBy(orderFn(orderColumn))
       .limit(limit)
       .offset(offset);
+
+    return { components: componentsList, total };
   }
 
   /**
@@ -199,14 +212,16 @@ export class ComponentRepository {
 
   /**
    * Delete a component
+   *
+   * @returns The deleted component, or null if not found
    */
-  async delete(orgId: string, id: string): Promise<boolean> {
-    const result = await this.db
+  async delete(orgId: string, id: string): Promise<Component | null> {
+    const [result] = await this.db
       .delete(components)
       .where(and(eq(components.orgId, orgId), eq(components.id, id)))
-      .returning({ id: components.id });
+      .returning();
 
-    return result.length > 0;
+    return result ?? null;
   }
 
   /**

--- a/packages/context-engine/db/src/repositories/embedding-repository.ts
+++ b/packages/context-engine/db/src/repositories/embedding-repository.ts
@@ -10,7 +10,7 @@
  */
 
 import type { AIManifest } from '@context-engine/core';
-import { and, cosineDistance, eq, sql } from 'drizzle-orm';
+import { and, cosineDistance, eq, inArray, sql } from 'drizzle-orm';
 
 import type { Database } from '../client.js';
 import { generateChunks } from '../embeddings/chunk-generator.js';
@@ -234,37 +234,40 @@ export class EmbeddingRepository {
     query: string,
     options: SearchOptions = {}
   ): Promise<SearchResult[]> {
-    const { limit = 10, minScore = 0.0, framework } = options;
+    const { limit = 10, minScore = 0.5, framework } = options;
 
     // Generate query embedding (query-optimized)
     const queryEmbedding = await this.embeddingService.embedQuery(query);
-
-    // Calculate similarity as 1 - cosineDistance (cosine similarity)
-    const similarity = sql<number>`1 - ${cosineDistance(embeddingChunks.embedding, queryEmbedding)}`;
 
     // Build framework filter conditions
     const frameworkCondition = framework
       ? eq(components.framework, framework)
       : undefined;
 
-    // Query chunks with similarity scores, ordered by distance (for index usage)
-    // Then aggregate by component in-memory for simplicity and type safety
+    // Use cosineDistance directly in select and orderBy (ensures HNSW index usage)
+    // Similarity is computed in JS as 1 - distance to avoid SQL type mismatch
+    const distance = cosineDistance(
+      embeddingChunks.embedding,
+      queryEmbedding
+    ).mapWith(Number);
+
     const rankedChunks = await this.db
       .select({
         componentId: embeddingChunks.componentId,
-        similarity,
+        distance,
       })
       .from(embeddingChunks)
       .where(eq(embeddingChunks.orgId, orgId))
-      .orderBy(cosineDistance(embeddingChunks.embedding, queryEmbedding))
+      .orderBy(distance)
       .limit(limit * 3);
 
-    // Aggregate: take max similarity per component
+    // Aggregate: take max similarity (1 - distance) per component
     const componentScores = new Map<string, number>();
     for (const chunk of rankedChunks) {
+      const similarity = 1 - (chunk.distance ?? 1);
       const current = componentScores.get(chunk.componentId) ?? 0;
-      if ((chunk.similarity ?? 0) > current) {
-        componentScores.set(chunk.componentId, chunk.similarity ?? 0);
+      if (similarity > current) {
+        componentScores.set(chunk.componentId, similarity);
       }
     }
 
@@ -292,7 +295,7 @@ export class EmbeddingRepository {
       .where(
         and(
           eq(components.orgId, orgId),
-          sql`${components.id} = ANY(${topComponentIds})`,
+          inArray(components.id, topComponentIds),
           frameworkCondition
         )
       );

--- a/packages/context-engine/db/src/repositories/embedding-repository.ts
+++ b/packages/context-engine/db/src/repositories/embedding-repository.ts
@@ -279,13 +279,14 @@ export class EmbeddingRepository {
       return [];
     }
 
-    // Fetch component details for top results
+    // Fetch component details for top results (including framework)
     const componentDetails = await this.db
       .select({
         id: components.id,
         slug: components.slug,
         name: components.name,
         description: sql<string | null>`${components.manifest}->>'description'`,
+        framework: components.framework,
       })
       .from(components)
       .where(
@@ -307,6 +308,7 @@ export class EmbeddingRepository {
           slug: component.slug,
           name: component.name,
           description: component.description,
+          framework: component.framework,
           score: componentScores.get(id) ?? 0,
         };
       })

--- a/packages/context-engine/db/src/repositories/organization-repository.ts
+++ b/packages/context-engine/db/src/repositories/organization-repository.ts
@@ -4,7 +4,7 @@
  * Simple CRUD operations for organizations.
  */
 
-import { eq } from 'drizzle-orm';
+import { count, desc, eq } from 'drizzle-orm';
 
 import type { Database } from '../client.js';
 import {
@@ -12,6 +12,21 @@ import {
   type Organization,
   organizations,
 } from '../schema.js';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Options for finding multiple organizations
+ */
+export interface FindManyOrganizationsOptions {
+  /** Maximum number of results */
+  limit?: number;
+
+  /** Number of results to skip */
+  offset?: number;
+}
 
 /**
  * Repository for organization CRUD operations
@@ -53,6 +68,34 @@ export class OrganizationRepository {
    */
   async findAll(): Promise<Organization[]> {
     return this.db.select().from(organizations);
+  }
+
+  /**
+   * Find organizations with pagination
+   *
+   * @returns Object containing the paginated organizations and total count
+   */
+  async findMany(
+    options: FindManyOrganizationsOptions = {}
+  ): Promise<{ organizations: Organization[]; total: number }> {
+    const { limit = 50, offset = 0 } = options;
+
+    // Count total records
+    const [countResult] = await this.db
+      .select({ count: count() })
+      .from(organizations);
+
+    const total = countResult?.count ?? 0;
+
+    // Fetch paginated results
+    const results = await this.db
+      .select()
+      .from(organizations)
+      .orderBy(desc(organizations.updatedAt))
+      .limit(limit)
+      .offset(offset);
+
+    return { organizations: results, total };
   }
 
   /**

--- a/packages/context-engine/db/src/repositories/organization-repository.ts
+++ b/packages/context-engine/db/src/repositories/organization-repository.ts
@@ -74,14 +74,15 @@ export class OrganizationRepository {
   /**
    * Delete an organization
    *
+   * @returns The deleted organization, or null if not found
    * @throws Error if organization has associated components (FK constraint)
    */
-  async delete(id: string): Promise<boolean> {
-    const result = await this.db
+  async delete(id: string): Promise<Organization | null> {
+    const [result] = await this.db
       .delete(organizations)
       .where(eq(organizations.id, id))
-      .returning({ id: organizations.id });
+      .returning();
 
-    return result.length > 0;
+    return result ?? null;
   }
 }

--- a/packages/context-engine/db/src/repositories/organization-repository.ts
+++ b/packages/context-engine/db/src/repositories/organization-repository.ts
@@ -64,13 +64,6 @@ export class OrganizationRepository {
   }
 
   /**
-   * Find all organizations
-   */
-  async findAll(): Promise<Organization[]> {
-    return this.db.select().from(organizations);
-  }
-
-  /**
    * Find organizations with pagination
    *
    * @returns Object containing the paginated organizations and total count

--- a/packages/context-engine/db/src/schema.ts
+++ b/packages/context-engine/db/src/schema.ts
@@ -123,21 +123,21 @@ export const components = pgTable(
     // =========================================================================
 
     /** Extraction result (JSONB) - props, variants, dependencies, stories */
-    extraction: jsonb('extraction').$type<ExtractedData>().notNull(),
+    extraction: jsonb('extraction').$type<ExtractedData | null>(),
 
     /** Generation result (JSONB) - LLM-generated descriptions, patterns, guidance */
-    generation: jsonb('generation').$type<ComponentMeta>().notNull(),
+    generation: jsonb('generation').$type<ComponentMeta | null>(),
 
     /** LLM provider used for generation (e.g., 'anthropic') */
     generationProvider: varchar('generation_provider', {
       length: 50,
-    }).notNull(),
+    }),
 
     /** LLM model used for generation (e.g., 'claude-sonnet-4-20250514') */
-    generationModel: varchar('generation_model', { length: 100 }).notNull(),
+    generationModel: varchar('generation_model', { length: 100 }),
 
     /** Final manifest (JSONB) - combined output for AI consumption */
-    manifest: jsonb('manifest').$type<AIManifest>().notNull(),
+    manifest: jsonb('manifest').$type<AIManifest | null>(),
 
     // =========================================================================
     // Embedding (for semantic search)
@@ -173,7 +173,7 @@ export const components = pgTable(
     // =========================================================================
 
     /** Hash of source code for change detection */
-    sourceHash: varchar('source_hash', { length: 64 }).notNull(),
+    sourceHash: varchar('source_hash', { length: 64 }),
 
     // =========================================================================
     // Timestamps

--- a/packages/context-engine/db/src/types.ts
+++ b/packages/context-engine/db/src/types.ts
@@ -89,6 +89,8 @@ export interface SearchResult {
   name: string;
   /** Component description (may be null) */
   description: string | null;
+  /** Target framework (e.g., 'react', 'vue') */
+  framework: string;
   /** Similarity score (0-1, higher is more relevant) */
   score: number;
 }

--- a/packages/context-engine/docker-compose.yml
+++ b/packages/context-engine/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - '5432:5432'
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
       # Init scripts run on first container creation (enables pgvector extension)
       - ./docker/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     healthcheck:

--- a/packages/context-engine/server/.env.example
+++ b/packages/context-engine/server/.env.example
@@ -1,0 +1,9 @@
+# Server
+PORT=3000
+NODE_ENV=development
+
+# Database (PostgreSQL)
+DATABASE_URL=postgresql://context_engine:context_engine_dev@localhost:5432/context_engine
+
+# Embeddings (Voyage AI) - Optional for search functionality
+VOYAGE_API_KEY=

--- a/packages/context-engine/server/package.json
+++ b/packages/context-engine/server/package.json
@@ -15,8 +15,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsx watch src/index.ts",
-    "start": "node dist/index.js",
+    "dev": "tsx watch --env-file=.env src/index.ts",
+    "start": "node --env-file=.env dist/index.js",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/packages/context-engine/server/package.json
+++ b/packages/context-engine/server/package.json
@@ -15,8 +15,8 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsx watch --env-file=.env src/index.ts",
-    "start": "node --env-file=.env dist/index.js",
+    "dev": "tsx watch --env-file=.env src/server.ts",
+    "start": "node --env-file=.env dist/server.js",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
@@ -27,8 +27,7 @@
     "@hono/node-server": "^1.14.1",
     "@hono/swagger-ui": "^0.5.1",
     "@hono/zod-openapi": "^0.19.3",
-    "hono": "^4.7.4",
-    "zod": "^3.24.2"
+    "hono": "^4.7.4"
   },
   "devDependencies": {
     "@types/node": "^25.2.0",

--- a/packages/context-engine/server/package.json
+++ b/packages/context-engine/server/package.json
@@ -18,6 +18,7 @@
     "dev": "tsx watch --env-file=.env src/server.ts",
     "start": "node --env-file=.env dist/server.js",
     "clean": "rm -rf dist",
+    "lint": "eslint src/",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/context-engine/server/package.json
+++ b/packages/context-engine/server/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@context-engine/server",
+  "version": "0.1.0",
+  "description": "HTTP API server for Context Engine",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@context-engine/db": "*",
+    "@hono/node-server": "^1.14.1",
+    "@hono/swagger-ui": "^0.5.1",
+    "@hono/zod-openapi": "^0.19.3",
+    "hono": "^4.7.4",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.0",
+    "tsup": "^8.5.1",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
+    "vitest": "4.0.18"
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/packages/context-engine/server/src/app.ts
+++ b/packages/context-engine/server/src/app.ts
@@ -1,0 +1,135 @@
+/**
+ * HTTP Server Application
+ *
+ * Assembles the Hono app with all routes, middleware, and OpenAPI documentation.
+ */
+
+import { swaggerUI } from '@hono/swagger-ui';
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { cors } from 'hono/cors';
+import { logger } from 'hono/logger';
+
+import { getConfig } from './config.js';
+import { ApiError } from './errors.js';
+import {
+  componentsRouter,
+  healthRouter,
+  organizationsRouter,
+  searchRouter,
+} from './routes/index.js';
+
+/**
+ * Create and configure the HTTP server application.
+ *
+ * Sets up:
+ * - Global middleware (CORS, logging)
+ * - Health check routes at root
+ * - API v1 routes for organizations, components, and search
+ * - OpenAPI documentation at /doc and /ui
+ * - Error handlers for 404 and 500
+ */
+export function createApp() {
+  const app = new OpenAPIHono();
+
+  // === Global Middleware ===
+  // CORS must be registered before routes per Hono best practices
+  app.use('*', cors());
+  app.use('*', logger());
+
+  // === Health Routes (at root) ===
+  // /health - liveness check
+  // /ready - readiness check with database connectivity
+  app.route('/', healthRouter);
+
+  // === API v1 Routes ===
+
+  // Organizations CRUD
+  // GET/POST /api/v1/organizations
+  // GET/PATCH/DELETE /api/v1/organizations/:id
+  app.route('/api/v1/organizations', organizationsRouter);
+
+  // Components CRUD (nested under organization)
+  // Expects orgId in path: /api/v1/organizations/:orgId/components
+  app.route('/api/v1/organizations/:orgId/components', componentsRouter);
+
+  // Semantic search (nested under organization)
+  // POST /api/v1/organizations/:orgId/search
+  app.route('/api/v1/organizations/:orgId/search', searchRouter);
+
+  // === OpenAPI Documentation ===
+  app.doc('/doc', {
+    openapi: '3.1.0',
+    info: {
+      title: 'Context Engine API',
+      version: '0.1.0',
+      description:
+        'API for managing design system component metadata. Makes components AI-accessible through semantic search and structured metadata.',
+    },
+    tags: [
+      { name: 'Health', description: 'Health check endpoints' },
+      { name: 'Organizations', description: 'Organization management' },
+      { name: 'Components', description: 'Component CRUD operations' },
+      { name: 'Search', description: 'Semantic component search' },
+    ],
+  });
+
+  // Swagger UI at /ui, reads spec from /doc
+  app.get('/ui', swaggerUI({ url: '/doc' }));
+
+  // === Error Handlers ===
+
+  // 404 Not Found handler
+  app.notFound((c) => {
+    return c.json(
+      {
+        success: false as const,
+        error: {
+          code: 'NOT_FOUND',
+          message: `Route not found: ${c.req.method} ${c.req.path}`,
+        },
+      },
+      404
+    );
+  });
+
+  // Global error handler
+  app.onError((err, c) => {
+    // Handle our custom API errors
+    if (err instanceof ApiError) {
+      return c.json(
+        {
+          success: false as const,
+          error: {
+            code: err.code,
+            message: err.message,
+            ...(err.details !== undefined && { details: err.details }),
+          },
+        },
+        err.status
+      );
+    }
+
+    // Handle unknown errors
+    console.error('[Server Error]', err);
+    const config = getConfig();
+    const isDevelopment = config.environment === 'development';
+
+    return c.json(
+      {
+        success: false as const,
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: isDevelopment ? err.message : 'Internal server error',
+        },
+      },
+      500
+    );
+  });
+
+  return app;
+}
+
+/**
+ * App type for use in tests and server entry point.
+ */
+export type App = ReturnType<typeof createApp>;

--- a/packages/context-engine/server/src/app.ts
+++ b/packages/context-engine/server/src/app.ts
@@ -11,12 +11,14 @@ import { logger } from 'hono/logger';
 
 import { getConfig } from './config.js';
 import { ApiError } from './errors.js';
+import { repositoriesMiddleware } from './middleware/index.js';
 import {
   componentsRouter,
   healthRouter,
   organizationsRouter,
   searchRouter,
 } from './routes/index.js';
+import type { AppEnv } from './types.js';
 
 /**
  * Create and configure the HTTP server application.
@@ -29,12 +31,17 @@ import {
  * - Error handlers for 404 and 500
  */
 export function createApp() {
-  const app = new OpenAPIHono();
+  const app = new OpenAPIHono<AppEnv>();
 
   // === Global Middleware ===
   // CORS must be registered before routes per Hono best practices
   app.use('*', cors());
   app.use('*', logger());
+
+  // === Repository DI Middleware ===
+  // Injects repositories into context for all API v1 routes
+  // Access via c.var.organizationRepo, c.var.componentRepo, c.var.embeddingRepo
+  app.use('/api/v1/*', repositoriesMiddleware);
 
   // === Health Routes (at root) ===
   // /health - liveness check

--- a/packages/context-engine/server/src/config.ts
+++ b/packages/context-engine/server/src/config.ts
@@ -1,0 +1,95 @@
+/**
+ * Server Configuration
+ *
+ * Loads configuration from environment variables.
+ * Required variables must be set; optional ones have sensible defaults.
+ */
+
+/**
+ * Runtime environment types
+ */
+export const Environment = {
+  Development: 'development',
+  Production: 'production',
+  Test: 'test',
+} as const;
+
+export type Environment = (typeof Environment)[keyof typeof Environment];
+
+/**
+ * Server configuration interface
+ */
+export interface ServerConfig {
+  /** Server port */
+  port: number;
+  /** Runtime environment */
+  environment: Environment;
+  /** PostgreSQL connection string */
+  databaseUrl: string;
+}
+
+/**
+ * Validate that a string is a valid environment
+ */
+function isValidEnvironment(value: string): value is Environment {
+  return Object.values(Environment).includes(value as Environment);
+}
+
+/**
+ * Load configuration from environment variables.
+ *
+ * @throws Error if required variables are missing
+ * @returns ServerConfig object
+ */
+export function loadConfig(): ServerConfig {
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL environment variable is required');
+  }
+
+  const envValue = process.env.NODE_ENV || 'development';
+  const environment = isValidEnvironment(envValue)
+    ? envValue
+    : Environment.Development;
+
+  const portString = process.env.PORT || '3000';
+  const port = parseInt(portString, 10);
+
+  if (isNaN(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid PORT value: ${portString}. Must be 1-65535`);
+  }
+
+  return {
+    port,
+    environment,
+    databaseUrl,
+  };
+}
+
+/**
+ * Server configuration singleton
+ *
+ * Note: This is lazily initialized to allow tests to set env vars before loading.
+ * Access via getConfig() for test-friendly usage.
+ */
+let _config: ServerConfig | null = null;
+
+/**
+ * Get server configuration (lazily loaded singleton)
+ *
+ * @throws Error if required environment variables are missing
+ */
+export function getConfig(): ServerConfig {
+  if (!_config) {
+    _config = loadConfig();
+  }
+  return _config;
+}
+
+/**
+ * Reset configuration singleton (for testing only)
+ */
+export function resetConfig(): void {
+  _config = null;
+}

--- a/packages/context-engine/server/src/config.ts
+++ b/packages/context-engine/server/src/config.ts
@@ -1,9 +1,22 @@
 /**
  * Server Configuration
  *
- * Loads configuration from environment variables.
+ * Loads configuration from environment variables with Zod validation.
  * Required variables must be set; optional ones have sensible defaults.
  */
+
+import { z } from 'zod';
+
+/**
+ * Environment variable schema with validation and coercion
+ */
+const envSchema = z.object({
+  DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
+  PORT: z.coerce.number().int().min(1).max(65535).default(3000),
+  NODE_ENV: z
+    .enum(['development', 'production', 'test'])
+    .default('development'),
+});
 
 /**
  * Runtime environment types
@@ -29,41 +42,25 @@ export interface ServerConfig {
 }
 
 /**
- * Validate that a string is a valid environment
- */
-function isValidEnvironment(value: string): value is Environment {
-  return Object.values(Environment).includes(value as Environment);
-}
-
-/**
  * Load configuration from environment variables.
  *
- * @throws Error if required variables are missing
+ * @throws Error if required variables are missing or invalid
  * @returns ServerConfig object
  */
 export function loadConfig(): ServerConfig {
-  const databaseUrl = process.env.DATABASE_URL;
+  const result = envSchema.safeParse(process.env);
 
-  if (!databaseUrl) {
-    throw new Error('DATABASE_URL environment variable is required');
-  }
-
-  const envValue = process.env.NODE_ENV || 'development';
-  const environment = isValidEnvironment(envValue)
-    ? envValue
-    : Environment.Development;
-
-  const portString = process.env.PORT || '3000';
-  const port = parseInt(portString, 10);
-
-  if (isNaN(port) || port < 1 || port > 65535) {
-    throw new Error(`Invalid PORT value: ${portString}. Must be 1-65535`);
+  if (!result.success) {
+    const errors = result.error.issues
+      .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+      .join(', ');
+    throw new Error(`Configuration error: ${errors}`);
   }
 
   return {
-    port,
-    environment,
-    databaseUrl,
+    port: result.data.PORT,
+    environment: result.data.NODE_ENV,
+    databaseUrl: result.data.DATABASE_URL,
   };
 }
 

--- a/packages/context-engine/server/src/config.ts
+++ b/packages/context-engine/server/src/config.ts
@@ -5,7 +5,7 @@
  * Required variables must be set; optional ones have sensible defaults.
  */
 
-import { z } from 'zod';
+import { z } from '@hono/zod-openapi';
 
 /**
  * Environment variable schema with validation and coercion

--- a/packages/context-engine/server/src/constants.ts
+++ b/packages/context-engine/server/src/constants.ts
@@ -5,9 +5,14 @@
  * Separated to avoid circular imports between routes and index.
  */
 
+import { createRequire } from 'node:module';
+
 // =============================================================================
 // Version
 // =============================================================================
 
-/** Current server version */
-export const SERVER_VERSION = '0.1.0';
+const require = createRequire(import.meta.url);
+const packageJson = require('../package.json') as { version: string };
+
+/** Current server version, read from package.json as single source of truth. */
+export const SERVER_VERSION: string = packageJson.version;

--- a/packages/context-engine/server/src/constants.ts
+++ b/packages/context-engine/server/src/constants.ts
@@ -1,0 +1,13 @@
+/**
+ * Server Constants
+ *
+ * Shared constants used across the server package.
+ * Separated to avoid circular imports between routes and index.
+ */
+
+// =============================================================================
+// Version
+// =============================================================================
+
+/** Current server version */
+export const SERVER_VERSION = '0.1.0';

--- a/packages/context-engine/server/src/constants.ts
+++ b/packages/context-engine/server/src/constants.ts
@@ -5,14 +5,12 @@
  * Separated to avoid circular imports between routes and index.
  */
 
-import { createRequire } from 'node:module';
-
 // =============================================================================
 // Version
 // =============================================================================
 
-const require = createRequire(import.meta.url);
-const packageJson = require('../package.json') as { version: string };
-
-/** Current server version, read from package.json as single source of truth. */
-export const SERVER_VERSION: string = packageJson.version;
+/**
+ * Current server version, injected at build time from package.json by tsup.
+ * Falls back to '0.0.0' in development mode (ts-node/tsx).
+ */
+export const SERVER_VERSION: string = process.env.PACKAGE_VERSION ?? '0.0.0';

--- a/packages/context-engine/server/src/errors.ts
+++ b/packages/context-engine/server/src/errors.ts
@@ -1,0 +1,65 @@
+/**
+ * API Errors
+ *
+ * Custom error classes for consistent error handling.
+ * Throw these in routes - they're caught by app.onError.
+ */
+
+import { HTTPException } from 'hono/http-exception';
+import type { ContentfulStatusCode } from 'hono/utils/http-status';
+
+type ErrorCode =
+  | 'NOT_FOUND'
+  | 'VALIDATION_ERROR'
+  | 'SERVICE_UNAVAILABLE'
+  | 'INTERNAL_ERROR';
+
+/**
+ * Base API error class.
+ * Extends HTTPException for Hono compatibility.
+ */
+export class ApiError extends HTTPException {
+  readonly code: ErrorCode;
+  readonly details?: unknown;
+
+  constructor(
+    status: ContentfulStatusCode,
+    code: ErrorCode,
+    message: string,
+    details?: unknown
+  ) {
+    super(status, { message });
+    this.code = code;
+    this.details = details;
+  }
+}
+
+/**
+ * Resource not found error.
+ * @param resource - The type of resource (e.g., "Organization", "Component")
+ * @param id - Optional identifier that was not found
+ */
+export const NotFound = (resource: string, id?: string) =>
+  new ApiError(
+    404,
+    'NOT_FOUND',
+    id ? `${resource} '${id}' not found` : `${resource} not found`
+  );
+
+/**
+ * Service unavailable error.
+ * Use when external dependencies (database, APIs) are unavailable.
+ * @param message - Description of what's unavailable
+ * @param details - Optional additional context
+ */
+export const ServiceUnavailable = (message: string, details?: unknown) =>
+  new ApiError(503, 'SERVICE_UNAVAILABLE', message, details);
+
+/**
+ * Validation error.
+ * Use when request data fails validation.
+ * @param message - Description of what's invalid
+ * @param details - Optional field-level details
+ */
+export const ValidationError = (message: string, details?: unknown) =>
+  new ApiError(400, 'VALIDATION_ERROR', message, details);

--- a/packages/context-engine/server/src/errors.ts
+++ b/packages/context-engine/server/src/errors.ts
@@ -11,6 +11,7 @@ import type { ContentfulStatusCode } from 'hono/utils/http-status';
 type ErrorCode =
   | 'NOT_FOUND'
   | 'VALIDATION_ERROR'
+  | 'CONFLICT'
   | 'SERVICE_UNAVAILABLE'
   | 'INTERNAL_ERROR';
 
@@ -39,7 +40,7 @@ export class ApiError extends HTTPException {
  * @param resource - The type of resource (e.g., "Organization", "Component")
  * @param id - Optional identifier that was not found
  */
-export const NotFound = (resource: string, id?: string) =>
+export const notFound = (resource: string, id?: string) =>
   new ApiError(
     404,
     'NOT_FOUND',
@@ -47,12 +48,21 @@ export const NotFound = (resource: string, id?: string) =>
   );
 
 /**
+ * Conflict error.
+ * Use when an operation conflicts with existing state (e.g., FK constraint).
+ * @param message - Description of the conflict
+ * @param details - Optional additional context
+ */
+export const conflict = (message: string, details?: unknown) =>
+  new ApiError(409, 'CONFLICT', message, details);
+
+/**
  * Service unavailable error.
  * Use when external dependencies (database, APIs) are unavailable.
  * @param message - Description of what's unavailable
  * @param details - Optional additional context
  */
-export const ServiceUnavailable = (message: string, details?: unknown) =>
+export const serviceUnavailable = (message: string, details?: unknown) =>
   new ApiError(503, 'SERVICE_UNAVAILABLE', message, details);
 
 /**
@@ -61,5 +71,5 @@ export const ServiceUnavailable = (message: string, details?: unknown) =>
  * @param message - Description of what's invalid
  * @param details - Optional field-level details
  */
-export const ValidationError = (message: string, details?: unknown) =>
+export const validationError = (message: string, details?: unknown) =>
   new ApiError(400, 'VALIDATION_ERROR', message, details);

--- a/packages/context-engine/server/src/index.ts
+++ b/packages/context-engine/server/src/index.ts
@@ -2,113 +2,17 @@
  * @context-engine/server
  *
  * HTTP API server for Context Engine.
+ *
+ * This is the library entry point — pure exports only.
+ * For the executable server, see `server.ts`.
  */
-
-import { closeDatabase, initializeDatabase } from '@context-engine/db';
-import { serve } from '@hono/node-server';
-
-import { createApp } from './app.js';
-import { loadConfig, type ServerConfig } from './config.js';
-
-// =============================================================================
-// Constants
-// =============================================================================
-
-export const SERVER_VERSION = '0.1.0';
-
-// =============================================================================
-// Server Startup
-// =============================================================================
-
-/**
- * Start the server with the given configuration.
- */
-async function startServer() {
-  // Load config first (will throw if DATABASE_URL missing)
-  const config = loadConfig();
-
-  // Initialize database connection
-  initializeDatabase({
-    url: config.databaseUrl,
-  });
-
-  // Create the app
-  const app = createApp();
-
-  // Print startup banner
-  printBanner(config);
-
-  // Start HTTP server
-  const server = serve({
-    fetch: app.fetch,
-    port: config.port,
-  });
-
-  console.log(`Server running at http://localhost:${config.port}`);
-  console.log(`API docs: http://localhost:${config.port}/ui`);
-  console.log(`OpenAPI spec: http://localhost:${config.port}/doc`);
-
-  // Setup graceful shutdown
-  const shutdown = async (signal: string) => {
-    console.log(`\n${signal} received, shutting down gracefully...`);
-
-    // Close the HTTP server
-    server.close((err) => {
-      if (err) {
-        console.error('Error closing HTTP server:', err);
-      } else {
-        console.log('HTTP server closed');
-      }
-    });
-
-    // Close database connection
-    await closeDatabase();
-    console.log('Database connection closed');
-
-    process.exit(0);
-  };
-
-  process.on('SIGINT', () => shutdown('SIGINT'));
-  process.on('SIGTERM', () => shutdown('SIGTERM'));
-}
-
-/**
- * Print server startup banner.
- */
-function printBanner(config: ServerConfig) {
-  // Extract database host from URL, safely handling various formats
-  let dbHost = 'configured';
-  try {
-    const urlParts = config.databaseUrl.split('@');
-    if (urlParts.length > 1) {
-      const hostPart = urlParts[1].split('/')[0];
-      dbHost = hostPart || 'configured';
-    }
-  } catch {
-    dbHost = 'configured';
-  }
-
-  // Check VOYAGE_API_KEY from env (used by @context-engine/db for search)
-  const embeddings = process.env.VOYAGE_API_KEY
-    ? 'Configured'
-    : 'Not configured';
-
-  console.log(`
-+=====================================================================+
-|                     Context Engine Server                           |
-+=====================================================================+
-|  Version:     ${SERVER_VERSION.padEnd(54)}|
-|  Environment: ${config.environment.padEnd(54)}|
-|  Port:        ${String(config.port).padEnd(54)}|
-|  Database:    ${dbHost.padEnd(54)}|
-|  Embeddings:  ${embeddings.padEnd(54)}|
-+=====================================================================+
-`);
-}
 
 // =============================================================================
 // Exports
 // =============================================================================
+
+// Re-export constants
+export { SERVER_VERSION } from './constants.js';
 
 // Re-export app factory and type
 export { type App, createApp } from './app.js';
@@ -127,13 +31,3 @@ export * from './schemas/index.js';
 
 // Re-export routes
 export * from './routes/index.js';
-
-// =============================================================================
-// Main
-// =============================================================================
-
-// Start the server
-startServer().catch((error) => {
-  console.error('Failed to start server:', error);
-  process.exit(1);
-});

--- a/packages/context-engine/server/src/index.ts
+++ b/packages/context-engine/server/src/index.ts
@@ -1,0 +1,139 @@
+/**
+ * @context-engine/server
+ *
+ * HTTP API server for Context Engine.
+ */
+
+import { closeDatabase, initializeDatabase } from '@context-engine/db';
+import { serve } from '@hono/node-server';
+
+import { createApp } from './app.js';
+import { loadConfig, type ServerConfig } from './config.js';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+export const SERVER_VERSION = '0.1.0';
+
+// =============================================================================
+// Server Startup
+// =============================================================================
+
+/**
+ * Start the server with the given configuration.
+ */
+async function startServer() {
+  // Load config first (will throw if DATABASE_URL missing)
+  const config = loadConfig();
+
+  // Initialize database connection
+  initializeDatabase({
+    url: config.databaseUrl,
+  });
+
+  // Create the app
+  const app = createApp();
+
+  // Print startup banner
+  printBanner(config);
+
+  // Start HTTP server
+  const server = serve({
+    fetch: app.fetch,
+    port: config.port,
+  });
+
+  console.log(`Server running at http://localhost:${config.port}`);
+  console.log(`API docs: http://localhost:${config.port}/ui`);
+  console.log(`OpenAPI spec: http://localhost:${config.port}/doc`);
+
+  // Setup graceful shutdown
+  const shutdown = async (signal: string) => {
+    console.log(`\n${signal} received, shutting down gracefully...`);
+
+    // Close the HTTP server
+    server.close((err) => {
+      if (err) {
+        console.error('Error closing HTTP server:', err);
+      } else {
+        console.log('HTTP server closed');
+      }
+    });
+
+    // Close database connection
+    await closeDatabase();
+    console.log('Database connection closed');
+
+    process.exit(0);
+  };
+
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+}
+
+/**
+ * Print server startup banner.
+ */
+function printBanner(config: ServerConfig) {
+  // Extract database host from URL, safely handling various formats
+  let dbHost = 'configured';
+  try {
+    const urlParts = config.databaseUrl.split('@');
+    if (urlParts.length > 1) {
+      const hostPart = urlParts[1].split('/')[0];
+      dbHost = hostPart || 'configured';
+    }
+  } catch {
+    dbHost = 'configured';
+  }
+
+  // Check VOYAGE_API_KEY from env (used by @context-engine/db for search)
+  const embeddings = process.env.VOYAGE_API_KEY
+    ? 'Configured'
+    : 'Not configured';
+
+  console.log(`
++=====================================================================+
+|                     Context Engine Server                           |
++=====================================================================+
+|  Version:     ${SERVER_VERSION.padEnd(54)}|
+|  Environment: ${config.environment.padEnd(54)}|
+|  Port:        ${String(config.port).padEnd(54)}|
+|  Database:    ${dbHost.padEnd(54)}|
+|  Embeddings:  ${embeddings.padEnd(54)}|
++=====================================================================+
+`);
+}
+
+// =============================================================================
+// Exports
+// =============================================================================
+
+// Re-export app factory and type
+export { type App, createApp } from './app.js';
+
+// Re-export config
+export {
+  Environment,
+  getConfig,
+  loadConfig,
+  resetConfig,
+  type ServerConfig,
+} from './config.js';
+
+// Re-export schemas
+export * from './schemas/index.js';
+
+// Re-export routes
+export * from './routes/index.js';
+
+// =============================================================================
+// Main
+// =============================================================================
+
+// Start the server
+startServer().catch((error) => {
+  console.error('Failed to start server:', error);
+  process.exit(1);
+});

--- a/packages/context-engine/server/src/middleware/index.ts
+++ b/packages/context-engine/server/src/middleware/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Middleware Index
+ *
+ * Re-exports all middleware modules for clean imports.
+ */
+
+export { repositoriesMiddleware } from './repositories.js';

--- a/packages/context-engine/server/src/middleware/repositories.ts
+++ b/packages/context-engine/server/src/middleware/repositories.ts
@@ -1,0 +1,61 @@
+/**
+ * Repository Middleware
+ *
+ * Injects repository instances into the Hono context for dependency injection.
+ * This enables route handlers to access repositories via `c.var` instead of
+ * creating them inline.
+ */
+
+import {
+  createComponentRepository,
+  createEmbeddingRepository,
+  createOrganizationRepository,
+} from '@context-engine/db';
+import { createMiddleware } from 'hono/factory';
+
+import type { AppEnv } from '../types.js';
+
+// =============================================================================
+// Middleware
+// =============================================================================
+
+/**
+ * Middleware that injects repository instances into the context.
+ *
+ * Provides:
+ * - `c.var.organizationRepo` - Always available
+ * - `c.var.componentRepo` - Always available
+ * - `c.var.embeddingRepo` - Only if VOYAGE_API_KEY is configured
+ *
+ * The embedding repository is optional because it requires the VOYAGE_API_KEY
+ * environment variable. Routes that need embedding functionality should check
+ * for its availability and return 503 if not configured.
+ *
+ * @example
+ * ```ts
+ * app.use('/api/v1/*', repositoriesMiddleware);
+ *
+ * app.get('/api/v1/orgs', (c) => {
+ *   const repo = c.var.organizationRepo;
+ *   // ...
+ * });
+ * ```
+ */
+export const repositoriesMiddleware = createMiddleware<AppEnv>(
+  async (c, next) => {
+    // Always inject organization and component repositories
+    c.set('organizationRepo', createOrganizationRepository());
+    c.set('componentRepo', createComponentRepository());
+
+    // Conditionally inject embedding repository if VOYAGE_API_KEY is available
+    // The factory function throws if the key is not set, so we catch and leave undefined
+    try {
+      c.set('embeddingRepo', createEmbeddingRepository());
+    } catch {
+      // VOYAGE_API_KEY not configured - embedding features will be unavailable
+      c.set('embeddingRepo', undefined);
+    }
+
+    await next();
+  }
+);

--- a/packages/context-engine/server/src/routes/components.ts
+++ b/packages/context-engine/server/src/routes/components.ts
@@ -15,15 +15,68 @@ import {
   ComponentListSchema,
   ComponentResponseSchema,
   ComponentSlugParamSchema,
+  type CreateComponent,
   CreateComponentSchema,
   DeleteComponentResponseSchema,
   IndexComponentResponseSchema,
   ListComponentsQuerySchema,
+  type UpdateComponent,
   UpdateComponentSchema,
 } from '../schemas/components.js';
 import { OrgIdPathParamSchema } from '../schemas/organizations.js';
 import type { AppEnv } from '../types.js';
 import { formatDates, successResponse } from '../utils/index.js';
+
+// =============================================================================
+// Body → Repository Mappers
+// =============================================================================
+
+/**
+ * Map validated create body to repository input.
+ *
+ * Explicit field mapping ensures compile-time safety: if the Zod schema
+ * or DB types diverge, TypeScript will error on the specific field.
+ * JSONB fields use `as` casts because the API intentionally accepts
+ * arbitrary JSON that the pipeline will later validate.
+ */
+function toCreateData(body: CreateComponent): Omit<NewComponent, 'orgId'> {
+  return {
+    slug: body.slug,
+    name: body.name,
+    framework: body.framework,
+    version: body.version,
+    visibility: body.visibility,
+    sourceHash: body.sourceHash,
+    extraction: body.extraction as NewComponent['extraction'],
+    generation: body.generation as NewComponent['generation'],
+    generationProvider: body.generationProvider,
+    generationModel: body.generationModel,
+    manifest: body.manifest as NewComponent['manifest'],
+  };
+}
+
+/**
+ * Map validated update body to repository input.
+ *
+ * Drizzle ignores `undefined` values in `.set()`, so we can map all
+ * fields directly — only fields present in the request body will be
+ * included in the SQL UPDATE.
+ */
+function toUpdateData(
+  body: UpdateComponent
+): Partial<Omit<NewComponent, 'id' | 'orgId'>> {
+  return {
+    name: body.name,
+    version: body.version,
+    visibility: body.visibility,
+    sourceHash: body.sourceHash,
+    extraction: body.extraction as NewComponent['extraction'],
+    generation: body.generation as NewComponent['generation'],
+    generationProvider: body.generationProvider,
+    generationModel: body.generationModel,
+    manifest: body.manifest as NewComponent['manifest'],
+  };
+}
 
 // =============================================================================
 // Helper Functions
@@ -470,13 +523,7 @@ componentsRouter.openapi(createComponentRoute, async (c) => {
   const isCreate = !existing;
 
   // Upsert the component
-  const createData: Omit<NewComponent, 'orgId'> = {
-    ...body,
-    extraction: body.extraction as NewComponent['extraction'],
-    generation: body.generation as NewComponent['generation'],
-    manifest: body.manifest as NewComponent['manifest'],
-  };
-  const component = await repository.upsert(orgId, createData);
+  const component = await repository.upsert(orgId, toCreateData(body));
 
   // Return 201 if created, 200 if updated
   const status = isCreate ? 201 : 200;
@@ -493,13 +540,7 @@ componentsRouter.openapi(updateComponentRoute, async (c) => {
   const body = c.req.valid('json');
   const repository = c.var.componentRepo;
 
-  const updateData: Partial<Omit<NewComponent, 'id' | 'orgId'>> = {
-    ...body,
-    extraction: body.extraction as NewComponent['extraction'],
-    generation: body.generation as NewComponent['generation'],
-    manifest: body.manifest as NewComponent['manifest'],
-  };
-  const component = await repository.update(orgId, id, updateData);
+  const component = await repository.update(orgId, id, toUpdateData(body));
 
   if (!component) {
     throw notFound('Component', id);

--- a/packages/context-engine/server/src/routes/components.ts
+++ b/packages/context-engine/server/src/routes/components.ts
@@ -8,7 +8,7 @@
 import type { Component, NewComponent } from '@context-engine/db';
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
 
-import { NotFound } from '../errors.js';
+import { NotFound, ServiceUnavailable, ValidationError } from '../errors.js';
 import { ErrorSchema } from '../schemas/common.js';
 import {
   ComponentIdParamSchema,
@@ -17,6 +17,7 @@ import {
   ComponentSlugParamSchema,
   CreateComponentSchema,
   DeleteComponentResponseSchema,
+  IndexComponentResponseSchema,
   ListComponentsQuerySchema,
   UpdateComponentSchema,
 } from '../schemas/components.js';
@@ -355,6 +356,56 @@ const deleteComponentRoute = createRoute({
   },
 });
 
+/**
+ * POST /:id/index - Index component for search
+ */
+const indexComponentRoute = createRoute({
+  method: 'post',
+  path: '/{id}/index',
+  tags: ['Components'],
+  summary: 'Index component for search',
+  description:
+    'Generate embeddings for a component to enable semantic search. Requires VOYAGE_API_KEY to be configured.',
+  request: {
+    params: ComponentIdParamSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: IndexComponentResponseSchema,
+        },
+      },
+      description: 'Component indexed successfully',
+    },
+    400: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Component has no manifest to index',
+    },
+    404: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Component not found',
+    },
+    503: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description:
+        'Embedding service unavailable (VOYAGE_API_KEY not configured)',
+    },
+  },
+});
+
 // =============================================================================
 // Router
 // =============================================================================
@@ -495,4 +546,52 @@ componentsRouter.openapi(deleteComponentRoute, async (c) => {
   }
 
   return c.json(successResponse({ deleted: true }), 200);
+});
+
+// -----------------------------------------------------------------------------
+// POST /:id/index - Index component for search
+// -----------------------------------------------------------------------------
+
+componentsRouter.openapi(indexComponentRoute, async (c) => {
+  const { orgId, id } = c.req.valid('param');
+  const componentRepo = c.var.componentRepo;
+  const embeddingRepo = c.var.embeddingRepo;
+
+  // Check if embedding service is available
+  if (!embeddingRepo) {
+    throw ServiceUnavailable(
+      'Embedding service unavailable',
+      'VOYAGE_API_KEY not configured'
+    );
+  }
+
+  // Get component
+  const component = await componentRepo.findById(orgId, id);
+  if (!component) {
+    throw NotFound('Component', id);
+  }
+
+  // Check if component has manifest
+  if (!component.manifest) {
+    throw ValidationError(
+      'Component has no manifest',
+      'Generate manifest before indexing'
+    );
+  }
+
+  // Index the component
+  const result = await embeddingRepo.index(orgId, id, component.manifest);
+
+  if (!result.success) {
+    throw ServiceUnavailable('Embedding generation failed', result.error);
+  }
+
+  return c.json(
+    successResponse({
+      componentId: id,
+      chunksCreated: result.chunksCreated,
+      embeddingStatus: 'indexed',
+    }),
+    200
+  );
 });

--- a/packages/context-engine/server/src/routes/components.ts
+++ b/packages/context-engine/server/src/routes/components.ts
@@ -5,7 +5,7 @@
  * All routes are nested under `/api/v1/organizations/:orgId/components`.
  */
 
-import type { Component } from '@context-engine/db';
+import type { Component, NewComponent } from '@context-engine/db';
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
 
 import { NotFound } from '../errors.js';
@@ -21,52 +21,25 @@ import {
   UpdateComponentSchema,
 } from '../schemas/components.js';
 import { OrgIdPathParamSchema } from '../schemas/organizations.js';
+import type { AppEnv } from '../types.js';
+import { successResponse } from '../utils/index.js';
 
 // =============================================================================
-// Types
+// Type Helpers
 // =============================================================================
 
 /**
- * Context type expected by the router.
- * Parent router must provide database and repositories.
+ * Create component data type (excludes orgId which is added by repository).
+ *
+ * The Zod schema uses z.record(z.any()) for flexibility, but the repository
+ * expects typed data. This type assertion bridges the API schema and DB types.
  */
-interface ComponentsRouterContext {
-  Variables: {
-    db: unknown;
-    componentRepository: {
-      findById: (orgId: string, id: string) => Promise<Component | null>;
-      findBySlug: (orgId: string, slug: string) => Promise<Component | null>;
-      findMany: (
-        orgId: string,
-        options: {
-          where?: {
-            framework?: string;
-            visibility?: string;
-            embeddingStatus?: string;
-          };
-          limit?: number;
-          offset?: number;
-          orderBy?: 'name' | 'createdAt' | 'updatedAt';
-          orderDir?: 'asc' | 'desc';
-        }
-      ) => Promise<{ components: Component[]; total: number }>;
-      create: (
-        orgId: string,
-        data: Record<string, unknown>
-      ) => Promise<Component>;
-      upsert: (
-        orgId: string,
-        data: Record<string, unknown>
-      ) => Promise<Component>;
-      update: (
-        orgId: string,
-        id: string,
-        data: Record<string, unknown>
-      ) => Promise<Component | null>;
-      delete: (orgId: string, id: string) => Promise<Component | null>;
-    };
-  };
-}
+type CreateComponentData = Omit<NewComponent, 'orgId'>;
+
+/**
+ * Update component data type.
+ */
+type UpdateComponentData = Partial<Omit<NewComponent, 'id' | 'orgId'>>;
 
 // =============================================================================
 // Helper Functions
@@ -389,8 +362,11 @@ const deleteComponentRoute = createRoute({
 /**
  * Components router.
  * Mount at `/api/v1/organizations/:orgId/components`.
+ *
+ * Requires repositories middleware to be applied at app level.
+ * Access component repository via `c.var.componentRepo`.
  */
-export const componentsRouter = new OpenAPIHono<ComponentsRouterContext>();
+export const componentsRouter = new OpenAPIHono<AppEnv>();
 
 // -----------------------------------------------------------------------------
 // GET / - List components
@@ -399,7 +375,7 @@ export const componentsRouter = new OpenAPIHono<ComponentsRouterContext>();
 componentsRouter.openapi(listComponentsRoute, async (c) => {
   const { orgId } = c.req.valid('param');
   const query = c.req.valid('query');
-  const repository = c.var.componentRepository;
+  const repository = c.var.componentRepo;
 
   const result = await repository.findMany(orgId, {
     where: {
@@ -414,15 +390,12 @@ componentsRouter.openapi(listComponentsRoute, async (c) => {
   });
 
   return c.json(
-    {
-      success: true as const,
-      data: {
-        components: result.components.map(formatComponentSummary),
-        total: result.total,
-        limit: query.limit,
-        offset: query.offset,
-      },
-    },
+    successResponse({
+      components: result.components.map(formatComponentSummary),
+      total: result.total,
+      limit: query.limit,
+      offset: query.offset,
+    }),
     200
   );
 });
@@ -433,20 +406,14 @@ componentsRouter.openapi(listComponentsRoute, async (c) => {
 
 componentsRouter.openapi(getComponentByIdRoute, async (c) => {
   const { orgId, id } = c.req.valid('param');
-  const repository = c.var.componentRepository;
+  const repository = c.var.componentRepo;
   const component = await repository.findById(orgId, id);
 
   if (!component) {
     throw NotFound('Component', id);
   }
 
-  return c.json(
-    {
-      success: true as const,
-      data: formatComponent(component),
-    },
-    200
-  );
+  return c.json(successResponse(formatComponent(component)), 200);
 });
 
 // -----------------------------------------------------------------------------
@@ -455,20 +422,14 @@ componentsRouter.openapi(getComponentByIdRoute, async (c) => {
 
 componentsRouter.openapi(getComponentBySlugRoute, async (c) => {
   const { orgId, slug } = c.req.valid('param');
-  const repository = c.var.componentRepository;
+  const repository = c.var.componentRepo;
   const component = await repository.findBySlug(orgId, slug);
 
   if (!component) {
     throw NotFound('Component', slug);
   }
 
-  return c.json(
-    {
-      success: true as const,
-      data: formatComponent(component),
-    },
-    200
-  );
+  return c.json(successResponse(formatComponent(component)), 200);
 });
 
 // -----------------------------------------------------------------------------
@@ -478,25 +439,23 @@ componentsRouter.openapi(getComponentBySlugRoute, async (c) => {
 componentsRouter.openapi(createComponentRoute, async (c) => {
   const { orgId } = c.req.valid('param');
   const body = c.req.valid('json');
-  const repository = c.var.componentRepository;
+  const repository = c.var.componentRepo;
 
   // Check if component already exists by slug
   const existing = await repository.findBySlug(orgId, body.slug);
   const isCreate = !existing;
 
   // Upsert the component
-  const component = await repository.upsert(orgId, body);
+  // Cast body to match repository expected type - Zod schema validates structure
+  const component = await repository.upsert(
+    orgId,
+    body as unknown as CreateComponentData
+  );
 
   // Return 201 if created, 200 if updated
   const status = isCreate ? 201 : 200;
 
-  return c.json(
-    {
-      success: true as const,
-      data: formatComponent(component),
-    },
-    status
-  );
+  return c.json(successResponse(formatComponent(component)), status);
 });
 
 // -----------------------------------------------------------------------------
@@ -506,20 +465,20 @@ componentsRouter.openapi(createComponentRoute, async (c) => {
 componentsRouter.openapi(updateComponentRoute, async (c) => {
   const { orgId, id } = c.req.valid('param');
   const body = c.req.valid('json');
-  const repository = c.var.componentRepository;
-  const component = await repository.update(orgId, id, body);
+  const repository = c.var.componentRepo;
+
+  // Cast body to match repository expected type - Zod schema validates structure
+  const component = await repository.update(
+    orgId,
+    id,
+    body as unknown as UpdateComponentData
+  );
 
   if (!component) {
     throw NotFound('Component', id);
   }
 
-  return c.json(
-    {
-      success: true as const,
-      data: formatComponent(component),
-    },
-    200
-  );
+  return c.json(successResponse(formatComponent(component)), 200);
 });
 
 // -----------------------------------------------------------------------------
@@ -528,20 +487,12 @@ componentsRouter.openapi(updateComponentRoute, async (c) => {
 
 componentsRouter.openapi(deleteComponentRoute, async (c) => {
   const { orgId, id } = c.req.valid('param');
-  const repository = c.var.componentRepository;
+  const repository = c.var.componentRepo;
   const deleted = await repository.delete(orgId, id);
 
   if (!deleted) {
     throw NotFound('Component', id);
   }
 
-  return c.json(
-    {
-      success: true as const,
-      data: {
-        deleted: true,
-      },
-    },
-    200
-  );
+  return c.json(successResponse({ deleted: true }), 200);
 });

--- a/packages/context-engine/server/src/routes/components.ts
+++ b/packages/context-engine/server/src/routes/components.ts
@@ -6,7 +6,6 @@
  */
 
 import type { Component, NewComponent } from '@context-engine/db';
-import type { z } from '@hono/zod-openapi';
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
 
 import { notFound, serviceUnavailable, validationError } from '../errors.js';
@@ -25,59 +24,6 @@ import {
 import { OrgIdPathParamSchema } from '../schemas/organizations.js';
 import type { AppEnv } from '../types.js';
 import { formatDates, successResponse } from '../utils/index.js';
-
-// =============================================================================
-// Body → Repository Mappers
-// =============================================================================
-
-/**
- * Map validated create body to repository input.
- *
- * Explicit field mapping ensures compile-time safety: if the Zod schema
- * or DB types diverge, TypeScript will error on the specific field.
- * JSONB fields use `as` casts because the API intentionally accepts
- * arbitrary JSON that the pipeline will later validate.
- */
-function toCreateData(
-  body: z.infer<typeof CreateComponentSchema>
-): Omit<NewComponent, 'orgId'> {
-  return {
-    slug: body.slug,
-    name: body.name,
-    framework: body.framework,
-    version: body.version,
-    visibility: body.visibility,
-    sourceHash: body.sourceHash,
-    extraction: body.extraction as NewComponent['extraction'],
-    generation: body.generation as NewComponent['generation'],
-    generationProvider: body.generationProvider,
-    generationModel: body.generationModel,
-    manifest: body.manifest as NewComponent['manifest'],
-  };
-}
-
-/**
- * Map validated update body to repository input.
- *
- * Drizzle ignores `undefined` values in `.set()`, so we can map all
- * fields directly — only fields present in the request body will be
- * included in the SQL UPDATE.
- */
-function toUpdateData(
-  body: z.infer<typeof UpdateComponentSchema>
-): Partial<Omit<NewComponent, 'id' | 'orgId'>> {
-  return {
-    name: body.name,
-    version: body.version,
-    visibility: body.visibility,
-    sourceHash: body.sourceHash,
-    extraction: body.extraction as NewComponent['extraction'],
-    generation: body.generation as NewComponent['generation'],
-    generationProvider: body.generationProvider,
-    generationModel: body.generationModel,
-    manifest: body.manifest as NewComponent['manifest'],
-  };
-}
 
 // =============================================================================
 // Helper Functions
@@ -524,7 +470,13 @@ componentsRouter.openapi(createComponentRoute, async (c) => {
   const isCreate = !existing;
 
   // Upsert the component
-  const component = await repository.upsert(orgId, toCreateData(body));
+  const createData: Omit<NewComponent, 'orgId'> = {
+    ...body,
+    extraction: body.extraction as NewComponent['extraction'],
+    generation: body.generation as NewComponent['generation'],
+    manifest: body.manifest as NewComponent['manifest'],
+  };
+  const component = await repository.upsert(orgId, createData);
 
   // Return 201 if created, 200 if updated
   const status = isCreate ? 201 : 200;
@@ -541,7 +493,13 @@ componentsRouter.openapi(updateComponentRoute, async (c) => {
   const body = c.req.valid('json');
   const repository = c.var.componentRepo;
 
-  const component = await repository.update(orgId, id, toUpdateData(body));
+  const updateData: Partial<Omit<NewComponent, 'id' | 'orgId'>> = {
+    ...body,
+    extraction: body.extraction as NewComponent['extraction'],
+    generation: body.generation as NewComponent['generation'],
+    manifest: body.manifest as NewComponent['manifest'],
+  };
+  const component = await repository.update(orgId, id, updateData);
 
   if (!component) {
     throw notFound('Component', id);

--- a/packages/context-engine/server/src/routes/components.ts
+++ b/packages/context-engine/server/src/routes/components.ts
@@ -86,8 +86,10 @@ function toUpdateData(
 /**
  * Format a component summary for list responses.
  * Excludes large JSONB fields for performance.
+ * Uses formatDates for date conversion to avoid duplicating .toISOString() logic.
  */
 function formatComponentSummary(component: Component) {
+  const { createdAt, updatedAt } = formatDates(component);
   return {
     id: component.id,
     slug: component.slug,
@@ -96,8 +98,8 @@ function formatComponentSummary(component: Component) {
     version: component.version,
     visibility: component.visibility,
     embeddingStatus: component.embeddingStatus,
-    createdAt: component.createdAt.toISOString(),
-    updatedAt: component.updatedAt.toISOString(),
+    createdAt,
+    updatedAt,
   };
 }
 

--- a/packages/context-engine/server/src/routes/components.ts
+++ b/packages/context-engine/server/src/routes/components.ts
@@ -1,0 +1,547 @@
+/**
+ * Components Routes
+ *
+ * CRUD endpoints for component management.
+ * All routes are nested under `/api/v1/organizations/:orgId/components`.
+ */
+
+import type { Component } from '@context-engine/db';
+import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
+
+import { NotFound } from '../errors.js';
+import { ErrorSchema } from '../schemas/common.js';
+import {
+  ComponentIdParamSchema,
+  ComponentListSchema,
+  ComponentResponseSchema,
+  ComponentSlugParamSchema,
+  CreateComponentSchema,
+  DeleteComponentResponseSchema,
+  ListComponentsQuerySchema,
+  UpdateComponentSchema,
+} from '../schemas/components.js';
+import { OrgIdPathParamSchema } from '../schemas/organizations.js';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Context type expected by the router.
+ * Parent router must provide database and repositories.
+ */
+interface ComponentsRouterContext {
+  Variables: {
+    db: unknown;
+    componentRepository: {
+      findById: (orgId: string, id: string) => Promise<Component | null>;
+      findBySlug: (orgId: string, slug: string) => Promise<Component | null>;
+      findMany: (
+        orgId: string,
+        options: {
+          where?: {
+            framework?: string;
+            visibility?: string;
+            embeddingStatus?: string;
+          };
+          limit?: number;
+          offset?: number;
+          orderBy?: 'name' | 'createdAt' | 'updatedAt';
+          orderDir?: 'asc' | 'desc';
+        }
+      ) => Promise<{ components: Component[]; total: number }>;
+      create: (
+        orgId: string,
+        data: Record<string, unknown>
+      ) => Promise<Component>;
+      upsert: (
+        orgId: string,
+        data: Record<string, unknown>
+      ) => Promise<Component>;
+      update: (
+        orgId: string,
+        id: string,
+        data: Record<string, unknown>
+      ) => Promise<Component | null>;
+      delete: (orgId: string, id: string) => Promise<Component | null>;
+    };
+  };
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Format a component for API response.
+ * Converts Date objects to ISO strings.
+ */
+function formatComponent(component: Component) {
+  return {
+    ...component,
+    createdAt: component.createdAt.toISOString(),
+    updatedAt: component.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Format a component summary for list responses.
+ * Excludes large JSONB fields for performance.
+ */
+function formatComponentSummary(component: Component) {
+  return {
+    id: component.id,
+    slug: component.slug,
+    name: component.name,
+    framework: component.framework,
+    version: component.version,
+    visibility: component.visibility,
+    embeddingStatus: component.embeddingStatus,
+    createdAt: component.createdAt.toISOString(),
+    updatedAt: component.updatedAt.toISOString(),
+  };
+}
+
+// =============================================================================
+// Route Definitions
+// =============================================================================
+
+/**
+ * GET / - List components with optional filters
+ */
+const listComponentsRoute = createRoute({
+  method: 'get',
+  path: '/',
+  tags: ['Components'],
+  summary: 'List components',
+  description:
+    'List components for an organization with optional filtering, pagination, and sorting.',
+  request: {
+    params: OrgIdPathParamSchema,
+    query: ListComponentsQuerySchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: ComponentListSchema,
+        },
+      },
+      description: 'List of components',
+    },
+    400: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Invalid request parameters',
+    },
+    500: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Internal server error',
+    },
+  },
+});
+
+/**
+ * GET /:id - Get component by ID
+ */
+const getComponentByIdRoute = createRoute({
+  method: 'get',
+  path: '/{id}',
+  tags: ['Components'],
+  summary: 'Get component by ID',
+  description: 'Retrieve a single component by its UUID.',
+  request: {
+    params: ComponentIdParamSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: ComponentResponseSchema,
+        },
+      },
+      description: 'Component details',
+    },
+    404: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Component not found',
+    },
+    500: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Internal server error',
+    },
+  },
+});
+
+/**
+ * GET /slug/:slug - Get component by slug
+ */
+const getComponentBySlugRoute = createRoute({
+  method: 'get',
+  path: '/slug/{slug}',
+  tags: ['Components'],
+  summary: 'Get component by slug',
+  description: 'Retrieve a single component by its URL-friendly slug.',
+  request: {
+    params: ComponentSlugParamSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: ComponentResponseSchema,
+        },
+      },
+      description: 'Component details',
+    },
+    404: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Component not found',
+    },
+    500: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Internal server error',
+    },
+  },
+});
+
+/**
+ * POST / - Create or upsert component
+ */
+const createComponentRoute = createRoute({
+  method: 'post',
+  path: '/',
+  tags: ['Components'],
+  summary: 'Create or update component',
+  description:
+    'Create a new component or update an existing one by slug. Returns 201 if created, 200 if updated.',
+  request: {
+    params: OrgIdPathParamSchema,
+    body: {
+      content: {
+        'application/json': {
+          schema: CreateComponentSchema,
+        },
+      },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: ComponentResponseSchema,
+        },
+      },
+      description: 'Component updated',
+    },
+    201: {
+      content: {
+        'application/json': {
+          schema: ComponentResponseSchema,
+        },
+      },
+      description: 'Component created',
+    },
+    400: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Invalid request body',
+    },
+    500: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Internal server error',
+    },
+  },
+});
+
+/**
+ * PATCH /:id - Update component
+ */
+const updateComponentRoute = createRoute({
+  method: 'patch',
+  path: '/{id}',
+  tags: ['Components'],
+  summary: 'Update component',
+  description: 'Partially update an existing component by ID.',
+  request: {
+    params: ComponentIdParamSchema,
+    body: {
+      content: {
+        'application/json': {
+          schema: UpdateComponentSchema,
+        },
+      },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: ComponentResponseSchema,
+        },
+      },
+      description: 'Component updated',
+    },
+    400: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Invalid request body',
+    },
+    404: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Component not found',
+    },
+    500: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Internal server error',
+    },
+  },
+});
+
+/**
+ * DELETE /:id - Delete component
+ */
+const deleteComponentRoute = createRoute({
+  method: 'delete',
+  path: '/{id}',
+  tags: ['Components'],
+  summary: 'Delete component',
+  description:
+    'Delete a component by ID. This also deletes associated embedding chunks.',
+  request: {
+    params: ComponentIdParamSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: DeleteComponentResponseSchema,
+        },
+      },
+      description: 'Component deleted',
+    },
+    404: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Component not found',
+    },
+    500: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Internal server error',
+    },
+  },
+});
+
+// =============================================================================
+// Router
+// =============================================================================
+
+/**
+ * Components router.
+ * Mount at `/api/v1/organizations/:orgId/components`.
+ */
+export const componentsRouter = new OpenAPIHono<ComponentsRouterContext>();
+
+// -----------------------------------------------------------------------------
+// GET / - List components
+// -----------------------------------------------------------------------------
+
+componentsRouter.openapi(listComponentsRoute, async (c) => {
+  const { orgId } = c.req.valid('param');
+  const query = c.req.valid('query');
+  const repository = c.var.componentRepository;
+
+  const result = await repository.findMany(orgId, {
+    where: {
+      framework: query.framework,
+      visibility: query.visibility,
+      embeddingStatus: query.embeddingStatus,
+    },
+    limit: query.limit,
+    offset: query.offset,
+    orderBy: query.orderBy,
+    orderDir: query.order,
+  });
+
+  return c.json(
+    {
+      success: true as const,
+      data: {
+        components: result.components.map(formatComponentSummary),
+        total: result.total,
+        limit: query.limit,
+        offset: query.offset,
+      },
+    },
+    200
+  );
+});
+
+// -----------------------------------------------------------------------------
+// GET /:id - Get component by ID
+// -----------------------------------------------------------------------------
+
+componentsRouter.openapi(getComponentByIdRoute, async (c) => {
+  const { orgId, id } = c.req.valid('param');
+  const repository = c.var.componentRepository;
+  const component = await repository.findById(orgId, id);
+
+  if (!component) {
+    throw NotFound('Component', id);
+  }
+
+  return c.json(
+    {
+      success: true as const,
+      data: formatComponent(component),
+    },
+    200
+  );
+});
+
+// -----------------------------------------------------------------------------
+// GET /slug/:slug - Get component by slug
+// -----------------------------------------------------------------------------
+
+componentsRouter.openapi(getComponentBySlugRoute, async (c) => {
+  const { orgId, slug } = c.req.valid('param');
+  const repository = c.var.componentRepository;
+  const component = await repository.findBySlug(orgId, slug);
+
+  if (!component) {
+    throw NotFound('Component', slug);
+  }
+
+  return c.json(
+    {
+      success: true as const,
+      data: formatComponent(component),
+    },
+    200
+  );
+});
+
+// -----------------------------------------------------------------------------
+// POST / - Create or upsert component
+// -----------------------------------------------------------------------------
+
+componentsRouter.openapi(createComponentRoute, async (c) => {
+  const { orgId } = c.req.valid('param');
+  const body = c.req.valid('json');
+  const repository = c.var.componentRepository;
+
+  // Check if component already exists by slug
+  const existing = await repository.findBySlug(orgId, body.slug);
+  const isCreate = !existing;
+
+  // Upsert the component
+  const component = await repository.upsert(orgId, body);
+
+  // Return 201 if created, 200 if updated
+  const status = isCreate ? 201 : 200;
+
+  return c.json(
+    {
+      success: true as const,
+      data: formatComponent(component),
+    },
+    status
+  );
+});
+
+// -----------------------------------------------------------------------------
+// PATCH /:id - Update component
+// -----------------------------------------------------------------------------
+
+componentsRouter.openapi(updateComponentRoute, async (c) => {
+  const { orgId, id } = c.req.valid('param');
+  const body = c.req.valid('json');
+  const repository = c.var.componentRepository;
+  const component = await repository.update(orgId, id, body);
+
+  if (!component) {
+    throw NotFound('Component', id);
+  }
+
+  return c.json(
+    {
+      success: true as const,
+      data: formatComponent(component),
+    },
+    200
+  );
+});
+
+// -----------------------------------------------------------------------------
+// DELETE /:id - Delete component
+// -----------------------------------------------------------------------------
+
+componentsRouter.openapi(deleteComponentRoute, async (c) => {
+  const { orgId, id } = c.req.valid('param');
+  const repository = c.var.componentRepository;
+  const deleted = await repository.delete(orgId, id);
+
+  if (!deleted) {
+    throw NotFound('Component', id);
+  }
+
+  return c.json(
+    {
+      success: true as const,
+      data: {
+        deleted: true,
+      },
+    },
+    200
+  );
+});

--- a/packages/context-engine/server/src/routes/components.ts
+++ b/packages/context-engine/server/src/routes/components.ts
@@ -6,9 +6,10 @@
  */
 
 import type { Component, NewComponent } from '@context-engine/db';
+import type { z } from '@hono/zod-openapi';
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
 
-import { NotFound, ServiceUnavailable, ValidationError } from '../errors.js';
+import { notFound, serviceUnavailable, validationError } from '../errors.js';
 import { ErrorSchema } from '../schemas/common.js';
 import {
   ComponentIdParamSchema,
@@ -23,40 +24,64 @@ import {
 } from '../schemas/components.js';
 import { OrgIdPathParamSchema } from '../schemas/organizations.js';
 import type { AppEnv } from '../types.js';
-import { successResponse } from '../utils/index.js';
+import { formatDates, successResponse } from '../utils/index.js';
 
 // =============================================================================
-// Type Helpers
+// Body → Repository Mappers
 // =============================================================================
 
 /**
- * Create component data type (excludes orgId which is added by repository).
+ * Map validated create body to repository input.
  *
- * The Zod schema uses z.record(z.any()) for flexibility, but the repository
- * expects typed data. This type assertion bridges the API schema and DB types.
+ * Explicit field mapping ensures compile-time safety: if the Zod schema
+ * or DB types diverge, TypeScript will error on the specific field.
+ * JSONB fields use `as` casts because the API intentionally accepts
+ * arbitrary JSON that the pipeline will later validate.
  */
-type CreateComponentData = Omit<NewComponent, 'orgId'>;
+function toCreateData(
+  body: z.infer<typeof CreateComponentSchema>
+): Omit<NewComponent, 'orgId'> {
+  return {
+    slug: body.slug,
+    name: body.name,
+    framework: body.framework,
+    version: body.version,
+    visibility: body.visibility,
+    sourceHash: body.sourceHash,
+    extraction: body.extraction as NewComponent['extraction'],
+    generation: body.generation as NewComponent['generation'],
+    generationProvider: body.generationProvider,
+    generationModel: body.generationModel,
+    manifest: body.manifest as NewComponent['manifest'],
+  };
+}
 
 /**
- * Update component data type.
+ * Map validated update body to repository input.
+ *
+ * Drizzle ignores `undefined` values in `.set()`, so we can map all
+ * fields directly — only fields present in the request body will be
+ * included in the SQL UPDATE.
  */
-type UpdateComponentData = Partial<Omit<NewComponent, 'id' | 'orgId'>>;
+function toUpdateData(
+  body: z.infer<typeof UpdateComponentSchema>
+): Partial<Omit<NewComponent, 'id' | 'orgId'>> {
+  return {
+    name: body.name,
+    version: body.version,
+    visibility: body.visibility,
+    sourceHash: body.sourceHash,
+    extraction: body.extraction as NewComponent['extraction'],
+    generation: body.generation as NewComponent['generation'],
+    generationProvider: body.generationProvider,
+    generationModel: body.generationModel,
+    manifest: body.manifest as NewComponent['manifest'],
+  };
+}
 
 // =============================================================================
 // Helper Functions
 // =============================================================================
-
-/**
- * Format a component for API response.
- * Converts Date objects to ISO strings.
- */
-function formatComponent(component: Component) {
-  return {
-    ...component,
-    createdAt: component.createdAt.toISOString(),
-    updatedAt: component.updatedAt.toISOString(),
-  };
-}
 
 /**
  * Format a component summary for list responses.
@@ -461,10 +486,10 @@ componentsRouter.openapi(getComponentByIdRoute, async (c) => {
   const component = await repository.findById(orgId, id);
 
   if (!component) {
-    throw NotFound('Component', id);
+    throw notFound('Component', id);
   }
 
-  return c.json(successResponse(formatComponent(component)), 200);
+  return c.json(successResponse(formatDates(component)), 200);
 });
 
 // -----------------------------------------------------------------------------
@@ -477,10 +502,10 @@ componentsRouter.openapi(getComponentBySlugRoute, async (c) => {
   const component = await repository.findBySlug(orgId, slug);
 
   if (!component) {
-    throw NotFound('Component', slug);
+    throw notFound('Component', slug);
   }
 
-  return c.json(successResponse(formatComponent(component)), 200);
+  return c.json(successResponse(formatDates(component)), 200);
 });
 
 // -----------------------------------------------------------------------------
@@ -497,16 +522,12 @@ componentsRouter.openapi(createComponentRoute, async (c) => {
   const isCreate = !existing;
 
   // Upsert the component
-  // Cast body to match repository expected type - Zod schema validates structure
-  const component = await repository.upsert(
-    orgId,
-    body as unknown as CreateComponentData
-  );
+  const component = await repository.upsert(orgId, toCreateData(body));
 
   // Return 201 if created, 200 if updated
   const status = isCreate ? 201 : 200;
 
-  return c.json(successResponse(formatComponent(component)), status);
+  return c.json(successResponse(formatDates(component)), status);
 });
 
 // -----------------------------------------------------------------------------
@@ -518,18 +539,13 @@ componentsRouter.openapi(updateComponentRoute, async (c) => {
   const body = c.req.valid('json');
   const repository = c.var.componentRepo;
 
-  // Cast body to match repository expected type - Zod schema validates structure
-  const component = await repository.update(
-    orgId,
-    id,
-    body as unknown as UpdateComponentData
-  );
+  const component = await repository.update(orgId, id, toUpdateData(body));
 
   if (!component) {
-    throw NotFound('Component', id);
+    throw notFound('Component', id);
   }
 
-  return c.json(successResponse(formatComponent(component)), 200);
+  return c.json(successResponse(formatDates(component)), 200);
 });
 
 // -----------------------------------------------------------------------------
@@ -542,7 +558,7 @@ componentsRouter.openapi(deleteComponentRoute, async (c) => {
   const deleted = await repository.delete(orgId, id);
 
   if (!deleted) {
-    throw NotFound('Component', id);
+    throw notFound('Component', id);
   }
 
   return c.json(successResponse({ deleted: true }), 200);
@@ -559,7 +575,7 @@ componentsRouter.openapi(indexComponentRoute, async (c) => {
 
   // Check if embedding service is available
   if (!embeddingRepo) {
-    throw ServiceUnavailable(
+    throw serviceUnavailable(
       'Embedding service unavailable',
       'VOYAGE_API_KEY not configured'
     );
@@ -568,12 +584,12 @@ componentsRouter.openapi(indexComponentRoute, async (c) => {
   // Get component
   const component = await componentRepo.findById(orgId, id);
   if (!component) {
-    throw NotFound('Component', id);
+    throw notFound('Component', id);
   }
 
   // Check if component has manifest
   if (!component.manifest) {
-    throw ValidationError(
+    throw validationError(
       'Component has no manifest',
       'Generate manifest before indexing'
     );
@@ -583,7 +599,7 @@ componentsRouter.openapi(indexComponentRoute, async (c) => {
   const result = await embeddingRepo.index(orgId, id, component.manifest);
 
   if (!result.success) {
-    throw ServiceUnavailable('Embedding generation failed', result.error);
+    throw serviceUnavailable('Embedding generation failed', result.error);
   }
 
   return c.json(

--- a/packages/context-engine/server/src/routes/health.ts
+++ b/packages/context-engine/server/src/routes/health.ts
@@ -1,0 +1,71 @@
+/**
+ * Health Routes
+ *
+ * Health and readiness check endpoints for the Context Engine server.
+ * These endpoints are used by orchestration systems (Kubernetes, load balancers)
+ * to determine server availability.
+ */
+
+import { checkHealth } from '@context-engine/db';
+import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
+
+import { getConfig } from '../config.js';
+import { SERVER_VERSION } from '../index.js';
+import { HealthSchema, ReadySchema } from '../schemas/index.js';
+
+export const healthRouter = new OpenAPIHono();
+
+// =============================================================================
+// GET /health - Liveness Check
+// =============================================================================
+
+const healthRoute = createRoute({
+  method: 'get',
+  path: '/health',
+  tags: ['Health'],
+  summary: 'Health check',
+  description: 'Returns server health status. Use for liveness probes.',
+  responses: {
+    200: {
+      content: { 'application/json': { schema: HealthSchema } },
+      description: 'Server is healthy',
+    },
+  },
+});
+
+healthRouter.openapi(healthRoute, (c) => {
+  const config = getConfig();
+  return c.json({
+    status: 'ok' as const,
+    version: SERVER_VERSION,
+    environment: config.environment,
+  });
+});
+
+// =============================================================================
+// GET /ready - Readiness Check
+// =============================================================================
+
+const readyRoute = createRoute({
+  method: 'get',
+  path: '/ready',
+  tags: ['Health'],
+  summary: 'Readiness check',
+  description:
+    'Returns whether server is ready to accept requests. Checks database connectivity. Use for readiness probes.',
+  responses: {
+    200: {
+      content: { 'application/json': { schema: ReadySchema } },
+      description: 'Readiness status',
+    },
+  },
+});
+
+healthRouter.openapi(readyRoute, async (c) => {
+  const dbHealthy = await checkHealth();
+
+  return c.json({
+    ready: dbHealthy,
+    database: dbHealthy ? ('ok' as const) : ('error' as const),
+  });
+});

--- a/packages/context-engine/server/src/routes/health.ts
+++ b/packages/context-engine/server/src/routes/health.ts
@@ -10,7 +10,7 @@ import { checkHealth } from '@context-engine/db';
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
 
 import { getConfig } from '../config.js';
-import { SERVER_VERSION } from '../index.js';
+import { SERVER_VERSION } from '../constants.js';
 import { HealthSchema, ReadySchema } from '../schemas/index.js';
 
 export const healthRouter = new OpenAPIHono();
@@ -56,16 +56,24 @@ const readyRoute = createRoute({
   responses: {
     200: {
       content: { 'application/json': { schema: ReadySchema } },
-      description: 'Readiness status',
+      description: 'Server is ready',
+    },
+    503: {
+      content: { 'application/json': { schema: ReadySchema } },
+      description: 'Server is not ready (database unavailable)',
     },
   },
 });
 
 healthRouter.openapi(readyRoute, async (c) => {
   const dbHealthy = await checkHealth();
+  const status = dbHealthy ? 200 : 503;
 
-  return c.json({
-    ready: dbHealthy,
-    database: dbHealthy ? ('ok' as const) : ('error' as const),
-  });
+  return c.json(
+    {
+      ready: dbHealthy,
+      database: dbHealthy ? 'ok' : 'error',
+    },
+    status
+  );
 });

--- a/packages/context-engine/server/src/routes/index.ts
+++ b/packages/context-engine/server/src/routes/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Routes Index
+ *
+ * Re-exports all route modules for clean imports.
+ */
+
+export { componentsRouter } from './components.js';
+export { healthRouter } from './health.js';
+export { organizationsRouter } from './organizations.js';
+export { searchRouter } from './search.js';

--- a/packages/context-engine/server/src/routes/organizations.ts
+++ b/packages/context-engine/server/src/routes/organizations.ts
@@ -1,0 +1,283 @@
+/**
+ * Organizations Routes
+ *
+ * CRUD endpoints for organization management.
+ * Organizations are the top-level multi-tenant entity in Context Engine.
+ */
+
+import type { Organization as DbOrganization } from '@context-engine/db';
+import { createOrganizationRepository } from '@context-engine/db';
+import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
+
+import { NotFound } from '../errors.js';
+import {
+  CreateOrganizationSchema,
+  DeleteOrganizationResponseSchema,
+  ErrorSchema,
+  OrganizationListSchema,
+  OrganizationResponseSchema,
+  OrgIdParamSchema,
+  UpdateOrganizationSchema,
+} from '../schemas/index.js';
+
+// =============================================================================
+// Router Setup
+// =============================================================================
+
+export const organizationsRouter = new OpenAPIHono();
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Format organization for API response.
+ * Converts Date objects to ISO strings.
+ */
+function formatOrganization(org: DbOrganization) {
+  return {
+    id: org.id,
+    name: org.name,
+    createdAt: org.createdAt.toISOString(),
+    updatedAt: org.updatedAt.toISOString(),
+  };
+}
+
+// =============================================================================
+// Route Definitions
+// =============================================================================
+
+const listOrganizationsRoute = createRoute({
+  method: 'get',
+  path: '/',
+  tags: ['Organizations'],
+  summary: 'List all organizations',
+  description: 'Retrieve a list of all organizations.',
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: OrganizationListSchema,
+        },
+      },
+      description: 'List of organizations',
+    },
+  },
+});
+
+const getOrganizationRoute = createRoute({
+  method: 'get',
+  path: '/{id}',
+  tags: ['Organizations'],
+  summary: 'Get organization by ID',
+  description: 'Retrieve a single organization by its UUID.',
+  request: {
+    params: OrgIdParamSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: OrganizationResponseSchema,
+        },
+      },
+      description: 'Organization found',
+    },
+    404: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Organization not found',
+    },
+  },
+});
+
+const createOrganizationRoute = createRoute({
+  method: 'post',
+  path: '/',
+  tags: ['Organizations'],
+  summary: 'Create organization',
+  description: 'Create a new organization.',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: CreateOrganizationSchema,
+        },
+      },
+      required: true,
+    },
+  },
+  responses: {
+    201: {
+      content: {
+        'application/json': {
+          schema: OrganizationResponseSchema,
+        },
+      },
+      description: 'Organization created',
+    },
+  },
+});
+
+const updateOrganizationRoute = createRoute({
+  method: 'patch',
+  path: '/{id}',
+  tags: ['Organizations'],
+  summary: 'Update organization',
+  description: 'Update an existing organization. All fields are optional.',
+  request: {
+    params: OrgIdParamSchema,
+    body: {
+      content: {
+        'application/json': {
+          schema: UpdateOrganizationSchema,
+        },
+      },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: OrganizationResponseSchema,
+        },
+      },
+      description: 'Organization updated',
+    },
+    404: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Organization not found',
+    },
+  },
+});
+
+const deleteOrganizationRoute = createRoute({
+  method: 'delete',
+  path: '/{id}',
+  tags: ['Organizations'],
+  summary: 'Delete organization',
+  description:
+    'Delete an organization by ID. Will fail if organization has associated components.',
+  request: {
+    params: OrgIdParamSchema,
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: DeleteOrganizationResponseSchema,
+        },
+      },
+      description: 'Organization deleted',
+    },
+    404: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Organization not found',
+    },
+  },
+});
+
+// =============================================================================
+// Route Handlers
+// =============================================================================
+
+organizationsRouter.openapi(listOrganizationsRoute, async (c) => {
+  const repo = createOrganizationRepository();
+  const organizations = await repo.findAll();
+
+  return c.json(
+    {
+      success: true as const,
+      data: {
+        organizations: organizations.map(formatOrganization),
+        total: organizations.length,
+      },
+    },
+    200
+  );
+});
+
+organizationsRouter.openapi(getOrganizationRoute, async (c) => {
+  const { id } = c.req.valid('param');
+  const repo = createOrganizationRepository();
+  const org = await repo.findById(id);
+
+  if (!org) {
+    throw NotFound('Organization', id);
+  }
+
+  return c.json(
+    {
+      success: true as const,
+      data: formatOrganization(org),
+    },
+    200
+  );
+});
+
+organizationsRouter.openapi(createOrganizationRoute, async (c) => {
+  const body = c.req.valid('json');
+  const repo = createOrganizationRepository();
+  const org = await repo.create({ name: body.name });
+
+  return c.json(
+    {
+      success: true as const,
+      data: formatOrganization(org),
+    },
+    201
+  );
+});
+
+organizationsRouter.openapi(updateOrganizationRoute, async (c) => {
+  const { id } = c.req.valid('param');
+  const body = c.req.valid('json');
+  const repo = createOrganizationRepository();
+
+  const org = await repo.update(id, body);
+
+  if (!org) {
+    throw NotFound('Organization', id);
+  }
+
+  return c.json(
+    {
+      success: true as const,
+      data: formatOrganization(org),
+    },
+    200
+  );
+});
+
+organizationsRouter.openapi(deleteOrganizationRoute, async (c) => {
+  const { id } = c.req.valid('param');
+  const repo = createOrganizationRepository();
+
+  const deleted = await repo.delete(id);
+
+  if (!deleted) {
+    throw NotFound('Organization', id);
+  }
+
+  return c.json(
+    {
+      success: true as const,
+      data: {
+        deleted: true,
+      },
+    },
+    200
+  );
+});

--- a/packages/context-engine/server/src/routes/organizations.ts
+++ b/packages/context-engine/server/src/routes/organizations.ts
@@ -7,7 +7,7 @@
 
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
 
-import { NotFound } from '../errors.js';
+import { ApiError, conflict, notFound } from '../errors.js';
 import {
   CreateOrganizationSchema,
   DeleteOrganizationResponseSchema,
@@ -15,6 +15,7 @@ import {
   OrganizationListSchema,
   OrganizationResponseSchema,
   OrgIdParamSchema,
+  PaginationQuerySchema,
   UpdateOrganizationSchema,
 } from '../schemas/index.js';
 import type { AppEnv } from '../types.js';
@@ -41,7 +42,10 @@ const listOrganizationsRoute = createRoute({
   path: '/',
   tags: ['Organizations'],
   summary: 'List all organizations',
-  description: 'Retrieve a list of all organizations.',
+  description: 'Retrieve a paginated list of all organizations.',
+  request: {
+    query: PaginationQuerySchema,
+  },
   responses: {
     200: {
       content: {
@@ -175,6 +179,14 @@ const deleteOrganizationRoute = createRoute({
       },
       description: 'Organization not found',
     },
+    409: {
+      content: {
+        'application/json': {
+          schema: ErrorSchema,
+        },
+      },
+      description: 'Cannot delete organization with existing components',
+    },
   },
 });
 
@@ -184,12 +196,18 @@ const deleteOrganizationRoute = createRoute({
 
 organizationsRouter.openapi(listOrganizationsRoute, async (c) => {
   const repo = c.var.organizationRepo;
-  const organizations = await repo.findAll();
+  const query = c.req.valid('query');
+  const all = await repo.findAll();
+
+  // Apply pagination in-memory (repo returns all)
+  const paginated = all.slice(query.offset, query.offset + query.limit);
 
   return c.json(
     successResponse({
-      organizations: organizations.map(formatDates),
-      total: organizations.length,
+      organizations: paginated.map(formatDates),
+      total: all.length,
+      limit: query.limit,
+      offset: query.offset,
     }),
     200
   );
@@ -201,7 +219,7 @@ organizationsRouter.openapi(getOrganizationRoute, async (c) => {
   const org = await repo.findById(id);
 
   if (!org) {
-    throw NotFound('Organization', id);
+    throw notFound('Organization', id);
   }
 
   return c.json(successResponse(formatDates(org)), 200);
@@ -223,7 +241,7 @@ organizationsRouter.openapi(updateOrganizationRoute, async (c) => {
   const org = await repo.update(id, body);
 
   if (!org) {
-    throw NotFound('Organization', id);
+    throw notFound('Organization', id);
   }
 
   return c.json(successResponse(formatDates(org)), 200);
@@ -233,11 +251,26 @@ organizationsRouter.openapi(deleteOrganizationRoute, async (c) => {
   const { id } = c.req.valid('param');
   const repo = c.var.organizationRepo;
 
-  const deleted = await repo.delete(id);
+  try {
+    const deleted = await repo.delete(id);
 
-  if (!deleted) {
-    throw NotFound('Organization', id);
+    if (!deleted) {
+      throw notFound('Organization', id);
+    }
+
+    return c.json(successResponse({ deleted: true }), 200);
+  } catch (err) {
+    // Re-throw our own API errors
+    if (err instanceof ApiError) throw err;
+
+    // Handle FK constraint violation (PostgreSQL error code 23503)
+    const pgError = err as { code?: string };
+    if (pgError.code === '23503') {
+      throw conflict(
+        'Cannot delete organization with existing components. Delete all components first.'
+      );
+    }
+
+    throw err;
   }
-
-  return c.json(successResponse({ deleted: true }), 200);
 });

--- a/packages/context-engine/server/src/routes/organizations.ts
+++ b/packages/context-engine/server/src/routes/organizations.ts
@@ -5,8 +5,6 @@
  * Organizations are the top-level multi-tenant entity in Context Engine.
  */
 
-import type { Organization as DbOrganization } from '@context-engine/db';
-import { createOrganizationRepository } from '@context-engine/db';
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
 
 import { NotFound } from '../errors.js';
@@ -19,29 +17,20 @@ import {
   OrgIdParamSchema,
   UpdateOrganizationSchema,
 } from '../schemas/index.js';
+import type { AppEnv } from '../types.js';
+import { formatDates, successResponse } from '../utils/index.js';
 
 // =============================================================================
 // Router Setup
 // =============================================================================
 
-export const organizationsRouter = new OpenAPIHono();
-
-// =============================================================================
-// Helpers
-// =============================================================================
-
 /**
- * Format organization for API response.
- * Converts Date objects to ISO strings.
+ * Organizations router.
+ *
+ * Requires repositories middleware to be applied at app level.
+ * Access organization repository via `c.var.organizationRepo`.
  */
-function formatOrganization(org: DbOrganization) {
-  return {
-    id: org.id,
-    name: org.name,
-    createdAt: org.createdAt.toISOString(),
-    updatedAt: org.updatedAt.toISOString(),
-  };
-}
+export const organizationsRouter = new OpenAPIHono<AppEnv>();
 
 // =============================================================================
 // Route Definitions
@@ -194,57 +183,42 @@ const deleteOrganizationRoute = createRoute({
 // =============================================================================
 
 organizationsRouter.openapi(listOrganizationsRoute, async (c) => {
-  const repo = createOrganizationRepository();
+  const repo = c.var.organizationRepo;
   const organizations = await repo.findAll();
 
   return c.json(
-    {
-      success: true as const,
-      data: {
-        organizations: organizations.map(formatOrganization),
-        total: organizations.length,
-      },
-    },
+    successResponse({
+      organizations: organizations.map(formatDates),
+      total: organizations.length,
+    }),
     200
   );
 });
 
 organizationsRouter.openapi(getOrganizationRoute, async (c) => {
   const { id } = c.req.valid('param');
-  const repo = createOrganizationRepository();
+  const repo = c.var.organizationRepo;
   const org = await repo.findById(id);
 
   if (!org) {
     throw NotFound('Organization', id);
   }
 
-  return c.json(
-    {
-      success: true as const,
-      data: formatOrganization(org),
-    },
-    200
-  );
+  return c.json(successResponse(formatDates(org)), 200);
 });
 
 organizationsRouter.openapi(createOrganizationRoute, async (c) => {
   const body = c.req.valid('json');
-  const repo = createOrganizationRepository();
+  const repo = c.var.organizationRepo;
   const org = await repo.create({ name: body.name });
 
-  return c.json(
-    {
-      success: true as const,
-      data: formatOrganization(org),
-    },
-    201
-  );
+  return c.json(successResponse(formatDates(org)), 201);
 });
 
 organizationsRouter.openapi(updateOrganizationRoute, async (c) => {
   const { id } = c.req.valid('param');
   const body = c.req.valid('json');
-  const repo = createOrganizationRepository();
+  const repo = c.var.organizationRepo;
 
   const org = await repo.update(id, body);
 
@@ -252,18 +226,12 @@ organizationsRouter.openapi(updateOrganizationRoute, async (c) => {
     throw NotFound('Organization', id);
   }
 
-  return c.json(
-    {
-      success: true as const,
-      data: formatOrganization(org),
-    },
-    200
-  );
+  return c.json(successResponse(formatDates(org)), 200);
 });
 
 organizationsRouter.openapi(deleteOrganizationRoute, async (c) => {
   const { id } = c.req.valid('param');
-  const repo = createOrganizationRepository();
+  const repo = c.var.organizationRepo;
 
   const deleted = await repo.delete(id);
 
@@ -271,13 +239,5 @@ organizationsRouter.openapi(deleteOrganizationRoute, async (c) => {
     throw NotFound('Organization', id);
   }
 
-  return c.json(
-    {
-      success: true as const,
-      data: {
-        deleted: true,
-      },
-    },
-    200
-  );
+  return c.json(successResponse({ deleted: true }), 200);
 });

--- a/packages/context-engine/server/src/routes/organizations.ts
+++ b/packages/context-engine/server/src/routes/organizations.ts
@@ -197,15 +197,16 @@ const deleteOrganizationRoute = createRoute({
 organizationsRouter.openapi(listOrganizationsRoute, async (c) => {
   const repo = c.var.organizationRepo;
   const query = c.req.valid('query');
-  const all = await repo.findAll();
 
-  // Apply pagination in-memory (repo returns all)
-  const paginated = all.slice(query.offset, query.offset + query.limit);
+  const result = await repo.findMany({
+    limit: query.limit,
+    offset: query.offset,
+  });
 
   return c.json(
     successResponse({
-      organizations: paginated.map(formatDates),
-      total: all.length,
+      organizations: result.organizations.map(formatDates),
+      total: result.total,
       limit: query.limit,
       offset: query.offset,
     }),

--- a/packages/context-engine/server/src/routes/search.ts
+++ b/packages/context-engine/server/src/routes/search.ts
@@ -1,0 +1,132 @@
+/**
+ * Search Routes
+ *
+ * Semantic search endpoint for finding components using natural language queries.
+ * Powers AI assistants to discover relevant components from the component library.
+ */
+
+import {
+  ComponentRepository,
+  createEmbeddingRepository,
+  getDatabase,
+} from '@context-engine/db';
+import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
+
+import { ServiceUnavailable } from '../errors.js';
+import {
+  ErrorSchema,
+  SearchParamsSchema,
+  SearchRequestSchema,
+  SearchResponseSchema,
+  type SearchResult,
+} from '../schemas/index.js';
+
+export const searchRouter = new OpenAPIHono();
+
+// =============================================================================
+// POST / - Semantic Search
+// =============================================================================
+
+const searchRoute = createRoute({
+  method: 'post',
+  path: '/',
+  tags: ['Search'],
+  summary: 'Search components',
+  description:
+    'Semantic search for components using natural language queries. Requires VOYAGE_API_KEY to be configured for embedding generation.',
+  request: {
+    params: SearchParamsSchema,
+    body: {
+      content: {
+        'application/json': {
+          schema: SearchRequestSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: { 'application/json': { schema: SearchResponseSchema } },
+      description: 'Search results ordered by relevance',
+    },
+    503: {
+      content: { 'application/json': { schema: ErrorSchema } },
+      description: 'Search service unavailable (VOYAGE_API_KEY not configured)',
+    },
+  },
+});
+
+searchRouter.openapi(searchRoute, async (c) => {
+  const { orgId } = c.req.valid('param');
+  const body = c.req.valid('json');
+
+  // Perform semantic search using embedding repository
+  // Note: createEmbeddingRepository() will throw if VOYAGE_API_KEY is not set
+  let embeddingRepo;
+  try {
+    embeddingRepo = createEmbeddingRepository();
+  } catch (error) {
+    // VOYAGE_API_KEY not configured
+    throw ServiceUnavailable(
+      'Search service unavailable',
+      error instanceof Error ? error.message : undefined
+    );
+  }
+
+  const results = await embeddingRepo.search(orgId, body.query, {
+    limit: body.limit,
+    minScore: body.minScore,
+    framework: body.framework,
+  });
+
+  // Build response with framework information
+  // Note: The db SearchResult type doesn't include framework, but the schema requires it.
+  // When a framework filter is provided, all results have that framework.
+  // Otherwise, we fetch each component's framework (bounded by search limit).
+  let resultsWithFramework: SearchResult[];
+
+  if (body.framework) {
+    // If filtered by framework, all results have that framework
+    const framework = body.framework; // Capture to avoid type narrowing issues
+    resultsWithFramework = results.map((r) => ({
+      componentId: r.componentId,
+      slug: r.slug,
+      name: r.name,
+      description: r.description,
+      framework,
+      score: r.score,
+    }));
+  } else if (results.length > 0) {
+    // Fetch component frameworks individually
+    // This is bounded by the search limit (max 50), so acceptable for now.
+    // TODO: Optimize by updating db SearchResult to include framework.
+    const componentRepo = new ComponentRepository(getDatabase());
+    resultsWithFramework = await Promise.all(
+      results.map(async (r) => {
+        const component = await componentRepo.findById(orgId, r.componentId);
+        return {
+          componentId: r.componentId,
+          slug: r.slug,
+          name: r.name,
+          description: r.description,
+          framework: component?.framework ?? 'react',
+          score: r.score,
+        };
+      })
+    );
+  } else {
+    resultsWithFramework = [];
+  }
+
+  return c.json(
+    {
+      success: true as const,
+      data: {
+        results: resultsWithFramework,
+        total: resultsWithFramework.length,
+        query: body.query,
+      },
+    },
+    200 as const
+  );
+});

--- a/packages/context-engine/server/src/routes/search.ts
+++ b/packages/context-engine/server/src/routes/search.ts
@@ -5,11 +5,6 @@
  * Powers AI assistants to discover relevant components from the component library.
  */
 
-import {
-  ComponentRepository,
-  createEmbeddingRepository,
-  getDatabase,
-} from '@context-engine/db';
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
 
 import { ServiceUnavailable } from '../errors.js';
@@ -20,8 +15,18 @@ import {
   SearchResponseSchema,
   type SearchResult,
 } from '../schemas/index.js';
+import type { AppEnv } from '../types.js';
+import { successResponse } from '../utils/index.js';
 
-export const searchRouter = new OpenAPIHono();
+/**
+ * Search router.
+ *
+ * Requires repositories middleware to be applied at app level.
+ * Access embedding repository via `c.var.embeddingRepo`.
+ *
+ * Note: embeddingRepo is undefined if VOYAGE_API_KEY is not configured.
+ */
+export const searchRouter = new OpenAPIHono<AppEnv>();
 
 // =============================================================================
 // POST / - Semantic Search
@@ -60,16 +65,14 @@ searchRouter.openapi(searchRoute, async (c) => {
   const { orgId } = c.req.valid('param');
   const body = c.req.valid('json');
 
-  // Perform semantic search using embedding repository
-  // Note: createEmbeddingRepository() will throw if VOYAGE_API_KEY is not set
-  let embeddingRepo;
-  try {
-    embeddingRepo = createEmbeddingRepository();
-  } catch (error) {
-    // VOYAGE_API_KEY not configured
+  // Get embedding repository from context
+  // Note: embeddingRepo is undefined if VOYAGE_API_KEY is not configured
+  const embeddingRepo = c.var.embeddingRepo;
+
+  if (!embeddingRepo) {
     throw ServiceUnavailable(
       'Search service unavailable',
-      error instanceof Error ? error.message : undefined
+      'VOYAGE_API_KEY environment variable is not configured'
     );
   }
 
@@ -79,54 +82,22 @@ searchRouter.openapi(searchRoute, async (c) => {
     framework: body.framework,
   });
 
-  // Build response with framework information
-  // Note: The db SearchResult type doesn't include framework, but the schema requires it.
-  // When a framework filter is provided, all results have that framework.
-  // Otherwise, we fetch each component's framework (bounded by search limit).
-  let resultsWithFramework: SearchResult[];
-
-  if (body.framework) {
-    // If filtered by framework, all results have that framework
-    const framework = body.framework; // Capture to avoid type narrowing issues
-    resultsWithFramework = results.map((r) => ({
-      componentId: r.componentId,
-      slug: r.slug,
-      name: r.name,
-      description: r.description,
-      framework,
-      score: r.score,
-    }));
-  } else if (results.length > 0) {
-    // Fetch component frameworks individually
-    // This is bounded by the search limit (max 50), so acceptable for now.
-    // TODO: Optimize by updating db SearchResult to include framework.
-    const componentRepo = new ComponentRepository(getDatabase());
-    resultsWithFramework = await Promise.all(
-      results.map(async (r) => {
-        const component = await componentRepo.findById(orgId, r.componentId);
-        return {
-          componentId: r.componentId,
-          slug: r.slug,
-          name: r.name,
-          description: r.description,
-          framework: component?.framework ?? 'react',
-          score: r.score,
-        };
-      })
-    );
-  } else {
-    resultsWithFramework = [];
-  }
+  // Map results to response format
+  const resultsWithFramework: SearchResult[] = results.map((r) => ({
+    componentId: r.componentId,
+    slug: r.slug,
+    name: r.name,
+    description: r.description,
+    framework: r.framework,
+    score: r.score,
+  }));
 
   return c.json(
-    {
-      success: true as const,
-      data: {
-        results: resultsWithFramework,
-        total: resultsWithFramework.length,
-        query: body.query,
-      },
-    },
+    successResponse({
+      results: resultsWithFramework,
+      total: resultsWithFramework.length,
+      query: body.query,
+    }),
     200 as const
   );
 });

--- a/packages/context-engine/server/src/routes/search.ts
+++ b/packages/context-engine/server/src/routes/search.ts
@@ -7,7 +7,7 @@
 
 import { createRoute, OpenAPIHono } from '@hono/zod-openapi';
 
-import { ServiceUnavailable } from '../errors.js';
+import { serviceUnavailable } from '../errors.js';
 import {
   ErrorSchema,
   SearchParamsSchema,
@@ -47,6 +47,7 @@ const searchRoute = createRoute({
           schema: SearchRequestSchema,
         },
       },
+      required: true,
     },
   },
   responses: {
@@ -70,7 +71,7 @@ searchRouter.openapi(searchRoute, async (c) => {
   const embeddingRepo = c.var.embeddingRepo;
 
   if (!embeddingRepo) {
-    throw ServiceUnavailable(
+    throw serviceUnavailable(
       'Search service unavailable',
       'VOYAGE_API_KEY environment variable is not configured'
     );
@@ -98,6 +99,6 @@ searchRouter.openapi(searchRoute, async (c) => {
       total: resultsWithFramework.length,
       query: body.query,
     }),
-    200 as const
+    200
   );
 });

--- a/packages/context-engine/server/src/schemas/common.ts
+++ b/packages/context-engine/server/src/schemas/common.ts
@@ -1,0 +1,157 @@
+/**
+ * Common Schemas
+ *
+ * Shared schemas for error responses, health checks, and common patterns.
+ * These are reusable across all API endpoints.
+ */
+
+import { z } from '@hono/zod-openapi';
+
+// =============================================================================
+// Error Schemas
+// =============================================================================
+
+/**
+ * Standard error response schema.
+ * All API errors follow this structure for consistent AI consumption.
+ */
+export const ErrorSchema = z
+  .object({
+    success: z.literal(false).openapi({
+      example: false,
+      description: 'Always false for error responses',
+    }),
+    error: z.object({
+      code: z.string().openapi({
+        example: 'NOT_FOUND',
+        description: 'Machine-readable error code for programmatic handling',
+      }),
+      message: z.string().openapi({
+        example: 'Resource not found',
+        description: 'Human/AI-readable error explanation',
+      }),
+      details: z.any().optional().openapi({
+        description: 'Additional context for error recovery',
+      }),
+    }),
+  })
+  .openapi('Error');
+
+/**
+ * Validation error detail schema.
+ * Used when request validation fails to provide field-level feedback.
+ */
+export const ValidationErrorDetailSchema = z
+  .object({
+    field: z.string().openapi({
+      example: 'name',
+      description: 'The field that failed validation',
+    }),
+    message: z.string().openapi({
+      example: 'Required field is missing',
+      description: 'What went wrong with this field',
+    }),
+  })
+  .openapi('ValidationErrorDetail');
+
+// =============================================================================
+// Health Check Schemas
+// =============================================================================
+
+/**
+ * Health check response schema.
+ * Basic liveness probe - server is running.
+ */
+export const HealthSchema = z
+  .object({
+    status: z.enum(['ok', 'degraded', 'error']).openapi({
+      example: 'ok',
+      description: 'Current health status',
+    }),
+    version: z.string().openapi({
+      example: '0.1.0',
+      description: 'Server version',
+    }),
+    environment: z.string().openapi({
+      example: 'development',
+      description: 'Runtime environment',
+    }),
+  })
+  .openapi('Health');
+
+/**
+ * Readiness check response schema.
+ * Readiness probe - server can handle requests (database connected).
+ */
+export const ReadySchema = z
+  .object({
+    ready: z.boolean().openapi({
+      example: true,
+      description: 'Whether the server is ready to handle requests',
+    }),
+    database: z.enum(['ok', 'error']).openapi({
+      example: 'ok',
+      description: 'Database connection status',
+    }),
+  })
+  .openapi('Ready');
+
+// =============================================================================
+// Pagination Schemas
+// =============================================================================
+
+/**
+ * Pagination query parameters.
+ * Standard pagination for list endpoints.
+ */
+export const PaginationQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(50).openapi({
+    example: 50,
+    description: 'Maximum number of items to return (1-100)',
+  }),
+  offset: z.coerce.number().int().min(0).default(0).openapi({
+    example: 0,
+    description: 'Number of items to skip',
+  }),
+});
+
+/**
+ * Pagination metadata in responses.
+ */
+export const PaginationMetaSchema = z.object({
+  total: z.number().int().openapi({
+    example: 100,
+    description: 'Total number of items available',
+  }),
+  limit: z.number().int().openapi({
+    example: 50,
+    description: 'Number of items per page',
+  }),
+  offset: z.number().int().openapi({
+    example: 0,
+    description: 'Current offset',
+  }),
+});
+
+// =============================================================================
+// Success Response Wrapper
+// =============================================================================
+
+/**
+ * Creates a success response schema wrapping the provided data schema.
+ * Enforces the `{ success: true, data: T }` pattern.
+ */
+export function createSuccessResponse<T extends z.ZodTypeAny>(
+  dataSchema: T,
+  name: string
+) {
+  return z
+    .object({
+      success: z.literal(true).openapi({
+        example: true,
+        description: 'Always true for successful responses',
+      }),
+      data: dataSchema,
+    })
+    .openapi(name);
+}

--- a/packages/context-engine/server/src/schemas/common.ts
+++ b/packages/context-engine/server/src/schemas/common.ts
@@ -37,23 +37,6 @@ export const ErrorSchema = z
   })
   .openapi('Error');
 
-/**
- * Validation error detail schema.
- * Used when request validation fails to provide field-level feedback.
- */
-export const ValidationErrorDetailSchema = z
-  .object({
-    field: z.string().openapi({
-      example: 'name',
-      description: 'The field that failed validation',
-    }),
-    message: z.string().openapi({
-      example: 'Required field is missing',
-      description: 'What went wrong with this field',
-    }),
-  })
-  .openapi('ValidationErrorDetail');
-
 // =============================================================================
 // Health Check Schemas
 // =============================================================================

--- a/packages/context-engine/server/src/schemas/common.ts
+++ b/packages/context-engine/server/src/schemas/common.ts
@@ -132,26 +132,3 @@ export const PaginationMetaSchema = z.object({
     description: 'Current offset',
   }),
 });
-
-// =============================================================================
-// Success Response Wrapper
-// =============================================================================
-
-/**
- * Creates a success response schema wrapping the provided data schema.
- * Enforces the `{ success: true, data: T }` pattern.
- */
-export function createSuccessResponse<T extends z.ZodTypeAny>(
-  dataSchema: T,
-  name: string
-) {
-  return z
-    .object({
-      success: z.literal(true).openapi({
-        example: true,
-        description: 'Always true for successful responses',
-      }),
-      data: dataSchema,
-    })
-    .openapi(name);
-}

--- a/packages/context-engine/server/src/schemas/components.ts
+++ b/packages/context-engine/server/src/schemas/components.ts
@@ -1,0 +1,428 @@
+/**
+ * Component Schemas
+ *
+ * Request and response schemas for component CRUD operations.
+ * Components are the core entity storing extracted and generated metadata.
+ */
+
+import { z } from '@hono/zod-openapi';
+
+import { OrgIdPathParamSchema } from './organizations.js';
+
+// =============================================================================
+// Enums / Constants
+// =============================================================================
+
+/**
+ * Supported component frameworks.
+ */
+export const FrameworkEnum = z.enum(['react', 'vue', 'svelte', 'angular']);
+export type Framework = z.infer<typeof FrameworkEnum>;
+
+/**
+ * Component visibility levels.
+ */
+export const VisibilityEnum = z.enum(['private', 'org', 'public']);
+export type Visibility = z.infer<typeof VisibilityEnum>;
+
+/**
+ * Embedding status values.
+ */
+export const EmbeddingStatusEnum = z.enum([
+  'pending',
+  'processing',
+  'indexed',
+  'failed',
+]);
+export type EmbeddingStatus = z.infer<typeof EmbeddingStatusEnum>;
+
+// =============================================================================
+// Request Schemas
+// =============================================================================
+
+/**
+ * Create component request body.
+ *
+ * All pipeline outputs (extraction, generation, manifest) are required
+ * because the server stores pre-processed data from the CLI.
+ */
+export const CreateComponentSchema = z
+  .object({
+    slug: z
+      .string()
+      .min(1, 'Slug is required')
+      .max(255, 'Slug must be 255 characters or less')
+      .regex(
+        /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
+        'Slug must be lowercase with hyphens only'
+      )
+      .openapi({
+        example: 'button',
+        description: 'URL-friendly component identifier (unique per org)',
+      }),
+    name: z
+      .string()
+      .min(1, 'Name is required')
+      .max(255, 'Name must be 255 characters or less')
+      .openapi({
+        example: 'Button',
+        description: 'Human-readable component name',
+      }),
+    framework: FrameworkEnum.default('react').openapi({
+      example: 'react',
+      description: 'Component framework',
+    }),
+    version: z.string().default('0.0.0').openapi({
+      example: '1.0.0',
+      description: 'Semantic version',
+    }),
+    visibility: VisibilityEnum.default('org').openapi({
+      example: 'org',
+      description: 'Component visibility level',
+    }),
+    sourceHash: z
+      .string()
+      .min(1, 'Source hash is required')
+      .max(64, 'Source hash must be 64 characters or less')
+      .openapi({
+        example: 'abc123def456789',
+        description: 'Hash of source code for change detection',
+      }),
+    extraction: z.record(z.any()).openapi({
+      example: {
+        props: [{ name: 'variant', type: 'string', required: false }],
+        variants: [],
+      },
+      description: 'Extracted component data (props, variants, dependencies)',
+    }),
+    generation: z.record(z.any()).openapi({
+      example: {
+        description: 'A clickable button component for user interactions',
+        patterns: ['form-submit', 'navigation'],
+      },
+      description: 'LLM-generated metadata (descriptions, patterns, guidance)',
+    }),
+    generationProvider: z
+      .string()
+      .min(1, 'Generation provider is required')
+      .openapi({
+        example: 'anthropic',
+        description: 'LLM provider used for generation',
+      }),
+    generationModel: z.string().min(1, 'Generation model is required').openapi({
+      example: 'claude-sonnet-4-20250514',
+      description: 'LLM model used for generation',
+    }),
+    manifest: z.record(z.any()).openapi({
+      example: {
+        name: 'Button',
+        description: 'A clickable button component',
+        props: [],
+      },
+      description: 'Complete AI manifest for consumption',
+    }),
+  })
+  .openapi('CreateComponent');
+
+/**
+ * Update component request body.
+ * All fields are optional for partial updates.
+ */
+export const UpdateComponentSchema = z
+  .object({
+    name: z
+      .string()
+      .min(1, 'Name cannot be empty')
+      .max(255, 'Name must be 255 characters or less')
+      .optional()
+      .openapi({
+        example: 'Button',
+        description: 'Human-readable component name',
+      }),
+    version: z.string().optional().openapi({
+      example: '1.1.0',
+      description: 'Semantic version',
+    }),
+    visibility: VisibilityEnum.optional().openapi({
+      example: 'public',
+      description: 'Component visibility level',
+    }),
+    sourceHash: z.string().min(1).max(64).optional().openapi({
+      example: 'def456abc789012',
+      description: 'Hash of source code for change detection',
+    }),
+    extraction: z.record(z.any()).optional().openapi({
+      description: 'Extracted component data (props, variants, dependencies)',
+    }),
+    generation: z.record(z.any()).optional().openapi({
+      description: 'LLM-generated metadata',
+    }),
+    generationProvider: z.string().min(1).optional().openapi({
+      example: 'anthropic',
+      description: 'LLM provider used for generation',
+    }),
+    generationModel: z.string().min(1).optional().openapi({
+      example: 'claude-sonnet-4-20250514',
+      description: 'LLM model used for generation',
+    }),
+    manifest: z.record(z.any()).optional().openapi({
+      description: 'Complete AI manifest for consumption',
+    }),
+  })
+  .openapi('UpdateComponent');
+
+/**
+ * List components query parameters.
+ */
+export const ListComponentsQuerySchema = z
+  .object({
+    framework: FrameworkEnum.optional().openapi({
+      description: 'Filter by framework',
+    }),
+    visibility: VisibilityEnum.optional().openapi({
+      description: 'Filter by visibility level',
+    }),
+    embeddingStatus: EmbeddingStatusEnum.optional().openapi({
+      description: 'Filter by embedding status',
+    }),
+    limit: z.coerce.number().int().min(1).max(100).default(50).openapi({
+      example: 50,
+      description: 'Maximum number of results (1-100)',
+    }),
+    offset: z.coerce.number().int().min(0).default(0).openapi({
+      example: 0,
+      description: 'Number of results to skip',
+    }),
+    orderBy: z
+      .enum(['name', 'createdAt', 'updatedAt'])
+      .default('name')
+      .openapi({
+        example: 'name',
+        description: 'Field to sort by',
+      }),
+    order: z.enum(['asc', 'desc']).default('asc').openapi({
+      example: 'asc',
+      description: 'Sort direction',
+    }),
+  })
+  .openapi('ListComponentsQuery');
+
+// =============================================================================
+// Response Schemas
+// =============================================================================
+
+/**
+ * Full component entity schema.
+ * Includes all fields for detailed views.
+ */
+export const ComponentSchema = z
+  .object({
+    id: z.string().uuid().openapi({
+      example: '123e4567-e89b-12d3-a456-426614174000',
+      description: 'Component UUID',
+    }),
+    orgId: z.string().uuid().openapi({
+      example: '123e4567-e89b-12d3-a456-426614174001',
+      description: 'Organization UUID',
+    }),
+    slug: z.string().openapi({
+      example: 'button',
+      description: 'URL-friendly identifier',
+    }),
+    name: z.string().openapi({
+      example: 'Button',
+      description: 'Human-readable name',
+    }),
+    framework: z.string().openapi({
+      example: 'react',
+      description: 'Component framework',
+    }),
+    version: z.string().openapi({
+      example: '1.0.0',
+      description: 'Semantic version',
+    }),
+    visibility: z.string().openapi({
+      example: 'org',
+      description: 'Visibility level',
+    }),
+    sourceHash: z.string().openapi({
+      example: 'abc123def456789',
+      description: 'Source code hash',
+    }),
+    embeddingStatus: z.string().openapi({
+      example: 'indexed',
+      description: 'Embedding processing status',
+    }),
+    embeddingError: z.string().nullable().openapi({
+      example: null,
+      description: 'Error message if embedding failed',
+    }),
+    extraction: z.record(z.any()).openapi({
+      description: 'Extracted component data',
+    }),
+    generation: z.record(z.any()).openapi({
+      description: 'LLM-generated metadata',
+    }),
+    generationProvider: z.string().openapi({
+      example: 'anthropic',
+      description: 'LLM provider',
+    }),
+    generationModel: z.string().openapi({
+      example: 'claude-sonnet-4-20250514',
+      description: 'LLM model',
+    }),
+    manifest: z.record(z.any()).openapi({
+      description: 'Complete AI manifest',
+    }),
+    createdAt: z.string().datetime().openapi({
+      example: '2025-01-15T10:00:00.000Z',
+      description: 'Creation timestamp',
+    }),
+    updatedAt: z.string().datetime().openapi({
+      example: '2025-01-15T10:00:00.000Z',
+      description: 'Last update timestamp',
+    }),
+  })
+  .openapi('Component');
+
+/**
+ * Component summary schema for list views.
+ * Excludes large JSONB fields for performance.
+ */
+export const ComponentSummarySchema = z
+  .object({
+    id: z.string().uuid().openapi({
+      example: '123e4567-e89b-12d3-a456-426614174000',
+      description: 'Component UUID',
+    }),
+    slug: z.string().openapi({
+      example: 'button',
+      description: 'URL-friendly identifier',
+    }),
+    name: z.string().openapi({
+      example: 'Button',
+      description: 'Human-readable name',
+    }),
+    framework: z.string().openapi({
+      example: 'react',
+      description: 'Component framework',
+    }),
+    version: z.string().openapi({
+      example: '1.0.0',
+      description: 'Semantic version',
+    }),
+    visibility: z.string().openapi({
+      example: 'org',
+      description: 'Visibility level',
+    }),
+    embeddingStatus: z.string().openapi({
+      example: 'indexed',
+      description: 'Embedding status',
+    }),
+    createdAt: z.string().datetime().openapi({
+      example: '2025-01-15T10:00:00.000Z',
+      description: 'Creation timestamp',
+    }),
+    updatedAt: z.string().datetime().openapi({
+      example: '2025-01-15T10:00:00.000Z',
+      description: 'Last update timestamp',
+    }),
+  })
+  .openapi('ComponentSummary');
+
+/**
+ * Component list response.
+ */
+export const ComponentListSchema = z
+  .object({
+    success: z.literal(true).openapi({ example: true }),
+    data: z.object({
+      components: z.array(ComponentSummarySchema).openapi({
+        description: 'List of components',
+      }),
+      total: z.number().int().openapi({
+        example: 100,
+        description: 'Total number of matching components',
+      }),
+      limit: z.number().int().openapi({
+        example: 50,
+        description: 'Number of items per page',
+      }),
+      offset: z.number().int().openapi({
+        example: 0,
+        description: 'Current offset',
+      }),
+    }),
+  })
+  .openapi('ComponentList');
+
+/**
+ * Single component response.
+ */
+export const ComponentResponseSchema = z
+  .object({
+    success: z.literal(true).openapi({ example: true }),
+    data: ComponentSchema,
+  })
+  .openapi('ComponentResponse');
+
+/**
+ * Delete component response.
+ */
+export const DeleteComponentResponseSchema = z
+  .object({
+    success: z.literal(true).openapi({ example: true }),
+    data: z.object({
+      deleted: z.boolean().openapi({
+        example: true,
+        description: 'Whether the component was deleted',
+      }),
+    }),
+  })
+  .openapi('DeleteComponentResponse');
+
+// =============================================================================
+// Parameter Schemas
+// =============================================================================
+
+/**
+ * Component ID path parameter.
+ * Used in routes like `/organizations/{orgId}/components/{id}`.
+ */
+export const ComponentIdParamSchema = OrgIdPathParamSchema.extend({
+  id: z
+    .string()
+    .uuid('Invalid component ID format')
+    .openapi({
+      param: { name: 'id', in: 'path' },
+      example: '123e4567-e89b-12d3-a456-426614174000',
+      description: 'Component UUID',
+    }),
+});
+
+/**
+ * Component slug path parameter.
+ * Used in routes like `/organizations/{orgId}/components/by-slug/{slug}`.
+ */
+export const ComponentSlugParamSchema = OrgIdPathParamSchema.extend({
+  slug: z
+    .string()
+    .min(1, 'Slug is required')
+    .openapi({
+      param: { name: 'slug', in: 'path' },
+      example: 'button',
+      description: 'Component slug',
+    }),
+});
+
+// =============================================================================
+// Type Exports
+// =============================================================================
+
+export type CreateComponent = z.infer<typeof CreateComponentSchema>;
+export type UpdateComponent = z.infer<typeof UpdateComponentSchema>;
+export type ListComponentsQuery = z.infer<typeof ListComponentsQuerySchema>;
+export type Component = z.infer<typeof ComponentSchema>;
+export type ComponentSummary = z.infer<typeof ComponentSummarySchema>;
+export type ComponentList = z.infer<typeof ComponentListSchema>;
+export type ComponentResponse = z.infer<typeof ComponentResponseSchema>;

--- a/packages/context-engine/server/src/schemas/components.ts
+++ b/packages/context-engine/server/src/schemas/components.ts
@@ -93,7 +93,7 @@ export const CreateComponentSchema = z
         description: 'Hash of source code for change detection',
       }),
     extraction: z
-      .record(z.any())
+      .record(z.string(), z.any())
       .optional()
       .openapi({
         example: {
@@ -103,7 +103,7 @@ export const CreateComponentSchema = z
         description: 'Extracted component data (props, variants, dependencies)',
       }),
     generation: z
-      .record(z.any())
+      .record(z.string(), z.any())
       .optional()
       .openapi({
         example: {
@@ -122,7 +122,7 @@ export const CreateComponentSchema = z
       description: 'LLM model used for generation',
     }),
     manifest: z
-      .record(z.any())
+      .record(z.string(), z.any())
       .optional()
       .openapi({
         example: {
@@ -162,10 +162,10 @@ export const UpdateComponentSchema = z
       example: 'def456abc789012',
       description: 'Hash of source code for change detection',
     }),
-    extraction: z.record(z.any()).optional().openapi({
+    extraction: z.record(z.string(), z.any()).optional().openapi({
       description: 'Extracted component data (props, variants, dependencies)',
     }),
-    generation: z.record(z.any()).optional().openapi({
+    generation: z.record(z.string(), z.any()).optional().openapi({
       description: 'LLM-generated metadata',
     }),
     generationProvider: z.string().min(1).optional().openapi({
@@ -176,7 +176,7 @@ export const UpdateComponentSchema = z
       example: 'claude-sonnet-4-20250514',
       description: 'LLM model used for generation',
     }),
-    manifest: z.record(z.any()).optional().openapi({
+    manifest: z.record(z.string(), z.any()).optional().openapi({
       description: 'Complete AI manifest for consumption',
     }),
   })
@@ -268,10 +268,10 @@ export const ComponentSchema = z
       example: null,
       description: 'Error message if embedding failed',
     }),
-    extraction: z.record(z.any()).nullable().openapi({
+    extraction: z.record(z.string(), z.any()).nullable().openapi({
       description: 'Extracted component data (null if not yet extracted)',
     }),
-    generation: z.record(z.any()).nullable().openapi({
+    generation: z.record(z.string(), z.any()).nullable().openapi({
       description: 'LLM-generated metadata (null if not yet generated)',
     }),
     generationProvider: z.string().nullable().openapi({
@@ -282,7 +282,7 @@ export const ComponentSchema = z
       example: 'claude-sonnet-4-20250514',
       description: 'LLM model (null if not yet generated)',
     }),
-    manifest: z.record(z.any()).nullable().openapi({
+    manifest: z.record(z.string(), z.any()).nullable().openapi({
       description: 'Complete AI manifest (null if not yet built)',
     }),
     createdAt: z.string().datetime().openapi({

--- a/packages/context-engine/server/src/schemas/components.ts
+++ b/packages/context-engine/server/src/schemas/components.ts
@@ -43,8 +43,12 @@ export type EmbeddingStatus = z.infer<typeof EmbeddingStatusEnum>;
 /**
  * Create component request body.
  *
- * All pipeline outputs (extraction, generation, manifest) are required
- * because the server stores pre-processed data from the CLI.
+ * Only slug and name are required. All other fields are optional to support
+ * incremental creation:
+ * 1. POST with minimal data (slug, name)
+ * 2. PATCH with extraction
+ * 3. PATCH with generation + provider + model
+ * 4. PATCH with manifest
  */
 export const CreateComponentSchema = z
   .object({
@@ -82,45 +86,52 @@ export const CreateComponentSchema = z
     }),
     sourceHash: z
       .string()
-      .min(1, 'Source hash is required')
       .max(64, 'Source hash must be 64 characters or less')
+      .optional()
       .openapi({
         example: 'abc123def456789',
         description: 'Hash of source code for change detection',
       }),
-    extraction: z.record(z.any()).openapi({
-      example: {
-        props: [{ name: 'variant', type: 'string', required: false }],
-        variants: [],
-      },
-      description: 'Extracted component data (props, variants, dependencies)',
-    }),
-    generation: z.record(z.any()).openapi({
-      example: {
-        description: 'A clickable button component for user interactions',
-        patterns: ['form-submit', 'navigation'],
-      },
-      description: 'LLM-generated metadata (descriptions, patterns, guidance)',
-    }),
-    generationProvider: z
-      .string()
-      .min(1, 'Generation provider is required')
+    extraction: z
+      .record(z.any())
+      .optional()
       .openapi({
-        example: 'anthropic',
-        description: 'LLM provider used for generation',
+        example: {
+          props: [{ name: 'variant', type: 'string', required: false }],
+          variants: [],
+        },
+        description: 'Extracted component data (props, variants, dependencies)',
       }),
-    generationModel: z.string().min(1, 'Generation model is required').openapi({
+    generation: z
+      .record(z.any())
+      .optional()
+      .openapi({
+        example: {
+          description: 'A clickable button component for user interactions',
+          patterns: ['form-submit', 'navigation'],
+        },
+        description:
+          'LLM-generated metadata (descriptions, patterns, guidance)',
+      }),
+    generationProvider: z.string().optional().openapi({
+      example: 'anthropic',
+      description: 'LLM provider used for generation',
+    }),
+    generationModel: z.string().optional().openapi({
       example: 'claude-sonnet-4-20250514',
       description: 'LLM model used for generation',
     }),
-    manifest: z.record(z.any()).openapi({
-      example: {
-        name: 'Button',
-        description: 'A clickable button component',
-        props: [],
-      },
-      description: 'Complete AI manifest for consumption',
-    }),
+    manifest: z
+      .record(z.any())
+      .optional()
+      .openapi({
+        example: {
+          name: 'Button',
+          description: 'A clickable button component',
+          props: [],
+        },
+        description: 'Complete AI manifest for consumption',
+      }),
   })
   .openapi('CreateComponent');
 
@@ -245,9 +256,9 @@ export const ComponentSchema = z
       example: 'org',
       description: 'Visibility level',
     }),
-    sourceHash: z.string().openapi({
+    sourceHash: z.string().nullable().openapi({
       example: 'abc123def456789',
-      description: 'Source code hash',
+      description: 'Source code hash (null if not yet computed)',
     }),
     embeddingStatus: z.string().openapi({
       example: 'indexed',
@@ -257,22 +268,22 @@ export const ComponentSchema = z
       example: null,
       description: 'Error message if embedding failed',
     }),
-    extraction: z.record(z.any()).openapi({
-      description: 'Extracted component data',
+    extraction: z.record(z.any()).nullable().openapi({
+      description: 'Extracted component data (null if not yet extracted)',
     }),
-    generation: z.record(z.any()).openapi({
-      description: 'LLM-generated metadata',
+    generation: z.record(z.any()).nullable().openapi({
+      description: 'LLM-generated metadata (null if not yet generated)',
     }),
-    generationProvider: z.string().openapi({
+    generationProvider: z.string().nullable().openapi({
       example: 'anthropic',
-      description: 'LLM provider',
+      description: 'LLM provider (null if not yet generated)',
     }),
-    generationModel: z.string().openapi({
+    generationModel: z.string().nullable().openapi({
       example: 'claude-sonnet-4-20250514',
-      description: 'LLM model',
+      description: 'LLM model (null if not yet generated)',
     }),
-    manifest: z.record(z.any()).openapi({
-      description: 'Complete AI manifest',
+    manifest: z.record(z.any()).nullable().openapi({
+      description: 'Complete AI manifest (null if not yet built)',
     }),
     createdAt: z.string().datetime().openapi({
       example: '2025-01-15T10:00:00.000Z',
@@ -381,6 +392,30 @@ export const DeleteComponentResponseSchema = z
   })
   .openapi('DeleteComponentResponse');
 
+/**
+ * Index component response.
+ * Returned after triggering embedding generation for a component.
+ */
+export const IndexComponentResponseSchema = z
+  .object({
+    success: z.literal(true).openapi({ example: true }),
+    data: z.object({
+      componentId: z.string().uuid().openapi({
+        example: '123e4567-e89b-12d3-a456-426614174000',
+        description: 'Component UUID that was indexed',
+      }),
+      chunksCreated: z.number().int().openapi({
+        example: 5,
+        description: 'Number of embedding chunks created',
+      }),
+      embeddingStatus: z.string().openapi({
+        example: 'indexed',
+        description: 'Current embedding status after indexing',
+      }),
+    }),
+  })
+  .openapi('IndexComponentResponse');
+
 // =============================================================================
 // Parameter Schemas
 // =============================================================================
@@ -426,3 +461,6 @@ export type Component = z.infer<typeof ComponentSchema>;
 export type ComponentSummary = z.infer<typeof ComponentSummarySchema>;
 export type ComponentList = z.infer<typeof ComponentListSchema>;
 export type ComponentResponse = z.infer<typeof ComponentResponseSchema>;
+export type IndexComponentResponse = z.infer<
+  typeof IndexComponentResponseSchema
+>;

--- a/packages/context-engine/server/src/schemas/index.ts
+++ b/packages/context-engine/server/src/schemas/index.ts
@@ -14,7 +14,6 @@ export {
   PaginationMetaSchema,
   PaginationQuerySchema,
   ReadySchema,
-  ValidationErrorDetailSchema,
 } from './common.js';
 
 // Organization schemas

--- a/packages/context-engine/server/src/schemas/index.ts
+++ b/packages/context-engine/server/src/schemas/index.ts
@@ -1,0 +1,76 @@
+/**
+ * Schema Exports
+ *
+ * Barrel file for all Zod schemas used in the Context Engine API.
+ * These schemas serve dual purposes:
+ * 1. Request/response validation at runtime
+ * 2. OpenAPI documentation generation
+ */
+
+// Common schemas (errors, health, pagination)
+export {
+  createSuccessResponse,
+  ErrorSchema,
+  HealthSchema,
+  PaginationMetaSchema,
+  PaginationQuerySchema,
+  ReadySchema,
+  ValidationErrorDetailSchema,
+} from './common.js';
+
+// Organization schemas
+export {
+  type CreateOrganization,
+  CreateOrganizationSchema,
+  DeleteOrganizationResponseSchema,
+  type Organization,
+  type OrganizationList,
+  OrganizationListSchema,
+  type OrganizationResponse,
+  OrganizationResponseSchema,
+  OrganizationSchema,
+  OrgIdParamSchema,
+  OrgIdPathParamSchema,
+  type UpdateOrganization,
+  UpdateOrganizationSchema,
+} from './organizations.js';
+
+// Component schemas
+export {
+  type Component,
+  ComponentIdParamSchema,
+  type ComponentList,
+  ComponentListSchema,
+  type ComponentResponse,
+  ComponentResponseSchema,
+  ComponentSchema,
+  ComponentSlugParamSchema,
+  type ComponentSummary,
+  ComponentSummarySchema,
+  type CreateComponent,
+  CreateComponentSchema,
+  DeleteComponentResponseSchema,
+  type EmbeddingStatus,
+  EmbeddingStatusEnum,
+  type Framework,
+  FrameworkEnum,
+  type ListComponentsQuery,
+  ListComponentsQuerySchema,
+  type UpdateComponent,
+  UpdateComponentSchema,
+  type Visibility,
+  VisibilityEnum,
+} from './components.js';
+
+// Search schemas
+export {
+  SearchParamsSchema,
+  type SearchQuery,
+  SearchQuerySchema,
+  type SearchRequest,
+  SearchRequestSchema,
+  type SearchResponse,
+  SearchResponseSchema,
+  type SearchResult,
+  SearchResultSchema,
+} from './search.js';

--- a/packages/context-engine/server/src/schemas/index.ts
+++ b/packages/context-engine/server/src/schemas/index.ts
@@ -54,6 +54,8 @@ export {
   EmbeddingStatusEnum,
   type Framework,
   FrameworkEnum,
+  type IndexComponentResponse,
+  IndexComponentResponseSchema,
   type ListComponentsQuery,
   ListComponentsQuerySchema,
   type UpdateComponent,

--- a/packages/context-engine/server/src/schemas/index.ts
+++ b/packages/context-engine/server/src/schemas/index.ts
@@ -9,7 +9,6 @@
 
 // Common schemas (errors, health, pagination)
 export {
-  createSuccessResponse,
   ErrorSchema,
   HealthSchema,
   PaginationMetaSchema,
@@ -67,8 +66,6 @@ export {
 // Search schemas
 export {
   SearchParamsSchema,
-  type SearchQuery,
-  SearchQuerySchema,
   type SearchRequest,
   SearchRequestSchema,
   type SearchResponse,

--- a/packages/context-engine/server/src/schemas/organizations.ts
+++ b/packages/context-engine/server/src/schemas/organizations.ts
@@ -88,6 +88,14 @@ export const OrganizationListSchema = z
         example: 10,
         description: 'Total number of organizations',
       }),
+      limit: z.number().int().openapi({
+        example: 50,
+        description: 'Number of items per page',
+      }),
+      offset: z.number().int().openapi({
+        example: 0,
+        description: 'Current offset',
+      }),
     }),
   })
   .openapi('OrganizationList');

--- a/packages/context-engine/server/src/schemas/organizations.ts
+++ b/packages/context-engine/server/src/schemas/organizations.ts
@@ -1,0 +1,162 @@
+/**
+ * Organization Schemas
+ *
+ * Request and response schemas for organization CRUD operations.
+ * Organizations are the top-level multi-tenant entity.
+ */
+
+import { z } from '@hono/zod-openapi';
+
+// =============================================================================
+// Request Schemas
+// =============================================================================
+
+/**
+ * Create organization request body.
+ */
+export const CreateOrganizationSchema = z
+  .object({
+    name: z
+      .string()
+      .min(1, 'Organization name is required')
+      .max(255, 'Organization name must be 255 characters or less')
+      .openapi({
+        example: 'Acme Corp',
+        description: 'Organization name',
+      }),
+  })
+  .openapi('CreateOrganization');
+
+/**
+ * Update organization request body.
+ * All fields are optional for partial updates.
+ */
+export const UpdateOrganizationSchema = z
+  .object({
+    name: z
+      .string()
+      .min(1, 'Organization name cannot be empty')
+      .max(255, 'Organization name must be 255 characters or less')
+      .optional()
+      .openapi({
+        example: 'Acme Corporation',
+        description: 'Updated organization name',
+      }),
+  })
+  .openapi('UpdateOrganization');
+
+// =============================================================================
+// Response Schemas
+// =============================================================================
+
+/**
+ * Organization entity schema.
+ * Represents a full organization record.
+ */
+export const OrganizationSchema = z
+  .object({
+    id: z.string().uuid().openapi({
+      example: '123e4567-e89b-12d3-a456-426614174000',
+      description: 'Organization UUID',
+    }),
+    name: z.string().openapi({
+      example: 'Acme Corp',
+      description: 'Organization name',
+    }),
+    createdAt: z.string().datetime().openapi({
+      example: '2025-01-15T10:00:00.000Z',
+      description: 'Creation timestamp (ISO 8601)',
+    }),
+    updatedAt: z.string().datetime().openapi({
+      example: '2025-01-15T10:00:00.000Z',
+      description: 'Last update timestamp (ISO 8601)',
+    }),
+  })
+  .openapi('Organization');
+
+/**
+ * Organization list response.
+ */
+export const OrganizationListSchema = z
+  .object({
+    success: z.literal(true).openapi({ example: true }),
+    data: z.object({
+      organizations: z.array(OrganizationSchema).openapi({
+        description: 'List of organizations',
+      }),
+      total: z.number().int().openapi({
+        example: 10,
+        description: 'Total number of organizations',
+      }),
+    }),
+  })
+  .openapi('OrganizationList');
+
+/**
+ * Single organization response.
+ */
+export const OrganizationResponseSchema = z
+  .object({
+    success: z.literal(true).openapi({ example: true }),
+    data: OrganizationSchema,
+  })
+  .openapi('OrganizationResponse');
+
+/**
+ * Delete organization response.
+ */
+export const DeleteOrganizationResponseSchema = z
+  .object({
+    success: z.literal(true).openapi({ example: true }),
+    data: z.object({
+      deleted: z.boolean().openapi({
+        example: true,
+        description: 'Whether the organization was deleted',
+      }),
+    }),
+  })
+  .openapi('DeleteOrganizationResponse');
+
+// =============================================================================
+// Parameter Schemas
+// =============================================================================
+
+/**
+ * Organization ID path parameter.
+ * Used in routes like `/organizations/{id}`.
+ */
+export const OrgIdParamSchema = z.object({
+  id: z
+    .string()
+    .uuid('Invalid organization ID format')
+    .openapi({
+      param: { name: 'id', in: 'path' },
+      example: '123e4567-e89b-12d3-a456-426614174000',
+      description: 'Organization UUID',
+    }),
+});
+
+/**
+ * Organization ID path parameter for nested resources.
+ * Used in routes like `/organizations/{orgId}/components`.
+ */
+export const OrgIdPathParamSchema = z.object({
+  orgId: z
+    .string()
+    .uuid('Invalid organization ID format')
+    .openapi({
+      param: { name: 'orgId', in: 'path' },
+      example: '123e4567-e89b-12d3-a456-426614174000',
+      description: 'Organization UUID',
+    }),
+});
+
+// =============================================================================
+// Type Exports
+// =============================================================================
+
+export type CreateOrganization = z.infer<typeof CreateOrganizationSchema>;
+export type UpdateOrganization = z.infer<typeof UpdateOrganizationSchema>;
+export type Organization = z.infer<typeof OrganizationSchema>;
+export type OrganizationList = z.infer<typeof OrganizationListSchema>;
+export type OrganizationResponse = z.infer<typeof OrganizationResponseSchema>;

--- a/packages/context-engine/server/src/schemas/search.ts
+++ b/packages/context-engine/server/src/schemas/search.ts
@@ -1,0 +1,149 @@
+/**
+ * Search Schemas
+ *
+ * Request and response schemas for semantic component search.
+ * These power the natural language search capabilities for AI assistants.
+ */
+
+import { z } from '@hono/zod-openapi';
+
+import { FrameworkEnum } from './components.js';
+import { OrgIdPathParamSchema } from './organizations.js';
+
+// =============================================================================
+// Request Schemas
+// =============================================================================
+
+/**
+ * Semantic search request body.
+ * Used by AI assistants to find relevant components.
+ */
+export const SearchRequestSchema = z
+  .object({
+    query: z
+      .string()
+      .min(1, 'Search query is required')
+      .max(500, 'Search query must be 500 characters or less')
+      .openapi({
+        example: 'button with loading state',
+        description: 'Natural language search query',
+      }),
+    limit: z.number().int().min(1).max(50).default(10).openapi({
+      example: 10,
+      description: 'Maximum number of results to return (1-50)',
+    }),
+    minScore: z.number().min(0).max(1).optional().openapi({
+      example: 0.7,
+      description: 'Minimum similarity score threshold (0-1)',
+    }),
+    framework: FrameworkEnum.optional().openapi({
+      description: 'Filter results by framework',
+    }),
+  })
+  .openapi('SearchRequest');
+
+/**
+ * Search query parameters (for GET requests).
+ * Alternative to POST body for simple searches.
+ */
+export const SearchQuerySchema = z
+  .object({
+    q: z
+      .string()
+      .min(1, 'Search query is required')
+      .max(500, 'Search query must be 500 characters or less')
+      .openapi({
+        example: 'modal dialog',
+        description: 'Natural language search query',
+      }),
+    limit: z.coerce.number().int().min(1).max(50).default(10).openapi({
+      example: 10,
+      description: 'Maximum number of results',
+    }),
+    minScore: z.coerce.number().min(0).max(1).optional().openapi({
+      example: 0.7,
+      description: 'Minimum similarity score',
+    }),
+    framework: FrameworkEnum.optional().openapi({
+      description: 'Filter by framework',
+    }),
+  })
+  .openapi('SearchQuery');
+
+// =============================================================================
+// Response Schemas
+// =============================================================================
+
+/**
+ * Individual search result.
+ * Provides enough context for AI to evaluate relevance.
+ */
+export const SearchResultSchema = z
+  .object({
+    componentId: z.string().uuid().openapi({
+      example: '123e4567-e89b-12d3-a456-426614174000',
+      description: 'Component UUID',
+    }),
+    slug: z.string().openapi({
+      example: 'button',
+      description: 'URL-friendly identifier',
+    }),
+    name: z.string().openapi({
+      example: 'Button',
+      description: 'Human-readable component name',
+    }),
+    description: z.string().nullable().openapi({
+      example: 'A clickable button component for user interactions',
+      description: 'Component description (from manifest)',
+    }),
+    framework: z.string().openapi({
+      example: 'react',
+      description: 'Component framework',
+    }),
+    score: z.number().openapi({
+      example: 0.92,
+      description: 'Similarity score (0-1, higher is more relevant)',
+    }),
+  })
+  .openapi('SearchResult');
+
+/**
+ * Search response with results and metadata.
+ */
+export const SearchResponseSchema = z
+  .object({
+    success: z.literal(true).openapi({ example: true }),
+    data: z.object({
+      results: z.array(SearchResultSchema).openapi({
+        description: 'Matching components ranked by relevance',
+      }),
+      total: z.number().int().openapi({
+        example: 5,
+        description: 'Number of results returned',
+      }),
+      query: z.string().openapi({
+        example: 'button with loading state',
+        description: 'The query that was searched',
+      }),
+    }),
+  })
+  .openapi('SearchResponse');
+
+// =============================================================================
+// Parameter Schemas
+// =============================================================================
+
+/**
+ * Search endpoint path parameters.
+ * Search is scoped to an organization.
+ */
+export const SearchParamsSchema = OrgIdPathParamSchema;
+
+// =============================================================================
+// Type Exports
+// =============================================================================
+
+export type SearchRequest = z.infer<typeof SearchRequestSchema>;
+export type SearchQuery = z.infer<typeof SearchQuerySchema>;
+export type SearchResult = z.infer<typeof SearchResultSchema>;
+export type SearchResponse = z.infer<typeof SearchResponseSchema>;

--- a/packages/context-engine/server/src/schemas/search.ts
+++ b/packages/context-engine/server/src/schemas/search.ts
@@ -42,34 +42,6 @@ export const SearchRequestSchema = z
   })
   .openapi('SearchRequest');
 
-/**
- * Search query parameters (for GET requests).
- * Alternative to POST body for simple searches.
- */
-export const SearchQuerySchema = z
-  .object({
-    q: z
-      .string()
-      .min(1, 'Search query is required')
-      .max(500, 'Search query must be 500 characters or less')
-      .openapi({
-        example: 'modal dialog',
-        description: 'Natural language search query',
-      }),
-    limit: z.coerce.number().int().min(1).max(50).default(10).openapi({
-      example: 10,
-      description: 'Maximum number of results',
-    }),
-    minScore: z.coerce.number().min(0).max(1).optional().openapi({
-      example: 0.7,
-      description: 'Minimum similarity score',
-    }),
-    framework: FrameworkEnum.optional().openapi({
-      description: 'Filter by framework',
-    }),
-  })
-  .openapi('SearchQuery');
-
 // =============================================================================
 // Response Schemas
 // =============================================================================
@@ -144,6 +116,5 @@ export const SearchParamsSchema = OrgIdPathParamSchema;
 // =============================================================================
 
 export type SearchRequest = z.infer<typeof SearchRequestSchema>;
-export type SearchQuery = z.infer<typeof SearchQuerySchema>;
 export type SearchResult = z.infer<typeof SearchResultSchema>;
 export type SearchResponse = z.infer<typeof SearchResponseSchema>;

--- a/packages/context-engine/server/src/server.ts
+++ b/packages/context-engine/server/src/server.ts
@@ -52,13 +52,17 @@ async function startServer() {
   const shutdown = async (signal: string) => {
     console.log(`\n${signal} received, shutting down gracefully...`);
 
-    // Close the HTTP server
-    server.close((err) => {
-      if (err) {
-        console.error('Error closing HTTP server:', err);
-      } else {
-        console.log('HTTP server closed');
-      }
+    // Close the HTTP server (wait for connections to drain)
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) {
+          console.error('Error closing HTTP server:', err);
+          reject(err);
+        } else {
+          console.log('HTTP server closed');
+          resolve();
+        }
+      });
     });
 
     // Close database connection

--- a/packages/context-engine/server/src/server.ts
+++ b/packages/context-engine/server/src/server.ts
@@ -1,0 +1,121 @@
+/**
+ * Server Entry Point
+ *
+ * Executable entry point that starts the HTTP server.
+ * This file is the only place with side effects (server startup).
+ *
+ * Usage:
+ *   Development: tsx watch --env-file=.env src/server.ts
+ *   Production:  node --env-file=.env dist/server.js
+ */
+
+import { closeDatabase, initializeDatabase } from '@context-engine/db';
+import { serve } from '@hono/node-server';
+
+import { createApp } from './app.js';
+import { loadConfig, type ServerConfig } from './config.js';
+import { SERVER_VERSION } from './constants.js';
+
+// =============================================================================
+// Server Startup
+// =============================================================================
+
+/**
+ * Start the server with the given configuration.
+ */
+async function startServer() {
+  // Load config first (will throw if DATABASE_URL missing)
+  const config = loadConfig();
+
+  // Initialize database connection
+  initializeDatabase({
+    url: config.databaseUrl,
+  });
+
+  // Create the app
+  const app = createApp();
+
+  // Print startup banner
+  printBanner(config);
+
+  // Start HTTP server
+  const server = serve({
+    fetch: app.fetch,
+    port: config.port,
+  });
+
+  console.log(`Server running at http://localhost:${config.port}`);
+  console.log(`API docs: http://localhost:${config.port}/ui`);
+  console.log(`OpenAPI spec: http://localhost:${config.port}/doc`);
+
+  // Setup graceful shutdown
+  const shutdown = async (signal: string) => {
+    console.log(`\n${signal} received, shutting down gracefully...`);
+
+    // Close the HTTP server
+    server.close((err) => {
+      if (err) {
+        console.error('Error closing HTTP server:', err);
+      } else {
+        console.log('HTTP server closed');
+      }
+    });
+
+    // Close database connection
+    await closeDatabase();
+    console.log('Database connection closed');
+
+    process.exit(0);
+  };
+
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+}
+
+// =============================================================================
+// Banner
+// =============================================================================
+
+/**
+ * Print server startup banner.
+ */
+function printBanner(config: ServerConfig) {
+  // Extract database host from URL, safely handling various formats
+  let dbHost = 'configured';
+  try {
+    const urlParts = config.databaseUrl.split('@');
+    if (urlParts.length > 1) {
+      const hostPart = urlParts[1].split('/')[0];
+      dbHost = hostPart || 'configured';
+    }
+  } catch {
+    dbHost = 'configured';
+  }
+
+  // Check VOYAGE_API_KEY from env (used by @context-engine/db for search)
+  const embeddings = process.env.VOYAGE_API_KEY
+    ? 'Configured'
+    : 'Not configured';
+
+  console.log(`
++=====================================================================+
+|                     Context Engine Server                           |
++=====================================================================+
+|  Version:     ${SERVER_VERSION.padEnd(54)}|
+|  Environment: ${config.environment.padEnd(54)}|
+|  Port:        ${String(config.port).padEnd(54)}|
+|  Database:    ${dbHost.padEnd(54)}|
+|  Embeddings:  ${embeddings.padEnd(54)}|
++=====================================================================+
+`);
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+// Start the server
+startServer().catch((error) => {
+  console.error('Failed to start server:', error);
+  process.exit(1);
+});

--- a/packages/context-engine/server/src/types.ts
+++ b/packages/context-engine/server/src/types.ts
@@ -1,0 +1,57 @@
+/**
+ * App Types
+ *
+ * Shared type definitions for the HTTP server application.
+ * Defines context variables for dependency injection via middleware.
+ */
+
+import type {
+  ComponentRepository,
+  EmbeddingRepository,
+  OrganizationRepository,
+} from '@context-engine/db';
+
+// =============================================================================
+// Context Variable Types
+// =============================================================================
+
+/**
+ * Repository variables injected via middleware.
+ *
+ * These are available on `c.var` in route handlers after the repositories
+ * middleware has run.
+ */
+export interface RepositoryVariables {
+  /**
+   * Repository for organization CRUD operations.
+   * Always available for `/api/v1/*` routes.
+   */
+  organizationRepo: OrganizationRepository;
+
+  /**
+   * Repository for component CRUD operations.
+   * Always available for `/api/v1/*` routes.
+   */
+  componentRepo: ComponentRepository;
+
+  /**
+   * Repository for embedding operations (indexing and search).
+   * Only available when VOYAGE_API_KEY is configured.
+   * Check availability with `c.var.embeddingRepo !== undefined`.
+   */
+  embeddingRepo: EmbeddingRepository | undefined;
+}
+
+// =============================================================================
+// App Environment Types
+// =============================================================================
+
+/**
+ * Environment type for the app.
+ *
+ * Extends Hono's Env type to include our custom context variables.
+ * Use this when creating middleware or handlers that need access to repositories.
+ */
+export interface AppEnv {
+  Variables: RepositoryVariables;
+}

--- a/packages/context-engine/server/src/utils/format.ts
+++ b/packages/context-engine/server/src/utils/format.ts
@@ -1,0 +1,45 @@
+/**
+ * Format Utilities
+ *
+ * Generic formatting functions for API responses.
+ */
+
+/**
+ * Entity with standard timestamp fields.
+ */
+type WithDates = {
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+/**
+ * Format an entity's Date fields to ISO strings for API responses.
+ *
+ * @example
+ * ```ts
+ * // Before (custom formatOrganization)
+ * function formatOrganization(org: DbOrganization) {
+ *   return {
+ *     id: org.id,
+ *     name: org.name,
+ *     createdAt: org.createdAt.toISOString(),
+ *     updatedAt: org.updatedAt.toISOString(),
+ *   };
+ * }
+ *
+ * // After (generic formatDates)
+ * formatDates(org)
+ * ```
+ */
+export function formatDates<T extends WithDates>(
+  entity: T
+): Omit<T, 'createdAt' | 'updatedAt'> & {
+  createdAt: string;
+  updatedAt: string;
+} {
+  return {
+    ...entity,
+    createdAt: entity.createdAt.toISOString(),
+    updatedAt: entity.updatedAt.toISOString(),
+  };
+}

--- a/packages/context-engine/server/src/utils/index.ts
+++ b/packages/context-engine/server/src/utils/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Utility Functions
+ *
+ * Re-exports all utility functions for convenient imports.
+ */
+
+export { formatDates } from './format.js';
+export { successResponse } from './response.js';

--- a/packages/context-engine/server/src/utils/response.ts
+++ b/packages/context-engine/server/src/utils/response.ts
@@ -1,0 +1,22 @@
+/**
+ * Response Helpers
+ *
+ * Utility functions for creating consistent API responses.
+ * Reduces repetition of `{ success: true as const, data: ... }` pattern.
+ */
+
+/**
+ * Create a success response wrapper.
+ *
+ * @example
+ * ```ts
+ * // Before
+ * return c.json({ success: true as const, data: formatOrganization(org) }, 200);
+ *
+ * // After
+ * return c.json(successResponse(formatOrganization(org)), 200);
+ * ```
+ */
+export function successResponse<T>(data: T) {
+  return { success: true as const, data };
+}

--- a/packages/context-engine/server/tsconfig.json
+++ b/packages/context-engine/server/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/context-engine/server/tsup.config.ts
+++ b/packages/context-engine/server/tsup.config.ts
@@ -1,4 +1,9 @@
+import { readFileSync } from 'node:fs';
 import { defineConfig } from 'tsup';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8')) as {
+  version: string;
+};
 
 export default defineConfig({
   entry: ['src/index.ts', 'src/server.ts'],
@@ -8,4 +13,7 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   external: ['@context-engine/db'],
+  define: {
+    'process.env.PACKAGE_VERSION': JSON.stringify(pkg.version),
+  },
 });

--- a/packages/context-engine/server/tsup.config.ts
+++ b/packages/context-engine/server/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  external: ['@context-engine/db'],
+});

--- a/packages/context-engine/server/tsup.config.ts
+++ b/packages/context-engine/server/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/server.ts'],
   format: ['esm', 'cjs'],
   dts: true,
   splitting: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,6 +46,13 @@
   resolved "https://registry.yarnpkg.com/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz#ad5549322dfe9d153d4b4dd6f7ff2ae234b06e24"
   integrity sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==
 
+"@asteasolutions/zod-to-openapi@^7.3.0":
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/@asteasolutions/zod-to-openapi/-/zod-to-openapi-7.3.4.tgz#ccf8c6c32f0092df23e9fc90c5e060316826eb15"
+  integrity sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==
+  dependencies:
+    openapi3-ts "^4.1.2"
+
 "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
@@ -774,6 +781,30 @@
     google-auth-library "^10.3.0"
     protobufjs "^7.5.4"
     ws "^8.18.0"
+
+"@hono/node-server@^1.14.1":
+  version "1.19.9"
+  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.9.tgz#8f37119b1acf283fd3f6035f3d1356fdb97a09ac"
+  integrity sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==
+
+"@hono/swagger-ui@^0.5.1":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@hono/swagger-ui/-/swagger-ui-0.5.3.tgz#5256fa5bf31715d3ffc3c24c8df727f51d741f36"
+  integrity sha512-Hn90DOOJ62ICJQplQvCDVpi9Jcn6EhtRaiffyJIS53wA5RmRLtMCDQGVc0bor8vQD7JIwpkweWjs+3cycp+IvA==
+
+"@hono/zod-openapi@^0.19.3":
+  version "0.19.10"
+  resolved "https://registry.yarnpkg.com/@hono/zod-openapi/-/zod-openapi-0.19.10.tgz#1002cdd6d07c9ac8aa9ae98e076d5f272ddcc9df"
+  integrity sha512-dpoS6DenvoJyvxtQ7Kd633FRZ/Qf74+4+o9s+zZI8pEqnbjdF/DtxIib08WDpCaWabMEJOL5TXpMgNEZvb7hpA==
+  dependencies:
+    "@asteasolutions/zod-to-openapi" "^7.3.0"
+    "@hono/zod-validator" "^0.7.1"
+    openapi3-ts "^4.5.0"
+
+"@hono/zod-validator@^0.7.1":
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/@hono/zod-validator/-/zod-validator-0.7.6.tgz#e51261e50138512f8b09996345c16b66d510355d"
+  integrity sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==
 
 "@humanfs/core@^0.19.1":
   version "0.19.1"
@@ -3949,6 +3980,11 @@ hermes-parser@^0.25.1:
   dependencies:
     hermes-estree "0.25.1"
 
+hono@^4.7.4:
+  version "4.11.7"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.11.7.tgz#f5b8d0b0b503ef0d913a246012dda52ea23dbe53"
+  integrity sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==
+
 html-encoding-sniffer@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz#696df529a7cfd82446369dc5193e590a3735b448"
@@ -4920,6 +4956,13 @@ open@^10.2.0:
     define-lazy-prop "^3.0.0"
     is-inside-container "^1.0.0"
     wsl-utils "^0.1.0"
+
+openapi3-ts@^4.1.2, openapi3-ts@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/openapi3-ts/-/openapi3-ts-4.5.0.tgz#1241fcdac0a711d654dfa74feebc2ce7a210790a"
+  integrity sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==
+  dependencies:
+    yaml "^2.8.0"
 
 optionator@^0.9.3:
   version "0.9.4"
@@ -6489,7 +6532,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@^2.8.1:
+yaml@^2.8.0, yaml@^2.8.1:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.2.tgz#5694f25eca0ce9c3e7a9d9e00ce0ddabbd9e35c5"
   integrity sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==
@@ -6503,6 +6546,11 @@ yocto-queue@^0.1.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-4.0.2.tgz#bc605eba49ce0fcd598c127fee1c236be3f22918"
   integrity sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==
+
+zod@^3.24.2:
+  version "3.25.76"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
+  integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
 "zod@^3.25.0 || ^4.0.0":
   version "4.2.1"


### PR DESCRIPTION
## Summary

- Adds `@context-engine/server` package with Hono-based HTTP API
- Implements Organization CRUD endpoints with pagination and FK constraint handling
- Implements Component CRUD endpoints with upsert pattern and JSONB field mapping
- Adds semantic search endpoint for AI-powered component discovery
- Includes health and readiness check endpoints (200/503 for Kubernetes probes)
- Generates OpenAPI documentation with Swagger UI at `/ui`
- Clean library/executable split: `index.ts` (pure exports) vs `server.ts` (side effects)
- Custom `ApiError` → `HTTPException` error handling with consistent `{ success, data }` envelope

## Linear Issue

Closes NEX-146

## Test Plan

- [ ] TypeScript compiles with no errors
- [ ] ESLint passes with no warnings
- [ ] Health endpoint returns 200 with version info
- [ ] Readiness endpoint returns 503 when DB is down
- [ ] Organization CRUD operations work correctly
- [ ] Component CRUD with upsert pattern works correctly
- [ ] Search endpoint validates request body
- [ ] FK constraint violation on org delete returns 409
- [ ] OpenAPI docs accessible at `/ui`

🤖 Generated with Claude Code