### PR TITLE
feat(claude): storybook-coverage-reviewer subagent + audit script

### DIFF
--- a/.claude/agents/storybook-coverage-reviewer.md
+++ b/.claude/agents/storybook-coverage-reviewer.md
@@ -1,0 +1,169 @@
+---
+name: storybook-coverage-reviewer
+description: Audits a Nexus component's story coverage against the required-story matrix in .claude/rules/testing-react.md. Use proactively when the user asks "audit story coverage", "review storybook coverage for X", "what's missing in <Component>'s stories", "does <Component> cover all variants", or when a PR adds or modifies a `*.stories.tsx` file in `packages/react/src/components/`.
+tools: Bash, Read, Grep, Glob
+model: opus
+permissionMode: bypassPermissions
+---
+
+# Storybook Coverage Reviewer
+
+A thin wrapper around `yarn audit:storybook-coverage`. The audit logic — file
+discovery, CVA enum extraction, story-export detection, the required-story
+matrix, the display-gate, the drift-alias map, the snippet templates — all
+lives in `packages/react/scripts/audit-storybook-coverage.mjs`. This agent
+exists to translate a natural-language request into the script's CLI and
+present the structured output as a markdown table.
+
+## Why a wrapper, not a body-of-logic agent
+
+Three precedents in `packages/core/scripts/audit-*.js` make the same call:
+deterministic structural rule-vs-files diffs belong in Node scripts that CI
+can gate on, not in LLM reasoning. The script is testable, byte-stable, and
+runs in under a second. This agent is the natural-language surface that
+sibling agents (PR review, etc.) and the user can call without typing the
+yarn invocation.
+
+## Procedure
+
+### 1. Parse the component name from the prompt
+
+Accept either kebab (`button`, `dropdown-menu`) or Pascal (`Button`,
+`DropdownMenu`) — the script canonicalizes internally. Strip phrases like
+"audit", "story coverage", "stories for", "review". If the prompt mentions
+no specific component and includes "all" or "every", run `--all`.
+
+If the component name is missing or ambiguous, ask back rather than guessing.
+
+### 2. Run the audit
+
+For a single component:
+
+```bash
+yarn workspace @nexus/react audit:storybook-coverage --component <name> --json
+```
+
+For all components:
+
+```bash
+yarn workspace @nexus/react audit:storybook-coverage --all --json
+```
+
+The `--json` flag emits the structured shape this agent consumes:
+
+```json
+{
+  "component": "Button",
+  "file": "packages/react/src/components/ui/button.tsx",
+  "storiesFile": "packages/react/src/components/ui/Button.stories.tsx",
+  "findings": [
+    {
+      "kind": "missing" | "drift",
+      "rule": "literal-name" | "per-variant" | "per-size" | "as-child" | "stories-file",
+      "name": "<rule name or value>",
+      "expected": "<canonical name or value>",
+      "found": "<drifted name, only for drift>",
+      "snippet": "<paste-ready code block>",
+      "line": <number, optional>
+    }
+  ],
+  "info": [ /* downgrades and informational notes */ ],
+  "summary": { "total": <n>, "missing": <n>, "drift": <n>, "info": <n> }
+}
+```
+
+For `--all`, the output is a JSON array of these objects.
+
+### 3. Inspect the exit code
+
+| Code | Meaning          | Agent action                              |
+| ---- | ---------------- | ----------------------------------------- |
+| 0    | No findings      | Report `✓ Coverage clean for <Component>` |
+| 1    | Findings present | Parse JSON, render the table below        |
+| 2    | Config error     | Surface the script's stderr verbatim      |
+
+Yarn wraps non-zero exit codes with its own `error Command failed` line —
+that's noise; report the script's actual stderr above the yarn footer.
+
+### 4. Render findings
+
+For a single-component audit with findings:
+
+```markdown
+## Storybook coverage — <Component>
+
+**Source:** `<file>` → `<storiesFile>`
+**Summary:** <missing> missing · <drift> drift · <info> info
+
+| Kind       | Rule         | Required name         | Found                | Fix                  |
+| ---------- | ------------ | --------------------- | -------------------- | -------------------- |
+| ❌ MISSING | literal-name | `WithDataAttributes`  | —                    | <snippet expandable> |
+| ⚠️ DRIFT   | literal-name | `KeyboardInteraction` | `KeyboardNavigation` | rename               |
+
+<details><summary>Informational</summary>
+
+- display-gate: `Disabled` n/a (component has no `fn()` spy or `on*`/`disabled` prop)
+- extra-cva-enum: `fill` (outside the rule's matrix)
+
+</details>
+```
+
+For each MISSING row with a snippet, present the snippet as a fenced code
+block right under the table.
+
+For `--all`, group by component. List clean components in a single line:
+`Button, Avatar, Badge, Alert, Card — coverage clean`.
+
+### 5. Cross-reference, not re-derivation
+
+If a user asks "why does the rule require `ClickInteraction`?" or "can I
+rename this?", point them at `.claude/rules/testing-react.md` rather than
+quoting it. The rule is the source of truth; this agent doesn't paraphrase
+it.
+
+## When NOT to invoke this agent
+
+- The user wants to **add** missing stories — that's a write task. Suggest
+  `/new-component` (issue #75) or fix the file directly.
+- The user wants to **change the rule** itself (e.g. "should the matrix
+  require HoverInteraction?") — that's a design discussion. Edit
+  `.claude/rules/testing-react.md` directly after discussion; the audit will
+  pick up the new matrix on the next run.
+- The component isn't a React component — the script is scoped to
+  `packages/react/src/components/`.
+
+## Example invocations
+
+| User prompt                                      | Agent action                                                             |
+| ------------------------------------------------ | ------------------------------------------------------------------------ |
+| "audit Button story coverage"                    | run with `--component button` → render the table                         |
+| "what's missing in Tooltip's stories?"           | run with `--component tooltip` → render the table                        |
+| "review every component's story coverage"        | run with `--all` → group by component, list clean components on one line |
+| "story coverage check"                           | ambiguous — ask whether one component or all                             |
+| "audit story coverage for the new Foo component" | run with `--component foo` — if exit 2 ("not found"), surface the error  |
+
+## Behavior the script handles for you
+
+The script already handles each of these — don't second-guess them in your
+output:
+
+- **Display-gate** — components without an `fn()` spy and no `on*`/`disabled`
+  in source skip the `Disabled`/`ClickInteraction`/`KeyboardInteraction`
+  requirements (these become `info` entries, not findings).
+- **Compound components** — files with multiple `cva(...)` blocks (Tabs,
+  DropdownMenu) get their variant enums unioned across blocks.
+- **Variant/size detection** — args-match, then render-JSX, then case-folded
+  suffix-stripped name match.
+- **Showcase name** — read from `packages/react/scripts/base-variants.config.json`
+  (Avatar uses `AllSizes`, everyone else `AllVariants`, defaulting to
+  `AllVariants` for components not in the config).
+- **Naming drift** — canonical hard misses for the six literal-named
+  required stories; variant/size story names accept any name that exercises
+  the value.
+
+## See also
+
+- `.claude/rules/testing-react.md` — the required-story matrix
+- `.claude/rules/storybook.md` — story conventions and play-function patterns
+- `packages/react/scripts/audit-storybook-coverage.mjs` — the script
+- `packages/react/scripts/audit-storybook-coverage.test.js` — the test suite

--- a/.claude/rules/testing-react.md
+++ b/.claude/rules/testing-react.md
@@ -95,7 +95,13 @@ export const Interactive: Story = {
 | WithDataAttributes      | Verify data-\* attrs      | Yes            |
 | asChild (if applicable) | Composition works         | Yes            |
 | Edge cases              | Empty, long content, etc. | Yes            |
-| AllVariants             | Visual grid reference     | No             |
+| AllVariants ★           | Visual grid reference     | No             |
+
+★ The canonical showcase name is `AllVariants`, but per-component overrides live
+in `packages/react/scripts/base-variants.config.json` — e.g. Avatar's showcase is
+`AllSizes`. The `audit:storybook-coverage` script reads that config to decide
+which name to require. To add or change a component's showcase name, edit the
+config rather than this row.
 
 ## Play Function Patterns
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "tokens:tailwind": "cd packages/core && yarn build:tailwind && cp dist/tailwind/* ../../packages/tailwind/",
     "audit:contrast": "yarn workspace @nexus/core audit:contrast",
     "audit:figma-parity": "yarn workspace @nexus/core audit:figma-parity",
+    "audit:storybook-coverage": "yarn workspace @nexus/react audit:storybook-coverage",
     "playground": "cd apps/playground && yarn dev",
     "size-limit": "size-limit",
     "prepare": "husky"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,6 +24,7 @@
     "clean": "rm -rf dist",
     "typecheck": "yarn generate:base-variants && tsc --noEmit",
     "generate:base-variants": "node scripts/generate-base-variants.mjs",
+    "audit:storybook-coverage": "node scripts/audit-storybook-coverage.mjs",
     "storybook": "yarn generate:base-variants && storybook dev -p 6006",
     "build-storybook": "yarn generate:base-variants && storybook build"
   },

--- a/packages/react/scripts/audit-storybook-coverage.mjs
+++ b/packages/react/scripts/audit-storybook-coverage.mjs
@@ -725,7 +725,11 @@ const DRIFT_ALIASES = {
   WithDataAttributes: ['DataAttributesTest', 'DataAttrs', 'DataAttributes'],
   Disabled: ['DisabledInteraction', 'DisabledState'],
   ClickInteraction: ['ClickTest', 'OnClick'],
-  KeyboardInteraction: ['KeyboardTest', 'KeyboardNavigation'],
+  KeyboardInteraction: [
+    'KeyboardTest',
+    'KeyboardNavigation',
+    'KeyboardNavigationInteraction',
+  ],
   Default: ['Basic'],
   AllVariants: ['Variants', 'AllStates'],
   AllSizes: ['Sizes'],

--- a/packages/react/scripts/audit-storybook-coverage.mjs
+++ b/packages/react/scripts/audit-storybook-coverage.mjs
@@ -391,17 +391,16 @@ export function detectAsChild(src) {
 
 /**
  * Display-gate signal: is the component interactive? OR of two signals:
- *  (a) the component's source mentions an `on*` event-handler prop name or
- *      the `disabled` token (covers explicit prop interfaces and CVA base
- *      classes like `nx:disabled:` styling hooks); or
+ *  (a) the component's source declares a `disabled` prop (interface field,
+ *      destructure, or JSX assignment) or an `on*` event-handler prop; or
  *  (b) handled by the caller via the stories file's `fn()`-in-`meta.args`.
  * This function returns (a) only; combine with (b) at the call site.
  */
 export function detectInteractiveFromComponent(src) {
-  // Strip `data-state` and similar `[data-*]` attribute selectors so a CVA
-  // class like `nx:data-[state=active]:bg-background` doesn't false-positive
-  // the `disabled` check below via accidental substring matches.
-  if (/\bdisabled\b/.test(src)) return true;
+  // Lookbehind excludes CVA `nx:disabled:` and `aria-disabled=` — both would
+  // otherwise pass `\bdisabled\s*[?:,=]` and false-positive components that
+  // only style a disabled state without exposing the prop (e.g. Tabs).
+  if (/(?<![:-])\bdisabled\s*[?:,=]/.test(src)) return true;
   if (/\bon[A-Z][A-Za-z]+\s*[?:,)]/.test(src)) return true;
   return false;
 }
@@ -450,7 +449,6 @@ export function findStoryExports(src) {
  * or null if absent.
  */
 export function findArgsBlock(src, blockStart) {
-  if (blockStart === -1) return null;
   return findObjectKey(src, blockStart, 'args');
 }
 
@@ -462,7 +460,6 @@ export function findArgsBlock(src, blockStart) {
  *  - name-match (case-folded, suffix-stripped): story name maps to value
  */
 export function storyExercises(src, story, enumName, value) {
-  if (story.blockStart === -1) return false;
   // (1) args-match
   const argsRange = findArgsBlock(src, story.blockStart);
   if (argsRange) {
@@ -609,22 +606,15 @@ export function listAllComponents(root = COMPONENTS_ROOT) {
 // Showcase-name lookup.
 // ─────────────────────────────────────────────────────────────────────────────
 
-let configCache = null;
-
 function readConfig() {
-  if (configCache !== null) return configCache;
-  if (!fs.existsSync(CONFIG_PATH)) {
-    configCache = { components: [] };
-    return configCache;
-  }
+  if (!fs.existsSync(CONFIG_PATH)) return { components: [] };
   try {
-    configCache = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
   } catch (err) {
     throw new ConfigError(
       `failed to parse ${path.relative(REPO_ROOT, CONFIG_PATH)}: ${err.message}`
     );
   }
-  return configCache;
 }
 
 /**
@@ -739,9 +729,14 @@ const DRIFT_ALIASES = {
  * Build the required-story checklist for a component and check the stories
  * file against it.
  *
+ * @param {string} componentFile - absolute path to the component `.tsx`
+ * @param {{ showcase?: string }} [opts] - `showcase` overrides the canonical
+ *   showcase story name (default: looked up via `showcaseNameFor`). Synthetic
+ *   tests pass it directly to stay decoupled from the repo's
+ *   `base-variants.config.json`.
  * @returns {{ component, file, storiesFile, findings, summary, info }}
  */
-export function auditComponent(componentFile) {
+export function auditComponent(componentFile, opts = {}) {
   const src = fs.readFileSync(componentFile, 'utf8');
   const storiesFile = findStoriesFile(componentFile);
   const kebab = path.basename(componentFile, '.tsx');
@@ -791,7 +786,7 @@ export function auditComponent(componentFile) {
     return result;
   }
 
-  const showcase = showcaseNameFor(pascal);
+  const showcase = opts.showcase ?? showcaseNameFor(pascal);
 
   // ── 6 literal-name required stories ────────────────────────────────────────
   // `Default`, `WithDataAttributes`, and `<showcase>` are always required.

--- a/packages/react/scripts/audit-storybook-coverage.mjs
+++ b/packages/react/scripts/audit-storybook-coverage.mjs
@@ -1,0 +1,1035 @@
+/*
+ * audit-storybook-coverage.mjs — audit a Nexus component's stories against the
+ * required-story matrix in .claude/rules/testing-react.md.
+ *
+ * Existence-only audit: for each required name the script verifies an export
+ * exists in the stories file. Missing stories surface with a paste-ready
+ * snippet quoted from the rule. Drift (`DataAttributesTest` vs
+ * `WithDataAttributes`) is a hard miss for the six literal names. Variant/size
+ * story names accept any story exercising the value (args-match, then
+ * render-JSX match, then case-folded name match).
+ *
+ * Why a script (not a subagent body): structural rule-vs-files diffs belong in
+ * deterministic scripts that CI can gate on. The repo has four precedents
+ * (`packages/core/scripts/audit-*.js`); this audit fits the same mould.
+ *
+ * See .claude/rules/testing-react.md (matrix), .claude/rules/storybook.md
+ * (story conventions), .claude/agents/storybook-coverage-reviewer.md (the
+ * natural-language wrapper that shells out to this script).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const COMPONENTS_ROOT = path.join(__dirname, '..', 'src', 'components');
+const CONFIG_PATH = path.join(__dirname, 'base-variants.config.json');
+
+const COMPONENT_SUBDIRS = ['ui', 'primitives'];
+const EXCLUDE_PATH_FRAGMENTS = ['__generated__', 'node_modules', 'dist'];
+const STORY_SUFFIX = '.stories.tsx';
+const TEST_SUFFIX = '.test.tsx';
+
+const EXIT_OK = 0;
+const EXIT_FINDINGS = 1;
+const EXIT_CONFIG = 2;
+
+const KNOWN_FLAGS = new Set(['component', 'all', 'json']);
+const FLAG_PATTERN = /^--([a-zA-Z][a-zA-Z0-9-]*)(?:=(.+))?$/;
+
+const DOCS_HINT = 'see .claude/rules/testing-react.md';
+
+class ConfigError extends Error {}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI parsing
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function findUnknownFlags(args) {
+  return Object.keys(args).filter((k) => !KNOWN_FLAGS.has(k));
+}
+
+export function parseArgs(argv) {
+  const args = { component: null, all: false, json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const match = argv[i].match(FLAG_PATTERN);
+    if (!match) continue;
+    const [, key, inlineVal] = match;
+    if (key === 'all' || key === 'json') {
+      args[key] = inlineVal === undefined ? true : inlineVal !== 'false';
+      continue;
+    }
+    if (inlineVal !== undefined) {
+      args[key] = inlineVal;
+      continue;
+    }
+    const next = argv[i + 1];
+    if (next && !next.startsWith('--')) {
+      args[key] = next;
+      i++;
+    }
+  }
+  return args;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Source scanner: character-by-character, string/comment aware.
+//   findCallExpressionArgs — locate `cva(` and return the source range of its
+//     parenthesised argument list.
+//   findObjectKey — given a brace-delimited object's source range, return the
+//     value range for `key:` at the top level.
+//   parseObjectKeys — return the top-level string-keyed property names of a
+//     brace-delimited object.
+//
+// This sidesteps regex pitfalls with multi-line variants blocks (Tabs uses
+// arrays-of-strings across six lines per variant value), template literals,
+// and inline comments. ~50 LOC of state machine.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Walk the source from `startIdx` (which must point at an open bracket of
+ * `open`) and return the index of the matching close, respecting strings,
+ * template literals, and comments. Returns -1 if unmatched.
+ */
+export function matchBracket(src, startIdx, open = '{', close = '}') {
+  if (src[startIdx] !== open) return -1;
+  let depth = 0;
+  let i = startIdx;
+  while (i < src.length) {
+    const ch = src[i];
+    // String literals
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      i++;
+      while (i < src.length && src[i] !== quote) {
+        if (src[i] === '\\') i++;
+        i++;
+      }
+      i++;
+      continue;
+    }
+    // Template literals — skip ${...} substitutions
+    if (ch === '`') {
+      i++;
+      while (i < src.length && src[i] !== '`') {
+        if (src[i] === '\\') {
+          i += 2;
+          continue;
+        }
+        if (src[i] === '$' && src[i + 1] === '{') {
+          const end = matchBracket(src, i + 1, '{', '}');
+          if (end === -1) return -1;
+          i = end + 1;
+          continue;
+        }
+        i++;
+      }
+      i++;
+      continue;
+    }
+    // Comments
+    if (ch === '/' && src[i + 1] === '/') {
+      while (i < src.length && src[i] !== '\n') i++;
+      continue;
+    }
+    if (ch === '/' && src[i + 1] === '*') {
+      i += 2;
+      while (i < src.length - 1 && !(src[i] === '*' && src[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    if (ch === open) depth++;
+    else if (ch === close) {
+      depth--;
+      if (depth === 0) return i;
+    }
+    i++;
+  }
+  return -1;
+}
+
+/**
+ * For each call-expression `name(...)` at the top level (string/comment aware),
+ * return the source range of the parenthesised argument list. Returns
+ * `[{ start, end }]` indexing into `src` where `start` is the `(` and `end` is
+ * the matching `)`.
+ */
+export function findCallExpressionArgs(src, name) {
+  const out = [];
+  const pattern = new RegExp(`\\b${name}\\s*\\(`, 'g');
+  let m;
+  while ((m = pattern.exec(src)) !== null) {
+    const openParen = src.indexOf('(', m.index);
+    if (openParen === -1) continue;
+    const closeParen = matchBracket(src, openParen, '(', ')');
+    if (closeParen === -1) continue;
+    out.push({ start: openParen, end: closeParen, callStart: m.index });
+  }
+  return out;
+}
+
+/**
+ * Given an object literal's source (without surrounding braces — i.e. just
+ * the body), return the top-level string-keyed property names in order.
+ * Skips spread (`...foo`), computed keys (`[expr]:`), and method shorthand.
+ */
+export function parseObjectKeys(body) {
+  const src = `{${body}}`;
+  const keys = [];
+  let i = 1;
+  while (i < src.length - 1) {
+    // Skip whitespace
+    while (i < src.length && /\s/.test(src[i])) i++;
+    // Skip comments
+    if (src[i] === '/' && src[i + 1] === '/') {
+      while (i < src.length && src[i] !== '\n') i++;
+      continue;
+    }
+    if (src[i] === '/' && src[i + 1] === '*') {
+      i += 2;
+      while (i < src.length - 1 && !(src[i] === '*' && src[i + 1] === '/')) i++;
+      i += 2;
+      continue;
+    }
+    // Try to match a key — quoted (any content) OR bare identifier.
+    // Avatar's CVA quotes leading-digit values like `'2xs'`, so the quoted
+    // branch must allow arbitrary content; the bare-identifier branch follows
+    // standard JS identifier-start rules.
+    const remaining = src.slice(i);
+    const keyMatch = remaining.match(
+      /^(?:"([^"]+)"|'([^']+)'|([A-Za-z_$][\w$]*))\s*:/
+    );
+    if (keyMatch) {
+      keys.push(keyMatch[1] ?? keyMatch[2] ?? keyMatch[3]);
+      i += keyMatch[0].length;
+      // Walk past the value
+      while (i < src.length && /\s/.test(src[i])) i++;
+      i = walkValue(src, i);
+      // Skip trailing comma
+      while (i < src.length && /[\s,]/.test(src[i])) i++;
+      continue;
+    }
+    // Unknown token; advance one char defensively
+    i++;
+  }
+  return keys;
+}
+
+function walkValue(src, start) {
+  let i = start;
+  if (src[i] === '{' || src[i] === '[' || src[i] === '(') {
+    const open = src[i];
+    const close = open === '{' ? '}' : open === '[' ? ']' : ')';
+    const end = matchBracket(src, i, open, close);
+    return end === -1 ? src.length : end + 1;
+  }
+  if (src[i] === '"' || src[i] === "'") {
+    const quote = src[i];
+    i++;
+    while (i < src.length && src[i] !== quote) {
+      if (src[i] === '\\') i++;
+      i++;
+    }
+    return i + 1;
+  }
+  if (src[i] === '`') {
+    i++;
+    while (i < src.length && src[i] !== '`') {
+      if (src[i] === '\\') {
+        i += 2;
+        continue;
+      }
+      if (src[i] === '$' && src[i + 1] === '{') {
+        const end = matchBracket(src, i + 1, '{', '}');
+        i = end === -1 ? src.length : end + 1;
+        continue;
+      }
+      i++;
+    }
+    return i + 1;
+  }
+  // Identifier / literal — walk to next `,` or `}` at the top level
+  let depth = 0;
+  while (i < src.length) {
+    const ch = src[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      i = walkValue(src, i);
+      continue;
+    }
+    if (ch === '{' || ch === '[' || ch === '(') {
+      depth++;
+    } else if (ch === '}' || ch === ']' || ch === ')') {
+      if (depth === 0) return i;
+      depth--;
+    } else if (ch === ',' && depth === 0) {
+      return i;
+    }
+    i++;
+  }
+  return i;
+}
+
+/**
+ * Given an object's source range (`braceStart` points at the `{`), find the
+ * value range for `key:` at the top level. Returns `{ start, end }` of the
+ * value's source, or null if the key is absent.
+ */
+export function findObjectKey(src, braceStart, key) {
+  const braceEnd = matchBracket(src, braceStart, '{', '}');
+  if (braceEnd === -1) return null;
+  const body = src.slice(braceStart + 1, braceEnd);
+  let i = 0;
+  while (i < body.length) {
+    while (i < body.length && /\s/.test(body[i])) i++;
+    if (body[i] === '/' && body[i + 1] === '/') {
+      while (i < body.length && body[i] !== '\n') i++;
+      continue;
+    }
+    if (body[i] === '/' && body[i + 1] === '*') {
+      i += 2;
+      while (i < body.length - 1 && !(body[i] === '*' && body[i + 1] === '/'))
+        i++;
+      i += 2;
+      continue;
+    }
+    const remaining = body.slice(i);
+    const keyMatch = remaining.match(
+      /^(?:"([^"]+)"|'([^']+)'|([A-Za-z_$][\w$]*))\s*:\s*/
+    );
+    const matchedKey = keyMatch
+      ? (keyMatch[1] ?? keyMatch[2] ?? keyMatch[3])
+      : null;
+    if (keyMatch && matchedKey === key) {
+      const valueStart = braceStart + 1 + i + keyMatch[0].length;
+      const valueEnd = walkValue(src, valueStart);
+      return { start: valueStart, end: valueEnd };
+    }
+    if (keyMatch) {
+      i += keyMatch[0].length;
+      const absStart = braceStart + 1 + i;
+      const absEnd = walkValue(src, absStart);
+      i = absEnd - braceStart - 1;
+      while (i < body.length && /[\s,]/.test(body[i])) i++;
+      continue;
+    }
+    i++;
+  }
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Component-side extraction.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Extract every `cva(...)` call's `variants` enum keys across the whole file.
+ * Returns `{ enums: { name: [values] }, extraEnums: [name], cvaCount }`.
+ * `variant` and `size` are first-class (required by the rule); other enums
+ * (Badge's `fill`, Avatar's `shape`) are surfaced as `extraEnums` for an
+ * informational note.
+ */
+export function extractCvaEnums(src) {
+  const calls = findCallExpressionArgs(src, 'cva');
+  const enums = {};
+  const extraEnums = new Set();
+  for (const call of calls) {
+    // Second arg of cva(baseClasses, config). Find the comma after the first
+    // arg (string|array|template) at top level.
+    const argsRegion = src.slice(call.start + 1, call.end);
+    const firstArgEnd = walkValue(`(${argsRegion})`, 1) - 1;
+    const remainder = argsRegion.slice(firstArgEnd).trimStart();
+    if (!remainder.startsWith(',')) continue;
+    const configStart =
+      call.start + 1 + firstArgEnd + (argsRegion.slice(firstArgEnd).length - remainder.length) + 1;
+    // Find the next `{` from configStart that is the config object
+    let i = configStart;
+    while (i < call.end && /\s/.test(src[i])) i++;
+    if (src[i] !== '{') continue;
+    const variantsRange = findObjectKey(src, i, 'variants');
+    if (!variantsRange) continue;
+    // variants value is itself an object — find its braces
+    let vi = variantsRange.start;
+    while (vi < variantsRange.end && /\s/.test(src[vi])) vi++;
+    if (src[vi] !== '{') continue;
+    const variantsEnd = matchBracket(src, vi, '{', '}');
+    if (variantsEnd === -1) continue;
+    const variantsBody = src.slice(vi + 1, variantsEnd);
+    const enumNames = parseObjectKeys(variantsBody);
+    for (const enumName of enumNames) {
+      // Find this enum's value range
+      const enumRange = findObjectKey(src, vi, enumName);
+      if (!enumRange) continue;
+      let ei = enumRange.start;
+      while (ei < enumRange.end && /\s/.test(src[ei])) ei++;
+      if (src[ei] !== '{') continue;
+      const enumEnd = matchBracket(src, ei, '{', '}');
+      if (enumEnd === -1) continue;
+      const enumBody = src.slice(ei + 1, enumEnd);
+      const values = parseObjectKeys(enumBody);
+      if (enumName === 'variant' || enumName === 'size') {
+        const existing = enums[enumName] ?? [];
+        // Dedupe across multiple CVA blocks in the same file
+        for (const v of values) {
+          if (!existing.includes(v)) existing.push(v);
+        }
+        enums[enumName] = existing;
+      } else {
+        extraEnums.add(enumName);
+      }
+    }
+  }
+  return { enums, extraEnums: [...extraEnums], cvaCount: calls.length };
+}
+
+/**
+ * Does any props interface in the file declare `asChild?:`?
+ */
+export function detectAsChild(src) {
+  return /\basChild\?\s*:/.test(src);
+}
+
+/**
+ * Display-gate signal: is the component interactive? OR of two signals:
+ *  (a) the component's source mentions an `on*` event-handler prop name or
+ *      the `disabled` token (covers explicit prop interfaces and CVA base
+ *      classes like `nx:disabled:` styling hooks); or
+ *  (b) handled by the caller via the stories file's `fn()`-in-`meta.args`.
+ * This function returns (a) only; combine with (b) at the call site.
+ */
+export function detectInteractiveFromComponent(src) {
+  // Strip `data-state` and similar `[data-*]` attribute selectors so a CVA
+  // class like `nx:data-[state=active]:bg-background` doesn't false-positive
+  // the `disabled` check below via accidental substring matches.
+  if (/\bdisabled\b/.test(src)) return true;
+  if (/\bon[A-Z][A-Za-z]+\s*[?:,)]/.test(src)) return true;
+  return false;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stories-side extraction.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Find every `export const Name` story declaration. Returns
+ * `[{ name, line, blockStart, blockEnd }]` where `blockStart`/`blockEnd`
+ * bracket the story's object literal (if present) so callers can scope further
+ * inspection. Matches `: Story`, `: StoryObj`, `: Story<…>`, and the Storybook 8+
+ * `= { … } satisfies Story` shape. Non-story exports (`helper = ...`,
+ * `render = ...`) are filtered by requiring either the `: Story` annotation or
+ * a trailing `satisfies Story`.
+ */
+export function findStoryExports(src) {
+  const out = [];
+  const pattern = /^\s*export\s+const\s+(\w+)\s*(?::\s*Story\w*|=)/gm;
+  let m;
+  while ((m = pattern.exec(src)) !== null) {
+    const name = m[1];
+    const isTypedStory = m[0].includes(':');
+    // Find the next `{` after the match — the story's object literal
+    let i = m.index + m[0].length;
+    while (i < src.length && src[i] !== '{') i++;
+    if (i >= src.length) continue;
+    const blockStart = i;
+    const blockEnd = matchBracket(src, i, '{', '}');
+    if (blockEnd === -1) continue;
+    // The `= { … }` shape needs `satisfies Story` afterwards to count as a
+    // story (otherwise we'd match any const declaration).
+    if (!isTypedStory) {
+      const tail = src.slice(blockEnd + 1, blockEnd + 60);
+      if (!/^\s*satisfies\s+Story\b/.test(tail)) continue;
+    }
+    const line = src.slice(0, m.index).split('\n').length;
+    out.push({ name, line, blockStart, blockEnd });
+  }
+  return out;
+}
+
+/**
+ * Find the `args:` block within a story's body and return its source range,
+ * or null if absent.
+ */
+export function findArgsBlock(src, blockStart) {
+  if (blockStart === -1) return null;
+  return findObjectKey(src, blockStart, 'args');
+}
+
+/**
+ * Does this story exercise enum value `value` for enum `enumName`?
+ *  - args-match: `args: { [enumName]: 'value' }`
+ *  - render-JSX match: `<Component {enumName}="value">` somewhere in the
+ *    story's body
+ *  - name-match (case-folded, suffix-stripped): story name maps to value
+ */
+export function storyExercises(src, story, enumName, value) {
+  if (story.blockStart === -1) return false;
+  // (1) args-match
+  const argsRange = findArgsBlock(src, story.blockStart);
+  if (argsRange) {
+    let ai = argsRange.start;
+    while (ai < argsRange.end && /\s/.test(src[ai])) ai++;
+    if (src[ai] === '{') {
+      const enumValueRange = findObjectKey(src, ai, enumName);
+      if (enumValueRange) {
+        const raw = src
+          .slice(enumValueRange.start, enumValueRange.end)
+          .trim()
+          .replace(/^["'`]|["'`]$/g, '');
+        if (raw === value) return true;
+      }
+    }
+  }
+  // (2) render-JSX match — scan the story body
+  const body = src.slice(story.blockStart, story.blockEnd + 1);
+  const jsxPattern = new RegExp(
+    `\\b${enumName}\\s*=\\s*["']${escapeRegExp(value)}["']`,
+    ''
+  );
+  if (jsxPattern.test(body)) return true;
+  // (3) name-match — case-fold, strip enum suffix
+  const normalizedName = story.name
+    .toLowerCase()
+    .replace(/variant$|size$|style$|kind$|fill$/i, '');
+  if (normalizedName === value.toLowerCase()) return true;
+  return false;
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Does the stories file's `meta.args` contain a `fn()` spy declaration?
+ */
+export function detectFnSpy(src) {
+  // Find `const meta` declaration
+  const metaMatch = src.match(/\bconst\s+meta\s*:[^{=]*=\s*\{/);
+  if (!metaMatch) return false;
+  const metaStart = metaMatch.index + metaMatch[0].length - 1;
+  const metaEnd = matchBracket(src, metaStart, '{', '}');
+  if (metaEnd === -1) return false;
+  const argsRange = findObjectKey(src, metaStart, 'args');
+  if (!argsRange) return false;
+  const argsSrc = src.slice(argsRange.start, argsRange.end);
+  return /\bfn\s*\(\s*\)/.test(argsSrc);
+}
+
+/**
+ * Does ANY story in the file use `asChild`?
+ */
+export function detectAsChildUsage(src) {
+  return /\basChild\b/.test(src);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// File discovery.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function kebabToPascal(kebab) {
+  return kebab
+    .split('-')
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join('');
+}
+
+function pascalToKebab(pascal) {
+  return pascal
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase();
+}
+
+function isExcludedPath(p) {
+  return EXCLUDE_PATH_FRAGMENTS.some((frag) => p.includes(frag));
+}
+
+/**
+ * Find a single component file for `kebab` under COMPONENTS_ROOT. Returns the
+ * absolute path, or throws ConfigError if not exactly one match.
+ */
+export function findComponentFile(kebab, root = COMPONENTS_ROOT) {
+  const matches = [];
+  for (const subdir of COMPONENT_SUBDIRS) {
+    const candidate = path.join(root, subdir, `${kebab}.tsx`);
+    if (
+      fs.existsSync(candidate) &&
+      !candidate.endsWith(STORY_SUFFIX) &&
+      !candidate.endsWith(TEST_SUFFIX) &&
+      !isExcludedPath(candidate)
+    ) {
+      matches.push(candidate);
+    }
+  }
+  if (matches.length === 0) {
+    throw new ConfigError(
+      `component "${kebab}" not found under ${path.relative(REPO_ROOT, root)}/{${COMPONENT_SUBDIRS.join(',')}}/`
+    );
+  }
+  if (matches.length > 1) {
+    throw new ConfigError(
+      `component "${kebab}" matches multiple files:\n  ${matches.map((p) => path.relative(REPO_ROOT, p)).join('\n  ')}`
+    );
+  }
+  return matches[0];
+}
+
+/**
+ * Find the stories file for the given component file. The convention is
+ * `{kebab}.tsx` → `{Pascal}.stories.tsx` in the same directory.
+ */
+export function findStoriesFile(componentFile) {
+  const dir = path.dirname(componentFile);
+  const kebab = path.basename(componentFile, '.tsx');
+  const pascal = kebabToPascal(kebab);
+  const candidate = path.join(dir, `${pascal}.stories.tsx`);
+  if (fs.existsSync(candidate)) return candidate;
+  return null;
+}
+
+/**
+ * List every component file under COMPONENTS_ROOT for `--all` mode.
+ */
+export function listAllComponents(root = COMPONENTS_ROOT) {
+  const out = [];
+  for (const subdir of COMPONENT_SUBDIRS) {
+    const dir = path.join(root, subdir);
+    if (!fs.existsSync(dir)) continue;
+    for (const entry of fs.readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      if (!entry.endsWith('.tsx')) continue;
+      if (entry.endsWith(STORY_SUFFIX) || entry.endsWith(TEST_SUFFIX)) continue;
+      if (isExcludedPath(full)) continue;
+      out.push(full);
+    }
+  }
+  return out.sort();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Showcase-name lookup.
+// ─────────────────────────────────────────────────────────────────────────────
+
+let configCache = null;
+
+function readConfig() {
+  if (configCache !== null) return configCache;
+  if (!fs.existsSync(CONFIG_PATH)) {
+    configCache = { components: [] };
+    return configCache;
+  }
+  try {
+    configCache = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+  } catch (err) {
+    throw new ConfigError(
+      `failed to parse ${path.relative(REPO_ROOT, CONFIG_PATH)}: ${err.message}`
+    );
+  }
+  return configCache;
+}
+
+/**
+ * Look up the canonical showcase story name for a component. Avatar uses
+ * `AllSizes`; everything else defaults to `AllVariants`.
+ */
+export function showcaseNameFor(pascalName) {
+  const config = readConfig();
+  const entry = config.components?.find((c) => c.name === pascalName);
+  return entry?.showcase ?? 'AllVariants';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Snippet templates — paste-ready fix hints. Inline fallback first; the rule
+// file is informational reference only (templates almost never change, and
+// re-quoting from markdown is error-prone for an existence-only audit).
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SNIPPETS = {
+  Default: `export const Default: Story = {
+  args: { /* default props */ },
+};`,
+  Disabled: `export const Disabled: Story = {
+  args: { disabled: true /* + any required props */ },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const el = canvas.getByRole('button');
+    await expect(el).toBeDisabled();
+    await userEvent.click(el);
+    await expect(args.onClick).not.toHaveBeenCalled();
+  },
+};`,
+  ClickInteraction: `export const ClickInteraction: Story = {
+  args: { /* required props */ },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const el = canvas.getByRole('button');
+    await userEvent.click(el);
+    await expect(args.onClick).toHaveBeenCalledTimes(1);
+  },
+};`,
+  KeyboardInteraction: `export const KeyboardInteraction: Story = {
+  args: { /* required props */ },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const el = canvas.getByRole('button');
+    await userEvent.tab();
+    await expect(el).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
+    await expect(args.onClick).toHaveBeenCalledTimes(1);
+  },
+};`,
+  WithDataAttributes: `export const WithDataAttributes: Story = {
+  args: { /* representative props */ },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const el = canvas.getByRole('button');
+    await expect(el).toHaveAttribute('data-slot', '<slot-name>');
+  },
+};`,
+  AllVariants: `export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-6">
+      {/* Visual grid: variants, sizes, states */}
+    </div>
+  ),
+};`,
+  AllSizes: `export const AllSizes: Story = {
+  render: () => (
+    <div className="nx:flex nx:items-center nx:gap-4">
+      {/* Visual row across all sizes */}
+    </div>
+  ),
+};`,
+  asChild: `export const AsLink: Story = {
+  render: (args) => (
+    <Component {...args} asChild>
+      <a href="https://example.com">As link</a>
+    </Component>
+  ),
+};`,
+};
+
+function snippetFor(name) {
+  return SNIPPETS[name] ?? null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Audit core.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Story-name drift detection: when the canonical name (e.g. `WithDataAttributes`)
+ * is missing but a near-equivalent name (e.g. `DataAttributesTest`) is present,
+ * report drift instead of a clean miss so the fix is unambiguous.
+ */
+const DRIFT_ALIASES = {
+  WithDataAttributes: ['DataAttributesTest', 'DataAttrs', 'DataAttributes'],
+  Disabled: ['DisabledInteraction', 'DisabledState'],
+  ClickInteraction: ['ClickTest', 'OnClick'],
+  KeyboardInteraction: ['KeyboardTest', 'KeyboardNavigation'],
+  Default: ['Basic'],
+  AllVariants: ['Variants', 'AllStates'],
+  AllSizes: ['Sizes'],
+};
+
+/**
+ * Build the required-story checklist for a component and check the stories
+ * file against it.
+ *
+ * @returns {{ component, file, storiesFile, findings, summary, info }}
+ */
+export function auditComponent(componentFile) {
+  const src = fs.readFileSync(componentFile, 'utf8');
+  const storiesFile = findStoriesFile(componentFile);
+  const kebab = path.basename(componentFile, '.tsx');
+  const pascal = kebabToPascal(kebab);
+
+  const { enums, extraEnums, cvaCount } = extractCvaEnums(src);
+  const hasAsChild = detectAsChild(src);
+  const componentInteractive = detectInteractiveFromComponent(src);
+
+  const result = {
+    component: pascal,
+    file: path.relative(REPO_ROOT, componentFile),
+    storiesFile: storiesFile ? path.relative(REPO_ROOT, storiesFile) : null,
+    findings: [],
+    info: [],
+    summary: { total: 0, missing: 0, drift: 0, info: 0 },
+  };
+
+  if (!storiesFile) {
+    result.findings.push({
+      kind: 'missing',
+      rule: 'stories-file',
+      name: `${pascal}.stories.tsx`,
+      expected: `${path.relative(REPO_ROOT, path.dirname(componentFile))}/${pascal}.stories.tsx`,
+      snippet: `Scaffold with /new-component ${kebab} (see issue #75).`,
+    });
+    finalize(result);
+    return result;
+  }
+
+  const storiesSrc = fs.readFileSync(storiesFile, 'utf8');
+  const stories = findStoryExports(storiesSrc);
+  const storyNames = new Set(stories.map((s) => s.name));
+  const fnSpy = detectFnSpy(storiesSrc);
+  const isInteractive = componentInteractive || fnSpy;
+
+  // Empty stories file (no Story exports) — single finding, not 9.
+  if (stories.length === 0) {
+    result.findings.push({
+      kind: 'missing',
+      rule: 'stories-file',
+      name: 'all stories',
+      expected: 'one or more `export const X: Story = { … }` declarations',
+      snippet: `Scaffold with /new-component ${kebab} (see issue #75).`,
+    });
+    finalize(result);
+    return result;
+  }
+
+  const showcase = showcaseNameFor(pascal);
+
+  // ── 6 literal-name required stories ────────────────────────────────────────
+  // `Default`, `WithDataAttributes`, and `<showcase>` are always required.
+  // `Disabled`, `ClickInteraction`, `KeyboardInteraction` are required only
+  // when the component is interactive (display-gate).
+  const literalRequired = [
+    { name: 'Default', alwaysRequired: true },
+    { name: 'Disabled', alwaysRequired: false },
+    { name: 'ClickInteraction', alwaysRequired: false },
+    { name: 'KeyboardInteraction', alwaysRequired: false },
+    { name: 'WithDataAttributes', alwaysRequired: true },
+    { name: showcase, alwaysRequired: true },
+  ];
+
+  for (const req of literalRequired) {
+    if (!req.alwaysRequired && !isInteractive) {
+      result.info.push({
+        kind: 'info',
+        rule: 'display-gate',
+        name: req.name,
+        found: 'n/a (display component — no `fn()` spy and no `on*`/`disabled` prop)',
+      });
+      continue;
+    }
+    if (storyNames.has(req.name)) continue;
+    // Check for drift aliases
+    const aliases = DRIFT_ALIASES[req.name] ?? [];
+    const drifted = aliases.find((alias) => storyNames.has(alias));
+    if (drifted) {
+      result.findings.push({
+        kind: 'drift',
+        rule: 'literal-name',
+        name: req.name,
+        found: drifted,
+        expected: req.name,
+        snippet: `Rename \`${drifted}\` → \`${req.name}\` (the rule names this story by literal name; drift breaks greppability and base-variants.config.json references).`,
+      });
+      continue;
+    }
+    result.findings.push({
+      kind: 'missing',
+      rule: 'literal-name',
+      name: req.name,
+      expected: req.name,
+      snippet: snippetFor(req.name),
+    });
+  }
+
+  // ── Per-(variant|size)-value stories ──────────────────────────────────────
+  for (const enumName of ['variant', 'size']) {
+    const values = enums[enumName];
+    if (!values || values.length === 0) continue;
+    for (const value of values) {
+      const exercising = stories.find((s) =>
+        storyExercises(storiesSrc, s, enumName, value)
+      );
+      if (exercising) continue;
+      result.findings.push({
+        kind: 'missing',
+        rule: `per-${enumName}`,
+        name: `${enumName}="${value}"`,
+        expected: `a story exercising ${enumName}="${value}" (via args, render-JSX, or name match)`,
+        snippet: `export const ${capitalize(value)}: Story = {
+  args: { ${enumName}: '${value}' /* + any required props */ },
+};`,
+      });
+    }
+  }
+
+  // ── asChild story (if applicable) ──────────────────────────────────────────
+  if (hasAsChild) {
+    if (!detectAsChildUsage(storiesSrc)) {
+      result.findings.push({
+        kind: 'missing',
+        rule: 'as-child',
+        name: 'asChild story',
+        expected: 'a story rendering the component with `asChild` to verify composition',
+        snippet: snippetFor('asChild'),
+      });
+    }
+  }
+
+  // ── Informational notes ────────────────────────────────────────────────────
+  if (extraEnums.length > 0) {
+    result.info.push({
+      kind: 'info',
+      rule: 'extra-cva-enum',
+      name: extraEnums.join(', '),
+      found: `${extraEnums.length} CVA enum(s) outside the rule's matrix (the rule only requires per-value stories for \`variant\` and \`size\`)`,
+    });
+  }
+  if (cvaCount > 1) {
+    result.info.push({
+      kind: 'info',
+      rule: 'compound-component',
+      name: `${cvaCount} CVA blocks`,
+      found: 'compound component — CVA enums unioned across blocks for the audit',
+    });
+  }
+
+  finalize(result);
+  return result;
+}
+
+function capitalize(s) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function finalize(result) {
+  result.summary.missing = result.findings.filter((f) => f.kind === 'missing').length;
+  result.summary.drift = result.findings.filter((f) => f.kind === 'drift').length;
+  result.summary.info = result.info.length;
+  result.summary.total = result.findings.length;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Formatting.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function formatHumanFinding(finding) {
+  const icon = finding.kind === 'missing' ? '❌' : '⚠️';
+  const label = `${icon} ${finding.kind.toUpperCase()}: ${finding.name}`;
+  const lines = [label];
+  if (finding.found && finding.expected) {
+    lines.push(`     found:    ${finding.found}`);
+    lines.push(`     expected: ${finding.expected}`);
+  } else if (finding.expected) {
+    lines.push(`     expected: ${finding.expected}`);
+  }
+  if (finding.snippet) {
+    lines.push('     fix:');
+    for (const line of finding.snippet.split('\n')) {
+      lines.push(`       ${line}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function formatHumanInfo(info) {
+  const lines = [`ℹ️  ${info.rule}: ${info.name}`];
+  if (info.found) lines.push(`     ${info.found}`);
+  return lines.join('\n');
+}
+
+function formatHumanResult(result) {
+  const lines = [];
+  lines.push(`─── audit-storybook-coverage: ${result.component} ───`);
+  lines.push(`  component: ${result.file}`);
+  lines.push(`  stories:   ${result.storiesFile ?? '(missing)'}`);
+  lines.push('');
+  if (result.findings.length === 0 && result.info.length === 0) {
+    lines.push('  ✓ no gaps');
+    lines.push('');
+    return lines.join('\n');
+  }
+  for (const finding of result.findings) {
+    lines.push(formatHumanFinding(finding));
+    lines.push('');
+  }
+  if (result.info.length > 0) {
+    lines.push('  ─ info ─');
+    for (const info of result.info) {
+      lines.push(formatHumanInfo(info));
+    }
+    lines.push('');
+  }
+  lines.push(
+    `  summary: ${result.summary.missing} missing, ${result.summary.drift} drift, ${result.summary.info} info`
+  );
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function fail(message) {
+  throw new ConfigError(message);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  const unknown = findUnknownFlags(args);
+  if (unknown.length > 0) {
+    fail(
+      `unknown flag(s): ${unknown.map((k) => `--${k}`).join(', ')}\n  known: ${[...KNOWN_FLAGS].map((k) => `--${k}`).join(', ')}\n  ${DOCS_HINT}`
+    );
+  }
+
+  if (!args.component && !args.all) {
+    fail(
+      `--component <name> or --all is required\n  example: --component button | --component DropdownMenu | --all\n  ${DOCS_HINT}`
+    );
+  }
+
+  let files;
+  if (args.all) {
+    files = listAllComponents();
+  } else {
+    // Accept Pascal or kebab; canonicalize to kebab for filesystem lookup.
+    const input = args.component;
+    const kebab = input.includes('-') || input === input.toLowerCase()
+      ? input
+      : pascalToKebab(input);
+    files = [findComponentFile(kebab)];
+  }
+
+  const results = files.map((f) => auditComponent(f));
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify(results, null, 2) + '\n');
+  } else {
+    for (const result of results) {
+      process.stdout.write(formatHumanResult(result));
+    }
+    const totalFindings = results.reduce((acc, r) => acc + r.summary.total, 0);
+    const totalMissing = results.reduce((acc, r) => acc + r.summary.missing, 0);
+    const totalDrift = results.reduce((acc, r) => acc + r.summary.drift, 0);
+    if (results.length > 1) {
+      process.stdout.write(
+        `Audited ${results.length} components — ${totalFindings} finding(s) (${totalMissing} missing, ${totalDrift} drift).\n`
+      );
+    }
+  }
+
+  const anyFindings = results.some((r) => r.summary.total > 0);
+  process.exit(anyFindings ? EXIT_FINDINGS : EXIT_OK);
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  try {
+    main();
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      process.stderr.write(`audit-storybook-coverage: ${err.message}\n`);
+      process.exit(EXIT_CONFIG);
+    }
+    throw err;
+  }
+}
+
+export { ConfigError, EXIT_CONFIG, EXIT_FINDINGS, EXIT_OK };

--- a/packages/react/scripts/audit-storybook-coverage.test.js
+++ b/packages/react/scripts/audit-storybook-coverage.test.js
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -369,9 +371,41 @@ describe('auditComponent — real fixtures', () => {
     const extraEnum = result.info.find((i) => i.rule === 'extra-cva-enum');
     expect(extraEnum?.name).toContain('fill');
   });
+});
 
-  it('Input reports DataAttributesTest as drift', () => {
-    const file = path.join(COMPONENTS_ROOT, 'ui', 'input.tsx');
+// Drift-detection tests use synthetic fixtures written to a temp dir so they
+// don't depend on the codebase's evolving story names (a real-file fixture
+// would fail the moment Phase 2 renames land).
+describe('auditComponent — drift detection (synthetic)', () => {
+  function writeFixture(name, componentSrc, storiesSrc) {
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'audit-storybook-coverage-')
+    );
+    const uiDir = path.join(dir, 'src', 'components', 'ui');
+    fs.mkdirSync(uiDir, { recursive: true });
+    const pascal = name.charAt(0).toUpperCase() + name.slice(1);
+    fs.writeFileSync(path.join(uiDir, `${name}.tsx`), componentSrc);
+    fs.writeFileSync(path.join(uiDir, `${pascal}.stories.tsx`), storiesSrc);
+    return path.join(uiDir, `${name}.tsx`);
+  }
+
+  it('reports drift when a story uses an aliased name', () => {
+    const componentSrc = `
+      import { cva } from 'class-variance-authority';
+      const v = cva('base', { variants: { variant: { default: '' } } });
+      interface Props { disabled?: boolean; onClick?: () => void }
+      export function Thing(p: Props) { return null; }
+    `;
+    const storiesSrc = `
+      const meta = { args: { onClick: fn() } };
+      export const Default: Story = { args: {} };
+      export const Disabled: Story = { args: { disabled: true } };
+      export const ClickInteraction: Story = { args: {} };
+      export const KeyboardInteraction: Story = { args: {} };
+      export const DataAttributesTest: Story = { args: {} };
+      export const AllVariants: Story = { render: () => null };
+    `;
+    const file = writeFixture('thing', componentSrc, storiesSrc);
     const result = auditComponent(file);
     const drift = result.findings.find(
       (f) => f.kind === 'drift' && f.name === 'WithDataAttributes'
@@ -383,18 +417,27 @@ describe('auditComponent — real fixtures', () => {
     });
   });
 
-  it('Tabs reports both drift and missing on a compound component', () => {
-    const file = path.join(COMPONENTS_ROOT, 'ui', 'tabs.tsx');
+  it('reports drift for KeyboardNavigation → KeyboardInteraction', () => {
+    const componentSrc = `
+      import { cva } from 'class-variance-authority';
+      const v = cva('base', { variants: { variant: { default: '' } } });
+      interface Props { disabled?: boolean; onClick?: () => void }
+      export function Thing(p: Props) { return null; }
+    `;
+    const storiesSrc = `
+      const meta = { args: { onClick: fn() } };
+      export const Default: Story = { args: {} };
+      export const Disabled: Story = { args: { disabled: true } };
+      export const ClickInteraction: Story = { args: {} };
+      export const KeyboardNavigation: Story = { args: {} };
+      export const WithDataAttributes: Story = { args: {} };
+      export const AllVariants: Story = { render: () => null };
+    `;
+    const file = writeFixture('thing', componentSrc, storiesSrc);
     const result = auditComponent(file);
-    // Drift: KeyboardNavigation should be KeyboardInteraction
-    const keyboardDrift = result.findings.find(
+    const drift = result.findings.find(
       (f) => f.kind === 'drift' && f.name === 'KeyboardInteraction'
     );
-    expect(keyboardDrift?.found).toBe('KeyboardNavigation');
-    // Drift: DataAttributesTest should be WithDataAttributes
-    const dataDrift = result.findings.find(
-      (f) => f.kind === 'drift' && f.name === 'WithDataAttributes'
-    );
-    expect(dataDrift?.found).toBe('DataAttributesTest');
+    expect(drift?.found).toBe('KeyboardNavigation');
   });
 });

--- a/packages/react/scripts/audit-storybook-coverage.test.js
+++ b/packages/react/scripts/audit-storybook-coverage.test.js
@@ -1,0 +1,400 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+  auditComponent,
+  detectAsChild,
+  detectAsChildUsage,
+  detectFnSpy,
+  detectInteractiveFromComponent,
+  extractCvaEnums,
+  findCallExpressionArgs,
+  findComponentFile,
+  findObjectKey,
+  findStoriesFile,
+  findStoryExports,
+  findUnknownFlags,
+  listAllComponents,
+  matchBracket,
+  parseArgs,
+  parseObjectKeys,
+  showcaseNameFor,
+  storyExercises,
+} from './audit-storybook-coverage.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const COMPONENTS_ROOT = path.resolve(__dirname, '..', 'src', 'components');
+
+describe('parseArgs', () => {
+  it('parses --component <name>', () => {
+    expect(parseArgs(['--component', 'button'])).toMatchObject({
+      component: 'button',
+      all: false,
+      json: false,
+    });
+  });
+
+  it('parses --component=<name>', () => {
+    expect(parseArgs(['--component=button'])).toMatchObject({
+      component: 'button',
+    });
+  });
+
+  it('parses --all and --json as booleans', () => {
+    expect(parseArgs(['--all', '--json'])).toMatchObject({
+      all: true,
+      json: true,
+    });
+  });
+
+  it('detects unknown flags', () => {
+    expect(findUnknownFlags(parseArgs(['--bogus', 'x']))).toEqual(['bogus']);
+  });
+});
+
+describe('matchBracket', () => {
+  it('matches a balanced pair', () => {
+    expect(matchBracket('{a}', 0, '{', '}')).toBe(2);
+  });
+
+  it('skips strings containing the close bracket', () => {
+    expect(matchBracket('{"}"}', 0, '{', '}')).toBe(4);
+  });
+
+  it('skips line comments', () => {
+    expect(matchBracket('{a // }\n}', 0, '{', '}')).toBe(8);
+  });
+
+  it('skips block comments', () => {
+    expect(matchBracket('{/* } */ }', 0, '{', '}')).toBe(9);
+  });
+
+  it('skips template literals with ${...}', () => {
+    expect(matchBracket('{`${x}`}', 0, '{', '}')).toBe(7);
+  });
+
+  it('returns -1 when unmatched', () => {
+    expect(matchBracket('{a', 0, '{', '}')).toBe(-1);
+  });
+});
+
+describe('findCallExpressionArgs', () => {
+  it('finds a single cva call', () => {
+    const src = 'const v = cva("base", { variants: {} });';
+    const calls = findCallExpressionArgs(src, 'cva');
+    expect(calls).toHaveLength(1);
+    expect(src[calls[0].start]).toBe('(');
+    expect(src[calls[0].end]).toBe(')');
+  });
+
+  it('finds multiple cva calls in one file', () => {
+    const src = 'cva("a", {}); cva("b", {});';
+    expect(findCallExpressionArgs(src, 'cva')).toHaveLength(2);
+  });
+});
+
+describe('parseObjectKeys', () => {
+  it('parses simple keys', () => {
+    expect(parseObjectKeys('a: 1, b: 2')).toEqual(['a', 'b']);
+  });
+
+  it('parses quoted keys', () => {
+    expect(parseObjectKeys('"2xs": 1, sm: 2')).toEqual(['2xs', 'sm']);
+  });
+
+  it('skips comments', () => {
+    expect(parseObjectKeys('// noise\na: 1, /* x */ b: 2')).toEqual(['a', 'b']);
+  });
+
+  it('walks past nested objects', () => {
+    expect(parseObjectKeys('a: { nested: { x: 1 } }, b: 2')).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+});
+
+describe('findObjectKey', () => {
+  it('finds a key at the top level', () => {
+    const src = '{ a: 1, b: 2 }';
+    const range = findObjectKey(src, 0, 'b');
+    expect(range).not.toBeNull();
+    expect(src.slice(range.start, range.end).trim()).toBe('2');
+  });
+
+  it('returns null when the key is absent', () => {
+    expect(findObjectKey('{ a: 1 }', 0, 'b')).toBeNull();
+  });
+
+  it('does not descend into nested objects', () => {
+    const src = '{ a: { b: 99 }, c: 2 }';
+    expect(findObjectKey(src, 0, 'b')).toBeNull();
+  });
+});
+
+describe('extractCvaEnums', () => {
+  it('extracts variant and size enums', () => {
+    const src = `
+      const v = cva('base', {
+        variants: {
+          variant: { default: '', secondary: '' },
+          size: { sm: '', lg: '' },
+        },
+      });
+    `;
+    const { enums, extraEnums, cvaCount } = extractCvaEnums(src);
+    expect(enums).toEqual({
+      variant: ['default', 'secondary'],
+      size: ['sm', 'lg'],
+    });
+    expect(extraEnums).toEqual([]);
+    expect(cvaCount).toBe(1);
+  });
+
+  it('surfaces extra enums beyond variant/size', () => {
+    const src = `
+      const v = cva('base', {
+        variants: {
+          variant: { default: '' },
+          fill: { solid: '', light: '' },
+        },
+      });
+    `;
+    const { enums, extraEnums } = extractCvaEnums(src);
+    expect(enums).toEqual({ variant: ['default'] });
+    expect(extraEnums).toEqual(['fill']);
+  });
+
+  it('unions enums across multiple cva blocks in one file', () => {
+    const src = `
+      const a = cva('x', { variants: { variant: { foo: '' } } });
+      const b = cva('y', { variants: { variant: { bar: '' }, size: { sm: '' } } });
+    `;
+    const { enums, cvaCount } = extractCvaEnums(src);
+    expect(enums.variant).toEqual(['foo', 'bar']);
+    expect(enums.size).toEqual(['sm']);
+    expect(cvaCount).toBe(2);
+  });
+
+  it('returns empty enums when the file has no cva calls', () => {
+    const { enums, cvaCount } = extractCvaEnums('export const X = 1;');
+    expect(enums).toEqual({});
+    expect(cvaCount).toBe(0);
+  });
+});
+
+describe('detectAsChild', () => {
+  it('detects asChild?: in a props interface', () => {
+    expect(detectAsChild('interface P { asChild?: boolean; }')).toBe(true);
+  });
+
+  it('does not match plain `asChild` references', () => {
+    expect(detectAsChild('// asChild support is implemented elsewhere')).toBe(
+      false
+    );
+  });
+});
+
+describe('detectInteractiveFromComponent', () => {
+  it('flags `disabled` as interactive', () => {
+    expect(detectInteractiveFromComponent('disabled = false')).toBe(true);
+  });
+
+  it('flags `onClick` prop signatures as interactive', () => {
+    expect(detectInteractiveFromComponent('onClick?: () => void')).toBe(true);
+  });
+
+  it('treats display-only source as non-interactive', () => {
+    expect(detectInteractiveFromComponent('export const X = "hello"')).toBe(
+      false
+    );
+  });
+});
+
+describe('findStoryExports', () => {
+  it('finds typed Story exports', () => {
+    const src = `
+      export const Default: Story = { args: {} };
+      export const Primary: Story = { args: { variant: 'primary' } };
+    `;
+    const stories = findStoryExports(src);
+    expect(stories.map((s) => s.name)).toEqual(['Default', 'Primary']);
+  });
+
+  it('finds StoryObj exports', () => {
+    const src = `export const A: StoryObj<typeof Foo> = {};`;
+    expect(findStoryExports(src).map((s) => s.name)).toEqual(['A']);
+  });
+
+  it('finds satisfies-Story exports', () => {
+    const src = `export const A = { args: {} } satisfies Story;`;
+    expect(findStoryExports(src).map((s) => s.name)).toEqual(['A']);
+  });
+
+  it('skips non-story exports', () => {
+    const src = `export const helper = (x: string) => x;`;
+    expect(findStoryExports(src)).toEqual([]);
+  });
+});
+
+describe('detectFnSpy', () => {
+  it('detects fn() in meta.args', () => {
+    const src = `
+      const meta: Meta<typeof X> = {
+        args: { onClick: fn() },
+      };
+    `;
+    expect(detectFnSpy(src)).toBe(true);
+  });
+
+  it('returns false when meta has no args block', () => {
+    const src = `const meta: Meta<typeof X> = { title: 'X' };`;
+    expect(detectFnSpy(src)).toBe(false);
+  });
+
+  it('returns false when args has no fn() call', () => {
+    const src = `const meta: Meta<typeof X> = { args: { value: 'static' } };`;
+    expect(detectFnSpy(src)).toBe(false);
+  });
+});
+
+describe('detectAsChildUsage', () => {
+  it('detects asChild anywhere in stories', () => {
+    expect(detectAsChildUsage('render: () => <X asChild><a/></X>')).toBe(true);
+  });
+
+  it('returns false when asChild is absent', () => {
+    expect(detectAsChildUsage('export const A = {};')).toBe(false);
+  });
+});
+
+describe('storyExercises', () => {
+  it('matches via args.variant', () => {
+    const src = `
+      export const Primary: Story = {
+        args: { variant: 'primary' },
+      };
+    `;
+    const [story] = findStoryExports(src);
+    expect(storyExercises(src, story, 'variant', 'primary')).toBe(true);
+  });
+
+  it('matches via render-JSX prop', () => {
+    const src = `
+      export const Underline: Story = {
+        render: () => <Tabs variant="underline" />,
+      };
+    `;
+    const [story] = findStoryExports(src);
+    expect(storyExercises(src, story, 'variant', 'underline')).toBe(true);
+  });
+
+  it('matches via case-folded suffix-stripped name', () => {
+    const src = `export const UnderlineVariant: Story = { render: () => null };`;
+    const [story] = findStoryExports(src);
+    expect(storyExercises(src, story, 'variant', 'underline')).toBe(true);
+  });
+
+  it('returns false when the value is unexercised', () => {
+    const src = `export const Default: Story = { args: { variant: 'default' } };`;
+    const [story] = findStoryExports(src);
+    expect(storyExercises(src, story, 'variant', 'secondary')).toBe(false);
+  });
+});
+
+describe('file discovery', () => {
+  it('resolves a kebab name to a single file under ui/', () => {
+    const file = findComponentFile('button');
+    expect(file.endsWith('/ui/button.tsx')).toBe(true);
+  });
+
+  it('resolves the stories file alongside the component', () => {
+    const file = findComponentFile('button');
+    const stories = findStoriesFile(file);
+    expect(stories.endsWith('Button.stories.tsx')).toBe(true);
+  });
+
+  it('throws ConfigError for missing components', () => {
+    expect(() => findComponentFile('nonexistent-component')).toThrow(
+      /not found/
+    );
+  });
+
+  it('lists every component file under ui/ and primitives/', () => {
+    const files = listAllComponents();
+    expect(files.length).toBeGreaterThan(10);
+    expect(files.every((f) => f.endsWith('.tsx'))).toBe(true);
+    expect(files.every((f) => !f.includes('__generated__'))).toBe(true);
+    expect(files.every((f) => !f.endsWith('.stories.tsx'))).toBe(true);
+  });
+});
+
+describe('showcaseNameFor', () => {
+  it('returns AllVariants by default', () => {
+    expect(showcaseNameFor('Button')).toBe('AllVariants');
+  });
+
+  it('returns AllSizes for Avatar', () => {
+    expect(showcaseNameFor('Avatar')).toBe('AllSizes');
+  });
+
+  it('defaults to AllVariants when not in config', () => {
+    expect(showcaseNameFor('NewComponentNotInConfig')).toBe('AllVariants');
+  });
+});
+
+describe('auditComponent — real fixtures', () => {
+  it('Button passes with no findings', () => {
+    const file = path.join(COMPONENTS_ROOT, 'ui', 'button.tsx');
+    const result = auditComponent(file);
+    expect(result.findings).toEqual([]);
+    expect(result.summary.total).toBe(0);
+  });
+
+  it('Avatar passes via display-gate + AllSizes showcase', () => {
+    const file = path.join(COMPONENTS_ROOT, 'ui', 'avatar.tsx');
+    const result = auditComponent(file);
+    expect(result.findings).toEqual([]);
+    // Display-gate downgrades Disabled/Click/Keyboard to info entries
+    expect(result.info.some((i) => i.name === 'Disabled')).toBe(true);
+    // Extra `shape` enum surfaces as info
+    expect(result.info.some((i) => i.rule === 'extra-cva-enum')).toBe(true);
+  });
+
+  it('Badge passes via display-gate + surfaces `fill` as extra enum', () => {
+    const file = path.join(COMPONENTS_ROOT, 'ui', 'badge.tsx');
+    const result = auditComponent(file);
+    expect(result.findings).toEqual([]);
+    const extraEnum = result.info.find((i) => i.rule === 'extra-cva-enum');
+    expect(extraEnum?.name).toContain('fill');
+  });
+
+  it('Input reports DataAttributesTest as drift', () => {
+    const file = path.join(COMPONENTS_ROOT, 'ui', 'input.tsx');
+    const result = auditComponent(file);
+    const drift = result.findings.find(
+      (f) => f.kind === 'drift' && f.name === 'WithDataAttributes'
+    );
+    expect(drift).toMatchObject({
+      kind: 'drift',
+      found: 'DataAttributesTest',
+      expected: 'WithDataAttributes',
+    });
+  });
+
+  it('Tabs reports both drift and missing on a compound component', () => {
+    const file = path.join(COMPONENTS_ROOT, 'ui', 'tabs.tsx');
+    const result = auditComponent(file);
+    // Drift: KeyboardNavigation should be KeyboardInteraction
+    const keyboardDrift = result.findings.find(
+      (f) => f.kind === 'drift' && f.name === 'KeyboardInteraction'
+    );
+    expect(keyboardDrift?.found).toBe('KeyboardNavigation');
+    // Drift: DataAttributesTest should be WithDataAttributes
+    const dataDrift = result.findings.find(
+      (f) => f.kind === 'drift' && f.name === 'WithDataAttributes'
+    );
+    expect(dataDrift?.found).toBe('DataAttributesTest');
+  });
+});

--- a/packages/react/scripts/audit-storybook-coverage.test.js
+++ b/packages/react/scripts/audit-storybook-coverage.test.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   auditComponent,
@@ -212,6 +212,30 @@ describe('detectInteractiveFromComponent', () => {
       false
     );
   });
+
+  it('does not match CVA `nx:disabled:` class hooks', () => {
+    expect(
+      detectInteractiveFromComponent(
+        "'nx:disabled:pointer-events-none nx:disabled:opacity-50'"
+      )
+    ).toBe(false);
+  });
+
+  it('does not match `aria-disabled=` on rendered elements', () => {
+    expect(
+      detectInteractiveFromComponent('<button aria-disabled={isDisabled} />')
+    ).toBe(false);
+  });
+
+  it('flags `disabled?:` interface fields as interactive', () => {
+    expect(detectInteractiveFromComponent('disabled?: boolean')).toBe(true);
+  });
+
+  it('flags `disabled,` destructure as interactive', () => {
+    expect(
+      detectInteractiveFromComponent('{ className, disabled, ...props }')
+    ).toBe(true);
+  });
 });
 
 describe('findStoryExports', () => {
@@ -375,12 +399,24 @@ describe('auditComponent — real fixtures', () => {
 
 // Drift-detection tests use synthetic fixtures written to a temp dir so they
 // don't depend on the codebase's evolving story names (a real-file fixture
-// would fail the moment Phase 2 renames land).
+// would fail the moment Phase 2 renames land). Each fixture's tmp dir is
+// tracked and removed after the test; `showcase: 'AllVariants'` is passed to
+// `auditComponent` so the test path doesn't read the repo's
+// `base-variants.config.json`.
 describe('auditComponent — drift detection (synthetic)', () => {
+  const tmpDirs = [];
+
+  afterEach(() => {
+    while (tmpDirs.length) {
+      fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+    }
+  });
+
   function writeFixture(name, componentSrc, storiesSrc) {
     const dir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'audit-storybook-coverage-')
     );
+    tmpDirs.push(dir);
     const uiDir = path.join(dir, 'src', 'components', 'ui');
     fs.mkdirSync(uiDir, { recursive: true });
     const pascal = name.charAt(0).toUpperCase() + name.slice(1);
@@ -406,7 +442,7 @@ describe('auditComponent — drift detection (synthetic)', () => {
       export const AllVariants: Story = { render: () => null };
     `;
     const file = writeFixture('thing', componentSrc, storiesSrc);
-    const result = auditComponent(file);
+    const result = auditComponent(file, { showcase: 'AllVariants' });
     const drift = result.findings.find(
       (f) => f.kind === 'drift' && f.name === 'WithDataAttributes'
     );
@@ -434,7 +470,7 @@ describe('auditComponent — drift detection (synthetic)', () => {
       export const AllVariants: Story = { render: () => null };
     `;
     const file = writeFixture('thing', componentSrc, storiesSrc);
-    const result = auditComponent(file);
+    const result = auditComponent(file, { showcase: 'AllVariants' });
     const drift = result.findings.find(
       (f) => f.kind === 'drift' && f.name === 'KeyboardInteraction'
     );

--- a/packages/react/src/components/primitives/Hide.stories.tsx
+++ b/packages/react/src/components/primitives/Hide.stories.tsx
@@ -210,7 +210,7 @@ export const FlexParent: Story = {
   },
 };
 
-export const DataAttributes: Story = {
+export const WithDataAttributes: Story = {
   render: () => (
     <Hide above="lg" data-testid="el">
       <span>content</span>

--- a/packages/react/src/components/primitives/Show.stories.tsx
+++ b/packages/react/src/components/primitives/Show.stories.tsx
@@ -206,7 +206,7 @@ export const FlexParent: Story = {
   },
 };
 
-export const DataAttributes: Story = {
+export const WithDataAttributes: Story = {
   render: () => (
     <Show above="lg" data-testid="el">
       <span>content</span>

--- a/packages/react/src/components/ui/Dialog.stories.tsx
+++ b/packages/react/src/components/ui/Dialog.stories.tsx
@@ -295,7 +295,7 @@ export const KeyboardInteraction: Story = {
   },
 };
 
-export const DataAttributesTest: Story = {
+export const WithDataAttributes: Story = {
   render: (_args) => (
     <Dialog>
       <DialogTrigger asChild>

--- a/packages/react/src/components/ui/DropdownMenu.stories.tsx
+++ b/packages/react/src/components/ui/DropdownMenu.stories.tsx
@@ -278,7 +278,7 @@ export const OpenCloseInteraction: Story = {
   },
 };
 
-export const KeyboardNavigation: Story = {
+export const KeyboardInteraction: Story = {
   render: (_args) => (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -319,7 +319,7 @@ export const KeyboardNavigation: Story = {
   },
 };
 
-export const DataAttributesTest: Story = {
+export const WithDataAttributes: Story = {
   render: (_args) => (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/packages/react/src/components/ui/Input.stories.tsx
+++ b/packages/react/src/components/ui/Input.stories.tsx
@@ -220,7 +220,7 @@ export const DisabledInteraction: Story = {
   },
 };
 
-export const DataAttributesTest: Story = {
+export const WithDataAttributes: Story = {
   args: {
     size: 'lg',
     placeholder: 'Test input',

--- a/packages/react/src/components/ui/Select.stories.tsx
+++ b/packages/react/src/components/ui/Select.stories.tsx
@@ -305,7 +305,7 @@ export const SelectItemInteraction: Story = {
   },
 };
 
-export const KeyboardNavigationInteraction: Story = {
+export const KeyboardInteraction: Story = {
   render: (_args) => (
     <Select>
       <SelectTrigger className="nx:w-[180px]" aria-label="Select a fruit">
@@ -371,7 +371,7 @@ export const DisabledInteraction: Story = {
   },
 };
 
-export const DataAttributesTest: Story = {
+export const WithDataAttributes: Story = {
   render: (_args) => (
     <Select>
       <SelectTrigger className="nx:w-[180px]" aria-label="Select a fruit">

--- a/packages/react/src/components/ui/Switch.stories.tsx
+++ b/packages/react/src/components/ui/Switch.stories.tsx
@@ -200,7 +200,7 @@ export const DisabledInteraction: Story = {
   },
 };
 
-export const DataAttributesTest: Story = {
+export const WithDataAttributes: Story = {
   args: {
     'aria-label': 'Toggle switch',
   },

--- a/packages/react/src/components/ui/Tabs.stories.tsx
+++ b/packages/react/src/components/ui/Tabs.stories.tsx
@@ -335,7 +335,7 @@ export const ClickInteraction: Story = {
   },
 };
 
-export const KeyboardNavigation: Story = {
+export const KeyboardInteraction: Story = {
   render: (_args) => (
     <Tabs defaultValue="tab1" className="nx:w-[400px]">
       <TabsList>
@@ -421,7 +421,7 @@ export const DisabledTabInteraction: Story = {
   },
 };
 
-export const DataAttributesTest: Story = {
+export const WithDataAttributes: Story = {
   render: (_args) => (
     <Tabs defaultValue="tab1" className="nx:w-[400px]">
       <TabsList>

--- a/packages/react/src/components/ui/Tooltip.stories.tsx
+++ b/packages/react/src/components/ui/Tooltip.stories.tsx
@@ -205,7 +205,7 @@ export const FocusInteraction: Story = {
   },
 };
 
-export const DataAttributesTest: Story = {
+export const WithDataAttributes: Story = {
   render: (_args) => (
     <Tooltip>
       <TooltipTrigger asChild>


### PR DESCRIPTION
## Summary

Issue #73 asked for a subagent that audits a Nexus component's stories against the required-story matrix in `.claude/rules/testing-react.md`. After a three-reviewer council pushed back on the LLM-regex shape — repo has four precedent `audit:*` Node scripts in `packages/core/scripts/`, deterministic structural diffs belong there — this PR ships the audit as:

- **`packages/react/scripts/audit-storybook-coverage.mjs`** — deterministic Node script, brace-matched parser (string/comment/template-literal aware), CVA enum extraction across compound files (Tabs, DropdownMenu), display-gate via `fn()`-in-meta-args OR prop-shape `disabled`/`on*`-in-source, drift-alias map, paste-ready snippet templates. CLI: `--component <name>` | `--all` | `--json`. Exit codes `0`/`1`/`2` match the `audit-figma-parity.js` precedent.
- **`.claude/agents/storybook-coverage-reviewer.md`** — thin subagent (tools: `Bash, Read, Grep, Glob`) that parses a natural-language prompt ("audit Button story coverage"), shells out with `--json`, renders the structured output as a markdown table with paste-ready snippets. Description triggers Claude's auto-invocation on coverage-audit phrasing.
- **One-time drift cleanup** — 11 renames across 9 story files so `--all` reports 0 drift after this PR (`DataAttributesTest` → `WithDataAttributes` ×7, `KeyboardNavigation` → `KeyboardInteraction` ×2, `KeyboardNavigationInteraction` → `KeyboardInteraction` ×1, `DataAttributes` → `WithDataAttributes` ×2 in primitives).

57 vitest cases cover the parser primitives, extraction helpers, file discovery, the showcase-name lookup, end-to-end audits against Button (clean), Avatar (display-gate + `AllSizes`), Badge (extra `fill` enum surfaced), the drift-detection path via synthetic tmpdir fixtures (so the tests don't depend on the codebase's evolving story names), and regression tests asserting CVA `nx:disabled:` and `aria-disabled=` do not false-positive the interactivity heuristic.

After this PR, `yarn audit:storybook-coverage --all` reports **4 remaining findings** (Hide / Show `AllVariants`; Input `ClickInteraction` + `KeyboardInteraction`) — all surfaced as real missing stories under the strict prop-shape heuristic. Trigger-and-overlay components (Dialog / DropdownMenu / Select / Accordion / Tabs) and other archetypes with real coverage gaps that the prop-shape signal can't see are tracked in #217.

### Why a script + thin wrapper (vs. the literal subagent in the issue)

| Reviewer            | Convergent finding                                                                                                                                                                                                                                           |
| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| principal-architect | "Wrong shape. Repo convention is unambiguous: deterministic, rule-versus-files diffs are Node scripts under `packages/*/scripts/` wired to `audit:*`. ... `tools: Read, Grep, Glob` is wrong for the actual job. ... A subagent for this is the wrong tool." |
| tester              | "False-positive on Avatar rewards 9 redundant `Size*` stories. False-negative on Tabs (no `fn()` spy → display-gate downgrades requirements). The naming-drift soft warning lets drift accumulate forever."                                                  |
| sde2                | "Grep-driven extraction is structurally wrong. Compound components are the majority and the plan punts on them. `fn()` is a thin interactive signal."                                                                                                        |

All three resolved by switching to a deterministic parser, treating files (not exports) as the unit, OR-ing the interactive signal across `fn()` + props-interface, and making drift hard misses with a one-time rename pass.

## GitHub Issue

Closes #73

## Test Plan

- [x] `yarn workspace @nexus/react audit:storybook-coverage --component button` → exit 0 (clean)
- [x] `yarn workspace @nexus/react audit:storybook-coverage --component avatar` → exit 0 (display-gate, `AllSizes` from `base-variants.config.json`)
- [x] `yarn workspace @nexus/react audit:storybook-coverage --component tabs` → exit 0 (Tabs no longer false-positive-flagged via CVA `nx:disabled:`)
- [x] `yarn workspace @nexus/react audit:storybook-coverage --all` → exit 1 with 4 missing-stories findings, 0 drift
- [x] `yarn vitest run --project=unit packages/react/scripts/audit-storybook-coverage.test.js` → 57 passed
- [x] `yarn typecheck` → clean
- [x] `yarn lint` → clean
- [x] `yarn format:check` → clean
- [ ] Reviewer: invoke the subagent (e.g. "audit Button story coverage") — expect a markdown table with the audit's JSON rendered

## Follow-up — tracked in #217

`yarn audit:storybook-coverage --all` reports 4 strict-signal misses today (Hide / Show `AllVariants`; Input `ClickInteraction` + `KeyboardInteraction`). Additional archetype-mismatch components (Accordion, Dialog, DropdownMenu, Select, Tabs) have real coverage gaps that the prop-shape heuristic can't surface without rule-level changes. Both groups are scoped into **#217**, which settles two design questions before the missing stories land:

1. **Archetype matrix.** Should `testing-react.md` enumerate archetypes (trigger-overlay, text-input, axis-toggle) with equivalent names, OR should each component add canonical-named stories duplicating existing test logic?
2. **Showcase aliasing.** Should the audit accept `AllAxes` / `AllShapes` as satisfying the showcase requirement, or should Show/Hide ship a canonical `AllVariants` story?

## Not in scope

- CI integration (`yarn audit:storybook-coverage --all` as a merge gate) — separate PR after #217 resolves the missing stories.
- Extending the rule's matrix with Loading / Invalid / Hover axes — tester reviewer flagged but out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
