### PR TITLE
refactor(react,core): source-code hygiene — dead code, dedup, CVA, JSDoc

### DIFF
--- a/packages/core/scripts/audit-colorblind.js
+++ b/packages/core/scripts/audit-colorblind.js
@@ -3,6 +3,7 @@ import { differenceEuclidean } from 'culori';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { BASE_PALETTES } from './lib/palettes.js';
 import { hexToSrgbInts } from './lib/perceptual-grid.js';
 import { readTokenFile, titleCase } from './utils.js';
 
@@ -38,7 +39,7 @@ export const SHADES = [
 
 // Grouped because the SVG sections them visually and the cross-status pair
 // confusability test only fires for STATUS_PALETTES.
-export const BASE_PALETTES = ['slate', 'neutral', 'zinc', 'gray', 'stone'];
+export { BASE_PALETTES };
 export const STATUS_PALETTES = ['red', 'green', 'amber', 'blue'];
 export const CHART_PALETTES = ['teal', 'lime', 'orange', 'rose', 'indigo'];
 export const ALL_PALETTES = [

--- a/packages/core/scripts/audit-contrast.js
+++ b/packages/core/scripts/audit-contrast.js
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { BASE_PALETTES } from './lib/palettes.js';
 import { hexToSrgbInts, isPaletteShadeKey } from './lib/perceptual-grid.js';
 import { extractTokens, readTokenFile } from './utils.js';
 
@@ -12,7 +13,6 @@ const SEMANTIC_DIR = path.join(TOKENS_DIR, 'semantic');
 const PRIMITIVES_FILE = path.join(TOKENS_DIR, 'primitives', 'color.json');
 const FOCUS_PRIMITIVES_DIR = path.join(TOKENS_DIR, 'primitives', 'focus');
 
-const BASE_PALETTES = ['slate', 'neutral', 'zinc', 'gray', 'stone'];
 const BRANDS = ['blue', 'gray', 'neutral', 'slate', 'stone'];
 const THEMES = ['light', 'dark'];
 

--- a/packages/core/scripts/lib/palettes.js
+++ b/packages/core/scripts/lib/palettes.js
@@ -1,0 +1,2 @@
+// Base palette keys shared by the Node audit scripts.
+export const BASE_PALETTES = ['slate', 'neutral', 'zinc', 'gray', 'stone'];

--- a/packages/core/src/lib/adjust-contrast.ts
+++ b/packages/core/src/lib/adjust-contrast.ts
@@ -41,9 +41,6 @@ export interface AdjustContrastOptions {
   palette?: AdjustContrastPalette;
 }
 
-// TODO(#84): parseToOklch / oklchToSrgbInts / formatOklch / clampForEmit
-// duplicate scripts/lib/perceptual-grid.js (~20 lines). Extract to a shared
-// browser-safe module once @nexus/colors lands.
 function stripAlpha(color: Oklch): Oklch {
   if (color.alpha === undefined || color.alpha === 1) return color;
   return { mode: 'oklch', l: color.l, c: color.c, h: color.h };

--- a/packages/react/src/components/ui/dropdown-menu.tsx
+++ b/packages/react/src/components/ui/dropdown-menu.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { cva, type VariantProps } from 'class-variance-authority';
 
 import { IconCheck, IconChevronRight, IconCircleFilled } from '@/lib/icons';
 import { cn } from '@/lib/utils';
@@ -66,6 +67,10 @@ const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 interface DropdownMenuSubTriggerProps extends React.ComponentProps<
   typeof DropdownMenuPrimitive.SubTrigger
 > {
+  /**
+   * Indents the trigger to align with items that have a leading icon or checkbox.
+   * @default false
+   */
   inset?: boolean;
 }
 
@@ -192,16 +197,36 @@ function DropdownMenuContent({
   );
 }
 
+const dropdownMenuItemVariants = cva(
+  'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2 nx:rounded-sm nx:px-2 nx:py-1.5 nx:text-sm nx:outline-none nx:transition-colors nx:focus:bg-background-hover nx:focus:text-foreground nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: '',
+        destructive:
+          'nx:text-error-subtle-foreground nx:focus:bg-error-background nx:focus:text-error-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
 /**
  * DropdownMenuItemProps
  *
  * Props for the DropdownMenuItem component.
  */
-interface DropdownMenuItemProps extends React.ComponentProps<
-  typeof DropdownMenuPrimitive.Item
-> {
+interface DropdownMenuItemProps
+  extends
+    React.ComponentProps<typeof DropdownMenuPrimitive.Item>,
+    VariantProps<typeof dropdownMenuItemVariants> {
+  /**
+   * Indents the item to align with items that have a leading icon or checkbox.
+   * @default false
+   */
   inset?: boolean;
-  variant?: 'default' | 'destructive';
 }
 
 /**
@@ -227,15 +252,8 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2',
-        'nx:rounded-sm nx:px-2 nx:py-1.5 nx:text-sm nx:outline-none',
-        'nx:transition-colors',
-        'nx:focus:bg-background-hover nx:focus:text-foreground',
-        'nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50',
-        'nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+        dropdownMenuItemVariants({ variant }),
         inset && 'nx:pl-8',
-        variant === 'destructive' &&
-          'nx:text-error-subtle-foreground nx:focus:bg-error-background nx:focus:text-error-foreground',
         className
       )}
       {...props}
@@ -352,6 +370,10 @@ function DropdownMenuRadioItem({
 interface DropdownMenuLabelProps extends React.ComponentProps<
   typeof DropdownMenuPrimitive.Label
 > {
+  /**
+   * Indents the label to align with items that have a leading icon or checkbox.
+   * @default false
+   */
   inset?: boolean;
 }
 
@@ -455,6 +477,7 @@ export {
   DropdownMenuGroup,
   DropdownMenuItem,
   type DropdownMenuItemProps,
+  dropdownMenuItemVariants,
   DropdownMenuLabel,
   type DropdownMenuLabelProps,
   DropdownMenuPortal,

--- a/packages/react/src/components/ui/switch.tsx
+++ b/packages/react/src/components/ui/switch.tsx
@@ -26,7 +26,7 @@ interface SwitchProps extends React.ComponentProps<
  *
  * @example
  * ```tsx
- * <div className="flex items-center gap-2">
+ * <div className="nx:flex nx:items-center nx:gap-2">
  *   <Switch id="airplane-mode" />
  *   <label htmlFor="airplane-mode">Airplane Mode</label>
  * </div>

--- a/packages/react/src/lib/icons.ts
+++ b/packages/react/src/lib/icons.ts
@@ -18,7 +18,6 @@ export { IconLoader2 } from '@tabler/icons-react';
 // Navigation
 export {
   IconChevronDown,
-  IconChevronLeft,
   IconChevronRight,
   IconChevronUp,
 } from '@tabler/icons-react';
@@ -33,6 +32,3 @@ export {
   IconCircleCheck,
   IconInfoCircle,
 } from '@tabler/icons-react';
-
-// Common UI
-export { IconEye, IconEyeOff, IconSearch } from '@tabler/icons-react';


### PR DESCRIPTION
## Summary

First source-code hygiene pass over `packages/*/src` + `scripts/` (the earlier cleanup was docs-only). The lint/type baseline was already clean (both are CI-gated), so this targets what those tools don't catch — dead code, duplication, and pattern inconsistency.

- **Dead code (SC-1, SC-2):** removed 4 unused icon re-exports (`IconChevronLeft` / `IconEye` / `IconEyeOff` / `IconSearch` — imported by zero files) and a stale `TODO(#84)` in `adjust-contrast.ts` (it waited on the **cancelled** `@nexus/colors` package).
- **Dedup (SC-4):** extracted the duplicated `BASE_PALETTES` list into `scripts/lib/palettes.js`, shared by `audit-contrast.js` + `audit-colorblind.js` (the latter re-exports it for its SVG generator + tests). `SHADES` is left per-file — it only duplicates across the runtime/script boundary, which can't share a module.
- **Consistency (SC-5, SC-6, SC-7):** converted `DropdownMenuItem`'s inline `variant` to a `cva` (the only variant component not using CVA) — behavior-preserving, identical emitted classes; added JSDoc to 3 undocumented `inset` props and `nx:`-prefixed a `switch.tsx` JSDoc example.

### On the OKLCH-helper duplication (SC-3) — intentionally left

`adjust-contrast.ts` (browser runtime) and `scripts/lib/perceptual-grid.js` (Node build script) keep parallel copies of ~15 lines of OKLCH helpers. We chose **not** to extract a shared module: they straddle a browser-runtime / Node-script and TS / JS boundary, deliberately differ on alpha handling, and feed values under an APCA byte-stability guarantee (#86) — so a shared module is more machinery (and risk) than the ~15 lines it saves. The dead TODO implying "merge later" was removed; this note records the decision (per `code-comments.md`, rationale lives here, not inline).

## GitHub Issue

No tracked issue — ad-hoc source-code hygiene pass (sibling to docs-hygiene #144).

## Test Plan

- [x] `yarn lint` — clean
- [x] `yarn typecheck` — clean (incl. the new CVA / `VariantProps`)
- [x] `audit:contrast` — **360/360 pairs pass** (proves the `BASE_PALETTES` move is behavior-preserving)
- [x] `yarn test:unit` — **173/173 tests pass** (11/11 files, incl. the 2 colorblind files that consume SC-4's re-export)
- [ ] Dropdown play-tests run in CI's browser project (CVA change is behavior-preserving by construction)

> ✅ **Resolved:** `@bjornlu/colorblind` was missing from the local environment (a pre-existing install gap, never touched by this diff). After `yarn install` it's present and `test:unit` is 173/173. `audit:colorblind` runs and exits non-zero only on the already-tracked finding **#141** (green.600 ↔ blue.600 confusable under tritanopia) — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
