### PR TITLE
feat(focus): premium brand-blue focus ring + glow

### DIFF
--- a/.claude/rules/components.md
+++ b/.claude/rules/components.md
@@ -274,21 +274,25 @@ See [`surfaces.md` Rule 6](surfaces.md#rules) and [`surfaces.md` § Known overla
 
 ## Focus States
 
-The canonical focus ring is an **outline** — not a box-shadow, and not Tailwind `ring-*`:
+The canonical focus ring is a brand-blue **outline + a soft translucent glow**:
 
 ```
+nx:focus-visible:outline-2 nx:focus-visible:outline-focus-brand nx:focus-visible:outline-offset-2 nx:focus-visible:shadow-focus-glow
+```
+
+- `outline-focus-brand` (`--color-focus-brand`, `blue-600` light / `blue-300` dark) is the load-bearing ring — a real CSS `outline`, so it **survives Windows High Contrast Mode (`forced-colors: active`)** and is APCA-gated at Lc ≥ 45 on every surface (see [`tokens.md` § APCA contrast gate](tokens.md#apca-contrast-gate)).
+- `shadow-focus-glow` (`--shadow-focus-glow`) is an additive translucent halo for polish. It is a box-shadow, so it does not survive WHCM — but the outline does, so the indicator never disappears.
+
+**Coloured-fill controls keep the neutral ring.** The destructive Button uses the grey, surface-invariant `outline-focus-default` with **no glow** — a brand ring would clash with, and barely contrast against, the red fill. For error-state inputs (invalid fields), use the red `outline-focus-error`.
+
+```tsx
+// destructive / coloured-fill control
 nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2
 ```
 
-For error focus on invalid fields, swap the colour to `nx:focus-visible:outline-focus-error`.
+### The glow is the only focus box-shadow
 
-The focus colour (`outline-focus-default` → `--color-focus-default`) is a neutral grey tuned to clear APCA Lc ≥ 45 on every surface it lands on — page, card, muted, primary, error (see [`tokens.md` § APCA contrast gate](tokens.md#apca-contrast-gate)). An outline is surface-invariant and, unlike a box-shadow ring, **survives Windows High Contrast Mode (`forced-colors: active`)**, where the OS forces it to a visible system colour.
-
-### Outline does not stack with elevation
-
-The focus ring lives on the CSS `outline` property, so it is independent of `box-shadow` and never competes with an elevation shadow. Elevated surfaces (Card `shadow-sm`, Dialog `shadow-lg`) keep their shadow while focusable children render their outline on top — the elevation/focus separation the box-shadow ring once required is no longer needed.
-
-Do not use `nx:shadow-*` or `nx:ring-*` utilities for focus.
+The ring is a CSS `outline` (independent of `box-shadow`); `shadow-focus-glow` is the one sanctioned focus box-shadow, and it is additive. Focusable controls carry no elevation shadow, so the glow never competes with elevation. Do not add any other `nx:shadow-*` or `nx:ring-*` utilities for focus.
 
 ## Adding to Exports
 
@@ -311,4 +315,4 @@ Before submitting a component:
 - [ ] Named interface with JSDoc for custom props
 - [ ] Exports include component, props type, and variants function
 - [ ] `asChild` support for interactive components
-- [ ] Focus uses the outline ring (`nx:focus-visible:outline-focus-default`), not `nx:ring-*` or `nx:shadow-*`
+- [ ] Focus uses the brand ring + glow (`outline-focus-brand` + `shadow-focus-glow`); coloured-fill controls (destructive) use grey `outline-focus-default`, not `nx:ring-*`

--- a/.claude/rules/shadcn-divergences.md
+++ b/.claude/rules/shadcn-divergences.md
@@ -14,7 +14,7 @@
 | Accent (hover)     | `hover:bg-accent`      | `nx:hover:bg-background-hover`         |
 | Card/container     | `bg-card`              | `nx:bg-container`                      |
 | Border input       | `border-input`         | `nx:border-border-default`             |
-| Focus ring         | `ring-ring`            | `nx:outline-focus-default`             |
+| Focus ring         | `ring-ring`            | `nx:outline-focus-brand` (+ glow)      |
 | Overlay            | `bg-black/80`          | `nx:bg-overlay`                        |
 | Component sizing   | Fixed heights (`h-10`) | Padding-based (`px-4 py-2`)            |
 | Data attributes    | Optional               | Required                               |
@@ -258,12 +258,14 @@ shadcn 2024+ ships a `sidebar-*` namespace; Nexus uses `nav-*` for the equivalen
 
 ## Focus Ring Tokens
 
-| shadcn                   | Nexus                                  | Notes                |
-| ------------------------ | -------------------------------------- | -------------------- |
-| `ring-ring`              | `nx:outline-focus-default`             | Focus outline colour |
-| `ring-offset-background` | `nx:focus-visible:outline-offset-2`    | Real outline offset  |
-| `focus-visible:ring-2`   | `nx:focus-visible:outline-2`           | Outline width        |
-| —                        | `nx:focus-visible:outline-focus-error` | Error focus ring     |
+| shadcn                   | Nexus                                  | Notes                         |
+| ------------------------ | -------------------------------------- | ----------------------------- |
+| `ring-ring`              | `nx:outline-focus-brand`               | Brand focus ring colour       |
+| `ring-offset-background` | `nx:focus-visible:outline-offset-2`    | Real outline offset           |
+| `focus-visible:ring-2`   | `nx:focus-visible:outline-2`           | Outline width                 |
+| `shadow` (focus glow)    | `nx:focus-visible:shadow-focus-glow`   | Translucent brand glow        |
+| —                        | `nx:outline-focus-default`             | Neutral ring (coloured fills) |
+| —                        | `nx:focus-visible:outline-focus-error` | Error focus ring              |
 
 **Example transformation:**
 
@@ -271,8 +273,8 @@ shadcn 2024+ ships a `sidebar-*` namespace; Nexus uses `nav-*` for the equivalen
 // shadcn
 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
 
-// Nexus
-'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2';
+// Nexus (brand ring + glow; coloured-fill controls use outline-focus-default)
+'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-brand nx:focus-visible:outline-offset-2 nx:focus-visible:shadow-focus-glow';
 ```
 
 ---

--- a/apps/playground/public/themes/focus-default.css
+++ b/apps/playground/public/themes/focus-default.css
@@ -3,9 +3,13 @@
 html {
   --nx-focus-color-default: oklch(0.5555 0 0);
   --nx-focus-color-error: oklch(0.5771 0.2152 27.325);
+  --nx-focus-color-brand: oklch(0.4991 0.1301 255.276);
+  --nx-focus-color-glow: oklch(0.5793 0.1352 255.145 / 0.4);
 }
 
 html.dark {
   --nx-focus-color-default: oklch(0.7572 0 0);
   --nx-focus-color-error: oklch(0.8077 0.1035 19.571);
+  --nx-focus-color-brand: oklch(0.8006 0.0751 254.248);
+  --nx-focus-color-glow: oklch(0.8006 0.0751 254.248 / 0.4);
 }

--- a/apps/playground/public/themes/focus.css
+++ b/apps/playground/public/themes/focus.css
@@ -3,4 +3,6 @@
 :root {
   --nx-color-focus-default: var(--nx-focus-color-default);
   --nx-color-focus-error: var(--nx-focus-color-error);
+  --nx-color-focus-brand: var(--nx-focus-color-brand);
+  --nx-color-focus-glow: var(--nx-focus-color-glow);
 }

--- a/apps/playground/public/themes/globals.css
+++ b/apps/playground/public/themes/globals.css
@@ -125,6 +125,8 @@
   --color-secondary-subtle-active: var(--nx-color-neutral-300);
   --color-focus-default: var(--nx-focus-color-default);
   --color-focus-error: var(--nx-focus-color-error);
+  --color-focus-brand: var(--nx-focus-color-brand);
+  --color-focus-glow: var(--nx-focus-color-glow);
 
   /* Spacing tokens */
   --spacing-0: var(--nx-size-0);
@@ -217,4 +219,5 @@
   --shadow-inner: inset var(--nx-shadow-inner-layer-1-x)
     var(--nx-shadow-inner-layer-1-y) var(--nx-shadow-inner-layer-1-blur)
     var(--nx-shadow-inner-layer-1-spread) var(--nx-shadow-inner-layer-1-color);
+  --shadow-focus-glow: 0px 0px 8px 2px var(--nx-focus-color-glow);
 }

--- a/apps/playground/src/styles/focus-default.css
+++ b/apps/playground/src/styles/focus-default.css
@@ -3,9 +3,13 @@
 html {
   --nx-focus-color-default: oklch(0.5555 0 0);
   --nx-focus-color-error: oklch(0.5771 0.2152 27.325);
+  --nx-focus-color-brand: oklch(0.4991 0.1301 255.276);
+  --nx-focus-color-glow: oklch(0.5793 0.1352 255.145 / 0.4);
 }
 
 html.dark {
   --nx-focus-color-default: oklch(0.7572 0 0);
   --nx-focus-color-error: oklch(0.8077 0.1035 19.571);
+  --nx-focus-color-brand: oklch(0.8006 0.0751 254.248);
+  --nx-focus-color-glow: oklch(0.8006 0.0751 254.248 / 0.4);
 }

--- a/apps/playground/src/styles/globals.css
+++ b/apps/playground/src/styles/globals.css
@@ -125,6 +125,8 @@
   --color-secondary-subtle-active: var(--nx-color-neutral-300);
   --color-focus-default: var(--nx-focus-color-default);
   --color-focus-error: var(--nx-focus-color-error);
+  --color-focus-brand: var(--nx-focus-color-brand);
+  --color-focus-glow: var(--nx-focus-color-glow);
 
   /* Spacing tokens */
   --spacing-0: var(--nx-size-0);
@@ -217,4 +219,5 @@
   --shadow-inner: inset var(--nx-shadow-inner-layer-1-x)
     var(--nx-shadow-inner-layer-1-y) var(--nx-shadow-inner-layer-1-blur)
     var(--nx-shadow-inner-layer-1-spread) var(--nx-shadow-inner-layer-1-color);
+  --shadow-focus-glow: 0px 0px 8px 2px var(--nx-focus-color-glow);
 }

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -75,10 +75,11 @@ describe('generateTailwindPackage', () => {
     expect(rootBlock).not.toMatch(/--nx-focus-geometry-/);
   });
 
-  // #92: focus ring moved from box-shadow to outline. The geometry-composed
-  // --shadow-focus-* tokens are gone; focus colours are promoted to the
-  // --color-* namespace so Tailwind emits outline-focus-* utilities.
-  it('promotes focus colours to --color-* and drops --shadow-focus-*', () => {
+  // The focus ring is outline-based; a translucent brand glow shadow sits on
+  // top. Focus colours (incl. the brand ring) are promoted to the --color-*
+  // namespace; the box-shadow *ring* tokens (default/error) stay gone — the
+  // additive glow is the only focus shadow.
+  it('emits brand + glow focus tokens and no box-shadow ring tokens', () => {
     const themeBlock = extractBlock(nexusCSS, '@theme');
     expect(themeBlock).toMatch(
       /--color-focus-default: var\(--nx-focus-color-default\);/
@@ -86,7 +87,11 @@ describe('generateTailwindPackage', () => {
     expect(themeBlock).toMatch(
       /--color-focus-error: var\(--nx-focus-color-error\);/
     );
-    expect(nexusCSS).not.toMatch(/--shadow-focus-/);
+    expect(themeBlock).toMatch(
+      /--color-focus-brand: var\(--nx-focus-color-brand\);/
+    );
+    expect(themeBlock).toMatch(/--shadow-focus-glow:/);
+    expect(nexusCSS).not.toMatch(/--shadow-focus-default|--shadow-focus-error/);
   });
 
   // Every var(--nx-shadow-*) or var(--nx-focus-*) ref in nexus.css must have a

--- a/packages/core/scripts/audit-contrast.js
+++ b/packages/core/scripts/audit-contrast.js
@@ -147,7 +147,7 @@ const CHART_SURFACES = ['background', 'container'];
 // `muted` and `disabled` are intentionally excluded — they are non-focusable
 // fills (de-emphasised text backgrounds and disabled-state backdrops).
 const FOCUS_SURFACES = ['background', 'container', 'popover'];
-const FOCUS_COLORS = ['color.default', 'color.error'];
+const FOCUS_COLORS = ['color.default', 'color.error', 'color.brand'];
 const FOCUS_PAIRS = FOCUS_COLORS.flatMap((fg) =>
   FOCUS_SURFACES.map((bg) => ({ fg, bg, minLc: 45, tier: 'incidental' }))
 );

--- a/packages/core/tokens/primitives/focus/focus-default-dark.json
+++ b/packages/core/tokens/primitives/focus/focus-default-dark.json
@@ -7,6 +7,14 @@
     "error": {
       "$value": "#fca5a5",
       "$type": "color"
+    },
+    "brand": {
+      "$value": "#9dc1ee",
+      "$type": "color"
+    },
+    "glow": {
+      "$value": "#9dc1ee66",
+      "$type": "color"
     }
   }
 }

--- a/packages/core/tokens/primitives/focus/focus-default-light.json
+++ b/packages/core/tokens/primitives/focus/focus-default-light.json
@@ -7,6 +7,14 @@
     "error": {
       "$value": "#dc2626",
       "$type": "color"
+    },
+    "brand": {
+      "$value": "#2863ab",
+      "$type": "color"
+    },
+    "glow": {
+      "$value": "#3d7bc866",
+      "$type": "color"
     }
   }
 }

--- a/packages/core/tokens/semantic/focus.json
+++ b/packages/core/tokens/semantic/focus.json
@@ -7,6 +7,14 @@
     "error": {
       "$value": "{focus.color.error}",
       "$type": "color"
+    },
+    "brand": {
+      "$value": "{focus.color.brand}",
+      "$type": "color"
+    },
+    "glow": {
+      "$value": "{focus.color.glow}",
+      "$type": "color"
     }
   }
 }

--- a/packages/core/tokens/styles/shadows.json
+++ b/packages/core/tokens/styles/shadows.json
@@ -114,5 +114,15 @@
       "spread": "{inner.layer-1.spread}",
       "color": "{inner.layer-1.color}"
     }
+  },
+  "focus-glow": {
+    "$type": "shadow",
+    "$value": {
+      "offsetX": { "value": 0, "unit": "px" },
+      "offsetY": { "value": 0, "unit": "px" },
+      "blur": { "value": 8, "unit": "px" },
+      "spread": { "value": 2, "unit": "px" },
+      "color": "{focus.color.glow}"
+    }
   }
 }

--- a/packages/react/src/components/ui/accordion.tsx
+++ b/packages/react/src/components/ui/accordion.tsx
@@ -72,7 +72,7 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          'nx:flex nx:flex-1 nx:items-center nx:justify-between nx:py-4 nx:text-sm nx:font-medium nx:text-foreground nx:transition-all nx:hover:underline nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2 nx:disabled:pointer-events-none nx:disabled:opacity-50 nx:[&[data-state=open]>svg]:rotate-180',
+          'nx:flex nx:flex-1 nx:items-center nx:justify-between nx:py-4 nx:text-sm nx:font-medium nx:text-foreground nx:transition-all nx:hover:underline nx:focus-visible:outline-2 nx:focus-visible:outline-focus-brand nx:focus-visible:outline-offset-2 nx:focus-visible:shadow-focus-glow nx:disabled:pointer-events-none nx:disabled:opacity-50 nx:[&[data-state=open]>svg]:rotate-180',
           className
         )}
         {...props}

--- a/packages/react/src/components/ui/button.tsx
+++ b/packages/react/src/components/ui/button.tsx
@@ -6,21 +6,22 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { IconLoader2 } from '@/lib/icons';
 import { cn } from '@/lib/utils';
 
+const focusBrand =
+  'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-brand nx:focus-visible:outline-offset-2 nx:focus-visible:shadow-focus-glow';
+const focusNeutral =
+  'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2';
+
 const buttonVariants = cva(
-  'nx:inline-flex nx:items-center nx:justify-center nx:gap-2 nx:rounded-md nx:text-sm nx:font-medium nx:whitespace-nowrap nx:transition-colors nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2 nx:disabled:pointer-events-none nx:disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+  'nx:inline-flex nx:items-center nx:justify-center nx:gap-2 nx:rounded-md nx:text-sm nx:font-medium nx:whitespace-nowrap nx:transition-colors nx:disabled:pointer-events-none nx:disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
   {
     variants: {
       variant: {
-        default:
-          'nx:bg-primary-background nx:text-primary-foreground nx:hover:bg-primary-background-hover',
-        destructive:
-          'nx:bg-error-background nx:text-error-foreground nx:hover:bg-error-background-hover',
-        outline:
-          'nx:border nx:border-border-default nx:bg-background nx:hover:bg-background-hover nx:hover:text-foreground',
-        secondary:
-          'nx:bg-secondary-background nx:text-secondary-foreground nx:hover:bg-secondary-background-hover',
-        ghost: 'nx:hover:bg-background-hover nx:hover:text-foreground',
-        link: 'nx:text-primary-subtle-foreground nx:underline-offset-4 nx:hover:underline',
+        default: `nx:bg-primary-background nx:text-primary-foreground nx:hover:bg-primary-background-hover ${focusBrand}`,
+        destructive: `nx:bg-error-background nx:text-error-foreground nx:hover:bg-error-background-hover ${focusNeutral}`,
+        outline: `nx:border nx:border-border-default nx:bg-background nx:hover:bg-background-hover nx:hover:text-foreground ${focusBrand}`,
+        secondary: `nx:bg-secondary-background nx:text-secondary-foreground nx:hover:bg-secondary-background-hover ${focusBrand}`,
+        ghost: `nx:hover:bg-background-hover nx:hover:text-foreground ${focusBrand}`,
+        link: `nx:text-primary-subtle-foreground nx:underline-offset-4 nx:hover:underline ${focusBrand}`,
       },
       size: {
         default: 'nx:px-4 nx:py-2',

--- a/packages/react/src/components/ui/dialog.tsx
+++ b/packages/react/src/components/ui/dialog.tsx
@@ -145,7 +145,7 @@ function DialogContent({
               'nx:absolute nx:right-4 nx:top-4 nx:rounded-sm nx:opacity-70',
               'nx:transition-opacity',
               'nx:hover:opacity-100',
-              'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2',
+              'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-brand nx:focus-visible:outline-offset-2 nx:focus-visible:shadow-focus-glow',
               'nx:disabled:pointer-events-none',
               'nx:data-[state=open]:bg-muted nx:data-[state=open]:text-muted-foreground'
             )}

--- a/packages/react/src/components/ui/input.tsx
+++ b/packages/react/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const inputVariants = cva(
     'nx:bg-background nx:text-foreground nx:transition-colors',
     'nx:file:border-0 nx:file:bg-transparent nx:file:text-sm nx:file:font-medium nx:file:text-foreground',
     'nx:placeholder:text-muted-foreground',
-    'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2',
+    'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-brand nx:focus-visible:outline-offset-2 nx:focus-visible:shadow-focus-glow',
     'nx:disabled:cursor-not-allowed nx:disabled:opacity-50',
   ],
   {

--- a/packages/react/src/components/ui/select.tsx
+++ b/packages/react/src/components/ui/select.tsx
@@ -70,7 +70,7 @@ function SelectTrigger({ className, children, ...props }: SelectTriggerProps) {
         'nx:px-3 nx:py-2 nx:text-sm',
         'nx:whitespace-nowrap',
         'nx:placeholder:text-muted-foreground',
-        'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2',
+        'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-brand nx:focus-visible:outline-offset-2 nx:focus-visible:shadow-focus-glow',
         'nx:disabled:cursor-not-allowed nx:disabled:opacity-50',
         'nx:[&>span]:line-clamp-1',
         className

--- a/packages/react/src/components/ui/switch.tsx
+++ b/packages/react/src/components/ui/switch.tsx
@@ -40,7 +40,7 @@ function Switch({ className, ...props }: SwitchProps) {
         'nx:peer nx:inline-flex nx:h-5 nx:w-9 nx:shrink-0 nx:cursor-pointer nx:items-center',
         'nx:rounded-full nx:border-2 nx:border-transparent',
         'nx:transition-colors',
-        'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2',
+        'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-brand nx:focus-visible:outline-offset-2 nx:focus-visible:shadow-focus-glow',
         'nx:disabled:cursor-not-allowed nx:disabled:opacity-50',
         'nx:data-[state=checked]:bg-primary-background nx:data-[state=unchecked]:bg-muted',
         className

--- a/packages/react/src/components/ui/tabs.tsx
+++ b/packages/react/src/components/ui/tabs.tsx
@@ -72,7 +72,7 @@ const tabsTriggerVariants = cva(
     'nx:whitespace-nowrap',
     'nx:font-medium nx:text-foreground/70',
     'nx:transition-all',
-    'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2',
+    'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-brand nx:focus-visible:outline-offset-2 nx:focus-visible:shadow-focus-glow',
     'nx:disabled:pointer-events-none nx:disabled:opacity-50',
   ],
   {
@@ -186,7 +186,7 @@ function TabsContent({ className, ...props }: TabsContentProps) {
       data-slot="tabs-content"
       className={cn(
         'nx:mt-2',
-        'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2',
+        'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-brand nx:focus-visible:outline-offset-2 nx:focus-visible:shadow-focus-glow',
         className
       )}
       {...props}

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -126,6 +126,8 @@
   --color-chart-categorical-5: var(--nx-color-indigo-600);
   --color-focus-default: var(--nx-focus-color-default);
   --color-focus-error: var(--nx-focus-color-error);
+  --color-focus-brand: var(--nx-focus-color-brand);
+  --color-focus-glow: var(--nx-focus-color-glow);
 
   /* Spacing tokens */
   --spacing-0: var(--nx-size-0);
@@ -218,6 +220,7 @@
   --shadow-inner: inset var(--nx-shadow-inner-layer-1-x)
     var(--nx-shadow-inner-layer-1-y) var(--nx-shadow-inner-layer-1-blur)
     var(--nx-shadow-inner-layer-1-spread) var(--nx-shadow-inner-layer-1-color);
+  --shadow-focus-glow: 0px 0px 8px 2px var(--nx-focus-color-glow);
 }
 
 /* ===== DARK MODE ===== */

--- a/packages/tailwind/variables.css
+++ b/packages/tailwind/variables.css
@@ -520,6 +520,8 @@
   /* focus (default) */
   --nx-focus-color-default: oklch(0.5555 0 0);
   --nx-focus-color-error: oklch(0.5771 0.2152 27.325);
+  --nx-focus-color-brand: oklch(0.4991 0.1301 255.276);
+  --nx-focus-color-glow: oklch(0.5793 0.1352 255.145 / 0.4);
 
   /* radius (sharp) */
   --nx-radius-base: 0px;
@@ -690,4 +692,6 @@
   /* focus (default dark) */
   --nx-focus-color-default: oklch(0.7572 0 0);
   --nx-focus-color-error: oklch(0.8077 0.1035 19.571);
+  --nx-focus-color-brand: oklch(0.8006 0.0751 254.248);
+  --nx-focus-color-glow: oklch(0.8006 0.0751 254.248 / 0.4);
 }


### PR DESCRIPTION
## Summary

Builds on #150 (outline focus ring) to make the ring **premium**: a brand-blue outline + a soft translucent glow, while keeping the accessibility guarantees.

**Design**
- Default controls (button, input, switch, tabs, accordion, dialog-close, select): brand-blue `outline-focus-brand` + translucent `shadow-focus-glow`.
- **Destructive Button keeps the neutral grey `outline-focus-default` (no glow)** — a brand ring clashes with, and barely contrasts against, the red fill (red-on-red is near-invisible). For invalid inputs, the red `outline-focus-error` stays available.
- The crisp ring is a real CSS `outline`, so it **survives Windows High Contrast Mode**; the glow is an additive box-shadow (decorative — doesn't survive WHCM, but the outline does).

**Tokens**
- `--color-focus-brand` (theme-split: `blue-600` light / `blue-300` dark), `--color-focus-glow` (translucent), `--shadow-focus-glow` (`0 0 8px 2px`).
- Grey `focus-default` and red `focus-error` unchanged.

**Tradeoff — reverses part of #44.** #44 chose neutral grey for surface-invariance; this intentionally adopts a brand ring for the default case (per design direction). Surface-invariance is preserved where it matters most (coloured-fill controls fall back to grey), and the brand ring is APCA-gated at Lc ≥ 45 on every surface.

## Stacked on

Base branch is #150's branch (`aishvarya/issue-92-feat-focus-outline-offset-ring`). GitHub will retarget this to `main` after #150 merges.

## Test Plan

- [x] APCA contrast: brand ring gated Lc ≥ 45 on every surface × theme (**390/390**)
- [x] `yarn lint`, `yarn typecheck` (5/5), `yarn format:check`
- [x] Core token tests (147)
- [x] `audit:class-refs` — `outline-focus-brand` + `shadow-focus-glow` resolve
- [x] Token freshness: zero drift
- [x] Storybook play tests for all 7 affected components (**108**)
- [x] Visual: brand ring + glow on default / input / on-card (light + dark); destructive shows the grey ring (screenshots verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)