### PR TITLE
[8/10] docs(responsive): create responsive.md (display classes + decision tree)

### DIFF
--- a/.claude/rules/responsive.md
+++ b/.claude/rules/responsive.md
@@ -1,6 +1,6 @@
 # Responsive Design Rules
 
-Nexus components are designed for **Standard (≥1024px)** as the primary target. Narrow (<1024px) is graceful degradation; Wide (≥1536px) gets breathing room when available. Use `nx:lg:` as the primary responsive prefix in consumer code.
+Nexus components are designed for **Standard (≥1024px)** as the primary target. Narrow (<1024px) is graceful degradation; Wide (≥1536px) gets breathing room when available. Standard spans `lg` (1024px floor — the prefix you reach for first when writing responsive consumer code) through `xl` (1280px — the design reference width components are tuned against).
 
 > **Consumer-brand inversion.** The ≥1024px primary target is the Nexus reference brand's default — set by `--breakpoint-*` in `packages/tailwind/nexus.css:236-240`. Consumer brands building mobile-first products override by re-aiming `@theme { --breakpoint-* }` and treating a different tier as primary. The display-class labels (Narrow / Standard / Wide) describe defaults, not hard-coded behaviour.
 
@@ -27,11 +27,11 @@ Nexus components are designed for **Standard (≥1024px)** as the primary target
 | `@container` query                    | Component renders differently based on its parent's width | Card that's full-width in a hero, narrow in a sidebar |
 | `nx:lg:` viewport prefix              | Page-shell decisions — nav collapse, side panel hide      | Hide secondary sidebar below `lg`                     |
 | `clamp()` (CSS primitive)             | Continuous adaptation of size — type, padding             | `font-size: clamp(1rem, 0.9rem + 0.5vw, 1.5rem)`      |
-| `svh` / `lvh` / `dvh` (CSS primitive) | Mobile browser-chrome accommodation                       | Full-screen modal: `min-height: 100dvh`               |
+| `svh` / `lvh` / `dvh` (CSS primitive) | Mobile browser-chrome accommodation                       | Modal that must not clip: `min-height: 100svh`        |
 
 ### `container-type` cost policy
 
-Only add `container-type: inline-size` to a component where a **child actually queries the container** via `@container (...)`. Each declaration creates a new formatting context with size containment, and the browser begins tracking that element's dimensions across resizes, scrolls, and animations.
+Only add `container-type: inline-size` to a component where a **child actually queries the container** via `@container (...)`. Each declaration creates a new formatting context with size containment, and the browser begins tracking that element's dimensions across layout-affecting size changes.
 
 Per MDN and web.dev: no element has size containment by default — you manually register a query container with `container-type` when you need it, precisely so the browser can limit the number of elements it tracks. Applying it indiscriminately reintroduces the per-element tracking cost the property was designed to avoid.
 
@@ -50,6 +50,8 @@ A forthcoming declarative primitive (see [#103](https://github.com/nexuslabs-ai/
 <Show containerAbove="md"><Stat /></Show>
 <Hide containerBelow="sm"><Avatar /></Hide>
 ```
+
+> **Proposed — subject to the #103 spike.** Prop names (`above` / `below` / `containerAbove` / `containerBelow`) are the working shape, not the final API. Issue #103 has a mandatory pre-implementation spike on `display: revert` semantics inside flex parents that may force a different shape; the snippet above will be re-synced when #103 lands.
 
 Until that primitive ships, the raw fallback is acceptable but verbose — and easy to invert by mistake.
 
@@ -72,12 +74,12 @@ Prefer the primitive when it ships. Pick the right axis: `above` / `below` for v
 ## Anti-patterns
 
 - **Don't use `nx:sm:` inside component internals.** Use `@container` queries instead. A viewport prefix inside a component leaks page-shell concerns into the component's internal layout — the component then renders inconsistently when dropped into a sidebar vs a hero. The exception is full-viewport overlays; see Viewport-driven exceptions below.
-- **Don't use raw `vh` units.** They reflect the largest possible viewport on mobile and overshoot when browser chrome is visible. Use `svh` for sticky elements (smallest viewport — never clipped), `dvh` for full-screen heroes (dynamic — adjusts as chrome shows/hides), and `lvh` for modals (largest — what the user sees fullscreen).
+- **Don't use raw `vh` units.** They reflect the largest possible viewport on mobile and overshoot when browser chrome is visible. Per [web.dev's viewport-units guide](https://web.dev/blog/viewport-units) and MDN: use `svh` (small viewport — chrome-shown size) for content that must not clip on initial load — modals, sticky elements; use `lvh` (large viewport — chrome-hidden size) for immersive full-bleed heroes; use `dvh` (dynamic) for layouts that should grow and shrink as chrome shows/hides.
 - **Don't write responsive component code that assumes a viewport width.** Components don't know their consumer's page shell. Render decisions should follow the component's parent width (`@container`) or be passed in as props — never inferred from the viewport.
 
 ## Viewport-driven exceptions
 
-Most components use `@container` for internal responsive behaviour. **Full-viewport overlay components are exceptions** — Dialog, future Sheet, future FullScreenOverlay — because their responsive trigger is positioning relative to the viewport, not their own container width.
+Most components use `@container` for internal responsive behaviour — though no shipped Nexus component reaches for it yet (Dialog is the only live datapoint, and it's the viewport-driven exception below). The `@container` default is forward-looking: it sets the bar for the next wave of internal-responsive components, not a pattern to retrofit existing ones against. **Full-viewport overlay components are exceptions** — Dialog, future Sheet, future FullScreenOverlay — because their responsive trigger is positioning relative to the viewport, not their own container width.
 
 A Dialog at 480px viewport is full-bleed (no rounded corners) because _the viewport is narrow_, not because the Dialog's own container is narrow. Migrating to `@container` would flip the rounded-corner threshold to the Dialog's intrinsic width, producing rounded corners on what's still effectively a full-bleed sheet — wrong UX.
 
@@ -94,3 +96,5 @@ Fluid scaling via `clamp()` and dynamic viewport units `svh` / `lvh` / `dvh` are
 - [components.md](components.md) — component-authoring rules; `@container` use in component internals is the responsive corollary of Sizing Convention and Layering model
 - `packages/tailwind/nexus.css:236-240` — the emitted `--breakpoint-*` token values
 - `packages/react/src/components/ui/dialog.tsx` — the live viewport-driven exception
+- [#102](https://github.com/nexuslabs-ai/nexus/issues/102) — cross-links from `components.md` / `figma.md` / `code-quality.md` that point readers at the display-class table here
+- [#103](https://github.com/nexuslabs-ai/nexus/issues/103) — the `<Show>` / `<Hide>` primitive that retires the raw-class fallback in the canonical pattern

--- a/.claude/rules/responsive.md
+++ b/.claude/rules/responsive.md
@@ -1,0 +1,96 @@
+# Responsive Design Rules
+
+Nexus components are designed for **Standard (≥1024px)** as the primary target. Narrow (<1024px) is graceful degradation; Wide (≥1536px) gets breathing room when available. Use `nx:lg:` as the primary responsive prefix in consumer code.
+
+> **Consumer-brand inversion.** The ≥1024px primary target is the Nexus reference brand's default — set by `--breakpoint-*` in `packages/tailwind/nexus.css:236-240`. Consumer brands building mobile-first products override by re-aiming `@theme { --breakpoint-* }` and treating a different tier as primary. The display-class labels (Narrow / Standard / Wide) describe defaults, not hard-coded behaviour.
+
+## Display class table
+
+**This table is the single source of truth.** Other rule files (`components.md`, `figma.md`) link here rather than duplicating these rows.
+
+| Tailwind class | Range (rem / px @16) | Nexus display class | Use as primary target? |
+| -------------- | -------------------- | ------------------- | ---------------------- |
+| `nx:sm:`       | 40rem / 640px+       | Narrow              | No (graceful)          |
+| `nx:md:`       | 48rem / 768px+       | Narrow              | No (graceful)          |
+| `nx:lg:`       | 64rem / 1024px+      | **Standard ★**      | Yes — floor            |
+| `nx:xl:`       | 80rem / 1280px+      | **Standard ★**      | Yes — reference        |
+| `nx:2xl:`      | 96rem / 1536px+      | Wide                | No (extended)          |
+
+**Narrow / Standard / Wide are documentation labels, not utilities.** There is no `nx:standard:` class. Contributors use the standard Tailwind class names (`nx:sm:`, `nx:md:`, `nx:lg:`, `nx:xl:`, `nx:2xl:`) in code; the display-class labels exist to anchor design and review conversations.
+
+> **Zoom-vs-rem.** Breakpoints are rem-based, so they fire at the user's **zoom-adjusted threshold** — not pixel-adjusted. A user at 1280px viewport zoomed to 200% triggers Narrow (`nx:md:` matches, `nx:lg:` does not), because their effective root font-size doubled. This is intended accessibility behaviour: zoom is text scaling, and layout should follow text. Designers should test components at 100%, 150%, and 200% browser zoom.
+
+## Decision tree — which responsive mechanism
+
+| Mechanism                             | Use case                                                  | Example                                               |
+| ------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------- |
+| `@container` query                    | Component renders differently based on its parent's width | Card that's full-width in a hero, narrow in a sidebar |
+| `nx:lg:` viewport prefix              | Page-shell decisions — nav collapse, side panel hide      | Hide secondary sidebar below `lg`                     |
+| `clamp()` (CSS primitive)             | Continuous adaptation of size — type, padding             | `font-size: clamp(1rem, 0.9rem + 0.5vw, 1.5rem)`      |
+| `svh` / `lvh` / `dvh` (CSS primitive) | Mobile browser-chrome accommodation                       | Full-screen modal: `min-height: 100dvh`               |
+
+### `container-type` cost policy
+
+Only add `container-type: inline-size` to a component where a **child actually queries the container** via `@container (...)`. Each declaration creates a new formatting context with size containment, and the browser begins tracking that element's dimensions across resizes, scrolls, and animations.
+
+Per MDN and web.dev: no element has size containment by default — you manually register a query container with `container-type` when you need it, precisely so the browser can limit the number of elements it tracks. Applying it indiscriminately reintroduces the per-element tracking cost the property was designed to avoid.
+
+Concrete rule: if you grep your file and find no `@container (...)` rule scoping to the declared container, the `container-type` declaration is dead weight — remove it.
+
+## Canonical pattern in JSX
+
+A forthcoming declarative primitive (see [#103](https://github.com/nexuslabs-ai/nexus/issues/103)) — `<Show>` / `<Hide>` — covers both viewport and container axes:
+
+```tsx
+// Viewport (page-shell decisions)
+<Show above="lg"><aside>Secondary nav</aside></Show>
+<Hide below="md"><span>Tablet-and-up context</span></Hide>
+
+// Container (component-internal — Nexus extension over Atlassian's primitive)
+<Show containerAbove="md"><Stat /></Show>
+<Hide containerBelow="sm"><Avatar /></Hide>
+```
+
+Until that primitive ships, the raw fallback is acceptable but verbose — and easy to invert by mistake.
+
+**Anti-pattern (raw class toggling):**
+
+```tsx
+<aside className="nx:hidden nx:lg:block">Secondary nav</aside>
+```
+
+**Correct pattern (declarative primitive, when available):**
+
+```tsx
+<Show above="lg">
+  <aside>Secondary nav</aside>
+</Show>
+```
+
+Prefer the primitive when it ships. Pick the right axis: `above` / `below` for viewport (page shell), `containerAbove` / `containerBelow` for component-internal — matching the decision tree above.
+
+## Anti-patterns
+
+- **Don't use `nx:sm:` inside component internals.** Use `@container` queries instead. A viewport prefix inside a component leaks page-shell concerns into the component's internal layout — the component then renders inconsistently when dropped into a sidebar vs a hero. The exception is full-viewport overlays; see Viewport-driven exceptions below.
+- **Don't use raw `vh` units.** They reflect the largest possible viewport on mobile and overshoot when browser chrome is visible. Use `svh` for sticky elements (smallest viewport — never clipped), `dvh` for full-screen heroes (dynamic — adjusts as chrome shows/hides), and `lvh` for modals (largest — what the user sees fullscreen).
+- **Don't write responsive component code that assumes a viewport width.** Components don't know their consumer's page shell. Render decisions should follow the component's parent width (`@container`) or be passed in as props — never inferred from the viewport.
+
+## Viewport-driven exceptions
+
+Most components use `@container` for internal responsive behaviour. **Full-viewport overlay components are exceptions** — Dialog, future Sheet, future FullScreenOverlay — because their responsive trigger is positioning relative to the viewport, not their own container width.
+
+A Dialog at 480px viewport is full-bleed (no rounded corners) because _the viewport is narrow_, not because the Dialog's own container is narrow. Migrating to `@container` would flip the rounded-corner threshold to the Dialog's intrinsic width, producing rounded corners on what's still effectively a full-bleed sheet — wrong UX.
+
+Live example: `packages/react/src/components/ui/dialog.tsx` uses `nx:sm:` at three sites — content rounding (`:135`), header text alignment (`:187`), footer flex direction and gap (`:220`). Each is a positioning concern relative to the viewport, not a container-width concern. Keep them.
+
+For exceptions, use viewport breakpoints (`nx:sm:`, `nx:md:`, etc.) as you normally would.
+
+## Forward direction
+
+Fluid scaling via `clamp()` and dynamic viewport units `svh` / `lvh` / `dvh` are forthcoming as tokens. Components that genuinely need them today should use the CSS primitives directly; Nexus token wrappers will follow.
+
+## See also
+
+- [components.md](components.md) — component-authoring rules; `@container` use in component internals is the responsive corollary of Sizing Convention and Layering model
+- `packages/tailwind/nexus.css:236-240` — the emitted `--breakpoint-*` token values
+- `packages/react/src/components/ui/dialog.tsx` — the live viewport-driven exception


### PR DESCRIPTION
## Summary

- Creates `.claude/rules/responsive.md` — the canonical Nexus rule on responsive design.
- Documents the Narrow / Standard / Wide display classes anchored on the ≥1024px primary target.
- Ships the `@container` vs `nx:lg:` vs `clamp()` vs `svh/lvh/dvh` decision tree.
- Marks the display-class table as the single source of truth so #102 can cross-link from `components.md` / `figma.md` without duplication.
- Documents Dialog as a viewport-driven exception (cites `dialog.tsx:135/187/220`) — the Phase 2 spike outcome from #100.
- References the forthcoming `<Show>` / `<Hide>` primitive (#103) with both viewport (`above` / `below`) and container (`containerAbove` / `containerBelow`) axes, plus a raw-class fallback until it ships.

## Acceptance criteria

All 10 criteria covered in a single file — 5 base + 5 from the Phase 2 spike cross-check.

| AC | Where it lives |
| --- | --- |
| All 6 sections present | Unnumbered H2s for Primary target, Display class table, Decision tree, Canonical pattern, Anti-patterns, Forward direction (plus the promoted Viewport-driven exceptions subsection) |
| Display class table is SoT | `:9` — "This table is the single source of truth" |
| Decision tree unambiguous | `:25-30` — 4-row table; `clamp()` and `svh/lvh/dvh` explicitly labelled "(CSS primitive)" so the Forward direction §reads as continuation |
| Anti-patterns explicitly listed | `:72-76` — three bullets, each with a why-sentence |
| Voice match | Unnumbered H2s, table-heavy, blockquote callouts, "See also" footer — same shape as `surfaces.md` / `components.md` |
| Narrow/Standard/Wide disclaimer | `:19` — "documentation labels, not utilities" |
| `container-type` cost policy | `:32-38` — MDN/web.dev-grounded paraphrase with a "grep for `@container (...)`" actionable rule |
| Viewport-driven exception clause | Standalone section `:78-86` — promoted out of the anti-pattern bullet so the Dialog carve-out reads as principled, not a violation |
| Zoom-vs-rem designer note | Blockquote `:21` — 100% / 150% / 200% testing guidance |
| Consumer-brand inversion note | Blockquote `:5` — re-aiming `@theme { --breakpoint-* }` for mobile-first consumer brands |

## Out of scope (tracked elsewhere)

- Cross-links from `components.md` / `figma.md` / `code-quality.md` pointing at the new SoT table → #102
- `<Show>` / `<Hide>` primitive implementation → #103
- Marking Dialog's `nx:sm:` usage as principled in code → #100 (this PR provides the rule it can reference)

## GitHub Issue

Closes #101

## Test Plan

- [x] File exists at `.claude/rules/responsive.md` (96 lines)
- [x] All cited paths resolve (`components.md`, `nexus.css:236-240`, `dialog.tsx:135/187/220`)
- [x] `--breakpoint-*` values in the display class table match `packages/tailwind/nexus.css:236-240` (rem-based, post-#153)
- [x] All 10 acceptance criteria mapped to specific line ranges (see table above)
- [ ] Reviewer confirms voice matches existing rule files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
