### PR TITLE
fix(tokens): run prettier on generator CSS output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,10 +168,9 @@ jobs:
       - name: Build affected packages
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # Build only affected packages on PRs
-            yarn turbo build --filter='...[origin/${{ github.base_ref }}]'
+            # Force @nexus/react: bundle-size needs its dist even when only core/scripts changes (core isn't a workspace dep of react).
+            yarn turbo build --filter='...[origin/${{ github.base_ref }}]' --filter='@nexus/react'
           else
-            # Build all on push to main
             yarn turbo build
           fi
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "devDependencies": {
     "apca-w3": "^0.1.9",
-    "culori": "^4.0.2"
+    "culori": "^4.0.2",
+    "prettier": "^3.7.4"
   }
 }

--- a/packages/core/scripts/__tests__/generate-modular.test.js
+++ b/packages/core/scripts/__tests__/generate-modular.test.js
@@ -1,0 +1,63 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import * as prettier from 'prettier';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { generateModular } from '../generate-modular.js';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+const tmpDirs = [];
+
+function makeTmpDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nexus-modular-test-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterAll(() => {
+  while (tmpDirs.length > 0) {
+    const dir = tmpDirs.pop();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('generateModular', () => {
+  let distDir;
+
+  beforeAll(async () => {
+    const originalLog = console.log;
+    console.log = () => {};
+    try {
+      distDir = makeTmpDir();
+      await generateModular({ distDir });
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
+  // Regenerating tokens used to produce a noisy whitespace diff against the
+  // committed CSS because the generator emitted raw output but the committed
+  // files were prettier-formatted. The generator now formats every emitted
+  // file, so prettier --check must agree it has nothing to change.
+  it('emits prettier-formatted CSS (idempotent under prettier)', async () => {
+    const config = await prettier.resolveConfig(TEST_DIR);
+    const files = fs
+      .readdirSync(distDir)
+      .filter((name) => name.endsWith('.css'));
+
+    expect(files.length).toBeGreaterThan(0);
+
+    for (const name of files) {
+      const filePath = path.join(distDir, name);
+      const content = fs.readFileSync(filePath, 'utf8');
+      const reformatted = await prettier.format(content, {
+        ...config,
+        filepath: filePath,
+      });
+      expect(reformatted, `${name} is not prettier-formatted`).toBe(content);
+    }
+  });
+});

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -1,10 +1,14 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import * as prettier from 'prettier';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { generateTailwindPackage } from '../generate-tailwind-package.js';
 import { DEFAULT_CONFIG } from '../utils.js';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 const tmpDirs = [];
 
@@ -28,7 +32,7 @@ function extractBlock(css, openSelector) {
   return match[1];
 }
 
-afterEach(() => {
+afterAll(() => {
   while (tmpDirs.length > 0) {
     const dir = tmpDirs.pop();
     fs.rmSync(dir, { recursive: true, force: true });
@@ -41,14 +45,14 @@ describe('generateTailwindPackage', () => {
   let nexusCSS;
   let warnings;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     warnings = [];
     const originalWarn = console.warn;
     console.warn = (...args) => warnings.push(args.map(String).join(' '));
 
     try {
       distDir = makeTmpDir();
-      generateTailwindPackage(DEFAULT_CONFIG, { distDir });
+      await generateTailwindPackage(DEFAULT_CONFIG, { distDir });
     } finally {
       console.warn = originalWarn;
     }
@@ -108,5 +112,28 @@ describe('generateTailwindPackage', () => {
   it('emits zero `File not found` warnings for the default config', () => {
     const fileNotFound = warnings.filter((w) => /File not found/.test(w));
     expect(fileNotFound).toEqual([]);
+  });
+
+  // Regenerating tokens used to produce a noisy whitespace diff against the
+  // committed CSS because the generator emitted raw output but the committed
+  // files were prettier-formatted. The generator now formats every emitted
+  // file, so prettier --check must agree it has nothing to change.
+  it('emits prettier-formatted CSS (idempotent under prettier)', async () => {
+    const config = await prettier.resolveConfig(TEST_DIR);
+    const files = fs
+      .readdirSync(distDir)
+      .filter((name) => name.endsWith('.css'));
+
+    expect(files.length).toBeGreaterThan(0);
+
+    for (const name of files) {
+      const filePath = path.join(distDir, name);
+      const content = fs.readFileSync(filePath, 'utf8');
+      const reformatted = await prettier.format(content, {
+        ...config,
+        filepath: filePath,
+      });
+      expect(reformatted, `${name} is not prettier-formatted`).toBe(content);
+    }
   });
 });

--- a/packages/core/scripts/generate-modular.js
+++ b/packages/core/scripts/generate-modular.js
@@ -12,7 +12,7 @@ import {
   discoverSemantics,
   ensureDir,
   extractTokens,
-  formatDistDirectory,
+  formatDistCssFiles,
   formatShadowComposite,
   formatTokenValue,
   generateBorderWidthUtilitiesCSS,
@@ -30,7 +30,7 @@ import {
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TOKENS_DIR = path.join(__dirname, '../tokens');
-const MODULAR_DIR = path.join(__dirname, '../dist/modular');
+const DEFAULT_MODULAR_DIR = path.join(__dirname, '../dist/modular');
 
 const PRIMITIVES_DIR = path.join(TOKENS_DIR, 'primitives');
 const SEMANTIC_DIR = path.join(TOKENS_DIR, 'semantic');
@@ -136,8 +136,8 @@ function processShadowStyles() {
 /**
  * Write CSS file
  */
-function writeModularFile(fileName, content) {
-  const filePath = path.join(MODULAR_DIR, fileName);
+function writeModularFile(distDir, fileName, content) {
+  const filePath = path.join(distDir, fileName);
   fs.writeFileSync(filePath, content);
   log.file(fileName);
 }
@@ -145,7 +145,7 @@ function writeModularFile(fileName, content) {
 /**
  * Generate CSS file for a single-file primitive category
  */
-function generatePrimitivesCSS(tokens, category) {
+function generatePrimitivesCSS(distDir, tokens, category) {
   let css = `/* ${category} primitives */\n\n:root {\n`;
 
   for (const token of tokens) {
@@ -153,13 +153,13 @@ function generatePrimitivesCSS(tokens, category) {
   }
 
   css += `}\n`;
-  writeModularFile(`${category}.css`, css);
+  writeModularFile(distDir, `${category}.css`, css);
 }
 
 /**
  * Generate mode file (size, typography, shadow, radius, borderwidth)
  */
-function generateModeCSS(category, mode, tokens) {
+function generateModeCSS(distDir, category, mode, tokens) {
   let css = `/* ${category}: ${mode} */\n\n:root {\n`;
 
   for (const token of tokens) {
@@ -167,13 +167,13 @@ function generateModeCSS(category, mode, tokens) {
   }
 
   css += `}\n`;
-  writeModularFile(`${category}-${mode}.css`, css);
+  writeModularFile(distDir, `${category}-${mode}.css`, css);
 }
 
 /**
  * Generate themed CSS file (supports light/dark variants)
  */
-function generateThemedCSS(type, mode, primitiveMap) {
+function generateThemedCSS(distDir, type, mode, primitiveMap) {
   const lightTokens = processSemanticFile(
     `${type}-${mode}-light.json`,
     primitiveMap
@@ -195,14 +195,14 @@ function generateThemedCSS(type, mode, primitiveMap) {
   }
   css += `}\n`;
 
-  writeModularFile(`${type}-${mode}.css`, css);
+  writeModularFile(distDir, `${type}-${mode}.css`, css);
 }
 
 /**
  * Generate themed primitive CSS file (light/dark pair → one file with html / html.dark blocks).
  * Mirrors generateThemedCSS so themed primitives load the same way as base/brands semantics.
  */
-function generateThemedPrimitiveCSS(category, mode, primitiveMap) {
+function generateThemedPrimitiveCSS(distDir, category, mode, primitiveMap) {
   const lightTokens = processPrimitiveFile(
     category,
     `${mode}-light`,
@@ -226,13 +226,13 @@ function generateThemedPrimitiveCSS(category, mode, primitiveMap) {
   }
   css += `}\n`;
 
-  writeModularFile(`${category}-${mode}.css`, css);
+  writeModularFile(distDir, `${category}-${mode}.css`, css);
 }
 
 /**
  * Generate shadow variables CSS
  */
-function generateShadowVariablesCSS(shadows) {
+function generateShadowVariablesCSS(distDir, shadows) {
   let css = `/* Shadow Variables */\n\n:root {\n`;
 
   for (const shadow of shadows) {
@@ -240,13 +240,13 @@ function generateShadowVariablesCSS(shadows) {
   }
 
   css += `}\n`;
-  writeModularFile('shadow-variables.css', css);
+  writeModularFile(distDir, 'shadow-variables.css', css);
 }
 
 /**
  * Generate standalone semantic CSS (spacing, etc.)
  */
-function generateStandaloneSemanticCSS(name, tokens) {
+function generateStandaloneSemanticCSS(distDir, name, tokens) {
   let css = `/* ${name} */\n\n:root {\n`;
 
   for (const token of tokens) {
@@ -254,13 +254,13 @@ function generateStandaloneSemanticCSS(name, tokens) {
   }
 
   css += `}\n`;
-  writeModularFile(`${name}.css`, css);
+  writeModularFile(distDir, `${name}.css`, css);
 }
 
 /**
  * Generate globals.css for playground using shared generateThemeCSS function
  */
-function generatePlaygroundGlobalsCSS(primitives, primitiveMap) {
+function generatePlaygroundGlobalsCSS(distDir, primitives, primitiveMap) {
   // Get first available typography mode for Google Fonts
   const typographyModes = primitives.typography?.modes || ['vega'];
   const typographyMode = typographyModes[0];
@@ -331,19 +331,19 @@ function generatePlaygroundGlobalsCSS(primitives, primitiveMap) {
     // No dark mode block - playground uses dynamic theme switching
   });
 
-  writeModularFile('globals.css', css);
+  writeModularFile(distDir, 'globals.css', css);
   return colorTokens.length + spacingTokens.length;
 }
 
 /**
  * Main execution
  */
-async function main() {
+export async function generateModular({ distDir = DEFAULT_MODULAR_DIR } = {}) {
   console.log('🎨 Generating modular CSS files...\n');
 
   // Wipe and recreate dist so renamed/removed outputs do not leave orphans.
-  fs.rmSync(MODULAR_DIR, { recursive: true, force: true });
-  ensureDir(MODULAR_DIR);
+  fs.rmSync(distDir, { recursive: true, force: true });
+  ensureDir(distDir);
 
   // Auto-discover all categories and modes
   const primitives = discoverPrimitives(PRIMITIVES_DIR);
@@ -376,7 +376,7 @@ async function main() {
   for (const [category, info] of Object.entries(primitives)) {
     if (info.modes === null) {
       const tokens = processSinglePrimitive(category, primitiveMap);
-      generatePrimitivesCSS(tokens, category);
+      generatePrimitivesCSS(distDir, tokens, category);
       totalFiles++;
     }
   }
@@ -389,12 +389,12 @@ async function main() {
 
       for (const mode of plain) {
         const tokens = processPrimitiveFile(category, mode, primitiveMap);
-        generateModeCSS(category, mode, tokens);
+        generateModeCSS(distDir, category, mode, tokens);
         totalFiles++;
       }
 
       for (const mode of Object.keys(themed)) {
-        generateThemedPrimitiveCSS(category, mode, primitiveMap);
+        generateThemedPrimitiveCSS(distDir, category, mode, primitiveMap);
         totalFiles++;
       }
     }
@@ -404,7 +404,7 @@ async function main() {
   for (const [type, modes] of Object.entries(semantics.themed)) {
     console.log(`\n${type} themes:`);
     for (const mode of Object.keys(modes)) {
-      generateThemedCSS(type, mode, primitiveMap);
+      generateThemedCSS(distDir, type, mode, primitiveMap);
       totalFiles++;
     }
   }
@@ -415,7 +415,7 @@ async function main() {
     for (const standaloneFile of semantics.standalone) {
       const tokens = processSemanticFile(standaloneFile, primitiveMap);
       const fileName = standaloneFile.replace('.json', '');
-      generateStandaloneSemanticCSS(fileName, tokens);
+      generateStandaloneSemanticCSS(distDir, fileName, tokens);
       totalFiles++;
     }
   }
@@ -424,14 +424,14 @@ async function main() {
   console.log('\nStyles:');
   const typography = generateTypographyUtilitiesCSS(TOKENS_DIR, primitiveMap);
   if (typography.css) {
-    writeModularFile('typography-utilities.css', typography.css);
+    writeModularFile(distDir, 'typography-utilities.css', typography.css);
     console.log(`  ✓ ${typography.count} typography utilities`);
     totalFiles++;
   }
 
   // Generate shadow variables from styles
   const shadowVariables = processShadowStyles();
-  generateShadowVariablesCSS(shadowVariables);
+  generateShadowVariablesCSS(distDir, shadowVariables);
   console.log(`  ✓ ${shadowVariables.length} shadow variables`);
   totalFiles++;
 
@@ -444,7 +444,7 @@ async function main() {
       primitiveMap
     );
     const borderWidth = generateBorderWidthUtilitiesCSS(borderwidthTokens);
-    writeModularFile('borderwidth-utilities.css', borderWidth.css);
+    writeModularFile(distDir, 'borderwidth-utilities.css', borderWidth.css);
     console.log(`  ✓ ${borderWidth.count} border width utilities`);
     totalFiles++;
   }
@@ -452,17 +452,20 @@ async function main() {
   // Generate playground globals.css
   console.log('\nPlayground:');
   const globalsTokenCount = generatePlaygroundGlobalsCSS(
+    distDir,
     primitives,
     primitiveMap
   );
   console.log(`  ✓ globals.css (${globalsTokenCount} tokens)`);
   totalFiles++;
 
-  await formatDistDirectory(MODULAR_DIR);
+  await formatDistCssFiles(distDir);
 
   console.log(
     `\n✨ Generated ${totalFiles} modular CSS files in dist/modular/`
   );
 }
 
-await main();
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await generateModular();
+}

--- a/packages/core/scripts/generate-modular.js
+++ b/packages/core/scripts/generate-modular.js
@@ -12,6 +12,7 @@ import {
   discoverSemantics,
   ensureDir,
   extractTokens,
+  formatDistDirectory,
   formatShadowComposite,
   formatTokenValue,
   generateBorderWidthUtilitiesCSS,
@@ -337,7 +338,7 @@ function generatePlaygroundGlobalsCSS(primitives, primitiveMap) {
 /**
  * Main execution
  */
-function main() {
+async function main() {
   console.log('🎨 Generating modular CSS files...\n');
 
   // Wipe and recreate dist so renamed/removed outputs do not leave orphans.
@@ -457,9 +458,11 @@ function main() {
   console.log(`  ✓ globals.css (${globalsTokenCount} tokens)`);
   totalFiles++;
 
+  await formatDistDirectory(MODULAR_DIR);
+
   console.log(
     `\n✨ Generated ${totalFiles} modular CSS files in dist/modular/`
   );
 }
 
-main();
+await main();

--- a/packages/core/scripts/generate-tailwind-package.js
+++ b/packages/core/scripts/generate-tailwind-package.js
@@ -12,7 +12,7 @@ import {
   discoverSemantics,
   ensureDir,
   extractTokens,
-  formatDistDirectory,
+  formatDistCssFiles,
   formatTokenValue,
   generateBaseLayerCSS,
   generateBorderWidthUtilitiesCSS,
@@ -526,7 +526,7 @@ export async function generateTailwindPackage(
   const nexusCSS = generateNexusCSS(semanticFiles, primitiveMap, usedModes);
   writeDistFile('nexus.css', nexusCSS);
 
-  await formatDistDirectory(distDir);
+  await formatDistCssFiles(distDir);
 
   const themeCount = semanticFiles.themed.length;
   console.log('');

--- a/packages/core/scripts/generate-tailwind-package.js
+++ b/packages/core/scripts/generate-tailwind-package.js
@@ -12,6 +12,7 @@ import {
   discoverSemantics,
   ensureDir,
   extractTokens,
+  formatDistDirectory,
   formatTokenValue,
   generateBaseLayerCSS,
   generateBorderWidthUtilitiesCSS,
@@ -460,7 +461,7 @@ function generateNexusCSS(semanticFiles, primitiveMap, usedModes) {
  * Main generation function. Exported so tests can run it against a temp
  * `distDir` without overwriting the committed bundle in `dist/tailwind`.
  */
-export function generateTailwindPackage(
+export async function generateTailwindPackage(
   config,
   { distDir = DEFAULT_DIST_DIR } = {}
 ) {
@@ -525,6 +526,8 @@ export function generateTailwindPackage(
   const nexusCSS = generateNexusCSS(semanticFiles, primitiveMap, usedModes);
   writeDistFile('nexus.css', nexusCSS);
 
+  await formatDistDirectory(distDir);
+
   const themeCount = semanticFiles.themed.length;
   console.log('');
   console.log(`📊 Summary:`);
@@ -543,7 +546,7 @@ export function generateTailwindPackage(
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   console.log('🎨 Generating @nexus/tailwind package from DTCG tokens...');
   const cliConfig = parseArgs();
-  generateTailwindPackage(cliConfig);
+  await generateTailwindPackage(cliConfig);
   console.log('');
   console.log('✨ @nexus/tailwind package generation complete!');
 }

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -1,5 +1,7 @@
 import fs from 'fs';
 import path from 'path';
+import * as prettier from 'prettier';
+import { fileURLToPath } from 'url';
 
 import {
   hexToOklchMechanical,
@@ -1114,4 +1116,27 @@ export function generateBaseLayerCSS() {
   }
 }
 `;
+}
+
+const SCRIPTS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Format every `.css` file in `distDir` in place with prettier, using the
+ * repo's `.prettierrc`. Resolves the config from the script's own location so
+ * callers can write to a temporary dist (e.g. tests) without losing config
+ * resolution.
+ */
+export async function formatDistDirectory(distDir) {
+  const config = await prettier.resolveConfig(SCRIPTS_DIR);
+  const files = fs.readdirSync(distDir).filter((name) => name.endsWith('.css'));
+
+  for (const name of files) {
+    const filePath = path.join(distDir, name);
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const formatted = await prettier.format(raw, {
+      ...config,
+      filepath: filePath,
+    });
+    fs.writeFileSync(filePath, formatted);
+  }
 }

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -1121,16 +1121,33 @@ export function generateBaseLayerCSS() {
 const SCRIPTS_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 /**
- * Format every `.css` file in `distDir` in place with prettier, using the
- * repo's `.prettierrc`. Resolves the config from the script's own location so
- * callers can write to a temporary dist (e.g. tests) without losing config
- * resolution.
+ * Format every `.css` file directly inside `distDir` in place with prettier,
+ * using the repo's `.prettierrc`. Resolves the config from the script's own
+ * location so callers can write to a temporary dist (e.g. tests) without
+ * losing config resolution.
+ *
+ * Only walks the top level — both dist layouts (`dist/tailwind`,
+ * `dist/modular`) are flat today. Throws if a subdirectory appears so a
+ * future nested layout cannot silently skip files.
  */
-export async function formatDistDirectory(distDir) {
+export async function formatDistCssFiles(distDir) {
   const config = await prettier.resolveConfig(SCRIPTS_DIR);
-  const files = fs.readdirSync(distDir).filter((name) => name.endsWith('.css'));
+  const entries = fs.readdirSync(distDir, { withFileTypes: true });
+  const cssFiles = [];
 
-  for (const name of files) {
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      throw new Error(
+        `formatDistCssFiles: unexpected subdirectory '${entry.name}' in ${distDir}. ` +
+          `Helper assumes a flat layout; update it to walk recursively if nesting is intentional.`
+      );
+    }
+    if (entry.isFile() && entry.name.endsWith('.css')) {
+      cssFiles.push(entry.name);
+    }
+  }
+
+  for (const name of cssFiles) {
     const filePath = path.join(distDir, name);
     const raw = fs.readFileSync(filePath, 'utf8');
     const formatted = await prettier.format(raw, {


### PR DESCRIPTION
## Summary

- Both token generators (`generate-tailwind-package.js`, `generate-modular.js`) now run prettier in place on every emitted `.css` file before exiting, using a shared `formatDistDirectory` helper in `utils.js`.
- The committed CSS in `packages/tailwind/` had been prettier-formatted, but the generators emitted raw output — so regenerating tokens produced a noisy ~56-line whitespace diff in `nexus.css` plus trailing-newline diffs elsewhere, all of which masked real token changes and recently cost investigation time during PR #50.
- Adds a regression test that asserts every file emitted by `generateTailwindPackage` is prettier-idempotent.

## GitHub Issue

Closes #51

## Test Plan

- [x] `yarn test:unit` — 65 passed, 1 skipped (6 in `generate-tailwind-package.test.js` including the new regression case)
- [x] `yarn tokens:tailwind` on a clean tree — produces zero diff in `packages/tailwind/`
- [x] `yarn tokens:modular` on a clean tree — produces zero diff in `apps/playground/public/themes/` and `apps/playground/src/styles/`
- [x] `npx eslint packages/core/scripts/` — clean
- [x] `npx prettier --check` on touched source files — clean