### PR TITLE
chore: ignore local tool artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,11 +41,19 @@ build-storybook.log
 # ESLint cache
 .eslintcache
 
-# Claude Code (local settings not committed)
+# Claude Code (local settings + runtime state, not committed)
 .claude/settings.local.json
+.claude/scheduled_tasks.json
+.claude/scheduled_tasks.lock
 CLAUDE.local.md
 **/CLAUDE.local.md
 
 # MCP / AI tool configs (may contain credentials)
 .mcp.json
 opencode.json
+
+# Playwright MCP (local browser session logs/snapshots)
+.playwright-mcp/
+
+# Local scratch artifacts (throwaway screenshots, etc.)
+/dataviz-*.png


### PR DESCRIPTION
## Summary

Add `.gitignore` rules for local, tool-generated artifacts so they stop surfacing in `git status`:

- `.playwright-mcp/` — Playwright MCP browser session logs/snapshots
- `.claude/scheduled_tasks.json` + `.claude/scheduled_tasks.lock` — Claude Code scheduling runtime state
- `/dataviz-*.png` — throwaway scratch screenshots (root-anchored so it won't mask PNGs in subdirs)

The existing untracked instances were also removed locally. They were never tracked, so they don't appear in this diff (which is the `.gitignore` change only).

## GitHub Issue

N/A — standalone cleanup chore (no tracked issue).

## Test Plan

- [x] `git check-ignore -v` matches each new pattern
- [x] Working tree clean after removal — no stray untracked artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)