### PR TITLE
docs(react): showcase all design tokens in Storybook

### DIFF
--- a/packages/react/src/stories/Radius.stories.tsx
+++ b/packages/react/src/stories/Radius.stories.tsx
@@ -1,0 +1,194 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { themeOnlyModes } from '@/storybook/modes';
+
+import borderwidthLyra from '../../../core/tokens/primitives/borderwidth/borderwidth-lyra.json';
+import borderwidthMaia from '../../../core/tokens/primitives/borderwidth/borderwidth-maia.json';
+import borderwidthMira from '../../../core/tokens/primitives/borderwidth/borderwidth-mira.json';
+import borderwidthNova from '../../../core/tokens/primitives/borderwidth/borderwidth-nova.json';
+import borderwidthVega from '../../../core/tokens/primitives/borderwidth/borderwidth-vega.json';
+import radiusBlunt from '../../../core/tokens/primitives/radius/radius-blunt.json';
+import radiusMellow from '../../../core/tokens/primitives/radius/radius-mellow.json';
+import radiusSharp from '../../../core/tokens/primitives/radius/radius-sharp.json';
+import radiusSmooth from '../../../core/tokens/primitives/radius/radius-smooth.json';
+import radiusSubtle from '../../../core/tokens/primitives/radius/radius-subtle.json';
+
+const BUNDLED_RADIUS_MODE = 'sharp';
+const BUNDLED_BORDERWIDTH_MODE = 'vega';
+
+type Dimension = { value: number; unit: string };
+type DimensionToken = { $value: Dimension; $type: string };
+type DimensionMap = Record<string, DimensionToken>;
+
+const RADIUS_KEYS = [
+  'base',
+  'sm',
+  'md',
+  'lg',
+  'xl',
+  '2xl',
+  '3xl',
+  'full',
+] as const;
+const BORDERWIDTH_KEYS = ['default', 'thick'] as const;
+
+const RADIUS_MODES: { name: string; tokens: DimensionMap }[] = [
+  { name: 'blunt', tokens: radiusBlunt as DimensionMap },
+  { name: 'mellow', tokens: radiusMellow as DimensionMap },
+  { name: 'sharp', tokens: radiusSharp as DimensionMap },
+  { name: 'smooth', tokens: radiusSmooth as DimensionMap },
+  { name: 'subtle', tokens: radiusSubtle as DimensionMap },
+];
+
+const BORDERWIDTH_MODES: { name: string; tokens: DimensionMap }[] = [
+  { name: 'vega', tokens: borderwidthVega as DimensionMap },
+  { name: 'lyra', tokens: borderwidthLyra as DimensionMap },
+  { name: 'maia', tokens: borderwidthMaia as DimensionMap },
+  { name: 'mira', tokens: borderwidthMira as DimensionMap },
+  { name: 'nova', tokens: borderwidthNova as DimensionMap },
+];
+
+function formatDimension(d: Dimension) {
+  return `${d.value}${d.unit}`;
+}
+
+function RadiusSwatch({ name, dim }: { name: string; dim: Dimension }) {
+  return (
+    <div className="nx:flex nx:flex-col nx:items-center nx:gap-1">
+      <div
+        className="nx:bg-primary-background"
+        style={{
+          width: 64,
+          height: 64,
+          borderRadius: `${dim.value}${dim.unit}`,
+        }}
+      />
+      <span className="nx:text-foreground nx:typography-label-default nx:font-mono">
+        {name}
+      </span>
+      <span className="nx:text-muted-foreground nx:typography-label-small nx:font-mono">
+        {formatDimension(dim)}
+      </span>
+    </div>
+  );
+}
+
+function BorderWidthSwatch({ name, dim }: { name: string; dim: Dimension }) {
+  return (
+    <div className="nx:flex nx:flex-col nx:items-center nx:gap-1">
+      <div
+        style={{
+          width: 64,
+          height: 64,
+          borderStyle: 'solid',
+          borderWidth: `${dim.value}${dim.unit}`,
+          borderColor: 'var(--color-foreground)',
+        }}
+      />
+      <span className="nx:text-foreground nx:typography-label-default nx:font-mono">
+        {name}
+      </span>
+      <span className="nx:text-muted-foreground nx:typography-label-small nx:font-mono">
+        {formatDimension(dim)}
+      </span>
+    </div>
+  );
+}
+
+function ModeSection({
+  mode,
+  bundled,
+  children,
+}: {
+  mode: string;
+  bundled: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="nx:flex nx:flex-col nx:gap-3">
+      <h3 className="nx:flex nx:items-center nx:gap-2 nx:text-foreground nx:typography-heading-xsmall">
+        <span>{mode}</span>
+        {bundled && (
+          <span className="nx:rounded-sm nx:bg-primary-subtle nx:text-primary-subtle-foreground nx:typography-label-small nx:px-1.5 nx:py-0.5">
+            Bundled
+          </span>
+        )}
+      </h3>
+      <div className="nx:flex nx:flex-wrap nx:items-start nx:gap-4">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+const meta: Meta = {
+  title: 'Tokens/Radius',
+  parameters: {
+    layout: 'fullscreen',
+    a11y: { test: 'off' },
+    chromatic: { modes: themeOnlyModes },
+    docs: {
+      description: {
+        component:
+          'Border radius and border width primitive scales. Each mode (radius: blunt/mellow/sharp/smooth/subtle; borderwidth: vega/lyra/maia/mira/nova) produces a different scale; the bundled mode is the one @nexus/tailwind currently ships with — see packages/core/package.json#scripts.build:tailwind.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Radii: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-10 nx:p-10 nx:bg-background nx:min-w-fit">
+      <div className="nx:flex nx:flex-col nx:gap-2">
+        <h2 className="nx:text-foreground nx:typography-heading-medium">
+          Border Radii
+        </h2>
+        <p className="nx:text-muted-foreground nx:typography-body-small nx:max-w-2xl">
+          Raw `--nx-radius-*` primitive scale. `full` resolves to 9999px so the
+          corner becomes a perfect arc on any container.
+        </p>
+      </div>
+      {RADIUS_MODES.map(({ name, tokens }) => (
+        <ModeSection
+          key={name}
+          mode={name}
+          bundled={name === BUNDLED_RADIUS_MODE}
+        >
+          {RADIUS_KEYS.map((key) => (
+            <RadiusSwatch key={key} name={key} dim={tokens[key].$value} />
+          ))}
+        </ModeSection>
+      ))}
+    </div>
+  ),
+};
+
+export const BorderWidths: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-10 nx:p-10 nx:bg-background nx:min-w-fit">
+      <div className="nx:flex nx:flex-col nx:gap-2">
+        <h2 className="nx:text-foreground nx:typography-heading-medium">
+          Border Widths
+        </h2>
+        <p className="nx:text-muted-foreground nx:typography-body-small nx:max-w-2xl">
+          Raw `--nx-borderwidth-*` primitives. The Tailwind utilities
+          `nx:border-default` and `nx:border-thick` consume these.
+        </p>
+      </div>
+      {BORDERWIDTH_MODES.map(({ name, tokens }) => (
+        <ModeSection
+          key={name}
+          mode={name}
+          bundled={name === BUNDLED_BORDERWIDTH_MODE}
+        >
+          {BORDERWIDTH_KEYS.map((key) => (
+            <BorderWidthSwatch key={key} name={key} dim={tokens[key].$value} />
+          ))}
+        </ModeSection>
+      ))}
+    </div>
+  ),
+};

--- a/packages/react/src/stories/Shadow.stories.tsx
+++ b/packages/react/src/stories/Shadow.stories.tsx
@@ -1,0 +1,196 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { themeOnlyModes } from '@/storybook/modes';
+
+import shadowLyraDark from '../../../core/tokens/primitives/shadow/shadow-lyra-dark.json';
+import shadowLyraLight from '../../../core/tokens/primitives/shadow/shadow-lyra-light.json';
+import shadowMaiaDark from '../../../core/tokens/primitives/shadow/shadow-maia-dark.json';
+import shadowMaiaLight from '../../../core/tokens/primitives/shadow/shadow-maia-light.json';
+import shadowMiraDark from '../../../core/tokens/primitives/shadow/shadow-mira-dark.json';
+import shadowMiraLight from '../../../core/tokens/primitives/shadow/shadow-mira-light.json';
+import shadowNovaDark from '../../../core/tokens/primitives/shadow/shadow-nova-dark.json';
+import shadowNovaLight from '../../../core/tokens/primitives/shadow/shadow-nova-light.json';
+import shadowVegaDark from '../../../core/tokens/primitives/shadow/shadow-vega-dark.json';
+import shadowVegaLight from '../../../core/tokens/primitives/shadow/shadow-vega-light.json';
+
+const BUNDLED_SHADOW_MODE = 'vega';
+
+type Dimension = { value: number; unit: string };
+type DimensionToken = { $value: Dimension; $type: string };
+type ColorToken = { $value: string; $type: string };
+type ShadowLayer = {
+  x: DimensionToken;
+  y: DimensionToken;
+  blur: DimensionToken;
+  spread: DimensionToken;
+  color: ColorToken;
+};
+type ShadowToken = Record<string, ShadowLayer>;
+type ShadowSet = Record<string, ShadowToken>;
+
+const SHADOW_KEYS = [
+  '2xs',
+  'xs',
+  'sm',
+  'base',
+  'md',
+  'lg',
+  'xl',
+  '2xl',
+] as const;
+
+const SHADOW_MODES_LIGHT: { name: string; tokens: ShadowSet }[] = [
+  { name: 'vega', tokens: shadowVegaLight as ShadowSet },
+  { name: 'lyra', tokens: shadowLyraLight as ShadowSet },
+  { name: 'maia', tokens: shadowMaiaLight as ShadowSet },
+  { name: 'mira', tokens: shadowMiraLight as ShadowSet },
+  { name: 'nova', tokens: shadowNovaLight as ShadowSet },
+];
+
+const SHADOW_MODES_DARK: { name: string; tokens: ShadowSet }[] = [
+  { name: 'vega', tokens: shadowVegaDark as ShadowSet },
+  { name: 'lyra', tokens: shadowLyraDark as ShadowSet },
+  { name: 'maia', tokens: shadowMaiaDark as ShadowSet },
+  { name: 'mira', tokens: shadowMiraDark as ShadowSet },
+  { name: 'nova', tokens: shadowNovaDark as ShadowSet },
+];
+
+function formatPx(d: Dimension) {
+  return `${d.value}${d.unit}`;
+}
+
+function composeShadow(token: ShadowToken): string {
+  return Object.values(token)
+    .map((layer) =>
+      [
+        formatPx(layer.x.$value),
+        formatPx(layer.y.$value),
+        formatPx(layer.blur.$value),
+        formatPx(layer.spread.$value),
+        layer.color.$value,
+      ].join(' ')
+    )
+    .join(', ');
+}
+
+function ShadowCard({ name, token }: { name: string; token: ShadowToken }) {
+  return (
+    <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
+      <div
+        className="nx:bg-container"
+        style={{
+          width: 96,
+          height: 96,
+          borderRadius: 8,
+          boxShadow: composeShadow(token),
+        }}
+      />
+      <span className="nx:text-foreground nx:typography-label-default nx:font-mono">
+        {name}
+      </span>
+    </div>
+  );
+}
+
+function ModeSection({
+  mode,
+  bundled,
+  tokens,
+}: {
+  mode: string;
+  bundled: boolean;
+  tokens: ShadowSet;
+}) {
+  return (
+    <section className="nx:flex nx:flex-col nx:gap-4">
+      <h3 className="nx:flex nx:items-center nx:gap-2 nx:text-foreground nx:typography-heading-xsmall">
+        <span>{mode}</span>
+        {bundled && (
+          <span className="nx:rounded-sm nx:bg-primary-subtle nx:text-primary-subtle-foreground nx:typography-label-small nx:px-1.5 nx:py-0.5">
+            Bundled
+          </span>
+        )}
+      </h3>
+      <div className="nx:flex nx:flex-wrap nx:items-end nx:gap-8 nx:px-2 nx:py-6">
+        {SHADOW_KEYS.map((sk) => (
+          <ShadowCard key={sk} name={sk} token={tokens[sk]} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+const meta: Meta = {
+  title: 'Tokens/Shadow',
+  parameters: {
+    layout: 'fullscreen',
+    a11y: { test: 'off' },
+    docs: {
+      description: {
+        component:
+          'Shadow primitives — composite tokens whose per-layer x/y/blur/spread/color values compose into a CSS `box-shadow` string. Each mode has light and dark variants because shadow colors and opacities differ by background tone. Shown: 8 elevation shadows (2xs → 2xl). Inner and focus tokens exist in JSON but use different visual treatments and are not part of this elevation showcase.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Light: Story = {
+  globals: { theme: 'light' },
+  parameters: {
+    chromatic: { modes: { 'light desktop': themeOnlyModes.light } },
+  },
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-10 nx:p-10 nx:bg-background nx:min-w-fit">
+      <div className="nx:flex nx:flex-col nx:gap-2">
+        <h2 className="nx:text-foreground nx:typography-heading-medium">
+          Shadows — Light
+        </h2>
+        <p className="nx:text-muted-foreground nx:typography-body-small nx:max-w-2xl">
+          Elevation shadows applied to cards on a light background. Each
+          mode&apos;s light JSON defines per-layer values that compose into the
+          CSS `box-shadow` string.
+        </p>
+      </div>
+      {SHADOW_MODES_LIGHT.map(({ name, tokens }) => (
+        <ModeSection
+          key={name}
+          mode={name}
+          bundled={name === BUNDLED_SHADOW_MODE}
+          tokens={tokens}
+        />
+      ))}
+    </div>
+  ),
+};
+
+export const Dark: Story = {
+  globals: { theme: 'dark' },
+  parameters: {
+    chromatic: { modes: { 'dark desktop': themeOnlyModes.dark } },
+  },
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-10 nx:p-10 nx:bg-background nx:min-w-fit">
+      <div className="nx:flex nx:flex-col nx:gap-2">
+        <h2 className="nx:text-foreground nx:typography-heading-medium">
+          Shadows — Dark
+        </h2>
+        <p className="nx:text-muted-foreground nx:typography-body-small nx:max-w-2xl">
+          Same elevation tokens, but each mode&apos;s dark JSON tunes colors and
+          opacities for dark UI. Use these when the surrounding page or panel
+          uses a dark background.
+        </p>
+      </div>
+      {SHADOW_MODES_DARK.map(({ name, tokens }) => (
+        <ModeSection
+          key={name}
+          mode={name}
+          bundled={name === BUNDLED_SHADOW_MODE}
+          tokens={tokens}
+        />
+      ))}
+    </div>
+  ),
+};

--- a/packages/react/src/stories/Spacing.stories.tsx
+++ b/packages/react/src/stories/Spacing.stories.tsx
@@ -1,0 +1,159 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { themeOnlyModes } from '@/storybook/modes';
+
+import sizeLyra from '../../../core/tokens/primitives/size/size-lyra.json';
+import sizeMaia from '../../../core/tokens/primitives/size/size-maia.json';
+import sizeMira from '../../../core/tokens/primitives/size/size-mira.json';
+import sizeNova from '../../../core/tokens/primitives/size/size-nova.json';
+import sizeVega from '../../../core/tokens/primitives/size/size-vega.json';
+import spacingTokens from '../../../core/tokens/semantic/spacing.json';
+
+const BUNDLED_SIZE_MODE = 'vega';
+
+type Dimension = { value: number; unit: string };
+type DimensionLiteralToken = { $value: Dimension; $type: string };
+type DimensionReferenceToken = { $value: string; $type: string };
+type PrimitiveSizeMap = Record<string, DimensionLiteralToken>;
+type SemanticSpacingMap = Record<string, DimensionReferenceToken>;
+
+const SIZE_MODES: { name: string; tokens: PrimitiveSizeMap }[] = [
+  { name: 'vega', tokens: sizeVega as PrimitiveSizeMap },
+  { name: 'lyra', tokens: sizeLyra as PrimitiveSizeMap },
+  { name: 'maia', tokens: sizeMaia as PrimitiveSizeMap },
+  { name: 'mira', tokens: sizeMira as PrimitiveSizeMap },
+  { name: 'nova', tokens: sizeNova as PrimitiveSizeMap },
+];
+
+const SPACING = spacingTokens as SemanticSpacingMap;
+
+function resolveReference(
+  ref: string,
+  primitives: PrimitiveSizeMap
+): Dimension {
+  const key = ref.slice(1, -1);
+  const prim = primitives[key];
+  if (!prim) throw new Error(`Unknown reference: ${ref}`);
+  return prim.$value;
+}
+
+function formatDimension(d: Dimension) {
+  return `${d.value}${d.unit}`;
+}
+
+function sortByValue(rows: [string, Dimension][]) {
+  return [...rows].sort((a, b) => a[1].value - b[1].value);
+}
+
+function Row({ name, dim }: { name: string; dim: Dimension }) {
+  return (
+    <div className="nx:flex nx:items-center nx:gap-4">
+      <span className="nx:w-32 nx:shrink-0 nx:text-foreground nx:typography-label-default nx:font-mono">
+        {name}
+      </span>
+      <span className="nx:w-16 nx:shrink-0 nx:text-muted-foreground nx:typography-label-small nx:font-mono">
+        {formatDimension(dim)}
+      </span>
+      <div
+        className="nx:rounded-sm nx:bg-primary-background nx:shrink-0"
+        style={{ width: `${dim.value}${dim.unit}`, height: 12 }}
+      />
+    </div>
+  );
+}
+
+function ModeSection({
+  mode,
+  rows,
+}: {
+  mode: string;
+  rows: [string, Dimension][];
+}) {
+  const isBundled = mode === BUNDLED_SIZE_MODE;
+  return (
+    <section className="nx:flex nx:flex-col nx:gap-3">
+      <h3 className="nx:flex nx:items-center nx:gap-2 nx:text-foreground nx:typography-heading-xsmall">
+        <span>{mode}</span>
+        {isBundled && (
+          <span className="nx:rounded-sm nx:bg-primary-subtle nx:text-primary-subtle-foreground nx:typography-label-small nx:px-1.5 nx:py-0.5">
+            Bundled
+          </span>
+        )}
+      </h3>
+      <div className="nx:flex nx:flex-col nx:gap-1">
+        {rows.map(([name, dim]) => (
+          <Row key={name} name={name} dim={dim} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+const meta: Meta = {
+  title: 'Tokens/Spacing',
+  parameters: {
+    layout: 'fullscreen',
+    a11y: { test: 'off' },
+    chromatic: { modes: themeOnlyModes },
+    docs: {
+      description: {
+        component:
+          'Spacing tokens used across the design system. Semantic `--spacing-*` aliases reference numeric `--nx-size-*` primitives. Each size mode (vega, lyra, maia, mira, nova) produces a different scale; the bundled mode is the one @nexus/tailwind currently ships with — see packages/core/package.json#scripts.build:tailwind.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Aliases: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-10 nx:p-10 nx:bg-background nx:min-w-fit">
+      <div className="nx:flex nx:flex-col nx:gap-2">
+        <h2 className="nx:text-foreground nx:typography-heading-medium">
+          Spacing Aliases
+        </h2>
+        <p className="nx:text-muted-foreground nx:typography-body-small nx:max-w-2xl">
+          Semantic `--spacing-*` aliases consumed through Tailwind utilities
+          like `nx:p-4` or `nx:gap-2`. Each row shows the alias name, the
+          resolved pixel value, and a bar drawn at that exact width. Compare
+          modes vertically to see how the scale shifts.
+        </p>
+      </div>
+      {SIZE_MODES.map(({ name, tokens }) => {
+        const rows = Object.entries(SPACING).map(
+          ([alias, token]) =>
+            [alias, resolveReference(token.$value, tokens)] as [
+              string,
+              Dimension,
+            ]
+        );
+        return <ModeSection key={name} mode={name} rows={sortByValue(rows)} />;
+      })}
+    </div>
+  ),
+};
+
+export const Primitives: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-10 nx:p-10 nx:bg-background nx:min-w-fit">
+      <div className="nx:flex nx:flex-col nx:gap-2">
+        <h2 className="nx:text-foreground nx:typography-heading-medium">
+          Size Primitives
+        </h2>
+        <p className="nx:text-muted-foreground nx:typography-body-small nx:max-w-2xl">
+          Raw `--nx-size-*` dimension primitives indexed by numeric keys. The
+          spacing aliases above reference these directly — the resolved values
+          here are exactly what the design system emits to CSS.
+        </p>
+      </div>
+      {SIZE_MODES.map(({ name, tokens }) => {
+        const rows = Object.entries(tokens).map(
+          ([key, token]) => [`size-${key}`, token.$value] as [string, Dimension]
+        );
+        return <ModeSection key={name} mode={name} rows={sortByValue(rows)} />;
+      })}
+    </div>
+  ),
+};

--- a/packages/react/src/stories/Typography.stories.tsx
+++ b/packages/react/src/stories/Typography.stories.tsx
@@ -1,0 +1,334 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { themeOnlyModes } from '@/storybook/modes';
+
+import typographyLyra from '../../../core/tokens/primitives/typography/typography-lyra.json';
+import typographyMaia from '../../../core/tokens/primitives/typography/typography-maia.json';
+import typographyMira from '../../../core/tokens/primitives/typography/typography-mira.json';
+import typographyNova from '../../../core/tokens/primitives/typography/typography-nova.json';
+import typographyVega from '../../../core/tokens/primitives/typography/typography-vega.json';
+
+const BUNDLED_TYPOGRAPHY_MODE = 'vega';
+
+type Dimension = { value: number; unit: string };
+type DimensionToken = { $value: Dimension; $type: string };
+type FontFamilyToken = { $value: string; $type: string };
+type FontWeightToken = { $value: number; $type: string };
+
+type TypographyTokenSet = {
+  family: Record<string, FontFamilyToken>;
+  size: Record<string, DimensionToken>;
+  weight: Record<string, FontWeightToken>;
+  'line-height': Record<string, DimensionToken>;
+  letterspacing: Record<string, DimensionToken>;
+};
+
+const VEGA = typographyVega as TypographyTokenSet;
+
+const TYPOGRAPHY_MODES: { name: string; tokens: TypographyTokenSet }[] = [
+  { name: 'vega', tokens: VEGA },
+  { name: 'lyra', tokens: typographyLyra as TypographyTokenSet },
+  { name: 'maia', tokens: typographyMaia as TypographyTokenSet },
+  { name: 'mira', tokens: typographyMira as TypographyTokenSet },
+  { name: 'nova', tokens: typographyNova as TypographyTokenSet },
+];
+
+const SIZE_KEYS = [
+  'xs',
+  'sm',
+  'base',
+  'lg',
+  'xl',
+  '2xl',
+  '3xl',
+  '4xl',
+  '5xl',
+  '6xl',
+  '7xl',
+  '8xl',
+  '9xl',
+] as const;
+const WEIGHT_KEYS = [
+  'thin',
+  'extralight',
+  'light',
+  'normal',
+  'medium',
+  'semibold',
+  'bold',
+  'extrabold',
+  'black',
+] as const;
+const FAMILY_KEYS = ['font-sans', 'font-serif', 'font-mono'] as const;
+const LINE_HEIGHT_DISPLAY_KEYS = [
+  'xs',
+  'sm',
+  'base',
+  'lg',
+  'xl',
+  '2xl',
+] as const;
+
+const SCALE_SAMPLE = 'Aa Bb 12';
+const WEIGHT_SAMPLE = 'The quick brown fox';
+const LINE_HEIGHT_SAMPLE =
+  'Typography is the art and technique of arranging type to make written language legible, readable, and appealing when displayed.';
+const FAMILY_SAMPLE = 'The quick brown fox jumps over the lazy dog. 0123456789';
+
+function formatDimension(d: Dimension) {
+  return `${d.value}${d.unit}`;
+}
+
+function TokenRow({
+  label,
+  value,
+  preview,
+  labelWidth = 'nx:w-12',
+  valueWidth = 'nx:w-20',
+  alignStart = false,
+}: {
+  label: string;
+  value: string;
+  preview: React.ReactNode;
+  labelWidth?: string;
+  valueWidth?: string;
+  alignStart?: boolean;
+}) {
+  const align = alignStart ? 'nx:items-start' : 'nx:items-baseline';
+  return (
+    <div className={`nx:flex ${align} nx:gap-6 nx:py-1`}>
+      <span
+        className={`${labelWidth} nx:shrink-0 nx:text-muted-foreground nx:typography-label-small nx:font-mono`}
+      >
+        {label}
+      </span>
+      <span
+        className={`${valueWidth} nx:shrink-0 nx:text-muted-foreground nx:typography-label-small nx:font-mono`}
+      >
+        {value}
+      </span>
+      {preview}
+    </div>
+  );
+}
+
+function ModeSection({
+  mode,
+  bundled,
+  children,
+}: {
+  mode: string;
+  bundled: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="nx:flex nx:flex-col nx:gap-3">
+      <h3 className="nx:flex nx:items-center nx:gap-2 nx:text-foreground nx:typography-heading-xsmall">
+        <span>{mode}</span>
+        {bundled && (
+          <span className="nx:rounded-sm nx:bg-primary-subtle nx:text-primary-subtle-foreground nx:typography-label-small nx:px-1.5 nx:py-0.5">
+            Bundled
+          </span>
+        )}
+      </h3>
+      <div className="nx:flex nx:flex-col">{children}</div>
+    </section>
+  );
+}
+
+const meta: Meta = {
+  title: 'Tokens/Typography',
+  parameters: {
+    layout: 'fullscreen',
+    a11y: { test: 'off' },
+    chromatic: { modes: themeOnlyModes, delay: 300 },
+    docs: {
+      description: {
+        component:
+          'Typography primitive tokens — sizes, weights, line-heights, and font families. The bundled mode is the one @nexus/tailwind currently ships with — see packages/core/package.json#scripts.build:tailwind. Weights are identical across modes; font families currently match across modes, so families are shown for the bundled mode only.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Scale: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-10 nx:p-10 nx:bg-background nx:min-w-fit">
+      <div className="nx:flex nx:flex-col nx:gap-2">
+        <h2 className="nx:text-foreground nx:typography-heading-medium">
+          Size Scale
+        </h2>
+        <p className="nx:text-muted-foreground nx:typography-body-small nx:max-w-2xl">
+          Raw `--nx-typography-size-*` primitives applied via `font-size` to a
+          short sample. Mode differences are subtle (often 1–2px shifts) —
+          compare `xs` or `base` across modes to spot the pattern.
+        </p>
+      </div>
+      {TYPOGRAPHY_MODES.map(({ name, tokens }) => (
+        <ModeSection
+          key={name}
+          mode={name}
+          bundled={name === BUNDLED_TYPOGRAPHY_MODE}
+        >
+          {SIZE_KEYS.map((sk) => {
+            const dim = tokens.size[sk].$value;
+            return (
+              <TokenRow
+                key={sk}
+                label={sk}
+                value={formatDimension(dim)}
+                preview={
+                  <span
+                    className="nx:text-foreground"
+                    style={{
+                      fontSize: `${dim.value}${dim.unit}`,
+                      lineHeight: 1,
+                    }}
+                  >
+                    {SCALE_SAMPLE}
+                  </span>
+                }
+              />
+            );
+          })}
+        </ModeSection>
+      ))}
+    </div>
+  ),
+};
+
+export const Weights: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-10 nx:p-10 nx:bg-background nx:min-w-fit">
+      <div className="nx:flex nx:flex-col nx:gap-2">
+        <h2 className="nx:text-foreground nx:typography-heading-medium">
+          Weights
+        </h2>
+        <p className="nx:text-muted-foreground nx:typography-body-small nx:max-w-2xl">
+          Weight tokens map descriptive names (thin … black) to numeric weights
+          (100 … 900). These values are identical across all typography modes,
+          so a single ramp is shown — rendered in the bundled `font-sans`.
+        </p>
+      </div>
+      <section className="nx:flex nx:flex-col">
+        {WEIGHT_KEYS.map((wk) => {
+          const weight = VEGA.weight[wk].$value;
+          return (
+            <TokenRow
+              key={wk}
+              label={wk}
+              value={String(weight)}
+              labelWidth="nx:w-24"
+              valueWidth="nx:w-12"
+              preview={
+                <span
+                  className="nx:text-foreground"
+                  style={{ fontSize: 22, fontWeight: weight }}
+                >
+                  {WEIGHT_SAMPLE}
+                </span>
+              }
+            />
+          );
+        })}
+      </section>
+    </div>
+  ),
+};
+
+export const LineHeights: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-10 nx:p-10 nx:bg-background nx:min-w-fit">
+      <div className="nx:flex nx:flex-col nx:gap-2">
+        <h2 className="nx:text-foreground nx:typography-heading-medium">
+          Line Heights
+        </h2>
+        <p className="nx:text-muted-foreground nx:typography-body-small nx:max-w-2xl">
+          Line-height tokens pair with size tokens by key. Each row shows the
+          paired size and line-height (in px), then a paragraph rendered at that
+          combination. Showing `xs` through `2xl` — the readable body range
+          where line-height rhythm matters most.
+        </p>
+      </div>
+      {TYPOGRAPHY_MODES.map(({ name, tokens }) => (
+        <ModeSection
+          key={name}
+          mode={name}
+          bundled={name === BUNDLED_TYPOGRAPHY_MODE}
+        >
+          {LINE_HEIGHT_DISPLAY_KEYS.map((sk) => {
+            const size = tokens.size[sk].$value;
+            const lineHeight = tokens['line-height'][sk].$value;
+            return (
+              <TokenRow
+                key={sk}
+                label={sk}
+                value={`${size.value}/${lineHeight.value}`}
+                labelWidth="nx:w-12"
+                valueWidth="nx:w-16"
+                alignStart={true}
+                preview={
+                  <p
+                    className="nx:text-foreground nx:max-w-md"
+                    style={{
+                      fontSize: `${size.value}${size.unit}`,
+                      lineHeight: `${lineHeight.value}${lineHeight.unit}`,
+                    }}
+                  >
+                    {LINE_HEIGHT_SAMPLE}
+                  </p>
+                }
+              />
+            );
+          })}
+        </ModeSection>
+      ))}
+    </div>
+  ),
+};
+
+export const FontFamilies: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-10 nx:p-10 nx:bg-background nx:min-w-fit">
+      <div className="nx:flex nx:flex-col nx:gap-2">
+        <h2 className="nx:text-foreground nx:typography-heading-medium">
+          Font Families
+        </h2>
+        <p className="nx:text-muted-foreground nx:typography-body-small nx:max-w-2xl">
+          Sans, serif, and mono font families. Showing the bundled mode only —
+          all modes currently ship the same families (Inter / Georgia /
+          JetBrains Mono). Rendering 5 modes with divergent fonts would require
+          loading multiple Google Font payloads on this page.
+        </p>
+      </div>
+      <ModeSection mode={BUNDLED_TYPOGRAPHY_MODE} bundled={true}>
+        {FAMILY_KEYS.map((fk) => {
+          const family = VEGA.family[fk].$value;
+          return (
+            <TokenRow
+              key={fk}
+              label={fk}
+              value={family}
+              labelWidth="nx:w-24"
+              valueWidth="nx:w-32"
+              preview={
+                <span
+                  className="nx:text-foreground"
+                  style={{
+                    fontSize: 18,
+                    fontFamily: `'${family}', system-ui, sans-serif`,
+                  }}
+                >
+                  {FAMILY_SAMPLE}
+                </span>
+              }
+            />
+          );
+        })}
+      </ModeSection>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary

- Add four new Storybook stories under `Tokens/*` documenting spacing, radius + border-width, typography, and shadow primitive scales (`Spacing.stories.tsx`, `Radius.stories.tsx`, `Typography.stories.tsx`, `Shadow.stories.tsx`)
- Each story reads source JSON from `packages/core/tokens/` and renders all five modes side-by-side, with a `Bundled` chip marking the mode that `@nexus/tailwind` currently ships
- Hybrid presentation for typography (sizes/line-heights show all modes, weights are consolidated since values are identical across modes, font families show the bundled mode only to avoid loading multiple Google Font payloads on a docs page); Shadow splits into `Light`/`Dark` stories so each captures against its intended background tone
- Mirrors the existing `Tokens/Colors` pattern (`packages/react/src/stories/Colors.stories.tsx`)

## Test Plan

- [ ] `yarn typecheck` clean
- [ ] `yarn lint` clean
- [ ] `yarn storybook` — open Tokens/Spacing, Tokens/Radius, Tokens/Typography, Tokens/Shadow; confirm every story renders without console errors
- [ ] Toggle theme to dark in toolbar — verify text legibility and `Bundled` chip contrast hold on every story
- [ ] Compare Shadow `Light` vs `Dark` — confirm each variant's shadows are visible against its matching background
- [ ] Spot-check that mode value differences match the JSON (e.g. \`nova\` spacing-4 = 14px, vs vega = 16px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)