### PR TITLE
[10/10] feat(responsive): Show/Hide primitives (experimental)

### DIFF
--- a/.claude/rules/responsive.md
+++ b/.claude/rules/responsive.md
@@ -39,7 +39,7 @@ Concrete rule: if you grep your file and find no `@container (...)` rule scoping
 
 ## Canonical pattern in JSX
 
-A forthcoming declarative primitive (see [#103](https://github.com/nexuslabs-ai/nexus/issues/103)) — `<Show>` / `<Hide>` — covers both viewport and container axes:
+The declarative `<Show>` / `<Hide>` primitives ([#103](https://github.com/nexuslabs-ai/nexus/issues/103), exported from `@nexus/react`) express responsive visibility across both axes. They toggle `display: contents` ↔ `display: none` — children always render; only visibility changes (no mount/unmount). Because a `contents` wrapper generates no box of its own, an inline, flex, or grid child keeps its natural layout (this is the conclusion of the #103 spike — `display: block`/`revert` would break those cases).
 
 ```tsx
 // Viewport (page-shell decisions)
@@ -51,9 +51,13 @@ A forthcoming declarative primitive (see [#103](https://github.com/nexuslabs-ai/
 <Hide containerBelow="sm"><Avatar /></Hide>
 ```
 
-> **Proposed — subject to the #103 spike.** Prop names (`above` / `below` / `containerAbove` / `containerBelow`) are the working shape, not the final API. Issue #103 has a mandatory pre-implementation spike on `display: revert` semantics inside flex parents that may force a different shape; the snippet above will be re-synced when #103 lands.
+Provide **exactly one** axis (`above` / `below` / `containerAbove` / `containerBelow`) — a discriminated union rejects zero or two at compile time. Container axes query the nearest `@container` ancestor, so a parent must declare one (e.g. the `nx:@container` utility).
 
-Until that primitive ships, the raw fallback is acceptable but verbose — and easy to invert by mistake.
+> **Two breakpoint scales, same names.** The viewport axes use the `--breakpoint-*` scale (`md` = 48rem); the container axes use Tailwind's native `@container` scale (`md` = 28rem), deliberately smaller because a component reads as "md" at a narrower width than the whole viewport. So `above="md"` and `containerAbove="md"` do **not** fire at the same width.
+
+> **Experimental.** The API is inferred from Atlassian's pattern and may change before it stabilises. Named-container queries (`@container/{name}`) are out of scope for v1 — fall back to raw `nx:@container/{name}/{bp}:` utilities if you need one.
+
+Prefer the primitive over raw class toggling, which is verbose and easy to invert by mistake:
 
 **Anti-pattern (raw class toggling):**
 
@@ -61,7 +65,7 @@ Until that primitive ships, the raw fallback is acceptable but verbose — and e
 <aside className="nx:hidden nx:lg:block">Secondary nav</aside>
 ```
 
-**Correct pattern (declarative primitive, when available):**
+**Correct pattern:**
 
 ```tsx
 <Show above="lg">
@@ -69,7 +73,7 @@ Until that primitive ships, the raw fallback is acceptable but verbose — and e
 </Show>
 ```
 
-Prefer the primitive when it ships. Pick the right axis: `above` / `below` for viewport (page shell), `containerAbove` / `containerBelow` for component-internal — matching the decision tree above.
+Pick the right axis: `above` / `below` for viewport (page shell), `containerAbove` / `containerBelow` for component-internal — matching the decision tree above.
 
 ## Anti-patterns
 
@@ -97,4 +101,5 @@ Fluid scaling via `clamp()` and dynamic viewport units `svh` / `lvh` / `dvh` are
 - `packages/tailwind/nexus.css:236-240` — the emitted `--breakpoint-*` token values
 - `packages/react/src/components/ui/dialog.tsx` — the live viewport-driven exception
 - [#102](https://github.com/nexuslabs-ai/nexus/issues/102) — cross-links from `components.md` / `figma.md` / `code-quality.md` that point readers at the display-class table here
-- [#103](https://github.com/nexuslabs-ai/nexus/issues/103) — the `<Show>` / `<Hide>` primitive that retires the raw-class fallback in the canonical pattern
+- [#103](https://github.com/nexuslabs-ai/nexus/issues/103) — the shipped `<Show>` / `<Hide>` primitives (`@nexus/react`) used in the canonical pattern above
+- `packages/react/src/components/primitives/` — the `<Show>` / `<Hide>` source, stories, and the spike-conclusion header

--- a/packages/react/src/components/primitives/Hide.stories.tsx
+++ b/packages/react/src/components/primitives/Hide.stories.tsx
@@ -1,0 +1,221 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor, within } from 'storybook/test';
+
+import { Hide } from './hide';
+
+const meta: Meta<typeof Hide> = {
+  title: 'Primitives/Hide',
+  component: Hide,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Hide>;
+
+const box =
+  'nx:rounded-md nx:border nx:border-border-default nx:p-3 nx:text-foreground';
+const label = 'nx:text-muted-foreground nx:mb-1 nx:block';
+
+// ============================================
+// VISUAL
+// ============================================
+
+export const Default: Story = {
+  render: () => (
+    <Hide above="lg" as="div">
+      <div className={box}>
+        Hidden when the viewport is <strong>lg</strong> (≥ 64rem) or wider —
+        shown below it.
+      </div>
+    </Hide>
+  ),
+};
+
+export const AllAxes: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-4">
+      <div>
+        <span className={label}>
+          {'<Hide above="lg">'} — hidden viewport ≥ lg
+        </span>
+        <Hide above="lg" as="div">
+          <div className={box}>Hidden on wide viewports.</div>
+        </Hide>
+      </div>
+      <div>
+        <span className={label}>
+          {'<Hide below="lg">'} — hidden viewport &lt; lg
+        </span>
+        <Hide below="lg" as="div">
+          <div className={box}>Hidden on narrow viewports.</div>
+        </Hide>
+      </div>
+      <div
+        className="nx:@container nx:rounded-md nx:border nx:border-border-default nx:p-2"
+        style={{ width: 600 }}
+      >
+        <span className={label}>
+          {'<Hide containerAbove="md">'} — hidden in this 600px container
+        </span>
+        <Hide containerAbove="md" as="div">
+          <div className={box}>Hidden because the container is wide.</div>
+        </Hide>
+      </div>
+      <div
+        className="nx:@container nx:rounded-md nx:border nx:border-border-default nx:p-2"
+        style={{ width: 240 }}
+      >
+        <span className={label}>
+          {'<Hide containerBelow="md">'} — hidden in this 240px container
+        </span>
+        <Hide containerBelow="md" as="div">
+          <div className={box}>Hidden because the container is narrow.</div>
+        </Hide>
+      </div>
+    </div>
+  ),
+};
+
+// ============================================
+// INTERACTION / PLAY TESTS  (inverse of <Show>)
+// ============================================
+
+export const ViewportAxis: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-2">
+      <Hide above="lg" as="div" data-testid="above">
+        <div className={box}>above=&quot;lg&quot;</div>
+      </Hide>
+      <Hide below="lg" as="div" data-testid="below">
+        <div className={box}>below=&quot;lg&quot;</div>
+      </Hide>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const above = canvas.getByTestId('above');
+    const below = canvas.getByTestId('below');
+    const lg = window.innerWidth >= 1024;
+    // Inverse of <Show>: Hide above="lg" is hidden at ≥ lg.
+    await waitFor(() => {
+      expect(getComputedStyle(above).display).toBe(lg ? 'none' : 'contents');
+      expect(getComputedStyle(below).display).toBe(lg ? 'contents' : 'none');
+    });
+  },
+};
+
+export const ContainerAxis: Story = {
+  render: () => (
+    <div className="nx:flex nx:gap-4">
+      <div className="nx:@container" style={{ width: 600 }} data-testid="wide">
+        <Hide containerAbove="md" as="div" data-testid="wide-above">
+          <div className={box}>wide · containerAbove</div>
+        </Hide>
+        <Hide containerBelow="md" as="div" data-testid="wide-below">
+          <div className={box}>wide · containerBelow</div>
+        </Hide>
+      </div>
+      <div
+        className="nx:@container"
+        style={{ width: 240 }}
+        data-testid="narrow"
+      >
+        <Hide containerAbove="md" as="div" data-testid="narrow-above">
+          <div className={box}>narrow · containerAbove</div>
+        </Hide>
+        <Hide containerBelow="md" as="div" data-testid="narrow-below">
+          <div className={box}>narrow · containerBelow</div>
+        </Hide>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Inverse of <Show>: 600 ≥ md, 240 < md.
+    await waitFor(() => {
+      expect(getComputedStyle(canvas.getByTestId('wide-above')).display).toBe(
+        'none'
+      );
+      expect(getComputedStyle(canvas.getByTestId('wide-below')).display).toBe(
+        'contents'
+      );
+      expect(getComputedStyle(canvas.getByTestId('narrow-above')).display).toBe(
+        'contents'
+      );
+      expect(getComputedStyle(canvas.getByTestId('narrow-below')).display).toBe(
+        'none'
+      );
+    });
+  },
+};
+
+// Confirms the `display: contents` mechanism also holds for <Hide>'s shown
+// state: <Hide containerBelow="md"> is shown at ≥ md, so its child is a flex item.
+export const FlexParent: Story = {
+  render: () => (
+    <div
+      className="nx:@container"
+      style={{ width: 600 }}
+      data-testid="container"
+    >
+      <div className="nx:flex nx:gap-4">
+        <div
+          data-testid="item-a"
+          className="nx:rounded-md nx:border nx:border-border-default"
+          style={{ width: 48, height: 48 }}
+        />
+        <Hide containerBelow="md" data-testid="wrap">
+          <div
+            data-testid="item-b"
+            className="nx:rounded-md nx:border nx:border-border-primary"
+            style={{ width: 48, height: 48 }}
+          />
+        </Hide>
+        <div
+          data-testid="item-c"
+          className="nx:rounded-md nx:border nx:border-border-default"
+          style={{ width: 48, height: 48 }}
+        />
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const container = canvas.getByTestId('container');
+    const wrap = canvas.getByTestId('wrap');
+    const rect = (id: string) => canvas.getByTestId(id).getBoundingClientRect();
+
+    // ≥ md: containerBelow is shown -> `contents`, item-b is a real flex sibling.
+    await waitFor(() =>
+      expect(getComputedStyle(wrap).display).toBe('contents')
+    );
+    expect(rect('item-b').top).toBe(rect('item-a').top);
+    expect(rect('item-a').left).toBeLessThan(rect('item-b').left);
+    expect(rect('item-b').left).toBeLessThan(rect('item-c').left);
+
+    // toggle below md: now hidden.
+    container.style.width = '300px';
+    await waitFor(() => expect(getComputedStyle(wrap).display).toBe('none'));
+
+    // toggle back ≥ md: flex child again (contents), not block.
+    container.style.width = '600px';
+    await waitFor(() => {
+      expect(getComputedStyle(wrap).display).toBe('contents');
+      expect(rect('item-b').top).toBe(rect('item-a').top);
+    });
+  },
+};
+
+export const DataAttributes: Story = {
+  render: () => (
+    <Hide above="lg" data-testid="el">
+      <span>content</span>
+    </Hide>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId('el')).toHaveAttribute('data-slot', 'hide');
+  },
+};

--- a/packages/react/src/components/primitives/Hide.stories.tsx
+++ b/packages/react/src/components/primitives/Hide.stories.tsx
@@ -95,14 +95,16 @@ export const ViewportAxis: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const above = canvas.getByTestId('above');
-    const below = canvas.getByTestId('below');
-    const lg = window.innerWidth >= 1024;
-    // Inverse of <Show>: Hide above="lg" is hidden at ≥ lg.
-    await waitFor(() => {
-      expect(getComputedStyle(above).display).toBe(lg ? 'none' : 'contents');
-      expect(getComputedStyle(below).display).toBe(lg ? 'contents' : 'none');
-    });
+    // <Hide> inverts <Show> (hide-above === show-below); assert the resolved
+    // classes, deterministic at any viewport. Toggle is covered in ContainerAxis.
+    expect(canvas.getByTestId('above')).toHaveClass(
+      'nx:contents',
+      'nx:lg:hidden'
+    );
+    expect(canvas.getByTestId('below')).toHaveClass(
+      'nx:hidden',
+      'nx:lg:contents'
+    );
   },
 };
 

--- a/packages/react/src/components/primitives/Show.stories.tsx
+++ b/packages/react/src/components/primitives/Show.stories.tsx
@@ -90,14 +90,17 @@ export const ViewportAxis: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const above = canvas.getByTestId('above');
-    const below = canvas.getByTestId('below');
-    // Self-consistent against the runner's own viewport — no hard-coded width.
-    const lg = window.innerWidth >= 1024;
-    await waitFor(() => {
-      expect(getComputedStyle(above).display).toBe(lg ? 'contents' : 'none');
-      expect(getComputedStyle(below).display).toBe(lg ? 'none' : 'contents');
-    });
+    // Deterministic at any viewport: assert the exact classes each axis resolves
+    // to, covering both. The contents↔none toggle is exercised across a real
+    // width boundary in ContainerAxis.
+    expect(canvas.getByTestId('above')).toHaveClass(
+      'nx:hidden',
+      'nx:lg:contents'
+    );
+    expect(canvas.getByTestId('below')).toHaveClass(
+      'nx:contents',
+      'nx:lg:hidden'
+    );
   },
 };
 

--- a/packages/react/src/components/primitives/Show.stories.tsx
+++ b/packages/react/src/components/primitives/Show.stories.tsx
@@ -1,0 +1,216 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, waitFor, within } from 'storybook/test';
+
+import { Show } from './show';
+
+const meta: Meta<typeof Show> = {
+  title: 'Primitives/Show',
+  component: Show,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Show>;
+
+const box =
+  'nx:rounded-md nx:border nx:border-border-default nx:p-3 nx:text-foreground';
+const label = 'nx:text-muted-foreground nx:mb-1 nx:block';
+
+// ============================================
+// VISUAL
+// ============================================
+
+export const Default: Story = {
+  render: () => (
+    <Show above="lg" as="div">
+      <div className={box}>
+        Visible when the viewport is <strong>lg</strong> (≥ 64rem) or wider.
+      </div>
+    </Show>
+  ),
+};
+
+export const AllAxes: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-4">
+      <div>
+        <span className={label}>{'<Show above="lg">'} — viewport ≥ lg</span>
+        <Show above="lg" as="div">
+          <div className={box}>Shown on wide viewports.</div>
+        </Show>
+      </div>
+      <div>
+        <span className={label}>{'<Show below="lg">'} — viewport &lt; lg</span>
+        <Show below="lg" as="div">
+          <div className={box}>Shown on narrow viewports.</div>
+        </Show>
+      </div>
+      <div
+        className="nx:@container nx:rounded-md nx:border nx:border-border-default nx:p-2"
+        style={{ width: 600 }}
+      >
+        <span className={label}>
+          {'<Show containerAbove="md">'} — this 600px container ≥ md
+        </span>
+        <Show containerAbove="md" as="div">
+          <div className={box}>Shown because the container is wide.</div>
+        </Show>
+      </div>
+      <div
+        className="nx:@container nx:rounded-md nx:border nx:border-border-default nx:p-2"
+        style={{ width: 240 }}
+      >
+        <span className={label}>
+          {'<Show containerBelow="md">'} — this 240px container &lt; md
+        </span>
+        <Show containerBelow="md" as="div">
+          <div className={box}>Shown because the container is narrow.</div>
+        </Show>
+      </div>
+    </div>
+  ),
+};
+
+// ============================================
+// INTERACTION / PLAY TESTS
+// ============================================
+
+export const ViewportAxis: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-2">
+      <Show above="lg" as="div" data-testid="above">
+        <div className={box}>above=&quot;lg&quot;</div>
+      </Show>
+      <Show below="lg" as="div" data-testid="below">
+        <div className={box}>below=&quot;lg&quot;</div>
+      </Show>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const above = canvas.getByTestId('above');
+    const below = canvas.getByTestId('below');
+    // Self-consistent against the runner's own viewport — no hard-coded width.
+    const lg = window.innerWidth >= 1024;
+    await waitFor(() => {
+      expect(getComputedStyle(above).display).toBe(lg ? 'contents' : 'none');
+      expect(getComputedStyle(below).display).toBe(lg ? 'none' : 'contents');
+    });
+  },
+};
+
+export const ContainerAxis: Story = {
+  render: () => (
+    <div className="nx:flex nx:gap-4">
+      <div className="nx:@container" style={{ width: 600 }} data-testid="wide">
+        <Show containerAbove="md" as="div" data-testid="wide-above">
+          <div className={box}>wide · containerAbove</div>
+        </Show>
+        <Show containerBelow="md" as="div" data-testid="wide-below">
+          <div className={box}>wide · containerBelow</div>
+        </Show>
+      </div>
+      <div
+        className="nx:@container"
+        style={{ width: 240 }}
+        data-testid="narrow"
+      >
+        <Show containerAbove="md" as="div" data-testid="narrow-above">
+          <div className={box}>narrow · containerAbove</div>
+        </Show>
+        <Show containerBelow="md" as="div" data-testid="narrow-below">
+          <div className={box}>narrow · containerBelow</div>
+        </Show>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // md container breakpoint = 28rem (448px): 600 ≥ md, 240 < md.
+    await waitFor(() => {
+      expect(getComputedStyle(canvas.getByTestId('wide-above')).display).toBe(
+        'contents'
+      );
+      expect(getComputedStyle(canvas.getByTestId('wide-below')).display).toBe(
+        'none'
+      );
+      expect(getComputedStyle(canvas.getByTestId('narrow-above')).display).toBe(
+        'none'
+      );
+      expect(getComputedStyle(canvas.getByTestId('narrow-below')).display).toBe(
+        'contents'
+      );
+    });
+  },
+};
+
+// The #103 spike guarantee: a shown wrapper is `display: contents`, never
+// `block`, so its child stays a real flex item — verified across a toggle.
+export const FlexParent: Story = {
+  render: () => (
+    <div
+      className="nx:@container"
+      style={{ width: 600 }}
+      data-testid="container"
+    >
+      <div className="nx:flex nx:gap-4">
+        <div
+          data-testid="item-a"
+          className="nx:rounded-md nx:border nx:border-border-default"
+          style={{ width: 48, height: 48 }}
+        />
+        <Show containerAbove="md" data-testid="wrap">
+          <div
+            data-testid="item-b"
+            className="nx:rounded-md nx:border nx:border-border-primary"
+            style={{ width: 48, height: 48 }}
+          />
+        </Show>
+        <div
+          data-testid="item-c"
+          className="nx:rounded-md nx:border nx:border-border-default"
+          style={{ width: 48, height: 48 }}
+        />
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const container = canvas.getByTestId('container');
+    const wrap = canvas.getByTestId('wrap');
+    const rect = (id: string) => canvas.getByTestId(id).getBoundingClientRect();
+
+    // ≥ md: wrapper is `contents`, so item-b is a real flex sibling of a and c.
+    await waitFor(() =>
+      expect(getComputedStyle(wrap).display).toBe('contents')
+    );
+    expect(rect('item-b').top).toBe(rect('item-a').top);
+    expect(rect('item-a').left).toBeLessThan(rect('item-b').left);
+    expect(rect('item-b').left).toBeLessThan(rect('item-c').left);
+
+    // toggle below md: hidden.
+    container.style.width = '300px';
+    await waitFor(() => expect(getComputedStyle(wrap).display).toBe('none'));
+
+    // toggle back ≥ md: flex child again (contents), not block.
+    container.style.width = '600px';
+    await waitFor(() => {
+      expect(getComputedStyle(wrap).display).toBe('contents');
+      expect(rect('item-b').top).toBe(rect('item-a').top);
+    });
+  },
+};
+
+export const DataAttributes: Story = {
+  render: () => (
+    <Show above="lg" data-testid="el">
+      <span>content</span>
+    </Show>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId('el')).toHaveAttribute('data-slot', 'show');
+  },
+};

--- a/packages/react/src/components/primitives/hide.tsx
+++ b/packages/react/src/components/primitives/hide.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+import {
+  type ResponsiveVisibilityProps,
+  visibilityClassName,
+} from './responsive-visibility';
+
+/**
+ * The inverse of `<Show>`: renders its children only when a responsive condition
+ * is **not** met, via a CSS `display` toggle (`contents` ↔ `none`). Children
+ * always render to the DOM; only their visibility changes (no mount / unmount).
+ *
+ * Provide **exactly one** axis (enforced at compile time):
+ * - `above` / `below` — viewport min / max width (scale: `sm` 40rem … `2xl` 96rem).
+ * - `containerAbove` / `containerBelow` — the nearest `@container` ancestor's
+ *   min / max width (Tailwind's container scale: `sm` 24rem … `2xl` 42rem —
+ *   smaller than the viewport scale for the same name).
+ *
+ * Container axes require an ancestor with `container-type` (e.g. a parent
+ * carrying the `nx:@container` utility). v1 queries the nearest *unnamed*
+ * container only; for a specific named container, fall back to raw
+ * `nx:@container/{name}/{bp}:` utilities.
+ *
+ * @experimental Inferred from Atlassian's `<Show>` / `<Hide>`; the API may change before stable.
+ * @example
+ * ```tsx
+ * <Hide below="md"><span>Tablet-and-up context</span></Hide>
+ * <Hide containerBelow="sm"><Avatar /></Hide>
+ * ```
+ */
+function Hide({
+  as: Comp = 'span',
+  className,
+  children,
+  above,
+  below,
+  containerAbove,
+  containerBelow,
+  ...props
+}: ResponsiveVisibilityProps) {
+  return (
+    <Comp
+      data-slot="hide"
+      className={cn(
+        className,
+        visibilityClassName(
+          { above, below, containerAbove, containerBelow },
+          true
+        )
+      )}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+}
+
+export { Hide, type ResponsiveVisibilityProps as HideProps };

--- a/packages/react/src/components/primitives/responsive-visibility.ts
+++ b/packages/react/src/components/primitives/responsive-visibility.ts
@@ -1,0 +1,124 @@
+/**
+ * Shared internals for the `<Show>` / `<Hide>` responsive-visibility primitives.
+ *
+ * Visibility toggles between `display: contents` (shown) and `display: none`
+ * (hidden) — never `display: block` / `revert`. A `contents` wrapper generates
+ * no box of its own, so its children keep their natural flow: inline stays
+ * inline, flex/grid children stay flex/grid items. Forcing `block` (or reverting
+ * to the element's UA default) would override the wrapper's display and break
+ * those layouts. This is the conclusion of the #103 pre-implementation spike.
+ *
+ * Class strings are full static literals in the maps below: Tailwind only emits
+ * a utility it can see as a complete string, so a computed `nx:${bp}:contents`
+ * would never ship in the CSS bundle.
+ *
+ * Container axes use Tailwind's native `@container` scale (`@md` = 28rem), which
+ * is intentionally smaller than the viewport scale (`md` = 48rem) — a component
+ * reads as "md" at a narrower width than the whole viewport. The two axes
+ * therefore resolve the same breakpoint name to different rem values.
+ */
+
+import type { ElementType, HTMLAttributes, ReactNode } from 'react';
+
+export type Breakpoint = 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+/**
+ * Exactly one axis must be provided. The `never` siblings make the four axes
+ * mutually exclusive at compile time (zero or two+ axes fail to typecheck).
+ */
+export type VisibilityAxis =
+  | {
+      above: Breakpoint;
+      below?: never;
+      containerAbove?: never;
+      containerBelow?: never;
+    }
+  | {
+      above?: never;
+      below: Breakpoint;
+      containerAbove?: never;
+      containerBelow?: never;
+    }
+  | {
+      above?: never;
+      below?: never;
+      containerAbove: Breakpoint;
+      containerBelow?: never;
+    }
+  | {
+      above?: never;
+      below?: never;
+      containerAbove?: never;
+      containerBelow: Breakpoint;
+    };
+
+export type ResponsiveVisibilityProps = HTMLAttributes<HTMLElement> & {
+  /**
+   * Element rendered as the display-managed wrapper. Keep it non-semantic:
+   * `display: contents` can drop a semantic element's box from the accessibility
+   * tree, so put semantics on a child *inside* `<Show>` / `<Hide>` instead.
+   * @default 'span'
+   */
+  as?: ElementType;
+  children: ReactNode;
+} & VisibilityAxis;
+
+/** Loose shape the resolver works with; the strict union is enforced at the prop boundary. */
+type AxisValues = {
+  above?: Breakpoint;
+  below?: Breakpoint;
+  containerAbove?: Breakpoint;
+  containerBelow?: Breakpoint;
+};
+
+// Shown = `contents`, hidden = `none`. Keyed by breakpoint; each value is a
+// complete, statically-scannable class string (see header for why).
+const VIEWPORT_ABOVE: Record<Breakpoint, string> = {
+  sm: 'nx:hidden nx:sm:contents',
+  md: 'nx:hidden nx:md:contents',
+  lg: 'nx:hidden nx:lg:contents',
+  xl: 'nx:hidden nx:xl:contents',
+  '2xl': 'nx:hidden nx:2xl:contents',
+};
+
+const VIEWPORT_BELOW: Record<Breakpoint, string> = {
+  sm: 'nx:contents nx:sm:hidden',
+  md: 'nx:contents nx:md:hidden',
+  lg: 'nx:contents nx:lg:hidden',
+  xl: 'nx:contents nx:xl:hidden',
+  '2xl': 'nx:contents nx:2xl:hidden',
+};
+
+const CONTAINER_ABOVE: Record<Breakpoint, string> = {
+  sm: 'nx:hidden nx:@sm:contents',
+  md: 'nx:hidden nx:@md:contents',
+  lg: 'nx:hidden nx:@lg:contents',
+  xl: 'nx:hidden nx:@xl:contents',
+  '2xl': 'nx:hidden nx:@2xl:contents',
+};
+
+const CONTAINER_BELOW: Record<Breakpoint, string> = {
+  sm: 'nx:contents nx:@sm:hidden',
+  md: 'nx:contents nx:@md:hidden',
+  lg: 'nx:contents nx:@lg:hidden',
+  xl: 'nx:contents nx:@xl:hidden',
+  '2xl': 'nx:contents nx:@2xl:hidden',
+};
+
+/**
+ * Resolve the visibility class string for the one provided axis. `invert` swaps
+ * show/hide so `<Hide>` is `<Show>` with the maps flipped (hide-above === show-below).
+ */
+export function visibilityClassName(
+  { above, below, containerAbove, containerBelow }: AxisValues,
+  invert: boolean
+): string {
+  if (above) return (invert ? VIEWPORT_BELOW : VIEWPORT_ABOVE)[above];
+  if (below) return (invert ? VIEWPORT_ABOVE : VIEWPORT_BELOW)[below];
+  if (containerAbove)
+    return (invert ? CONTAINER_BELOW : CONTAINER_ABOVE)[containerAbove];
+  if (containerBelow)
+    return (invert ? CONTAINER_ABOVE : CONTAINER_BELOW)[containerBelow];
+  // unreachable — the props union guarantees exactly one axis
+  return '';
+}

--- a/packages/react/src/components/primitives/responsive-visibility.ts
+++ b/packages/react/src/components/primitives/responsive-visibility.ts
@@ -18,7 +18,7 @@
  * therefore resolve the same breakpoint name to different rem values.
  */
 
-import type { ElementType, HTMLAttributes, ReactNode } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 
 export type Breakpoint = 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 
@@ -54,12 +54,13 @@ export type VisibilityAxis =
 
 export type ResponsiveVisibilityProps = HTMLAttributes<HTMLElement> & {
   /**
-   * Element rendered as the display-managed wrapper. Keep it non-semantic:
-   * `display: contents` can drop a semantic element's box from the accessibility
-   * tree, so put semantics on a child *inside* `<Show>` / `<Hide>` instead.
+   * Wrapper tag: `span` (inline) or `div` (block) — match the child's layout.
+   * Tag-only by design and intentionally non-semantic: `display: contents` can
+   * drop a semantic element's box from the accessibility tree, so put semantics
+   * on a child *inside* `<Show>` / `<Hide>` instead.
    * @default 'span'
    */
-  as?: ElementType;
+  as?: 'span' | 'div';
   children: ReactNode;
 } & VisibilityAxis;
 

--- a/packages/react/src/components/primitives/show.tsx
+++ b/packages/react/src/components/primitives/show.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+import {
+  type ResponsiveVisibilityProps,
+  visibilityClassName,
+} from './responsive-visibility';
+
+/**
+ * Renders its children only when a responsive condition is met, via a CSS
+ * `display` toggle (`contents` ↔ `none`). Children always render to the DOM;
+ * only their visibility changes (no mount / unmount).
+ *
+ * Provide **exactly one** axis (enforced at compile time):
+ * - `above` / `below` — viewport min / max width (scale: `sm` 40rem … `2xl` 96rem).
+ * - `containerAbove` / `containerBelow` — the nearest `@container` ancestor's
+ *   min / max width (Tailwind's container scale: `sm` 24rem … `2xl` 42rem —
+ *   smaller than the viewport scale for the same name).
+ *
+ * Container axes require an ancestor with `container-type` (e.g. a parent
+ * carrying the `nx:@container` utility). v1 queries the nearest *unnamed*
+ * container only; for a specific named container, fall back to raw
+ * `nx:@container/{name}/{bp}:` utilities.
+ *
+ * @experimental Inferred from Atlassian's `<Show>` / `<Hide>`; the API may change before stable.
+ * @example
+ * ```tsx
+ * <Show above="lg"><aside>Secondary nav</aside></Show>
+ * <Show containerAbove="md"><Stat /></Show>
+ * ```
+ */
+function Show({
+  as: Comp = 'span',
+  className,
+  children,
+  above,
+  below,
+  containerAbove,
+  containerBelow,
+  ...props
+}: ResponsiveVisibilityProps) {
+  return (
+    <Comp
+      data-slot="show"
+      className={cn(
+        className,
+        visibilityClassName(
+          { above, below, containerAbove, containerBelow },
+          false
+        )
+      )}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+}
+
+export { Show, type ResponsiveVisibilityProps as ShowProps };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -22,3 +22,7 @@ export * from '@/components/ui/select';
 export * from '@/components/ui/switch';
 export * from '@/components/ui/tabs';
 export * from '@/components/ui/tooltip';
+
+// Primitives
+export * from '@/components/primitives/hide';
+export * from '@/components/primitives/show';

--- a/reports/phase-2-token-decisions.html
+++ b/reports/phase-2-token-decisions.html
@@ -2060,6 +2060,11 @@ nx:focus-visible:outline-offset-2</pre>
     <h4>E · Ship <code>&lt;Show&gt;</code> / <code>&lt;Hide&gt;</code> primitives (Atlassian-inspired) <span class="verdict verdict-pick">propose</span></h4>
     <p class="sub-q">Two small components that wrap responsive visibility. Removes the most common breakpoint friction in JSX.</p>
 
+    <div class="callout callout-warn">
+      <strong>Superseded by the shipped implementation (#103)</strong>
+      Live spec: <code>.claude/rules/responsive.md</code> § Canonical pattern in JSX. Two details below predate the pre-implementation spike: (1) visibility toggles <code>display: contents</code> ↔ <code>display: none</code>, not <code>display: revert</code> — a <code>contents</code> wrapper makes no box, so inline and flex/grid children keep their layout; (2) the container axes use Tailwind's native <code>@container</code> scale (<code>md</code> = 28rem), distinct from the viewport scale (<code>md</code> = 48rem), so the same breakpoint name resolves to different widths on the two axes.
+    </div>
+
     <p>
       Today, hiding a sidebar below <code>lg</code> in Nexus consumer code looks like:
     </p>


### PR DESCRIPTION
## Summary

Ships the experimental `<Show>` / `<Hide>` declarative responsive-visibility primitives in a new `packages/react/src/components/primitives/` folder. Atlassian-inspired, Nexus-extended with container-query axes.

- **Four axes**, exactly one required (a discriminated union enforces it at compile time): `above` / `below` (viewport) and `containerAbove` / `containerBelow` (nearest `@container` — the Nexus extension).
- **`display: contents` ↔ `display: none`** toggle — children always render (no mount/unmount); a `contents` wrapper makes no box, so inline / flex / grid children keep their natural layout.
- Static class-map strategy so the utilities ship in the built CSS; the resolver is shared between the two components (`Hide` = `Show` inverted).

### Pre-implementation spike (mandated by the issue) — done

Resolved empirically against the real Tailwind v4 toolchain:

1. **Mechanism:** `display: contents`, not `display: revert` / `block` — the latter break inline (default `as="span"`) and flex/grid children.
2. **Class strategy:** static literal maps — Tailwind won't emit template-literal (`nx:${bp}:contents`) classes, so they'd be missing from the shipped CSS.
3. **Container scale:** the container axes use Tailwind's native `@container` scale (`md` = 28rem), deliberately distinct from the viewport scale (`md` = 48rem). Documented in `responsive.md`.

## GitHub Issue

Closes #103

## Test Plan

- [x] `yarn workspace @nexus/react typecheck` — union rejects zero/two axes; no export collision
- [x] Lint clean on all new/edited files
- [x] **12/12 storybook play tests pass** in real headless Chrome (vitest browser mode), incl. axe a11y
- [x] Container-query + **flex-child spike** tests verify `display: contents` across a width toggle
- [x] Passing `@container` assertions confirm `nx:@md:contents` emits in the built CSS
- [x] `responsive.md` finalized; scoped Decision-E superseded note added to the phase-2 artifact

## Notes

- Marked `@experimental` (JSDoc) — inferred from Atlassian's pattern; no consumer has validated demand yet.
- Named-container queries (`@container/{name}`) are out of scope for v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)