### PR TITLE
docs(responsive): cross-link responsive.md in existing rules

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -18,6 +18,7 @@ Every rule below is a concrete application of this principle. When they conflict
 - `composition-over-render-props.md` — `children` or per-mode components; never `renderItem` / `mode` discriminators
 - `extract-inline-handlers.md` — multi-line / branching JSX handlers get a named function above `return`; one-liners stay inline
 - `useeffect-escape-hatch.md` — effects sync with external systems, not React state
+- `responsive.md` — `@container` for component-internal, viewport prefixes for page-shell; decision tree for which mechanism
 - `logging-proportionality.md` — one dense canonical log line beats ten incremental ones
 - `code-comments.md` — comment non-obvious logic only; TODOs must cite a tracked issue
 - `no-follow-up-deferral.md` — every issue flagged by a PR review is fixed in the same PR

--- a/.claude/rules/components.md
+++ b/.claude/rules/components.md
@@ -209,6 +209,12 @@ size: {
 
 **Exceptions:** Avatars, progress bars, modals may need fixed dimensions.
 
+## Responsive behaviour
+
+Component-internal responsive behaviour uses `@container` queries, not viewport breakpoints — a component should adapt to its parent's width, not the viewport, so it renders consistently whether it lands in a sidebar or a hero. Viewport prefixes (`nx:lg:`, etc.) are reserved for page-shell decisions; full-viewport overlays (e.g. Dialog) are the documented exception, since their trigger is position relative to the viewport.
+
+See [responsive.md](responsive.md) for the decision tree, the display-class table, and the `<Show>` / `<Hide>` primitives.
+
 ## Export Pattern
 
 Always export component, props type, and variants function:

--- a/.claude/rules/components.md
+++ b/.claude/rules/components.md
@@ -211,7 +211,7 @@ size: {
 
 ## Responsive behaviour
 
-Component-internal responsive behaviour uses `@container` queries, not viewport breakpoints — a component should adapt to its parent's width, not the viewport, so it renders consistently whether it lands in a sidebar or a hero. Viewport prefixes (`nx:lg:`, etc.) are reserved for page-shell decisions; full-viewport overlays (e.g. Dialog) are the documented exception, since their trigger is position relative to the viewport.
+Component-internal responsive behaviour should use `@container` queries, not viewport breakpoints — a component adapts to its parent's width, not the viewport, so it renders consistently whether it lands in a sidebar or a hero. Viewport prefixes (`nx:lg:`, etc.) are reserved for page-shell decisions; full-viewport overlays (e.g. Dialog) are the documented exception, since their trigger is position relative to the viewport.
 
 See [responsive.md](responsive.md) for the decision tree, the display-class table, and the `<Show>` / `<Hide>` primitives.
 

--- a/.claude/rules/responsive.md
+++ b/.claude/rules/responsive.md
@@ -6,7 +6,7 @@ Nexus components are designed for **Standard (≥1024px)** as the primary target
 
 ## Display class table
 
-**This table is the single source of truth.** Other rule files (`components.md`, `figma.md`) link here rather than duplicating these rows.
+**This table is the single source of truth.** Other rule files (`components.md`) link here rather than duplicating these rows.
 
 | Tailwind class | Range (rem / px @16) | Nexus display class | Use as primary target? |
 | -------------- | -------------------- | ------------------- | ---------------------- |

--- a/.claude/rules/responsive.md
+++ b/.claude/rules/responsive.md
@@ -100,6 +100,6 @@ Fluid scaling via `clamp()` and dynamic viewport units `svh` / `lvh` / `dvh` are
 - [components.md](components.md) — component-authoring rules; `@container` use in component internals is the responsive corollary of Sizing Convention and Layering model
 - `packages/tailwind/nexus.css:236-240` — the emitted `--breakpoint-*` token values
 - `packages/react/src/components/ui/dialog.tsx` — the live viewport-driven exception
-- [#102](https://github.com/nexuslabs-ai/nexus/issues/102) — cross-links from `components.md` / `figma.md` / `code-quality.md` that point readers at the display-class table here
+- [#102](https://github.com/nexuslabs-ai/nexus/issues/102) — cross-links from `components.md` / `code-quality.md` that point readers at the display-class table here
 - [#103](https://github.com/nexuslabs-ai/nexus/issues/103) — the shipped `<Show>` / `<Hide>` primitives (`@nexus/react`) used in the canonical pattern above
 - `packages/react/src/components/primitives/` — the `<Show>` / `<Hide>` source, stories, and the spike-conclusion header


### PR DESCRIPTION
## Summary

- **`components.md`** — new `## Responsive behaviour` section (under Sizing Convention) pointing at `responsive.md` for the decision tree, display-class table, and `<Show>` / `<Hide>` primitives. Makes the cross-reference bidirectional (`responsive.md` already links back to `components.md`).
- **`code-quality.md`** — added `responsive.md` to the "Rules in this set" list (grouped with the component/React-authoring rules) for discoverability.
- **`responsive.md`** — removed the now-false `figma.md` reference from the `#102` See-also line (see deviation below).

## Deviation from the issue — Edit 2 (figma.md) is obsolete

The issue specified a third edit to `figma.md:329` (the "Responsive" row of the **Figma↔Code Divergence Patterns table**, "Tailwind responsive prefixes") plus an adjacent Guidance paragraph. **That table no longer exists** — it was removed in the 2026-05 `figma.md` scope-note refactor ("Figma _authoring_ conventions … divergence patterns … were removed pending design-system solidification"). Current `figma.md` is 152 lines with no line 329, no "Tailwind responsive prefixes" text, no Guidance paragraph, and zero responsive content — so there is no natural anchor for a responsive cross-link there.

Because `responsive.md`'s See-also (line 103) still advertised a `figma.md` back-link as part of this issue, leaving `figma.md` untouched would have left that line inaccurate. Per `ripple-effect.md`, the ripple was instead resolved by dropping `figma.md` from that enumeration, keeping every cross-reference accurate.

### Acceptance-criteria status

| AC | Status |
| --- | --- |
| `components.md` has a "Responsive behaviour" subsection linking to `responsive.md` | ✅ |
| `code-quality.md` lists `responsive.md` in its rules-in-this-set list | ✅ |
| All cross-links resolve correctly when followed | ✅ |
| ~~`figma.md:329` updated~~ | N/A — target table removed pre-existing |
| ~~`figma.md` Guidance paragraph updated~~ | N/A — removed in the same refactor |

## GitHub Issue

Closes #102

## Test Plan

- [ ] `yarn format:check` passes (`.claude/*.md` included via #213)
- [ ] `components.md` → `responsive.md` link resolves
- [ ] `responsive.md` → `components.md` / `code-quality.md` links resolve
- [ ] `responsive.md:103` no longer references `figma.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)