### PR TITLE
feat(responsive): rem-based --breakpoint-* tokens

### DIFF
--- a/apps/playground/public/themes/globals.css
+++ b/apps/playground/public/themes/globals.css
@@ -26,6 +26,7 @@
   --spacing-*: initial;
   --radius-*: initial;
   --shadow-*: initial;
+  --breakpoint-*: initial;
 
   /* Semantic color tokens */
   --color-background: var(--nx-color-white);
@@ -229,4 +230,11 @@
   --z-index-popover: 70;
   --z-index-toast: 100;
   --z-index-max: 9999;
+
+  /* Breakpoint tokens */
+  --breakpoint-sm: 40rem;
+  --breakpoint-md: 48rem;
+  --breakpoint-lg: 64rem;
+  --breakpoint-xl: 80rem;
+  --breakpoint-2xl: 96rem;
 }

--- a/apps/playground/src/styles/globals.css
+++ b/apps/playground/src/styles/globals.css
@@ -26,6 +26,7 @@
   --spacing-*: initial;
   --radius-*: initial;
   --shadow-*: initial;
+  --breakpoint-*: initial;
 
   /* Semantic color tokens */
   --color-background: var(--nx-color-white);
@@ -229,4 +230,11 @@
   --z-index-popover: 70;
   --z-index-toast: 100;
   --z-index-max: 9999;
+
+  /* Breakpoint tokens */
+  --breakpoint-sm: 40rem;
+  --breakpoint-md: 48rem;
+  --breakpoint-lg: 64rem;
+  --breakpoint-xl: 80rem;
+  --breakpoint-2xl: 96rem;
 }

--- a/packages/core/scripts/__tests__/generate-modular.test.js
+++ b/packages/core/scripts/__tests__/generate-modular.test.js
@@ -66,4 +66,10 @@ describe('generateModular', () => {
     expect(globals).toMatch(/--z-index-popover: 70;/);
     expect(globals).toMatch(/--z-index-modal: 50;/);
   });
+
+  it('emits breakpoint tokens in playground globals.css', () => {
+    const globals = fs.readFileSync(path.join(distDir, 'globals.css'), 'utf8');
+    expect(globals).toMatch(/--breakpoint-sm: 40rem;/);
+    expect(globals).toMatch(/--breakpoint-2xl: 96rem;/);
+  });
 });

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -145,6 +145,16 @@ describe('generateTailwindPackage', () => {
     expect(themeBlock).toMatch(/--z-index-max: 9999;/);
   });
 
+  it('emits breakpoint tokens (with reset) in @theme', () => {
+    const themeBlock = extractBlock(nexusCSS, '@theme');
+    expect(themeBlock).toMatch(/--breakpoint-\*: initial;/);
+    expect(themeBlock).toMatch(/--breakpoint-sm: 40rem;/);
+    expect(themeBlock).toMatch(/--breakpoint-md: 48rem;/);
+    expect(themeBlock).toMatch(/--breakpoint-lg: 64rem;/);
+    expect(themeBlock).toMatch(/--breakpoint-xl: 80rem;/);
+    expect(themeBlock).toMatch(/--breakpoint-2xl: 96rem;/);
+  });
+
   it('emits zero `File not found` warnings for the default config', () => {
     const fileNotFound = warnings.filter((w) => /File not found/.test(w));
     expect(fileNotFound).toEqual([]);

--- a/packages/core/scripts/__tests__/utils.test.js
+++ b/packages/core/scripts/__tests__/utils.test.js
@@ -4,6 +4,7 @@ import path from 'path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  collectBreakpointsTokens,
   collectZIndexTokens,
   DEFAULT_CONFIG,
   extractRefPath,
@@ -452,6 +453,63 @@ describe('utils', () => {
       withZIndexFixture({ 'z-index-modal': { $type: 'number' } }, (dir) => {
         expect(() => collectZIndexTokens(dir)).toThrow(/z-index-modal/);
       });
+    });
+  });
+
+  describe('collectBreakpointsTokens', () => {
+    function withBreakpointsFixture(tokenData, fn) {
+      const dir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'nexus-breakpoint-test-')
+      );
+      try {
+        fs.writeFileSync(
+          path.join(dir, 'breakpoints.json'),
+          JSON.stringify(tokenData)
+        );
+        return fn(dir);
+      } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+
+    it('collects rem dimensions as direct values, skipping metadata', () => {
+      withBreakpointsFixture(
+        {
+          $description: 'ignored metadata',
+          'breakpoint-lg': {
+            $value: { value: 64, unit: 'rem' },
+            $type: 'dimension',
+          },
+        },
+        (dir) => {
+          expect(collectBreakpointsTokens(dir)).toEqual([
+            { cssName: 'breakpoint-lg', value: '64rem' },
+          ]);
+        }
+      );
+    });
+
+    it('throws (naming the token) when a token $type is not dimension', () => {
+      withBreakpointsFixture(
+        { 'breakpoint-lg': { $value: 64, $type: 'number' } },
+        (dir) => {
+          expect(() => collectBreakpointsTokens(dir)).toThrow(/breakpoint-lg/);
+        }
+      );
+    });
+
+    it('throws (naming the token) when the unit is not rem', () => {
+      withBreakpointsFixture(
+        {
+          'breakpoint-lg': {
+            $value: { value: 1024, unit: 'px' },
+            $type: 'dimension',
+          },
+        },
+        (dir) => {
+          expect(() => collectBreakpointsTokens(dir)).toThrow(/breakpoint-lg/);
+        }
+      );
     });
   });
 });

--- a/packages/core/scripts/__tests__/utils.test.js
+++ b/packages/core/scripts/__tests__/utils.test.js
@@ -511,5 +511,14 @@ describe('utils', () => {
         }
       );
     });
+
+    it('throws (naming the token) when a dimension token is missing its $value', () => {
+      withBreakpointsFixture(
+        { 'breakpoint-lg': { $type: 'dimension' } },
+        (dir) => {
+          expect(() => collectBreakpointsTokens(dir)).toThrow(/breakpoint-lg/);
+        }
+      );
+    });
   });
 });

--- a/packages/core/scripts/generate-modular.js
+++ b/packages/core/scripts/generate-modular.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url';
 
 import {
   collectBorderwidthTokens,
+  collectBreakpointsTokens,
   collectRadiusTokens,
   collectSemanticColorTokensVarRef,
   collectShadowTokens,
@@ -254,6 +255,7 @@ function generatePlaygroundGlobalsCSS(distDir, primitives, primitiveMap) {
     : [];
   const shadowTokens = collectShadowTokens(TOKENS_DIR, primitiveMap);
   const zIndexTokens = collectZIndexTokens(SEMANTIC_DIR);
+  const breakpointTokens = collectBreakpointsTokens(SEMANTIC_DIR);
 
   // Generate using shared function
   const header = `/*
@@ -286,6 +288,7 @@ function generatePlaygroundGlobalsCSS(distDir, primitives, primitiveMap) {
     borderwidthTokens,
     shadowTokens,
     zIndexTokens,
+    breakpointTokens,
     // No dark mode block - playground uses dynamic theme switching
   });
 

--- a/packages/core/scripts/generate-tailwind-package.js
+++ b/packages/core/scripts/generate-tailwind-package.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url';
 
 import {
   collectBorderwidthTokens,
+  collectBreakpointsTokens,
   collectRadiusTokens,
   collectSemanticColorTokensVarRef,
   collectShadowTokens,
@@ -416,6 +417,7 @@ function generateNexusCSS(semanticFiles, primitiveMap, usedModes) {
   );
   const shadowTokens = collectShadowTokens(TOKENS_DIR, primitiveMap);
   const zIndexTokens = collectZIndexTokens(SEMANTIC_DIR);
+  const breakpointTokens = collectBreakpointsTokens(SEMANTIC_DIR);
 
   // Generate header
   const header = `/* ===== NEXUS DESIGN SYSTEM - TAILWIND THEME ===== */
@@ -445,6 +447,7 @@ function generateNexusCSS(semanticFiles, primitiveMap, usedModes) {
     borderwidthTokens,
     shadowTokens,
     zIndexTokens,
+    breakpointTokens,
     darkColorTokens,
     darkSelector: '.dark',
     prefixDarkVars: true, // Use --nx-color-* for dark mode overrides

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -763,6 +763,50 @@ export function collectZIndexTokens(semanticDir) {
 }
 
 /**
+ * Collect breakpoint token mappings from breakpoints.json.
+ * Returns array of { cssName, value } for the @theme block. Like z-index,
+ * breakpoints are standalone semantics with direct values (no primitive layer,
+ * no modes, no light/dark) — but they carry rem dimensions, so the value is
+ * formatted from a structured { value, unit } and the unit is required to be
+ * rem (a px breakpoint would silently defeat font-size scaling).
+ *
+ * @param {string} semanticDir - Path to semantic directory
+ * @returns {object[]} Array of { cssName, value }
+ */
+export function collectBreakpointsTokens(semanticDir) {
+  const filePath = path.join(semanticDir, 'breakpoints.json');
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Breakpoints semantic file missing: ${filePath}`);
+  }
+
+  const tokenData = readTokenFile(filePath);
+  const tokens = [];
+
+  for (const [key, value] of Object.entries(tokenData)) {
+    if (key.startsWith('$')) continue;
+    if (value.$type !== 'dimension') {
+      throw new Error(
+        `Breakpoint token "${key}" has $type "${value.$type}" but must be "dimension" (${filePath})`
+      );
+    }
+    const dim = value.$value;
+    if (
+      typeof dim !== 'object' ||
+      dim === null ||
+      typeof dim.value !== 'number' ||
+      dim.unit !== 'rem'
+    ) {
+      throw new Error(
+        `Breakpoint token "${key}" must be a rem dimension { value: number, unit: "rem" } (${filePath})`
+      );
+    }
+    tokens.push({ cssName: key, value: formatTokenValue(dim, 'dimension') });
+  }
+
+  return tokens;
+}
+
+/**
  * Collect radius token mappings from a mode file
  * Returns array of { cssName, varRef } for @theme block
  *
@@ -958,6 +1002,7 @@ export function generateThemeCSS(config) {
     borderwidthTokens = [],
     shadowTokens = [],
     zIndexTokens = [],
+    breakpointTokens = [],
     darkColorTokens = [],
     darkSelector = '.dark',
     prefixDarkVars = false,
@@ -987,7 +1032,8 @@ export function generateThemeCSS(config) {
   css += `  --color-*: initial;\n`;
   css += `  --spacing-*: initial;\n`;
   css += `  --radius-*: initial;\n`;
-  css += `  --shadow-*: initial;\n\n`;
+  css += `  --shadow-*: initial;\n`;
+  css += `  --breakpoint-*: initial;\n\n`;
 
   // Color tokens
   if (colorTokens.length > 0) {
@@ -1033,6 +1079,14 @@ export function generateThemeCSS(config) {
   if (zIndexTokens.length > 0) {
     css += `\n  /* Z-index tokens */\n`;
     for (const token of zIndexTokens) {
+      css += `  --${token.cssName}: ${token.value};\n`;
+    }
+  }
+
+  // Breakpoint tokens
+  if (breakpointTokens.length > 0) {
+    css += `\n  /* Breakpoint tokens */\n`;
+    for (const token of breakpointTokens) {
       css += `  --${token.cssName}: ${token.value};\n`;
     }
   }

--- a/packages/core/tokens/semantic/breakpoints.json
+++ b/packages/core/tokens/semantic/breakpoints.json
@@ -14,7 +14,7 @@
       "unit": "rem"
     },
     "$type": "dimension",
-    "$description": "768px @ 16px root — narrow."
+    "$description": "768px @ 16px root — compact."
   },
   "breakpoint-lg": {
     "$value": {

--- a/packages/core/tokens/semantic/breakpoints.json
+++ b/packages/core/tokens/semantic/breakpoints.json
@@ -1,0 +1,43 @@
+{
+  "$description": "Responsive breakpoints (rem). Values match Tailwind v4's own defaults exactly — Nexus declares them explicitly so they fall under the same reset-and-own discipline as every other namespace (color/spacing/radius/shadow) instead of being inherited implicitly. Tailwind v4 auto-discovers --breakpoint-* from @theme and uses them to generate the nx:sm:…nx:2xl: responsive variants. Override at BUILD TIME by re-declaring a value in a consumer @theme block — NOT at runtime: @media cannot read var(), so Tailwind bakes the resolved value into the generated media queries at build time.",
+  "breakpoint-sm": {
+    "$value": {
+      "value": 40,
+      "unit": "rem"
+    },
+    "$type": "dimension",
+    "$description": "640px @ 16px root — narrow."
+  },
+  "breakpoint-md": {
+    "$value": {
+      "value": 48,
+      "unit": "rem"
+    },
+    "$type": "dimension",
+    "$description": "768px @ 16px root — narrow."
+  },
+  "breakpoint-lg": {
+    "$value": {
+      "value": 64,
+      "unit": "rem"
+    },
+    "$type": "dimension",
+    "$description": "1024px @ 16px root — standard floor."
+  },
+  "breakpoint-xl": {
+    "$value": {
+      "value": 80,
+      "unit": "rem"
+    },
+    "$type": "dimension",
+    "$description": "1280px @ 16px root — standard reference."
+  },
+  "breakpoint-2xl": {
+    "$value": {
+      "value": 96,
+      "unit": "rem"
+    },
+    "$type": "dimension",
+    "$description": "1536px @ 16px root — wide."
+  }
+}

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -22,6 +22,7 @@
   --spacing-*: initial;
   --radius-*: initial;
   --shadow-*: initial;
+  --breakpoint-*: initial;
 
   /* Semantic color tokens */
   --color-background: var(--nx-color-white);
@@ -230,6 +231,13 @@
   --z-index-popover: 70;
   --z-index-toast: 100;
   --z-index-max: 9999;
+
+  /* Breakpoint tokens */
+  --breakpoint-sm: 40rem;
+  --breakpoint-md: 48rem;
+  --breakpoint-lg: 64rem;
+  --breakpoint-xl: 80rem;
+  --breakpoint-2xl: 96rem;
 }
 
 /* ===== DARK MODE ===== */


### PR DESCRIPTION
## Summary

- Ship 5 rem-based `--breakpoint-*` tokens (`sm`/`md`/`lg`/`xl`/`2xl` = `40`/`48`/`64`/`80`/`96rem`) plus a `--breakpoint-*: initial` reset into the Tailwind `@theme` block — **via the token source + generators**, mirroring the z-index scale (#149), not by hand-editing the generated `nexus.css`.
- New `packages/core/tokens/semantic/breakpoints.json` (standalone semantic — no primitive layer, no modes, no light/dark), collected by `collectBreakpointsTokens()` in `utils.js` and emitted through the shared `generateThemeCSS()` into both `generate-tailwind-package.js` and `generate-modular.js`.
- Regenerated `packages/tailwind/nexus.css` + playground `globals.css` (breakpoint-only diff; no brand/color/`package.json` drift).

### Rationale — corrected from the issue's original premise

The issue originally framed this as a **px → rem accessibility upgrade**. That's a **Tailwind v3 fact** — **Tailwind v4 already ships these exact rem breakpoints** (`node_modules/tailwindcss/theme.css`). I re-verified against v4.1.18 and **updated the #99 body** to fix the premise. So this is **net-zero at runtime**; the real value is:

1. **Governance / consistency** — every other namespace (`--color-*`, `--spacing-*`, `--radius-*`, `--shadow-*`) is `initial`-reset + re-declared so Nexus _owns_ the values. Breakpoints were the lone namespace inherited implicitly; this brings them under the same reset-and-own discipline and insulates Nexus if Tailwind changes its defaults.
2. **Explicit + documented + greppable** in `nexus.css`.
3. **Override surface** — a documented build-time path for consumers.
4. **`:root` exposure** — explicit declaration guarantees the vars are emitted for non-Tailwind contexts.

### Build-time, not runtime

Override is **build-time only** (consumer adds their own `@theme` block). `@media` can't read `var()`, so Tailwind bakes the resolved value at build time — documented in the token file's `$description`, and deliberately **not** claimed as runtime override.

### Out of scope

Display-class documentation + responsive demo page is deferred to **[8/10]** per the issue.

## GitHub Issue

Closes #99

## Test Plan

- [x] `yarn typecheck` — passes
- [x] Lint — real-source (`eslint packages apps scripts`) passes (repo-wide `yarn lint` only flags a local untracked `.claude/worktrees/` copy; clean checkout / CI is unaffected)
- [x] 5 new tests pass — `collectBreakpointsTokens` (collects rem dimensions, throws naming the token on non-dimension `$type` and non-rem unit) + `@theme` / playground `globals.css` emission assertions
- [x] **Compile-proof:** `nx:sm:`…`nx:2xl:` compile against the regenerated `nexus.css` → `@media (width >= 40/48/64/80/96rem)` (Tailwind v4 range syntax)
- [x] Regen diff is breakpoint-only — no brand/color/`package.json` drift
- [x] No React component changes → no Storybook regression (re-added values are identical to Tailwind v4 defaults; the existing `nx:sm:` usages in `dialog.tsx` resolve unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
