### PR TITLE
feat(focus): outline + offset ring pattern [2/10]

### DIFF
--- a/.claude/rules/components.md
+++ b/.claude/rules/components.md
@@ -274,22 +274,21 @@ See [`surfaces.md` Rule 6](surfaces.md#rules) and [`surfaces.md` § Known overla
 
 ## Focus States
 
-Use the design-system focus token, not Tailwind `ring-*` utilities:
+The canonical focus ring is an **outline** — not a box-shadow, and not Tailwind `ring-*`:
 
 ```
-nx:focus-visible:outline-none nx:focus-visible:shadow-focus-default
+nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2
 ```
 
-For error focus on invalid fields, use `shadow-focus-error`.
+For error focus on invalid fields, swap the colour to `nx:focus-visible:outline-focus-error`.
 
-### Shadow Stacking
+The focus colour (`outline-focus-default` → `--color-focus-default`) is a neutral grey tuned to clear APCA Lc ≥ 45 on every surface it lands on — page, card, muted, primary, error (see [`tokens.md` § APCA contrast gate](tokens.md#apca-contrast-gate)). An outline is surface-invariant and, unlike a box-shadow ring, **survives Windows High Contrast Mode (`forced-colors: active`)**, where the OS forces it to a visible system colour.
 
-`shadow-focus-default` is a box-shadow utility, so it **replaces** any existing elevation shadow during focus. The system avoids this conflict by structurally separating elevation from focusable controls:
+### Outline does not stack with elevation
 
-- **Non-focusable elevated surfaces** — Card (`shadow-sm`), Dialog (`shadow-lg`) — keep their elevation. Their focus rings appear on focusable children (DialogClose, controls inside Card), not on the surface itself.
-- **Focusable controls** — Input, Switch — do not use shadow elevation. They rely on border/background for visual depth. This avoids the elevation/focus conflict by design.
+The focus ring lives on the CSS `outline` property, so it is independent of `box-shadow` and never competes with an elevation shadow. Elevated surfaces (Card `shadow-sm`, Dialog `shadow-lg`) keep their shadow while focusable children render their outline on top — the elevation/focus separation the box-shadow ring once required is no longer needed.
 
-Do not add `nx:shadow-*` utilities to focusable elements.
+Do not use `nx:shadow-*` or `nx:ring-*` utilities for focus.
 
 ## Adding to Exports
 
@@ -312,4 +311,4 @@ Before submitting a component:
 - [ ] Named interface with JSDoc for custom props
 - [ ] Exports include component, props type, and variants function
 - [ ] `asChild` support for interactive components
-- [ ] Focus uses `nx:focus-visible:shadow-focus-default` (not `nx:ring-*`)
+- [ ] Focus uses the outline ring (`nx:focus-visible:outline-focus-default`), not `nx:ring-*` or `nx:shadow-*`

--- a/.claude/rules/shadcn-divergences.md
+++ b/.claude/rules/shadcn-divergences.md
@@ -14,7 +14,7 @@
 | Accent (hover)     | `hover:bg-accent`      | `nx:hover:bg-background-hover`         |
 | Card/container     | `bg-card`              | `nx:bg-container`                      |
 | Border input       | `border-input`         | `nx:border-border-default`             |
-| Focus ring         | `ring-ring`            | `nx:shadow-focus-default`              |
+| Focus ring         | `ring-ring`            | `nx:outline-focus-default`             |
 | Overlay            | `bg-black/80`          | `nx:bg-overlay`                        |
 | Component sizing   | Fixed heights (`h-10`) | Padding-based (`px-4 py-2`)            |
 | Data attributes    | Optional               | Required                               |
@@ -258,12 +258,12 @@ shadcn 2024+ ships a `sidebar-*` namespace; Nexus uses `nav-*` for the equivalen
 
 ## Focus Ring Tokens
 
-| shadcn                   | Nexus                                   | Notes             |
-| ------------------------ | --------------------------------------- | ----------------- |
-| `ring-ring`              | `nx:shadow-focus-default`               | Focus shadow      |
-| `ring-offset-background` | (handled by shadow)                     | Built into shadow |
-| `focus-visible:ring-2`   | `nx:focus-visible:shadow-focus-default` | Shadow-based      |
-| —                        | `nx:shadow-focus-error`                 | Error focus ring  |
+| shadcn                   | Nexus                                  | Notes                |
+| ------------------------ | -------------------------------------- | -------------------- |
+| `ring-ring`              | `nx:outline-focus-default`             | Focus outline colour |
+| `ring-offset-background` | `nx:focus-visible:outline-offset-2`    | Real outline offset  |
+| `focus-visible:ring-2`   | `nx:focus-visible:outline-2`           | Outline width        |
+| —                        | `nx:focus-visible:outline-focus-error` | Error focus ring     |
 
 **Example transformation:**
 
@@ -272,7 +272,7 @@ shadcn 2024+ ships a `sidebar-*` namespace; Nexus uses `nav-*` for the equivalen
 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
 
 // Nexus
-'nx:focus-visible:outline-none nx:focus-visible:shadow-focus-default';
+'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2';
 ```
 
 ---

--- a/apps/playground/public/themes/focus-default.css
+++ b/apps/playground/public/themes/focus-default.css
@@ -3,10 +3,6 @@
 html {
   --nx-focus-color-default: oklch(0.5555 0 0);
   --nx-focus-color-error: oklch(0.5771 0.2152 27.325);
-  --nx-focus-geometry-x: 0px;
-  --nx-focus-geometry-y: 0px;
-  --nx-focus-geometry-blur: 0px;
-  --nx-focus-geometry-spread: 2px;
 }
 
 html.dark {

--- a/apps/playground/public/themes/focus.css
+++ b/apps/playground/public/themes/focus.css
@@ -1,0 +1,6 @@
+/* focus */
+
+:root {
+  --nx-color-focus-default: var(--nx-focus-color-default);
+  --nx-color-focus-error: var(--nx-focus-color-error);
+}

--- a/apps/playground/public/themes/globals.css
+++ b/apps/playground/public/themes/globals.css
@@ -123,6 +123,8 @@
   --color-secondary-subtle-foreground: var(--nx-color-neutral-600);
   --color-secondary-subtle-hover: var(--nx-color-neutral-200);
   --color-secondary-subtle-active: var(--nx-color-neutral-300);
+  --color-focus-default: var(--nx-focus-color-default);
+  --color-focus-error: var(--nx-focus-color-error);
 
   /* Spacing tokens */
   --spacing-0: var(--nx-size-0);
@@ -215,10 +217,4 @@
   --shadow-inner: inset var(--nx-shadow-inner-layer-1-x)
     var(--nx-shadow-inner-layer-1-y) var(--nx-shadow-inner-layer-1-blur)
     var(--nx-shadow-inner-layer-1-spread) var(--nx-shadow-inner-layer-1-color);
-  --shadow-focus-default: var(--nx-focus-geometry-x) var(--nx-focus-geometry-y)
-    var(--nx-focus-geometry-blur) var(--nx-focus-geometry-spread)
-    var(--nx-focus-color-default);
-  --shadow-focus-error: var(--nx-focus-geometry-x) var(--nx-focus-geometry-y)
-    var(--nx-focus-geometry-blur) var(--nx-focus-geometry-spread)
-    var(--nx-focus-color-error);
 }

--- a/apps/playground/src/components/ComponentShowcase.tsx
+++ b/apps/playground/src/components/ComponentShowcase.tsx
@@ -191,7 +191,6 @@ export function ComponentShowcase() {
             <ShadowBox name="xl" shadowClass="nx:shadow-xl" />
             <ShadowBox name="2xl" shadowClass="nx:shadow-2xl" />
             <ShadowBox name="inner" shadowClass="nx:shadow-inner" />
-            <ShadowBox name="focus" shadowClass="nx:shadow-focus-default" />
           </div>
         </Section>
 

--- a/apps/playground/src/styles/focus-default.css
+++ b/apps/playground/src/styles/focus-default.css
@@ -3,10 +3,6 @@
 html {
   --nx-focus-color-default: oklch(0.5555 0 0);
   --nx-focus-color-error: oklch(0.5771 0.2152 27.325);
-  --nx-focus-geometry-x: 0px;
-  --nx-focus-geometry-y: 0px;
-  --nx-focus-geometry-blur: 0px;
-  --nx-focus-geometry-spread: 2px;
 }
 
 html.dark {

--- a/apps/playground/src/styles/globals.css
+++ b/apps/playground/src/styles/globals.css
@@ -123,6 +123,8 @@
   --color-secondary-subtle-foreground: var(--nx-color-neutral-600);
   --color-secondary-subtle-hover: var(--nx-color-neutral-200);
   --color-secondary-subtle-active: var(--nx-color-neutral-300);
+  --color-focus-default: var(--nx-focus-color-default);
+  --color-focus-error: var(--nx-focus-color-error);
 
   /* Spacing tokens */
   --spacing-0: var(--nx-size-0);
@@ -215,10 +217,4 @@
   --shadow-inner: inset var(--nx-shadow-inner-layer-1-x)
     var(--nx-shadow-inner-layer-1-y) var(--nx-shadow-inner-layer-1-blur)
     var(--nx-shadow-inner-layer-1-spread) var(--nx-shadow-inner-layer-1-color);
-  --shadow-focus-default: var(--nx-focus-geometry-x) var(--nx-focus-geometry-y)
-    var(--nx-focus-geometry-blur) var(--nx-focus-geometry-spread)
-    var(--nx-focus-color-default);
-  --shadow-focus-error: var(--nx-focus-geometry-x) var(--nx-focus-geometry-y)
-    var(--nx-focus-geometry-blur) var(--nx-focus-geometry-spread)
-    var(--nx-focus-color-error);
 }

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -67,11 +67,26 @@ describe('generateTailwindPackage', () => {
     expect(variablesCSS).toMatch(/^:root \{/m);
   });
 
-  it('emits shadow and focus primitives in :root (light values)', () => {
+  it('emits focus colour primitives but no geometry in :root (light values)', () => {
     const rootBlock = extractBlock(variablesCSS, ':root');
     expect(rootBlock).toMatch(/--nx-shadow-2xs-layer-1-x: 0px;/);
     expect(rootBlock).toMatch(/--nx-focus-color-default:/);
-    expect(rootBlock).toMatch(/--nx-focus-geometry-spread: 2px;/);
+    // #92 moved focus to an outline ring; the geometry primitives were dropped.
+    expect(rootBlock).not.toMatch(/--nx-focus-geometry-/);
+  });
+
+  // #92: focus ring moved from box-shadow to outline. The geometry-composed
+  // --shadow-focus-* tokens are gone; focus colours are promoted to the
+  // --color-* namespace so Tailwind emits outline-focus-* utilities.
+  it('promotes focus colours to --color-* and drops --shadow-focus-*', () => {
+    const themeBlock = extractBlock(nexusCSS, '@theme');
+    expect(themeBlock).toMatch(
+      /--color-focus-default: var\(--nx-focus-color-default\);/
+    );
+    expect(themeBlock).toMatch(
+      /--color-focus-error: var\(--nx-focus-color-error\);/
+    );
+    expect(nexusCSS).not.toMatch(/--shadow-focus-/);
   });
 
   // Every var(--nx-shadow-*) or var(--nx-focus-*) ref in nexus.css must have a

--- a/packages/core/scripts/audit-class-refs.js
+++ b/packages/core/scripts/audit-class-refs.js
@@ -30,6 +30,7 @@ const SEMANTIC_PREFIXES = [
   'border',
   'overlay',
   'disabled',
+  'focus',
   'accent', // not a real token in Nexus — surfaces the migration bug
 ];
 

--- a/packages/core/scripts/generate-modular.js
+++ b/packages/core/scripts/generate-modular.js
@@ -255,7 +255,14 @@ function generatePlaygroundGlobalsCSS(distDir, primitives, primitiveMap) {
     'brands-blue-light.json',
     primitiveMap
   );
-  const colorTokens = [...baseTokens, ...brandTokens];
+  // Standalone semantic color files (e.g. focus.json): fold their color tokens
+  // into @theme too, so their utilities (outline-focus-*) emit in the playground.
+  const standaloneColorTokens = discoverSemantics(
+    SEMANTIC_DIR
+  ).standalone.flatMap((file) =>
+    collectSemanticColorTokensVarRef(SEMANTIC_DIR, file, primitiveMap)
+  );
+  const colorTokens = [...baseTokens, ...brandTokens, ...standaloneColorTokens];
 
   // Collect other tokens using shared functions
   const spacingTokens = collectSpacingTokens(SEMANTIC_DIR);

--- a/packages/core/tokens/primitives/focus/focus-default-dark.json
+++ b/packages/core/tokens/primitives/focus/focus-default-dark.json
@@ -8,35 +8,5 @@
       "$value": "#fca5a5",
       "$type": "color"
     }
-  },
-  "geometry": {
-    "x": {
-      "$value": {
-        "value": 0,
-        "unit": "px"
-      },
-      "$type": "dimension"
-    },
-    "y": {
-      "$value": {
-        "value": 0,
-        "unit": "px"
-      },
-      "$type": "dimension"
-    },
-    "blur": {
-      "$value": {
-        "value": 0,
-        "unit": "px"
-      },
-      "$type": "dimension"
-    },
-    "spread": {
-      "$value": {
-        "value": 2,
-        "unit": "px"
-      },
-      "$type": "dimension"
-    }
   }
 }

--- a/packages/core/tokens/semantic/focus.json
+++ b/packages/core/tokens/semantic/focus.json
@@ -1,11 +1,11 @@
 {
-  "color": {
+  "focus": {
     "default": {
-      "$value": "#737373",
+      "$value": "{focus.color.default}",
       "$type": "color"
     },
     "error": {
-      "$value": "#dc2626",
+      "$value": "{focus.color.error}",
       "$type": "color"
     }
   }

--- a/packages/core/tokens/styles/shadows.json
+++ b/packages/core/tokens/styles/shadows.json
@@ -114,27 +114,5 @@
       "spread": "{inner.layer-1.spread}",
       "color": "{inner.layer-1.color}"
     }
-  },
-  "focus": {
-    "default": {
-      "$type": "shadow",
-      "$value": {
-        "offsetX": "{focus.geometry.x}",
-        "offsetY": "{focus.geometry.y}",
-        "blur": "{focus.geometry.blur}",
-        "spread": "{focus.geometry.spread}",
-        "color": "{focus.color.default}"
-      }
-    },
-    "error": {
-      "$type": "shadow",
-      "$value": {
-        "offsetX": "{focus.geometry.x}",
-        "offsetY": "{focus.geometry.y}",
-        "blur": "{focus.geometry.blur}",
-        "spread": "{focus.geometry.spread}",
-        "color": "{focus.color.error}"
-      }
-    }
   }
 }

--- a/packages/react/src/components/ui/accordion.tsx
+++ b/packages/react/src/components/ui/accordion.tsx
@@ -72,7 +72,7 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          'nx:flex nx:flex-1 nx:items-center nx:justify-between nx:py-4 nx:text-sm nx:font-medium nx:text-foreground nx:transition-all nx:hover:underline nx:focus-visible:outline-none nx:focus-visible:shadow-focus-default nx:disabled:pointer-events-none nx:disabled:opacity-50 nx:[&[data-state=open]>svg]:rotate-180',
+          'nx:flex nx:flex-1 nx:items-center nx:justify-between nx:py-4 nx:text-sm nx:font-medium nx:text-foreground nx:transition-all nx:hover:underline nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2 nx:disabled:pointer-events-none nx:disabled:opacity-50 nx:[&[data-state=open]>svg]:rotate-180',
           className
         )}
         {...props}

--- a/packages/react/src/components/ui/button.tsx
+++ b/packages/react/src/components/ui/button.tsx
@@ -7,7 +7,7 @@ import { IconLoader2 } from '@/lib/icons';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'nx:inline-flex nx:items-center nx:justify-center nx:gap-2 nx:rounded-md nx:text-sm nx:font-medium nx:whitespace-nowrap nx:transition-colors nx:focus-visible:outline-none nx:focus-visible:shadow-focus-default nx:disabled:pointer-events-none nx:disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+  'nx:inline-flex nx:items-center nx:justify-center nx:gap-2 nx:rounded-md nx:text-sm nx:font-medium nx:whitespace-nowrap nx:transition-colors nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2 nx:disabled:pointer-events-none nx:disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
   {
     variants: {
       variant: {

--- a/packages/react/src/components/ui/dialog.tsx
+++ b/packages/react/src/components/ui/dialog.tsx
@@ -145,7 +145,7 @@ function DialogContent({
               'nx:absolute nx:right-4 nx:top-4 nx:rounded-sm nx:opacity-70',
               'nx:transition-opacity',
               'nx:hover:opacity-100',
-              'nx:focus-visible:outline-none nx:focus-visible:shadow-focus-default',
+              'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2',
               'nx:disabled:pointer-events-none',
               'nx:data-[state=open]:bg-muted nx:data-[state=open]:text-muted-foreground'
             )}

--- a/packages/react/src/components/ui/input.tsx
+++ b/packages/react/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const inputVariants = cva(
     'nx:bg-background nx:text-foreground nx:transition-colors',
     'nx:file:border-0 nx:file:bg-transparent nx:file:text-sm nx:file:font-medium nx:file:text-foreground',
     'nx:placeholder:text-muted-foreground',
-    'nx:focus-visible:outline-none nx:focus-visible:shadow-focus-default',
+    'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2',
     'nx:disabled:cursor-not-allowed nx:disabled:opacity-50',
   ],
   {

--- a/packages/react/src/components/ui/select.tsx
+++ b/packages/react/src/components/ui/select.tsx
@@ -70,7 +70,7 @@ function SelectTrigger({ className, children, ...props }: SelectTriggerProps) {
         'nx:px-3 nx:py-2 nx:text-sm',
         'nx:whitespace-nowrap',
         'nx:placeholder:text-muted-foreground',
-        'nx:focus-visible:outline-none nx:focus-visible:shadow-focus-default',
+        'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2',
         'nx:disabled:cursor-not-allowed nx:disabled:opacity-50',
         'nx:[&>span]:line-clamp-1',
         className

--- a/packages/react/src/components/ui/switch.tsx
+++ b/packages/react/src/components/ui/switch.tsx
@@ -40,7 +40,7 @@ function Switch({ className, ...props }: SwitchProps) {
         'nx:peer nx:inline-flex nx:h-5 nx:w-9 nx:shrink-0 nx:cursor-pointer nx:items-center',
         'nx:rounded-full nx:border-2 nx:border-transparent',
         'nx:transition-colors',
-        'nx:focus-visible:outline-none nx:focus-visible:shadow-focus-default',
+        'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2',
         'nx:disabled:cursor-not-allowed nx:disabled:opacity-50',
         'nx:data-[state=checked]:bg-primary-background nx:data-[state=unchecked]:bg-muted',
         className

--- a/packages/react/src/components/ui/tabs.tsx
+++ b/packages/react/src/components/ui/tabs.tsx
@@ -72,7 +72,7 @@ const tabsTriggerVariants = cva(
     'nx:whitespace-nowrap',
     'nx:font-medium nx:text-foreground/70',
     'nx:transition-all',
-    'nx:focus-visible:outline-none nx:focus-visible:shadow-focus-default',
+    'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2',
     'nx:disabled:pointer-events-none nx:disabled:opacity-50',
   ],
   {
@@ -186,7 +186,7 @@ function TabsContent({ className, ...props }: TabsContentProps) {
       data-slot="tabs-content"
       className={cn(
         'nx:mt-2',
-        'nx:focus-visible:outline-none nx:focus-visible:shadow-focus-default',
+        'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2',
         className
       )}
       {...props}

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -124,6 +124,8 @@
   --color-chart-categorical-3: var(--nx-color-orange-600);
   --color-chart-categorical-4: var(--nx-color-rose-600);
   --color-chart-categorical-5: var(--nx-color-indigo-600);
+  --color-focus-default: var(--nx-focus-color-default);
+  --color-focus-error: var(--nx-focus-color-error);
 
   /* Spacing tokens */
   --spacing-0: var(--nx-size-0);
@@ -216,12 +218,6 @@
   --shadow-inner: inset var(--nx-shadow-inner-layer-1-x)
     var(--nx-shadow-inner-layer-1-y) var(--nx-shadow-inner-layer-1-blur)
     var(--nx-shadow-inner-layer-1-spread) var(--nx-shadow-inner-layer-1-color);
-  --shadow-focus-default: var(--nx-focus-geometry-x) var(--nx-focus-geometry-y)
-    var(--nx-focus-geometry-blur) var(--nx-focus-geometry-spread)
-    var(--nx-focus-color-default);
-  --shadow-focus-error: var(--nx-focus-geometry-x) var(--nx-focus-geometry-y)
-    var(--nx-focus-geometry-blur) var(--nx-focus-geometry-spread)
-    var(--nx-focus-color-error);
 }
 
 /* ===== DARK MODE ===== */

--- a/packages/tailwind/variables.css
+++ b/packages/tailwind/variables.css
@@ -520,10 +520,6 @@
   /* focus (default) */
   --nx-focus-color-default: oklch(0.5555 0 0);
   --nx-focus-color-error: oklch(0.5771 0.2152 27.325);
-  --nx-focus-geometry-x: 0px;
-  --nx-focus-geometry-y: 0px;
-  --nx-focus-geometry-blur: 0px;
-  --nx-focus-geometry-spread: 2px;
 
   /* radius (sharp) */
   --nx-radius-base: 0px;


### PR DESCRIPTION
## Summary

Migrate the canonical focus ring from a box-shadow token to a CSS **outline** (research basis: `reports/phase-2-token-decisions.html § 1`). An outline ring is surface-invariant, survives Windows High Contrast Mode, and does not stack with elevation shadows.

**Token pipeline** (token JSON edited; `packages/tailwind/*` + playground CSS are **regenerated**, never hand-edited):
- Remove focus geometry primitives (`focus-default-{light,dark}.json`) and the `--shadow-focus-{default,error}` tokens (`styles/shadows.json`).
- Promote focus colours to a standalone semantic `focus.json` → `--color-focus-{default,error}`, so Tailwind emits `outline-focus-*` utilities. They adapt light/dark automatically through the already theme-split focus primitive — no `.dark` override needed.
- `generate-modular`: fold standalone semantic colours into the playground `@theme` so `outline-focus-*` emits there too.
- `audit-class-refs`: add `focus` to `SEMANTIC_PREFIXES` to enforce in CI that `outline-focus-*` resolves to a real `--color-focus-*` token.

**Components** — all 8 focus sites (7 components: button, input, switch, tabs ×2, accordion, dialog, select):

`nx:focus-visible:outline-none nx:focus-visible:shadow-focus-default`
→ `nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2`

**Docs / ripple**: rewrite `components.md` Focus States (cite APCA Lc ≥ 45 + WHCM survival; replace the obsolete Shadow-Stacking note with outline/elevation independence); remap `shadcn-divergences.md` focus rows; remove the dead `focus` ShadowBox from the playground.

Compiled chain verified end-to-end: `outline-focus-default` → `var(--nx-color-focus-default)` → `var(--nx-focus-color-default)` → `oklch(...)`.

## GitHub Issue

Closes #92

## Test Plan

- [x] `yarn lint`, `yarn typecheck` (5/5), `yarn format:check`
- [x] Core token tests (147) — incl. new assertions: `--color-focus-*` present, geometry + `--shadow-focus-*` gone
- [x] `audit:contrast` 360/360 (focus colours unchanged)
- [x] `audit:class-refs` (now enforces `outline-focus-*` resolves)
- [x] Token freshness: re-running the generators produces zero drift
- [x] Storybook play tests for the 7 affected components (108 tests)
- [x] Visual check across 5 surfaces (page / card / muted / primary / error), light + dark
- [x] WHCM / `forced-colors: active` — focus ring visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)
