### PR TITLE
[7/10] docs(responsive): Dialog as viewport-driven exception (§5 Decision C)

### DIFF
--- a/reports/phase-2-token-decisions.html
+++ b/reports/phase-2-token-decisions.html
@@ -1501,7 +1501,7 @@ nx:focus-visible:outline-offset-2</pre>
     Nexus inherits Tailwind v4's 5 default breakpoints with zero customisation and zero
     documented opinion. The cross-check found Dialog already uses <code>nx:sm:</code> in
     3 places, which initially read as at odds with the "desktop-primary" stance (a spike later
-    confirmed it's a legitimate viewport-driven exception — see Decision D). Meanwhile 2026 industry consensus
+    confirmed it's a legitimate viewport-driven exception). Meanwhile 2026 industry consensus
     has shifted decisively: container queries are now Baseline (Chrome 105+, Safari 16+,
     Firefox 110+ → ~95% coverage) and have largely replaced viewport media queries for
     component-internal responsive behaviour.
@@ -1530,7 +1530,8 @@ nx:focus-visible:outline-offset-2</pre>
     The implication: a new contributor (human or LLM) has no Nexus opinion to follow. They
     default to Tailwind defaults, default to viewport media queries, and default to mobile-first
     — none of which match how a desktop-tool design system actually performs. The gap is almost
-    entirely documentation, with one piece of contradictory code (Dialog).
+    entirely documentation, with one piece of seemingly contradictory code — Dialog, which
+    the spike confirmed is a legitimate viewport-driven exception.
   </p>
 
   <h3 id="bp-benchmarks">Benchmark survey — 10 systems</h3>

--- a/reports/phase-2-token-decisions.html
+++ b/reports/phase-2-token-decisions.html
@@ -708,7 +708,7 @@
       <li><a href="#bp-problem">Codebase audit</a></li>
       <li><a href="#bp-benchmarks">10-system survey</a></li>
       <li><a href="#bp-headlines">2026 consensus</a></li>
-      <li><a href="#bp-decisions">4 sub-decisions</a></li>
+      <li><a href="#bp-decisions">5 sub-decisions</a></li>
       <li><a href="#bp-demo">Live demo (@container)</a></li>
       <li><a href="#bp-migration">Migration plan</a></li>
       <li><a href="#bp-future">Forward direction</a></li>
@@ -1727,9 +1727,9 @@ nx:focus-visible:outline-offset-2</pre>
     adapt to width" should be <code>@container</code>, not <code>nx:sm:</code>.
   </p>
 
-  <h3 id="bp-decisions">The four decisions</h3>
+  <h3 id="bp-decisions">The five decisions</h3>
   <p>
-    Breakpoint strategy isn't one decision — it's four interleaved. Each addressed below
+    Breakpoint strategy isn't one decision — it's five interleaved. Each addressed below
     with its own recommendation. The end of the section ties them into a single migration plan.
   </p>
 
@@ -1908,6 +1908,18 @@ nx:focus-visible:outline-offset-2</pre>
       depends on the <em>viewport's width</em> (shell-level decisions), use <code>nx:lg:</code>.
       Most Nexus component-internal adaptation falls into the first bucket.
     </p>
+
+    <div class="callout callout-note">
+      <strong>Carve-out: full-viewport overlays (Dialog, Sheet, FullScreenOverlay)</strong>
+      The "component-internal uses <code>@container</code>" rule has one principled exception:
+      full-viewport overlay components. Their responsive trigger is positioning relative to the
+      <em>viewport</em> (full-bleed sheet vs centred card), not the overlay's own container
+      width — so they stay on viewport breakpoints (<code>nx:sm:</code>). The May 2026 spike that
+      established this — including the width table showing why a naïve <code>nx:@sm:</code>
+      migration would flip Dialog's rounded corners on at viewports 384–640px — is in Decision D
+      below. In-rule documentation lives in <code>.claude/rules/responsive.md</code> §
+      Viewport-driven exceptions.
+    </div>
   </div>
 
   <!-- DECISION D -->

--- a/reports/phase-2-token-decisions.html
+++ b/reports/phase-2-token-decisions.html
@@ -1500,15 +1500,18 @@ nx:focus-visible:outline-offset-2</pre>
   <p class="lede">
     Nexus inherits Tailwind v4's 5 default breakpoints with zero customisation and zero
     documented opinion. The cross-check found Dialog already uses <code>nx:sm:</code> in
-    3 places, contradicting any "desktop-primary" stance. Meanwhile 2026 industry consensus
+    3 places, which initially read as at odds with the "desktop-primary" stance (a spike later
+    confirmed it's a legitimate viewport-driven exception — see Decision D). Meanwhile 2026 industry consensus
     has shifted decisively: container queries are now Baseline (Chrome 105+, Safari 16+,
     Firefox 110+ → ~95% coverage) and have largely replaced viewport media queries for
     component-internal responsive behaviour.
     <strong>Recommendation: Option D — Token + Documentation + Container Queries default.</strong>
     Promote 5 breakpoint CSS variables to the semantic namespace, document Narrow/Standard/Wide
     display classes with ≥1024px as the primary target, adopt <code>@container</code> as the
-    canonical pattern for component-internal responsive behaviour, and migrate Dialog's three
-    <code>nx:sm:</code> sites to container queries.
+    canonical pattern for component-internal responsive behaviour, and keep Dialog's three
+    <code>nx:sm:</code> sites as a documented viewport-driven exception (a pre-implementation
+    spike found the naïve <code>@container</code> swap breaks Dialog at 384–640px viewports — see
+    Decision D).
   </p>
 
   <h3 id="bp-problem">The problem — codebase audit</h3>
@@ -1916,8 +1919,8 @@ nx:focus-visible:outline-offset-2</pre>
       <em>viewport</em> (full-bleed sheet vs centred card), not the overlay's own container
       width — so they stay on viewport breakpoints (<code>nx:sm:</code>). The May 2026 spike that
       established this — including the width table showing why a naïve <code>nx:@sm:</code>
-      migration would flip Dialog's rounded corners on at viewports 384–640px — is in Decision D
-      below. In-rule documentation lives in <code>.claude/rules/responsive.md</code> §
+      migration would flip Dialog's rounded corners on prematurely (at viewports 384–640px) — is
+      in Decision D below. In-rule documentation lives in <code>.claude/rules/responsive.md</code> §
       Viewport-driven exceptions.
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Add a **"Carve-out: full-viewport overlays"** callout to §5 Decision C of `reports/phase-2-token-decisions.html`. Decision C's "Key rule" presented a binary — own-width → `@container`, viewport-width → `nx:lg:` — and never named the third case: full-viewport overlays (Dialog, future Sheet, FullScreenOverlay) whose responsive trigger is viewport positioning, not container width. The callout cross-references Decision D (the May 2026 spike) and `.claude/rules/responsive.md` § Viewport-driven exceptions.
- **Refresh the §5 lede** — it still carried pre-spike framing ("migrate Dialog's three `nx:sm:` sites to container queries" and "contradicting any desktop-primary stance"), both contradicted by the post-spike Decision D outcome the rest of §5 already reflects (Recommendation callout, Summary card, Postmortem row). The finding now reads as a first impression the spike resolved; the recommendation clause keeps Dialog as a documented viewport-driven exception.
- **Adjacent consistency fix** — the §5 heading, TOC entry, and intro sentence all said "four (sub-)decisions" but the section has held five (A–E) since sub-decision E was added. Updated all three.

**Zero code change.** `dialog.tsx:135/187/220` retain their `nx:sm:` usage as the issue's revised (post-spike) scope requires; `responsive.md` already documents the exception (shipped in #155).

## GitHub Issue

Closes #100

## Test Plan

- [x] `dialog.tsx` lines 135/187/220 retain `nx:sm:` (verified byte-identical to `main`)
- [x] `.claude/rules/responsive.md` documents Dialog as a viewport-driven exception (shipped in #155)
- [x] §5 Decision C notes the Dialog carve-out
- [x] No regression in Dialog Storybook stories at any viewport (no code change → no behaviour change)
- [x] Dialog at 480px viewport remains full-bleed / no rounded corners (no code change)
- [ ] Reviewer confirms the carve-out callout voice matches the surrounding Decision D / designer-note callouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
