### PR TITLE
feat(claude): PostToolUse hooks for prettier + nx: prefix lint

### DIFF
--- a/.claude/hooks/format-edited-file.mjs
+++ b/.claude/hooks/format-edited-file.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const input = JSON.parse(readFileSync(0, 'utf8'));
+const file = input?.tool_input?.file_path;
+
+if (!file || !/\.(ts|tsx|js|jsx|json|md|css|yml|yaml)$/.test(file)) {
+  process.exit(0);
+}
+
+const projectDir = process.env.CLAUDE_PROJECT_DIR ?? process.cwd();
+const prettierBin = path.join(projectDir, 'node_modules/.bin/prettier');
+
+if (!existsSync(prettierBin)) process.exit(0);
+
+const result = spawnSync(
+  prettierBin,
+  ['--write', '--ignore-unknown', '--log-level', 'error', file],
+  { cwd: projectDir, stdio: ['ignore', 'pipe', 'pipe'] },
+);
+
+if (result.status && result.status !== 0) {
+  const err = result.stderr?.toString() || result.stdout?.toString() || '';
+  process.stderr.write(`prettier: ${err.trim()}\n`);
+}
+
+process.exit(0);

--- a/.claude/hooks/lint-nx-prefix.mjs
+++ b/.claude/hooks/lint-nx-prefix.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs';
+
+const input = JSON.parse(readFileSync(0, 'utf8'));
+const file = input?.tool_input?.file_path;
+
+if (!file || !file.endsWith('.tsx') || !existsSync(file)) {
+  process.exit(0);
+}
+
+const lines = readFileSync(file, 'utf8').split('\n');
+
+const checks = [
+  {
+    re: /[a-z][a-z0-9_-]*:nx:|\]:nx:/,
+    label:
+      'Wrong nx: prefix order — must come BEFORE all modifiers (e.g. `nx:hover:bg-*`, not `hover:nx:bg-*`)',
+  },
+  {
+    re: /nx:(?:hover:|active:|focus:|focus-visible:)?(?:bg|text)-accent\b/,
+    label:
+      'Banned accent token — Nexus has no `accent`; use `background-hover` / `container-hover` / `popover-hover` (see shadcn-divergences.md)',
+  },
+  {
+    re: /nx:(?:hover:|active:|focus:|focus-visible:)?(?:bg|text|border)-(?:primary|secondary|error|success|warning|information|destructive)(?![\w-])/,
+    label:
+      'Incomplete semantic token path — use `-background`, `-foreground`, or `-subtle` suffix (e.g. `nx:bg-primary-background`)',
+  },
+  {
+    re: /nx:(?:hover:|active:|focus:|focus-visible:)?(?:bg|text|border)-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d{2,3}/,
+    label:
+      'Raw Tailwind primitive color — use a semantic token instead (e.g. `nx:bg-primary-background`, not `nx:bg-blue-500`)',
+  },
+];
+
+const violations = [];
+for (const { re, label } of checks) {
+  lines.forEach((line, idx) => {
+    if (re.test(line)) {
+      violations.push(`  ${file}:${idx + 1}: ${line.trim()}\n    → ${label}`);
+    }
+  });
+}
+
+if (violations.length === 0) process.exit(0);
+
+const msg = [
+  `nx: prefix lint found ${violations.length} violation(s):`,
+  '',
+  ...violations,
+  '',
+  'Reference: .claude/rules/components.md, .claude/rules/shadcn-divergences.md',
+].join('\n');
+
+process.stdout.write(
+  JSON.stringify({
+    additionalContext: msg,
+    systemMessage: `nx: prefix lint: ${violations.length} violation(s) in ${file}`,
+  }),
+);
+process.exit(0);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -63,6 +63,23 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/format-edited-file.mjs",
+            "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/lint-nx-prefix.mjs",
+            "timeout": 10
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

- `format-edited-file.mjs` — runs `prettier --write` after every `Edit|Write|MultiEdit` so the in-flight working tree stays formatted (no more interim diff noise)
- `lint-nx-prefix.mjs` — scans edited `.tsx` files for the four most-cited rule violations from `components.md` / `shadcn-divergences.md`:
  - Wrong `nx:` prefix order (`hover:nx:bg-*` instead of `nx:hover:bg-*`)
  - Banned `accent` token (`nx:bg-accent`, `nx:hover:bg-accent`)
  - Incomplete semantic token paths (`nx:bg-primary` instead of `nx:bg-primary-background`)
  - Raw Tailwind primitive colors (`nx:bg-blue-500` instead of a semantic token)
- Violations surface to Claude via the PostToolUse `additionalContext` channel so the fix happens on the same turn, not in PR review
- Wired in `.claude/settings.json` under `PostToolUse` matching `Edit|Write|MultiEdit`

## GitHub Issue

Closes #71
Closes #72

## Test Plan

- [x] Synthetic fixture with all 4 violation types → linter emits `additionalContext` listing each `file:line` + remediation hint
- [x] Clean component file (`button.tsx`) → linter exits 0 silently
- [x] Non-TSX path → linter exits 0 silently
- [x] Formatter on `.bin` (non-formattable) → exits 0 silently
- [x] Verified live: writing a fixture in this session triggered the formatter and reformatted multi-line JSX
- [x] `JSON.parse(settings.json)` passes — config is valid
- [ ] Reviewer: confirm hooks fire in your own session after pulling this branch

## Design Notes

- Hooks run as Node ESM scripts (`*.mjs`) rather than inline bash because the regex set needs lookahead (`(?![\\w-])` on incomplete tokens) which BSD grep can't express cleanly
- Order matters: format runs before lint so the linter sees the canonical formatted output
- Linter only inspects `.tsx` — CSS files have their own conventions and stories are exempt from the `nx:` rule (TBD if we want to extend)
- Both hooks exit 0 on every code path; formatter failure logs to stderr but never blocks Claude (formatting is best-effort)

## Out of Scope

- TypeScript type-check on edit (turbo cache helps but adds latency; consider in a follow-up if useful)
- ESLint auto-fix on edit (lint-staged already covers this at commit; reconsider once nx: prefix linter shakes out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)