### PR TITLE
docs(claude): .claude tooling hygiene (skills/commands/agents)

### DIFF
--- a/.claude/agents/devops.md
+++ b/.claude/agents/devops.md
@@ -70,7 +70,7 @@ When working on infrastructure or tooling:
 **The Right Process:**
 
 1. **Understand the system** — Read existing configs, understand the flow
-2. **Test changes safely** — Use feature flags, staged rollouts, dry-run modes
+2. **Test changes safely** — Use dry-run modes and reversible, incremental changes
 3. **Document decisions** — Future you will thank present you
 4. **Ask when unsure** — Infrastructure mistakes are expensive to fix
 

--- a/.claude/agents/sde2.md
+++ b/.claude/agents/sde2.md
@@ -7,7 +7,6 @@ permissionMode: bypassPermissions
 skills:
   - pr-review-guide
   - pr-review-follow-up
-  - shadcn
   - frontend-design
 ---
 

--- a/.claude/agents/sde2.md
+++ b/.claude/agents/sde2.md
@@ -7,7 +7,6 @@ permissionMode: bypassPermissions
 skills:
   - pr-review-guide
   - pr-review-follow-up
-  - frontend-design
 ---
 
 # SDE2 Agent

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -153,7 +153,7 @@ Agent(
   - Deprecated or incorrect library API usage (Zod, Next.js, etc.)
   - Error handling completeness
   - Redundant or overly complex code patterns
-  - Naming and readability for the target audience (design students)
+  - Naming and readability for the target audience (design-system maintainers)
   - Edge cases and potential runtime bugs
 
   ## Out of Scope for You
@@ -411,7 +411,7 @@ Agent(
   - Deprecated or incorrect library API usage (Zod, Next.js, etc.)
   - Error handling completeness
   - Redundant or overly complex code patterns
-  - Naming and readability for the target audience (design students)
+  - Naming and readability for the target audience (design-system maintainers)
   - Edge cases and potential runtime bugs
 
   ## Output Caps (strict — enforced; see pr-review-follow-up skill for full rules)

--- a/.claude/skills/analyze-deps-guide/SKILL.md
+++ b/.claude/skills/analyze-deps-guide/SKILL.md
@@ -305,7 +305,7 @@ Grep(pattern: "require\\(['\"]package-name", glob: "**/*.{js,ts}")
 **Impacted files:**
 | File | Line | Impact |
 |------|------|--------|
-| `packages/react/src/components/modal.tsx` | 12 | Uses deprecated `open` prop |
+| `packages/react/src/components/ui/dialog.tsx` | 12 | Uses deprecated `open` prop |
 ```
 
 **If no files are impacted by breaking changes:**

--- a/.claude/skills/implement-guide/SKILL.md
+++ b/.claude/skills/implement-guide/SKILL.md
@@ -253,8 +253,8 @@ When a reflex fires and you're not certain of the spec, open the linked rule fil
 Run after completing:
 
 ```bash
-npm run typecheck
-npm run lint
+yarn typecheck
+yarn lint
 ```
 
 Fix all errors before presenting your summary.

--- a/.claude/skills/pr-fix-guide/SKILL.md
+++ b/.claude/skills/pr-fix-guide/SKILL.md
@@ -99,7 +99,7 @@ Do **not** wait for explicit approval. The plan is a preview so the user can int
 
 ## Part 2: Fixing
 
-After user approves the analysis, fix all issues.
+After emitting the plan, fix all issues.
 
 ### Fix Process
 
@@ -130,8 +130,8 @@ Two reflexes specific to fixing:
 1. **Run checks:**
 
    ```bash
-   npm run typecheck
-   npm run lint
+   yarn typecheck
+   yarn lint
    ```
 
 2. **Review against original comments:**

--- a/.claude/skills/ui-audit-guide/SKILL.md
+++ b/.claude/skills/ui-audit-guide/SKILL.md
@@ -27,7 +27,7 @@ Always load and audit against:
 
 ## Prerequisites
 
-- Playwright MCP server must be configured in `.mcp.json` (runs headless by default)
+- **Playwright MCP** server available — provides the `mcp__playwright__*` browser tools this skill uses (runs headless by default). Note: this repo's `.mcp.json` ships `chrome-devtools`, not Playwright, so configure the Playwright MCP at user or project scope if it isn't already available.
 - The application must be running at a known URL
 
 ## Process


### PR DESCRIPTION
## Summary

Hygiene pass over the `.claude/` tooling (skills / commands / agents) — the agent-context surface the earlier rules cleanup didn't cover. These files load **on-demand** (name+description until invoked), so this is about **correctness**, not context size.

**Fixed:**
- **`npm run` → `yarn`** in `implement-guide` + `pr-fix-guide` — repo is `yarn@1.22.22`-only; `npm run lint` doesn't even resolve.
- **`pr-fix-guide` self-contradiction:** Part 2 said "After user approves the analysis" while the skill states "Do **not** wait for explicit approval … not an approval gate" 6 lines earlier → reworded.
- **`devops` agent vs its own base rule:** dropped "feature flags, staged rollouts" (it loads `project-stage.md`: "No feature flags or shims"); kept dry-run.
- **`pr-review` stale audience:** "design students" → "design-system maintainers" (both agent prompts).
- **`analyze-deps-guide` example path:** `components/modal.tsx` (nonexistent) → `components/ui/dialog.tsx`.
- **(T9) `shadcn` detached from `sde2`:** it taught upstream shadcn tokens contradicting the repo's `nx:`-prefix rule + `shadcn-divergences.md`. Skill stays available standalone.
- **(T10) `frontend-design` detached from `sde2`:** its "bold/maximalist, avoid system fonts" guidance conflicts with Nexus's restrained token system. With T9+T10, `sde2` now carries only review skills (`pr-review-guide`, `pr-review-follow-up`) — matching how it's actually used (spawned only by `/pr-review`).
- **(T7) `ui-audit` Playwright prerequisite corrected:** no longer falsely claims Playwright is in `.mcp.json` (this repo ships `chrome-devtools`; Playwright is global and works). Kept ui-audit on Playwright.

## GitHub Issue

No tracked issue — ad-hoc tooling-hygiene pass (sibling to #144 docs and #145 source).

## Test Plan

- [x] Tooling/docs only — no code, no build/test impact
- [x] prettier ran via lint-staged on all touched files
- [x] Changes verified by diff review

## Deferred (need a larger decision — not in this PR)

- **T6 — command↔skill duplication:** `implement.md` / `pr-fix.md` / `ui-audit.md` duplicate their `-guide` skills' full workflow + templates (vs the thin `implement-test` / `analyze-deps`). A multi-file refactor to single-source the workflow.
- **T8 — `sde2` stale scaffolding:** "When Implementing" / "When Fixing PR Issues" sections reference `implement`/`pr-fix` skills the single-agent commands no longer spawn (and now that T9/T10 left sde2 review-only, they're doubly orphaned). Delete vs keep+repair — judgment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
