### PR TITLE
fix(tokens): replace non-existent token refs across code and docs

### DIFF
--- a/.claude/rules/figma.md
+++ b/.claude/rules/figma.md
@@ -72,18 +72,18 @@ Figma uses `spacing-{n}` which maps to code's `--spacing-{n}`:
 
 ### Color Tokens
 
-| Figma Token            | Code Token                     | Usage               |
-| ---------------------- | ------------------------------ | ------------------- |
-| `background`           | `--color-background`           | Page background     |
-| `foreground`           | `--color-foreground`           | Primary text        |
-| `muted`                | `--color-muted`                | Muted backgrounds   |
-| `muted-foreground`     | `--color-muted-foreground`     | Secondary text      |
-| `primary-background`   | `--color-primary-background`   | Primary buttons     |
-| `primary-foreground`   | `--color-primary-foreground`   | Text on primary     |
-| `primary-hover`        | `--color-primary-hover`        | Primary hover state |
-| `secondary-background` | `--color-secondary-background` | Secondary buttons   |
-| `error-background`     | `--color-error-background`     | Error/destructive   |
-| `border-default`       | `--color-border-default`       | Default borders     |
+| Figma Token                | Code Token                         | Usage               |
+| -------------------------- | ---------------------------------- | ------------------- |
+| `background`               | `--color-background`               | Page background     |
+| `foreground`               | `--color-foreground`               | Primary text        |
+| `muted`                    | `--color-muted`                    | Muted backgrounds   |
+| `muted-foreground`         | `--color-muted-foreground`         | Secondary text      |
+| `primary-background`       | `--color-primary-background`       | Primary buttons     |
+| `primary-foreground`       | `--color-primary-foreground`       | Text on primary     |
+| `primary-background-hover` | `--color-primary-background-hover` | Primary hover state |
+| `secondary-background`     | `--color-secondary-background`     | Secondary buttons   |
+| `error-background`         | `--color-error-background`         | Error/destructive   |
+| `border-default`           | `--color-border-default`           | Default borders     |
 
 ### Typography Tokens
 

--- a/.claude/rules/tokens.md
+++ b/.claude/rules/tokens.md
@@ -45,11 +45,12 @@ OKLCH requires Chrome 111+, Safari 15.4+, Firefox 113+ (Baseline 2023). No hex f
 
 `yarn workspace @nexus/core audit:contrast` (implemented in `packages/core/scripts/audit-contrast.js`) runs APCA Lc on every base and brand foreground↔background pair, with thresholds chosen per APCA's intended-use tiers:
 
-| Pair                                                                             | Threshold | Rationale |
-| -------------------------------------------------------------------------------- | --------- | --------- | ----- | ------------------------------- |
-| `foreground ↔ background`                                                        | `         | Lc        | ≥ 75` | Body text, fluent reading       |
-| `{primary,secondary,error,success,warning,information}-foreground ↔ -background` | `         | Lc        | ≥ 60` | UI labels (buttons, badges)     |
-| `muted-foreground ↔ muted`                                                       | `         | Lc        | ≥ 45` | Incidental / de-emphasised text |
+| Pair                                                                                | Threshold | Rationale |
+| ----------------------------------------------------------------------------------- | --------- | --------- | ----- | ------------------------------- |
+| `foreground ↔ background`                                                           | `         | Lc        | ≥ 75` | Body text, fluent reading       |
+| `{primary,secondary,error,success,warning,information}-foreground ↔ -background`    | `         | Lc        | ≥ 60` | UI labels (buttons, badges)     |
+| `{primary,secondary,error,success,warning,information}-subtle-foreground ↔ -subtle` | `         | Lc        | ≥ 60` | Labels on tinted (subtle) fills |
+| `muted-foreground ↔ muted`                                                          | `         | Lc        | ≥ 45` | Incidental / de-emphasised text |
 
 Failures must be fixed by adjusting the semantic token reference (which shade a given role points to) or the L grid values — not by lowering the thresholds. The tiers themselves come from APCA's published guidance and are not negotiable per-finding.
 

--- a/.claude/rules/tokens.md
+++ b/.claude/rules/tokens.md
@@ -88,18 +88,20 @@ Semantic tokens use nested groups for states:
 ```json
 {
   "primary": {
-    "background": { "$value": "{blue.500}", "$type": "color" },
-    "foreground": { "$value": "{blue.50}", "$type": "color" },
-    "hover": { "$value": "{blue.600}", "$type": "color" },
-    "active": { "$value": "{blue.700}", "$type": "color" },
+    "background": { "$value": "{blue.600}", "$type": "color" },
+    "background-hover": { "$value": "{blue.700}", "$type": "color" },
+    "background-active": { "$value": "{blue.800}", "$type": "color" },
+    "foreground": { "$value": "{white}", "$type": "color" },
     "disabled": { "$value": "{blue.300}", "$type": "color" },
-    "text": { "$value": "{blue.500}", "$type": "color" },
-    "surface": { "$value": "{blue.100}", "$type": "color" }
+    "subtle": { "$value": "{blue.50}", "$type": "color" },
+    "subtle-foreground": { "$value": "{blue.600}", "$type": "color" },
+    "subtle-hover": { "$value": "{blue.100}", "$type": "color" },
+    "subtle-active": { "$value": "{blue.200}", "$type": "color" }
   }
 }
 ```
 
-This generates CSS variables like `--color-primary-background`, `--color-primary-hover`, etc.
+This generates CSS variables like `--color-primary-background`, `--color-primary-background-hover`, etc.
 
 ## Reference Syntax
 
@@ -136,14 +138,14 @@ Primitive colors use Tailwind's shade scale (50-950):
 
 ## Semantic Token Categories
 
-| Category | Properties                                                            | Example                      |
-| -------- | --------------------------------------------------------------------- | ---------------------------- |
-| Layout   | `background`, `foreground`, `container`, `popover`, `muted`, `accent` | `--color-background`         |
-| Brand    | `primary.*`, `secondary.*`                                            | `--color-primary-background` |
-| Status   | `error.*`, `success.*`, `warning.*`, `information.*`                  | `--color-error-text`         |
-| Borders  | `border.default`, `border.primary`, `border.error`, etc.              | `--color-border-default`     |
+| Category | Properties                                                  | Example                           |
+| -------- | ----------------------------------------------------------- | --------------------------------- |
+| Layout   | `background`, `foreground`, `container`, `popover`, `muted` | `--color-background`              |
+| Brand    | `primary.*`, `secondary.*`                                  | `--color-primary-background`      |
+| Status   | `error.*`, `success.*`, `warning.*`, `information.*`        | `--color-error-subtle-foreground` |
+| Borders  | `border.default`, `border.primary`, `border.error`, etc.    | `--color-border-default`          |
 
-Each brand/status group has: `background`, `foreground`, `hover`, `active`, `disabled`, `text`, `surface`
+Each brand/status group has: `background`, `background-hover`, `background-active`, `foreground`, `disabled`, `subtle`, `subtle-foreground`, `subtle-hover`, `subtle-active`
 
 ## Light/Dark Theme Tokens
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,38 @@ jobs:
       - name: Run unit tests
         run: yarn test:unit
 
+  audit-tokens:
+    name: Audit Tokens
+    runs-on: ubuntu-latest
+    needs: [changes, build]
+    if: needs.changes.outputs.react == 'true' && needs.build.result == 'success'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Regenerate @nexus/tailwind and check freshness
+        run: |
+          yarn workspace @nexus/core build:tailwind
+          if ! git diff --exit-code -- packages/tailwind; then
+            echo "::error::packages/tailwind/ is stale — run 'yarn workspace @nexus/core build:tailwind' and commit the result."
+            exit 1
+          fi
+
+      - name: APCA contrast audit
+        run: yarn workspace @nexus/core audit:contrast
+
+      - name: Tailwind class-ref audit
+        run: yarn workspace @nexus/core audit:class-refs
+
   test-storybook:
     name: Storybook Tests
     runs-on: ubuntu-latest

--- a/apps/playground/src/components/IconShowcase.tsx
+++ b/apps/playground/src/components/IconShowcase.tsx
@@ -26,7 +26,7 @@ export function IconShowcase() {
                 href={meta.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="nx:text-primary-text nx:underline hover:nx:no-underline"
+                className="nx:text-primary-subtle-foreground nx:underline nx:hover:no-underline"
               >
                 {meta.label}
               </a>
@@ -42,7 +42,7 @@ export function IconShowcase() {
           {iconNames.map((name) => (
             <div
               key={name}
-              className="nx:bg-muted/50 nx:flex nx:flex-col nx:items-center nx:gap-2 nx:rounded-lg nx:p-3 hover:nx:bg-muted nx:transition-colors nx:cursor-default"
+              className="nx:bg-muted/50 nx:flex nx:flex-col nx:items-center nx:gap-2 nx:rounded-lg nx:p-3 nx:hover:bg-muted nx:transition-colors nx:cursor-default"
             >
               <PlaygroundIcon
                 name={name}

--- a/apps/playground/src/components/ThemeSwitcher.tsx
+++ b/apps/playground/src/components/ThemeSwitcher.tsx
@@ -87,7 +87,7 @@ function ColorSelect({
           id={id}
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          className="nx:appearance-none nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:pl-7 nx:pr-8 nx:py-1.5 nx:text-sm nx:cursor-pointer hover:nx:bg-accent nx:transition-colors"
+          className="nx:appearance-none nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:pl-7 nx:pr-8 nx:py-1.5 nx:text-sm nx:cursor-pointer nx:hover:bg-background-hover nx:transition-colors"
         >
           {options.map((opt) => (
             <option key={opt.value} value={opt.value}>
@@ -134,7 +134,7 @@ function TokenSelect({
           id={id}
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          className="nx:appearance-none nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:pl-3 nx:pr-8 nx:py-1.5 nx:text-sm nx:cursor-pointer hover:nx:bg-accent nx:transition-colors nx:capitalize"
+          className="nx:appearance-none nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:pl-3 nx:pr-8 nx:py-1.5 nx:text-sm nx:cursor-pointer nx:hover:bg-background-hover nx:transition-colors nx:capitalize"
         >
           {options.map((opt) => (
             <option key={opt} value={opt}>
@@ -301,7 +301,7 @@ export function ThemeSwitcher({ theme, setTheme }: ThemeSwitcherProps) {
                 id="icon-library-select"
                 value={iconLibrary}
                 onChange={(e) => setIconLibrary(e.target.value as IconLibrary)}
-                className="nx:appearance-none nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:pl-3 nx:pr-8 nx:py-1.5 nx:text-sm nx:cursor-pointer hover:nx:bg-accent nx:transition-colors"
+                className="nx:appearance-none nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:pl-3 nx:pr-8 nx:py-1.5 nx:text-sm nx:cursor-pointer nx:hover:bg-background-hover nx:transition-colors"
               >
                 {ICON_LIBRARIES.map((lib) => (
                   <option key={lib} value={lib}>
@@ -326,7 +326,7 @@ export function ThemeSwitcher({ theme, setTheme }: ThemeSwitcherProps) {
       <div className="nx:p-4 nx:border-t nx:border-border-default">
         <button
           onClick={handleReset}
-          className="nx:w-full nx:flex nx:items-center nx:justify-center nx:gap-2 nx:bg-background nx:border nx:border-border-default nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium hover:nx:bg-accent nx:transition-colors"
+          className="nx:w-full nx:flex nx:items-center nx:justify-center nx:gap-2 nx:bg-background nx:border nx:border-border-default nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium nx:hover:bg-background-hover nx:transition-colors"
         >
           <PlaygroundIcon name="x" size={14} />
           Reset to Default

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build:tokens:modular": "node scripts/generate-modular.js",
     "build:tailwind": "node scripts/generate-tailwind-package.js --base=stone --brand=neutral --borderwidth=vega --radius=sharp --shadow=vega --size=vega --typography=vega",
-    "audit:contrast": "node scripts/audit-contrast.js"
+    "audit:contrast": "node scripts/audit-contrast.js",
+    "audit:class-refs": "node scripts/audit-class-refs.js"
   },
   "dependencies": {},
   "license": "MIT",

--- a/packages/core/scripts/__tests__/semantic-shape.test.js
+++ b/packages/core/scripts/__tests__/semantic-shape.test.js
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SEMANTIC_DIR = path.resolve(TEST_DIR, '..', '..', 'tokens', 'semantic');
+
+const REQUIRED_KEYS = [
+  'background',
+  'background-hover',
+  'background-active',
+  'foreground',
+  'disabled',
+  'subtle',
+  'subtle-foreground',
+  'subtle-hover',
+  'subtle-active',
+];
+
+const BASE_ROLES = ['error', 'success', 'warning', 'information'];
+const BRAND_ROLES = ['primary', 'secondary'];
+
+function semanticFiles(prefix) {
+  return fs
+    .readdirSync(SEMANTIC_DIR)
+    .filter((name) => name.startsWith(`${prefix}-`) && name.endsWith('.json'))
+    .map((name) => path.join(SEMANTIC_DIR, name));
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+describe('semantic token shape', () => {
+  // `.claude/rules/tokens.md` documents that each brand/status role exposes
+  // a fixed nine-key shape. Without a test, the doc and the JSON drift
+  // (see #54: badge.tsx referenced `*-surface` / `*-text` keys that never
+  // existed). Walk every semantic file and prove the shape end-to-end.
+  it.each(semanticFiles('base'))(
+    'base file %s exposes the 9-key shape for status roles',
+    (filePath) => {
+      const data = readJson(filePath);
+      for (const role of BASE_ROLES) {
+        expect(data[role], `${role} role missing`).toBeDefined();
+        for (const key of REQUIRED_KEYS) {
+          expect(
+            data[role][key]?.$value,
+            `${path.basename(filePath)} ${role}.${key} missing $value`
+          ).toBeTruthy();
+        }
+      }
+    }
+  );
+
+  it.each(semanticFiles('brands'))(
+    'brand file %s exposes the 9-key shape for brand roles',
+    (filePath) => {
+      const data = readJson(filePath);
+      for (const role of BRAND_ROLES) {
+        expect(data[role], `${role} role missing`).toBeDefined();
+        for (const key of REQUIRED_KEYS) {
+          expect(
+            data[role][key]?.$value,
+            `${path.basename(filePath)} ${role}.${key} missing $value`
+          ).toBeTruthy();
+        }
+      }
+    }
+  );
+});

--- a/packages/core/scripts/__tests__/utils.test.js
+++ b/packages/core/scripts/__tests__/utils.test.js
@@ -130,8 +130,8 @@ describe('utils', () => {
 
     it('adds prefix when provided', () => {
       expect(pathToCssVar(['background'], 'color')).toBe('color-background');
-      expect(pathToCssVar(['primary', 'hover'], 'color')).toBe(
-        'color-primary-hover'
+      expect(pathToCssVar(['primary', 'background-hover'], 'color')).toBe(
+        'color-primary-background-hover'
       );
     });
 

--- a/packages/core/scripts/audit-class-refs.js
+++ b/packages/core/scripts/audit-class-refs.js
@@ -1,0 +1,145 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const NEXUS_CSS = path.join(REPO_ROOT, 'packages', 'tailwind', 'nexus.css');
+const SOURCE_DIRS = [
+  path.join(REPO_ROOT, 'packages', 'react', 'src'),
+  path.join(REPO_ROOT, 'apps'),
+];
+
+// Prefixes whose value-slot we own as semantic tokens. Anything that starts
+// with one of these (after the utility prefix) must resolve to a --color-*
+// variable in the emitted CSS. Other class names — including Tailwind
+// built-ins like text-sm, border-2, bg-transparent — fall through this
+// allowlist and are not validated.
+const SEMANTIC_PREFIXES = [
+  'background',
+  'foreground',
+  'container',
+  'popover',
+  'muted',
+  'primary',
+  'secondary',
+  'error',
+  'success',
+  'warning',
+  'information',
+  'border',
+  'overlay',
+  'disabled',
+  'accent', // not a real token in Nexus — surfaces the migration bug
+];
+
+// Utility prefixes that consume a color-like value (e.g., `nx:bg-X`, `nx:text-X`).
+const UTILITY_PREFIXES = [
+  'bg',
+  'text',
+  'border',
+  'ring',
+  'fill',
+  'stroke',
+  'outline',
+  'shadow',
+  'divide',
+];
+
+function loadEmittedColorNames() {
+  const css = fs.readFileSync(NEXUS_CSS, 'utf8');
+  const set = new Set();
+  for (const match of css.matchAll(/--color-([a-z0-9-]+):/g)) {
+    set.add(match[1]);
+  }
+  return set;
+}
+
+function isSemanticName(name) {
+  for (const prefix of SEMANTIC_PREFIXES) {
+    if (name === prefix || name.startsWith(`${prefix}-`)) return true;
+  }
+  return false;
+}
+
+function* walkSources(dir) {
+  if (!fs.existsSync(dir)) return;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkSources(full);
+    } else if (/\.(tsx?|jsx?|mdx?)$/.test(entry.name)) {
+      yield full;
+    }
+  }
+}
+
+function findClassRefs(content) {
+  // Match: nx:<optional state chain>:(utility)-<color-name>
+  // State chain segments may be:
+  //   - bare words like `hover:`, `focus:`, `focus-visible:`, `dark:`
+  //   - words with arbitrary-value suffix like `data-[state=open]:`
+  //   - pure arbitrary selectors like `[&_svg]:`
+  // The leading `nx:` is anchored at a non-word boundary so `foonx:` does not
+  // match.
+  const utilityAlt = UTILITY_PREFIXES.join('|');
+  const re = new RegExp(
+    String.raw`(?:^|[^\w-])nx:(?:[a-z-]+(?:\[[^\]]+\])?:|\[[^\]]+\]:)*(?:${utilityAlt})-([a-z][a-z0-9-]*)`,
+    'g'
+  );
+  const hits = [];
+  for (const match of content.matchAll(re)) {
+    hits.push({ name: match[1], offset: match.index });
+  }
+  return hits;
+}
+
+function lineOf(content, offset) {
+  return content.slice(0, offset).split('\n').length;
+}
+
+function main() {
+  const known = loadEmittedColorNames();
+  const failures = [];
+  let scanned = 0;
+
+  for (const dir of SOURCE_DIRS) {
+    for (const file of walkSources(dir)) {
+      scanned += 1;
+      const content = fs.readFileSync(file, 'utf8');
+      const seen = new Set();
+      for (const hit of findClassRefs(content)) {
+        if (!isSemanticName(hit.name)) continue;
+        if (known.has(hit.name)) continue;
+        const key = `${file}:${hit.name}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        failures.push({
+          file: path.relative(REPO_ROOT, file),
+          line: lineOf(content, hit.offset),
+          name: hit.name,
+        });
+      }
+    }
+  }
+
+  if (failures.length === 0) {
+    process.stdout.write(
+      `audit-class-refs: scanned ${scanned} files — all semantic color refs resolve.\n`
+    );
+    process.exit(0);
+  }
+
+  process.stdout.write(
+    `audit-class-refs: scanned ${scanned} files — ${failures.length} unresolved semantic color ref(s):\n`
+  );
+  for (const f of failures) {
+    process.stdout.write(
+      `  ${f.file}:${f.line}  nx:…-${f.name}  (no --color-${f.name} in nexus.css)\n`
+    );
+  }
+  process.exit(1);
+}
+
+main();

--- a/packages/core/scripts/audit-contrast.js
+++ b/packages/core/scripts/audit-contrast.js
@@ -21,14 +21,20 @@ const BASE_PAIRS = [
   ['foreground', 'background', 75],
   ['muted-foreground', 'muted', 45],
   ['error.foreground', 'error.background', 60],
+  ['error.subtle-foreground', 'error.subtle', 60],
   ['success.foreground', 'success.background', 60],
+  ['success.subtle-foreground', 'success.subtle', 60],
   ['warning.foreground', 'warning.background', 60],
+  ['warning.subtle-foreground', 'warning.subtle', 60],
   ['information.foreground', 'information.background', 60],
+  ['information.subtle-foreground', 'information.subtle', 60],
 ];
 
 const BRAND_PAIRS = [
   ['primary.foreground', 'primary.background', 60],
+  ['primary.subtle-foreground', 'primary.subtle', 60],
   ['secondary.foreground', 'secondary.background', 60],
+  ['secondary.subtle-foreground', 'secondary.subtle', 60],
 ];
 
 const REF_RE = /^\{([^}]+)\}$/;

--- a/packages/core/tokens/semantic/base-gray-dark.json
+++ b/packages/core/tokens/semantic/base-gray-dark.json
@@ -157,7 +157,7 @@
       "$type": "color"
     },
     "subtle-foreground": {
-      "$value": "{red.300}",
+      "$value": "{red.200}",
       "$type": "color"
     },
     "subtle-hover": {

--- a/packages/core/tokens/semantic/base-neutral-dark.json
+++ b/packages/core/tokens/semantic/base-neutral-dark.json
@@ -157,7 +157,7 @@
       "$type": "color"
     },
     "subtle-foreground": {
-      "$value": "{red.300}",
+      "$value": "{red.200}",
       "$type": "color"
     },
     "subtle-hover": {

--- a/packages/core/tokens/semantic/base-slate-dark.json
+++ b/packages/core/tokens/semantic/base-slate-dark.json
@@ -157,7 +157,7 @@
       "$type": "color"
     },
     "subtle-foreground": {
-      "$value": "{red.300}",
+      "$value": "{red.200}",
       "$type": "color"
     },
     "subtle-hover": {

--- a/packages/core/tokens/semantic/base-stone-dark.json
+++ b/packages/core/tokens/semantic/base-stone-dark.json
@@ -157,7 +157,7 @@
       "$type": "color"
     },
     "subtle-foreground": {
-      "$value": "{red.300}",
+      "$value": "{red.200}",
       "$type": "color"
     },
     "subtle-hover": {

--- a/packages/core/tokens/semantic/base-zinc-dark.json
+++ b/packages/core/tokens/semantic/base-zinc-dark.json
@@ -157,7 +157,7 @@
       "$type": "color"
     },
     "subtle-foreground": {
-      "$value": "{red.300}",
+      "$value": "{red.200}",
       "$type": "color"
     },
     "subtle-hover": {

--- a/packages/core/tokens/semantic/brands-blue-dark.json
+++ b/packages/core/tokens/semantic/brands-blue-dark.json
@@ -63,7 +63,7 @@
       "$type": "color"
     },
     "subtle-foreground": {
-      "$value": "{neutral.400}",
+      "$value": "{neutral.200}",
       "$type": "color"
     },
     "subtle-hover": {

--- a/packages/core/tokens/semantic/brands-gray-dark.json
+++ b/packages/core/tokens/semantic/brands-gray-dark.json
@@ -63,7 +63,7 @@
       "$type": "color"
     },
     "subtle-foreground": {
-      "$value": "{gray.400}",
+      "$value": "{gray.200}",
       "$type": "color"
     },
     "subtle-hover": {

--- a/packages/core/tokens/semantic/brands-neutral-dark.json
+++ b/packages/core/tokens/semantic/brands-neutral-dark.json
@@ -63,7 +63,7 @@
       "$type": "color"
     },
     "subtle-foreground": {
-      "$value": "{neutral.400}",
+      "$value": "{neutral.200}",
       "$type": "color"
     },
     "subtle-hover": {

--- a/packages/core/tokens/semantic/brands-slate-dark.json
+++ b/packages/core/tokens/semantic/brands-slate-dark.json
@@ -63,7 +63,7 @@
       "$type": "color"
     },
     "subtle-foreground": {
-      "$value": "{slate.400}",
+      "$value": "{slate.200}",
       "$type": "color"
     },
     "subtle-hover": {

--- a/packages/core/tokens/semantic/brands-stone-dark.json
+++ b/packages/core/tokens/semantic/brands-stone-dark.json
@@ -63,7 +63,7 @@
       "$type": "color"
     },
     "subtle-foreground": {
-      "$value": "{stone.400}",
+      "$value": "{stone.200}",
       "$type": "color"
     },
     "subtle-hover": {

--- a/packages/react/src/components/ui/Badge.stories.tsx
+++ b/packages/react/src/components/ui/Badge.stories.tsx
@@ -174,8 +174,6 @@ export const Sentence: Story = {
 export const WithDataAttributes: Story = {
   parameters: {
     chromatic: { disableSnapshot: true },
-    // TODO: Fix success-surface/success-text token contrast
-    a11y: { test: 'todo' },
   },
   args: {
     children: 'Status',

--- a/packages/react/src/components/ui/badge.tsx
+++ b/packages/react/src/components/ui/badge.tsx
@@ -33,7 +33,7 @@ const badgeVariants = cva(
       {
         variant: 'secondary',
         fill: 'solid',
-        className: 'nx:bg-secondary-background nx:text-secondary-text',
+        className: 'nx:bg-secondary-background nx:text-secondary-foreground',
       },
       {
         variant: 'outline',
@@ -66,12 +66,12 @@ const badgeVariants = cva(
       {
         variant: 'default',
         fill: 'light',
-        className: 'nx:bg-primary-surface nx:text-primary-text',
+        className: 'nx:bg-primary-subtle nx:text-primary-subtle-foreground',
       },
       {
         variant: 'secondary',
         fill: 'light',
-        className: 'nx:bg-secondary-surface nx:text-secondary-text',
+        className: 'nx:bg-secondary-subtle nx:text-secondary-subtle-foreground',
       },
       {
         variant: 'outline',
@@ -82,22 +82,23 @@ const badgeVariants = cva(
       {
         variant: 'error',
         fill: 'light',
-        className: 'nx:bg-error-surface nx:text-error-text',
+        className: 'nx:bg-error-subtle nx:text-error-subtle-foreground',
       },
       {
         variant: 'warning',
         fill: 'light',
-        className: 'nx:bg-warning-surface nx:text-warning-text',
+        className: 'nx:bg-warning-subtle nx:text-warning-subtle-foreground',
       },
       {
         variant: 'success',
         fill: 'light',
-        className: 'nx:bg-success-surface nx:text-success-text',
+        className: 'nx:bg-success-subtle nx:text-success-subtle-foreground',
       },
       {
         variant: 'information',
         fill: 'light',
-        className: 'nx:bg-information-surface nx:text-information-text',
+        className:
+          'nx:bg-information-subtle nx:text-information-subtle-foreground',
       },
     ],
     defaultVariants: {

--- a/packages/react/src/components/ui/dropdown-menu.tsx
+++ b/packages/react/src/components/ui/dropdown-menu.tsx
@@ -89,7 +89,7 @@ function DropdownMenuSubTrigger({
         'nx:rounded-sm nx:px-2 nx:py-1.5 nx:text-sm nx:outline-none',
         'nx:focus:bg-background-hover',
         'nx:data-[state=open]:bg-background-hover',
-        '[&_svg]:nx:pointer-events-none [&_svg]:nx:size-4 [&_svg]:nx:shrink-0',
+        'nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
         inset && 'nx:pl-8',
         className
       )}
@@ -232,7 +232,7 @@ function DropdownMenuItem({
         'nx:transition-colors',
         'nx:focus:bg-background-hover nx:focus:text-foreground',
         'nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50',
-        '[&_svg]:nx:pointer-events-none [&_svg]:nx:size-4 [&_svg]:nx:shrink-0',
+        'nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
         inset && 'nx:pl-8',
         variant === 'destructive' &&
           'nx:text-error-subtle-foreground nx:focus:bg-error-background nx:focus:text-error-foreground',

--- a/packages/react/src/components/ui/dropdown-menu.tsx
+++ b/packages/react/src/components/ui/dropdown-menu.tsx
@@ -235,7 +235,7 @@ function DropdownMenuItem({
         '[&_svg]:nx:pointer-events-none [&_svg]:nx:size-4 [&_svg]:nx:shrink-0',
         inset && 'nx:pl-8',
         variant === 'destructive' &&
-          'nx:text-error-foreground nx:focus:bg-error-background nx:focus:text-error-foreground',
+          'nx:text-error-subtle-foreground nx:focus:bg-error-background nx:focus:text-error-foreground',
         className
       )}
       {...props}

--- a/yarn.lock
+++ b/yarn.lock
@@ -516,18 +516,6 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
-"@isaacs/balanced-match@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz#3081dadbc3460661b751e7591d7faea5df39dd29"
-  integrity sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==
-
-"@isaacs/brace-expansion@^5.0.0", "@isaacs/brace-expansion@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz#0ef5a92d91f2fff2a37646ce54da9e5f599f6eff"
-  integrity sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==
-  dependencies:
-    "@isaacs/balanced-match" "^4.0.1"
-
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -2251,10 +2239,10 @@ axobject-query@^4.1.0:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-4.1.0.tgz#28768c76d0e3cff21bc62a9e2d0b6ac30042a1ee"
   integrity sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==
 
-balanced-match@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
-  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
 baseline-browser-mapping@^2.9.0:
   version "2.9.10"
@@ -2268,20 +2256,12 @@ bidi-js@^1.0.3:
   dependencies:
     require-from-string "^2.0.2"
 
-brace-expansion@^1.1.7:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.14.tgz#d9de602370d91347cd9ddad1224d4fd701eb348b"
-  integrity sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==
+brace-expansion@^5.0.5:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.6.tgz#ec68fe0a641a29d8711579caf641d05bae1f2285"
+  integrity sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==
   dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
-brace-expansion@^2.0.2:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.0.tgz#4f41a41190216ee36067ec381526fe9539c4f0ae"
-  integrity sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==
-  dependencies:
-    balanced-match "^1.0.0"
+    balanced-match "^4.0.2"
 
 braces@^3.0.3:
   version "3.0.3"
@@ -2465,11 +2445,6 @@ compare-versions@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.1.tgz#7af3cc1099ba37d244b3145a9af5201b629148a9"
   integrity sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 confbox@^0.1.8:
   version "0.1.8"
@@ -4132,33 +4107,12 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-minimatch@10.0.3:
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.0.3.tgz#cf7a0314a16c4d9ab73a7730a0e8e3c3502d47aa"
-  integrity sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==
+minimatch@10.0.3, minimatch@^10.1.1, minimatch@^10.1.2, minimatch@^3.1.2, minimatch@^9.0.3, minimatch@^9.0.4:
+  version "10.2.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
+  integrity sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==
   dependencies:
-    "@isaacs/brace-expansion" "^5.0.0"
-
-minimatch@^10.1.1:
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.1.2.tgz#6c3f289f9de66d628fa3feb1842804396a43d81c"
-  integrity sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==
-  dependencies:
-    "@isaacs/brace-expansion" "^5.0.1"
-
-minimatch@^3.1.2:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
-  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@^9.0.3, minimatch@^9.0.4:
-  version "9.0.9"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
-  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
-  dependencies:
-    brace-expansion "^2.0.2"
+    brace-expansion "^5.0.5"
 
 minimist@^1.2.6:
   version "1.2.8"


### PR DESCRIPTION
## Summary

- 7 bad compound-variant token strings in Badge (`*-surface` / `*-text`) now reference real `*-subtle` / `*-subtle-foreground` tokens — fixes #37 (light-fill variants were rendering transparent on the default body fg)
- DropdownMenu destructive item visible in the default state (red text on default bg, full red bg + white text on focus) — was white-on-white
- Playground (`ThemeSwitcher`, `IconShowcase`) no longer models the anti-patterns the rules forbid (4× `hover:nx:bg-accent`, two prefix-order bugs, `primary-text`)
- Rule docs (`tokens.md`, `figma.md`) describe tokens that actually exist; one stale test fixture in `utils.test.js` swapped for a realistic key path

### Review-follow-up additions

- `dropdown-menu.tsx`: same `[&_svg]:nx:` → `nx:[&_svg]:` prefix-order fix at the two sites this PR already edited (ripple miss from initial pass — `nx:[&_svg]:` is the form `button.tsx:10` and `alert.tsx:8` use)
- `audit-contrast.js`: `BASE_PAIRS` / `BRAND_PAIRS` now include `{role}.subtle-foreground ↔ {role}.subtle` at Lc 60 for every status/brand role. That gap is why the 13 broken `*-subtle` references in Badge slipped past `audit:contrast`. The new pairs surfaced 10 pre-existing dark-mode contrast failures (`error.subtle-foreground` in base-*-dark, `secondary.subtle-foreground` in brands-*-dark); fixed by lifting those references one shade (300 → 200 / 400 → 200) per `tokens.md`'s rule that audit failures must be fixed via token references, not threshold changes.
- New `audit:class-refs` script: greps `nx:(bg|text|border|…)-{name}` class refs across `packages/react/src/` and `apps/` against the `--color-*` set emitted in `nexus.css`. Catches exactly the `nx:bg-error-surface` / `nx:hover:bg-accent` / `nx:text-primary-text` failure mode that motivated #37 / #39.
- New `semantic-shape.test.js`: walks every `base-*` / `brands-*` semantic JSON file and asserts each role exposes the full 9-key shape documented in `tokens.md`, so the doc and JSON cannot drift again.

### Note on `yarn.lock`

The `minimatch` / `@isaacs/brace-expansion` dedup churn in `yarn.lock` is an unrelated side-effect of `yarn install` against the existing `resolutions` field — it is not part of the token-ref fix and contains no source-level changes.

## GitHub Issue

Closes #39
Closes #37

## Test Plan

- [ ] Storybook Badge `LightFill` and `AllVariants` show tinted backgrounds for all 6 colored variants in both light and dark themes
- [ ] DropdownMenu destructive item shows red text in default state, full red bg + white text on hover/focus
- [ ] Playground theme switcher selects + reset button show a subtle bg change on hover (not unstyled)
- [ ] Chromatic visual regression: review intentional churn on Badge light-fill stories, DropdownMenu destructive item, and dark-mode `error.subtle` / `secondary.subtle` foregrounds (one shade lighter)
- [x] `yarn workspace @nexus/react typecheck` clean
- [x] `yarn workspace @nexus/core audit:contrast` — 140/140 passing (was 130/140 before subtle-foreground bumps)
- [x] `yarn workspace @nexus/core audit:class-refs` — 46 files scanned, all semantic color refs resolve
- [x] `yarn test:unit` — 86/86 passing (added 20 nine-key shape assertions)
- [x] `yarn test:storybook` — 211/211 passing
- [x] Ripple grep across `packages/` and `apps/` for `*-surface | *-text | hover:nx: | bg-accent | [&_svg]:nx:` — zero hits
