### PR TITLE
fix(react): import tw-animate-css so overlay animations render

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -40,6 +40,7 @@
     "recharts": "^3.8.1",
     "storybook": "^10.1.10",
     "tailwindcss": "^4.1.18",
+    "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
     "vite": "^7.3.0",
     "vite-plugin-dts": "^4.5.4"

--- a/packages/react/src/index.css
+++ b/packages/react/src/index.css
@@ -1,36 +1,4 @@
 /* Nexus Tailwind theme with nx: prefix */
 @import '@nexus/tailwind';
-
-/* ===== COMPONENT ANIMATIONS ===== */
-/* Accordion expand/collapse animations */
-@keyframes accordion-down {
-  from {
-    height: 0;
-  }
-  to {
-    height: var(--radix-accordion-content-height);
-  }
-}
-
-@keyframes accordion-up {
-  from {
-    height: var(--radix-accordion-content-height);
-  }
-  to {
-    height: 0;
-  }
-}
-
-@theme inline {
-  --animate-accordion-down: accordion-down 0.2s ease-out;
-  --animate-accordion-up: accordion-up 0.2s ease-out;
-}
-
-/* Accordion animation utilities (explicit for JIT compatibility) */
-@utility animate-accordion-down {
-  animation: accordion-down 0.2s ease-out;
-}
-
-@utility animate-accordion-up {
-  animation: accordion-up 0.2s ease-out;
-}
+/* Radix overlay enter/exit + accordion animations (Dialog, Dropdown, Select, Tooltip). */
+@import 'tw-animate-css';

--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -19,8 +19,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "devDependencies": {
-    "tw-animate-css": "^1.4.0"
   }
 }


### PR DESCRIPTION
## Summary

- Dialog/DropdownMenu/Select/Tooltip reference `animate-in` / `fade-in` / `zoom-in` / `slide-in` utilities from **`tw-animate-css`**, but nothing imported the library — it was declared in `@nexus/tailwind` yet never `@import`ed. Those utilities silently generated nothing, so the Radix overlays shipped with **no enter/exit animation**. The "unused dependency" was the symptom; the missing `@import` was the bug.
- Import `tw-animate-css` in `@nexus/react`'s `index.css`. **Default build, not `/prefix`** — `nexus.css` resets the base spacing unit (`--spacing-*: initial`) that `/prefix`'s `--spacing()` function requires, so `/prefix` hard-fails the build.
- Move the dependency to `@nexus/react` (whose CSS now imports it); remove it from `@nexus/tailwind`, which never used it.
- Remove the hand-rolled accordion keyframes/utilities from `index.css` — `tw-animate-css` already supplies `accordion-down/up`, so the local block was duplication.

## Verification

Built `react.css` now emits `@keyframes enter / exit / accordion-down / accordion-up` plus the `animate-in` / `fade-in-0` / `zoom-in-95` / `slide-in-from-*` / `animate-accordion-*` utilities — **zero** of which were in the bundle before. Bundle: **13.5 kB gzip**, under the 30 kB size-limit.

## Known limitation (pre-existing, not introduced here)

Numeric `slide-in-from-*-N` distances resolve to `calc(N * var(--spacing) * -1)`, and the design system intentionally resets `--spacing` — so directional slide is inert; overlays fade + zoom in (the dominant effect). Making slide distances work is a **design decision** (reintroduce a base `--spacing` unit, or strip the inert slide classes), out of scope for wiring up the animations.

## GitHub Issue

N/A — surfaced by a repo quality/cleanliness audit (not previously tracked).

## Test Plan

- [x] `yarn workspace @nexus/react build` succeeds; `react.css` emits the animation keyframes + utilities
- [x] Bundle size within limit (13.5 kB gzip < 30 kB)
- [x] Prettier clean; lint-staged passed on commit
- [ ] CI: lint · typecheck · test-react (Storybook/Playwright) · build-storybook · bundle-size
- [ ] Manual smoke: open a Dialog / Dropdown in Storybook and confirm fade + zoom enter/exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)