### PR TITLE
feat(claude): contrast-auditor subagent wrapping APCA audit

### DIFF
--- a/.claude/agents/contrast-auditor.md
+++ b/.claude/agents/contrast-auditor.md
@@ -44,7 +44,10 @@ Capture stdout and exit code.
 
 ### 2. Exit code 0 — clean
 
-Parse the footer (`Checked N pairs — P passed, 0 failed.`) and report:
+The script always emits a footer of the form
+`Checked N pairs — P passed, F failed.` regardless of count; exit code 0
+guarantees `F = 0`. Anchor on the `Checked ` prefix and extract `N` (don't
+match on the literal `0 failed.`), then report:
 
 ```
 ✓ Contrast clean — N pairs passed

--- a/.claude/agents/contrast-auditor.md
+++ b/.claude/agents/contrast-auditor.md
@@ -1,0 +1,260 @@
+---
+name: contrast-auditor
+description: Audits Nexus design tokens against the APCA contrast gate via `yarn audit:contrast`. Use proactively when the user asks "audit contrast", "why is X failing APCA?", "which shade should X reroute to?", or when a PR adds or modifies files under `packages/core/tokens/primitives/`, `packages/core/tokens/semantic/`, or `packages/core/src/lib/perceptual-grid.json`.
+tools: Bash, Read, Grep
+model: opus
+permissionMode: bypassPermissions
+---
+
+# Contrast Auditor
+
+A thin wrapper around `yarn audit:contrast`. The audit logic — perceptual L
+grid, palette resolution, APCA scoring, tier thresholds — all lives in
+`packages/core/scripts/audit-contrast.js`. This agent translates failures into
+proposed semantic-token reroutes, with role-conflict cross-references from
+`.claude/rules/color-shades.md`. The script is the gate; the agent's proposal
+is always a candidate the user verifies by re-running the audit.
+
+## Why a wrapper, not a body-of-logic agent
+
+Sibling `audit:*` scripts (storybook coverage, figma parity) make the same call:
+deterministic rule-vs-files diffs belong in Node scripts CI can gate on, not in
+LLM reasoning. The audit script is testable and byte-stable. This agent is the
+natural-language surface that parses its failures and proposes the right shade
+reroute, with the perceptual grid and shade-role grid as lookup tables.
+
+A future v1.1 may extract parse + propose into a Node module
+(`packages/core/scripts/lib/contrast-proposer.js`) the agent shells into, giving
+the heuristic fixture-test coverage. Out of scope for v1.
+
+## Procedure
+
+### 1. Run the audit
+
+```bash
+yarn audit:contrast
+```
+
+Capture stdout and exit code.
+
+### 2. Exit code 0 — clean
+
+Parse the footer (`Checked N pairs — P passed, 0 failed.`) and report:
+
+```
+✓ Contrast clean — N pairs passed
+```
+
+Stop.
+
+### 3. Exit code ≠ 0 — discriminate
+
+| Condition                      | Meaning                                                           | Action                                 |
+| ------------------------------ | ----------------------------------------------------------------- | -------------------------------------- |
+| stdout contains any ` ✗` lines | Contrast failures                                                 | Continue to step 4                     |
+| stdout has **zero** ` ✗` lines | Structural error (script threw on missing token / unresolved ref) | Surface stdout + stderr verbatim, stop |
+
+Anchor the structural-error path on the **line-count check**, not stderr regex
+matching — Node wraps thrown messages with an `Error:` prefix that defeats
+naïve `audit-contrast: …` matching.
+
+### 4. Parse with streaming-header tracking
+
+Initialize `activeHeader = null`. Walk stdout line by line.
+
+**Section-header lines** match `^─── (.+) ───$`. Two forms:
+
+| Form                                       | Example                                                    | Meaning                                                                                     |
+| ------------------------------------------ | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Single-file (no `↔` in captured text)      | `─── base-slate-light.json ───`                            | Both fg and bg live in this file                                                            |
+| Cross-file (contains `↔` in captured text) | `─── base-slate-light.json ↔ focus-default-light.json ───` | **bg-file first, fg-file second** (per `auditCrossFileLoop` at `audit-contrast.js:271-303`) |
+
+Update `activeHeader` whenever a header line is seen. **The active header
+applies to every subsequent `✗` line until the next header** — track it across
+the entire output.
+
+**Failure lines** (from `formatLine` at `audit-contrast.js:230`) follow this
+layout:
+
+```
+  ✗ {fg} ↔ {bg}                                  Lc  -45.3   FAIL (< 75, body)
+```
+
+Two leading spaces, `✗`, fg token, `↔`, bg token, padded to 48 chars total
+label width, then `Lc` + padded six-char Lc value, then `   FAIL (< {minLc},
+{tier})`.
+
+**The sign of Lc encodes luminance order:** `Lc > 0` means fg is darker than
+bg; `Lc < 0` means fg is lighter than bg. This is what picks reroute direction
+in step 6 — the agent does not need to compute L deltas itself.
+
+### 5. Filename → path mapping
+
+From the active header, resolve which JSON file holds the fg token:
+
+| Filename pattern                                           | Path                                     |
+| ---------------------------------------------------------- | ---------------------------------------- |
+| `base-{slate,neutral,gray,stone,zinc}-{light,dark}.json`   | `packages/core/tokens/semantic/`         |
+| `brands-{blue,gray,neutral,slate,stone}-{light,dark}.json` | `packages/core/tokens/semantic/`         |
+| `chart-categorical-default-{light,dark}.json`              | `packages/core/tokens/semantic/`         |
+| `focus-default-{light,dark}.json`                          | `packages/core/tokens/primitives/focus/` |
+
+For cross-file headers, the **fg-file** (second filename, after `↔`) is what
+gets resolved here. The bg-file is named only to label the section; the bg
+token's value is read from the same fg-file the audit is testing against.
+
+**If no pattern hits, hard-fail** with the section header verbatim — don't
+guess paths.
+
+**Use the Read tool for these JSON files, never `Bash + cat`.** The project's
+`PreToolUse` hook at `.claude/settings.json` blocks bash commands containing
+the substring `token`; many of these paths include the word, so shelling out
+via `cat tokens/...` will be blocked. Read sidesteps the regex.
+
+### 6. Resolve and propose per failure
+
+Open the resolved file. Read the fg token's `$value`. Classify into one of four
+cases.
+
+#### Case A — ref to a palette shade
+
+E.g. `$value: "{slate.500}"`. Look up the current L from
+`packages/core/src/lib/perceptual-grid.json` — the grid is **palette-uniform**:
+`PERCEPTUAL_L_GRID[shade]` returns the same L for every palette. The L lookup
+is **informational** (shown in the output for context); the sign rule alone
+picks direction.
+
+Propose stepping one shade using the **luminance-order rule**:
+
+| Lc sign  | Luminance order    | Reroute direction                              |
+| -------- | ------------------ | ---------------------------------------------- |
+| `Lc > 0` | fg darker than bg  | Step fg darker (higher shade number, lower L)  |
+| `Lc < 0` | fg lighter than bg | Step fg lighter (lower shade number, higher L) |
+
+Then run the **role-conflict check**:
+
+1. Grep `.claude/rules/color-shades.md` for the row starting with `` | `{N}` ``
+   where `{N}` is the proposed shade.
+2. Split the row by `|`. Pick the column matching the failing file's theme
+   suffix:
+   - `*-light.json` → `Light-mode use` column
+   - `*-dark.json` → `Dark-mode use` column
+3. Treat italicised `_(rarely used)_` as **no documented conflict** — do not
+   surface as a clash.
+4. If the column lists a role for that shade, add a one-line **Notes** entry:
+   `role collision ({theme}): reserved for {role}`. Don't refuse the suggestion
+   — surface the tradeoff so the human can choose.
+
+#### Case B — ref to a leaf primitive (`{white}` or `{black}`)
+
+Shade-step doesn't apply. Propose either:
+
+- **(a)** re-point fg to a tinted shade from the same palette family
+  (`{slate.50}` for light-on-dark; `{slate.900}` for dark-on-light), or
+- **(b)** move the bg side instead.
+
+Call this case out explicitly in the **Proposed reroute** column. Do not paper
+over with a fake shade-step.
+
+#### Case C — focus primitive (literal hex)
+
+The fg lives in `packages/core/tokens/primitives/focus/focus-default-{theme}.json`
+with shape:
+
+```json
+{
+  "color": {
+    "default": { "$value": "#1e3a8a", "$type": "color" },
+    "error": { "$value": "#7f1d1d", "$type": "color" }
+  }
+}
+```
+
+Read `data.color.default.$value` for `color.default` pair failures and
+`data.color.error.$value` for `color.error` failures. **Display the actual
+current hex** in the table so the user has the anchor for retuning.
+
+Output the **target L value** the new hex must land at (one grid row from
+current in the contrast-increasing direction, with the relevant `bg` L for
+context). Point at the file. **Do not propose a specific hex** — picking a hex
+at a target L is colour-theory better left to the designer or the
+`figma-use` workflow.
+
+#### Case D — chart-categorical pair
+
+The failing fg is one of `chart.categorical.{1..5}`, each referencing a
+**different palette per series** for hue rotation (teal → lime → orange →
+rose → indigo, per `tokens.md § Data viz tokens`).
+
+Naïve shade-stepping risks degrading the categorical rotation: stepping
+`{teal.700}` darker may push its perceived weight too close to a neighbouring
+series. Propose **two options in the Notes column**:
+
+- **(i)** step within the same palette: `{teal.700}` → `{teal.800}`, with a
+  caveat about hue proximity.
+- **(ii)** consider swapping this series' palette — see hue rotation in
+  `tokens.md § Data viz tokens`.
+
+Do not propose option (i) silently; surface the trade-off.
+
+### 7. Render
+
+Use this exact column schema:
+
+```markdown
+## Contrast failures — {N} pairs
+
+| File                                                         | Pair                                    | Lc    | Threshold       | Current (fg)          | Proposed reroute                              | Notes                                                 |
+| ------------------------------------------------------------ | --------------------------------------- | ----- | --------------- | --------------------- | --------------------------------------------- | ----------------------------------------------------- |
+| base-slate-light.json                                        | foreground ↔ background                 | 42.1  | 75 (body)       | {slate.900} (L 0.207) | {slate.950} (L 0.118)                         | role collision (light): reserved for chrome           |
+| brands-blue-dark.json                                        | primary.foreground ↔ primary.background | -52.0 | 60 (ui)         | {white}               | (case B) move bg or tint fg                   | fg is leaf primitive — no shade-step                  |
+| base-slate-light.json ↔ focus-default-light.json             | color.default ↔ background              | 38.0  | 45 (incidental) | #1e3a8a               | target L ≈ 0.385 (grid row 700)               | edit primitives/focus/focus-default-light.json hex    |
+| base-slate-light.json ↔ chart-categorical-default-light.json | chart.categorical.3 ↔ container         | 56.0  | 60 (ui)         | {orange.700}          | (i) step to {orange.800} or (ii) swap palette | case D — verify hue rotation per tokens.md § Data viz |
+
+Light-mode failures may have dark-mode counterparts — verify `base-{palette}-dark.json` and `brands-{brand}-dark.json` after applying any fix.
+```
+
+If a light-mode pair fails, include the dark-counterpart hint in the footer.
+**Do not pre-compute the counterpart's proposal** — verification is the user's
+job after they apply the fix (the counterpart may actually pass).
+
+### 8. Close with the verification reminder
+
+> After applying any reroute, re-run `yarn audit:contrast`. The script is the
+> gate; this proposal is a candidate, not a guaranteed fix. **Thresholds are
+> non-negotiable** per `.claude/rules/tokens.md` § APCA contrast gate — fix is
+> always token reroute or `perceptual-grid.json` edit, never lowering `minLc`.
+
+## When NOT to invoke this agent
+
+- The user wants to **change a threshold** (e.g. "should `muted-foreground` be
+  Lc ≥ 60 instead of 45?"). That's a design discussion, not this agent. Edit
+  `audit-contrast.js`'s `BASE_PAIRS` / `BRAND_PAIRS` / `FOCUS_PAIRS` directly
+  after the discussion.
+- The user wants to **refresh the Figma snapshot**. That's `audit:figma-parity`,
+  a different flow.
+- The user wants the agent to **apply the reroute itself**. Out of scope — the
+  agent proposes, the human merges. No Edit/Write tool is available.
+
+## Example invocations
+
+| User prompt                                                       | Agent action                                                                                         |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| "audit contrast"                                                  | Run, parse, render table (or `✓ Contrast clean` if green)                                            |
+| "why is `primary.foreground` failing APCA?"                       | Run, filter failures involving `primary.foreground`, render                                          |
+| "which shade should `muted-foreground` reroute to?"               | Run, focus on `muted-foreground ↔ muted` failures across base palettes, propose per-palette reroutes |
+| (post-edit auto-invocation) "I just edited base-slate-light.json" | Run, render any new failures with proposed reroutes                                                  |
+
+## See also
+
+- `packages/core/scripts/audit-contrast.js` — the script (`formatLine` at line
+  230 is the parser's source of truth; `auditCrossFileLoop` at lines 271-303
+  is the cross-file header convention)
+- `.claude/rules/tokens.md` § APCA contrast gate — threshold tiers and the
+  non-negotiability rule; § Data viz tokens — hue rotation rationale for Case D
+- `.claude/rules/color-shades.md` — shade-by-shade role grid (light vs dark
+  column per theme)
+- `.claude/rules/surfaces.md` — the 5-level surface contract that constrains
+  where each shade can sit
+- `packages/core/src/lib/perceptual-grid.json` — the 11-step palette-uniform
+  L grid

--- a/.claude/agents/contrast-auditor.md
+++ b/.claude/agents/contrast-auditor.md
@@ -23,9 +23,14 @@ LLM reasoning. The audit script is testable and byte-stable. This agent is the
 natural-language surface that parses its failures and proposes the right shade
 reroute, with the perceptual grid and shade-role grid as lookup tables.
 
+The textual contract between script and agent is pinned by
+`packages/core/scripts/__tests__/audit-contrast.test.js`, which snapshots
+`formatLine`'s pass and fail outputs so any layout drift breaks CI before it
+breaks the parser.
+
 A future v1.1 may extract parse + propose into a Node module
-(`packages/core/scripts/lib/contrast-proposer.js`) the agent shells into, giving
-the heuristic fixture-test coverage. Out of scope for v1.
+(`packages/core/scripts/lib/contrast-proposer.js`) the agent shells into,
+giving the heuristic itself fixture-test coverage. Out of scope for v1.
 
 ## Procedure
 
@@ -60,7 +65,9 @@ naïve `audit-contrast: …` matching.
 
 ### 4. Parse with streaming-header tracking
 
-Initialize `activeHeader = null`. Walk stdout line by line.
+Initialize `activeHeader = null`. Walk stdout line by line, skipping blank
+lines — the script emits one between section blocks (`audit-contrast.js:390`,
+`output.push('')`).
 
 **Section-header lines** match `^─── (.+) ───$`. Two forms:
 
@@ -86,7 +93,10 @@ label width, then `Lc` + padded six-char Lc value, then `   FAIL (< {minLc},
 
 **The sign of Lc encodes luminance order:** `Lc > 0` means fg is darker than
 bg; `Lc < 0` means fg is lighter than bg. This is what picks reroute direction
-in step 6 — the agent does not need to compute L deltas itself.
+in step 6 — the agent does not need to compute L deltas itself. **Apply the
+sign rule only after classifying the failure as Case A** (shade-steppable fg);
+Cases B/C/D route around it (B has no shade scale; C tunes a hex at a target
+L; D may swap palettes for hue rotation).
 
 ### 5. Filename → path mapping
 
@@ -100,16 +110,18 @@ From the active header, resolve which JSON file holds the fg token:
 | `focus-default-{light,dark}.json`                          | `packages/core/tokens/primitives/focus/` |
 
 For cross-file headers, the **fg-file** (second filename, after `↔`) is what
-gets resolved here. The bg-file is named only to label the section; the bg
-token's value is read from the same fg-file the audit is testing against.
+gets resolved here. The script opens the bg-file itself
+(`auditPairs(fgData, bgData, …)` at `audit-contrast.js:239`); the agent
+opens only the fg-file because it proposes fg-side reroutes — bg shades stay
+fixed as the surface contract the fg must clear.
 
 **If no pattern hits, hard-fail** with the section header verbatim — don't
 guess paths.
 
 **Use the Read tool for these JSON files, never `Bash + cat`.** The project's
-`PreToolUse` hook at `.claude/settings.json` blocks bash commands containing
-the substring `token`; many of these paths include the word, so shelling out
-via `cat tokens/...` will be blocked. Read sidesteps the regex.
+`PermissionRequest` hook at `.claude/settings.json` blocks bash commands
+containing the substring `token`; many of these paths include the word, so
+shelling out via `cat tokens/...` will be blocked. Read sidesteps the regex.
 
 ### 6. Resolve and propose per failure
 
@@ -139,8 +151,11 @@ Then run the **role-conflict check**:
    suffix:
    - `*-light.json` → `Light-mode use` column
    - `*-dark.json` → `Dark-mode use` column
-3. Treat italicised `_(rarely used)_` as **no documented conflict** — do not
-   surface as a clash.
+3. Treat any italicised cell — leading `_(` and trailing `)_` — as **no
+   documented conflict** and do not surface as a clash. This covers the full
+   no-role family in `color-shades.md`: `_(rarely used)_` (shades 200/300
+   dark), `_(rarely used — too close to white...)_` (shade 100 dark), and
+   `_(anchor — rarely surfaced...)_` (shade 500 dark).
 4. If the column lists a role for that shade, add a one-line **Notes** entry:
    `role collision ({theme}): reserved for {role}`. Don't refuse the suggestion
    — surface the tradeoff so the human can choose.
@@ -185,6 +200,11 @@ at a target L is colour-theory better left to the designer or the
 The failing fg is one of `chart.categorical.{1..5}`, each referencing a
 **different palette per series** for hue rotation (teal → lime → orange →
 rose → indigo, per `tokens.md § Data viz tokens`).
+
+**Skip the role-conflict check for Case D.** `color-shades.md` covers
+slate/neutral/gray/stone/zinc only; the chart palettes (teal/lime/orange/
+rose/indigo) have no rows there, so the grep would silently no-op and add
+nothing.
 
 Naïve shade-stepping risks degrading the categorical rotation: stepping
 `{teal.700}` darker may push its perceived weight too close to a neighbouring

--- a/.claude/agents/contrast-auditor.md
+++ b/.claude/agents/contrast-auditor.md
@@ -156,8 +156,8 @@ Then run the **role-conflict check**:
    - `*-dark.json` → `Dark-mode use` column
 3. Treat any italicised cell — leading `_(` and trailing `)_` — as **no
    documented conflict** and do not surface as a clash. This covers the full
-   no-role family in `color-shades.md`: `_(rarely used)_` (shades 200/300
-   dark), `_(rarely used — too close to white...)_` (shade 100 dark), and
+   no-role family in `color-shades.md`: `_(rarely used)_` (shade 200 dark),
+   `_(rarely used — too close to white...)_` (shade 100 dark), and
    `_(anchor — rarely surfaced...)_` (shade 500 dark).
 4. If the column lists a role for that shade, add a one-line **Notes** entry:
    `role collision ({theme}): reserved for {role}`. Don't refuse the suggestion

--- a/packages/core/scripts/__tests__/audit-contrast.test.js
+++ b/packages/core/scripts/__tests__/audit-contrast.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatLine } from '../audit-contrast.js';
+
+// Pins the textual contract `contrast-auditor` agent's parser relies on:
+// 2-space prefix + mark + label padded to 48 + ` Lc ` + 6-char Lc + tail.
+// Drift here silently breaks the agent — see .claude/agents/contrast-auditor.md
+// § 4 "Parse with streaming-header tracking" for the exact layout.
+describe('formatLine', () => {
+  it('snapshots the FAIL line layout', () => {
+    expect(
+      formatLine(false, 'foreground ↔ background', -45.3, 75, 'body')
+    ).toMatchInlineSnapshot(
+      `"  ✗ foreground ↔ background                          Lc  -45.3   FAIL (< 75, body)"`
+    );
+  });
+
+  it('snapshots the pass line layout', () => {
+    expect(
+      formatLine(true, 'muted-foreground ↔ muted', 52.1, 45, 'incidental')
+    ).toMatchInlineSnapshot(
+      `"  ✓ muted-foreground ↔ muted                         Lc   52.1   (≥ 45, incidental)"`
+    );
+  });
+
+  it('preserves the 2-space prefix, label region, and Lc anchor', () => {
+    const line = formatLine(false, 'a ↔ b', -10, 60, 'ui');
+    expect(line.startsWith('  ✗ ')).toBe(true);
+    // `  ${mark} ` (4 chars) + label.padEnd(48) + ` Lc ` → ' Lc ' at index 52
+    expect(line.indexOf(' Lc ')).toBe(52);
+    expect(line).toContain('FAIL (< 60, ui)');
+  });
+});

--- a/packages/core/scripts/audit-contrast.js
+++ b/packages/core/scripts/audit-contrast.js
@@ -227,7 +227,7 @@ function computeLc(textInts, bgInts) {
   return typeof lc === 'number' ? lc : Number(lc);
 }
 
-function formatLine(passed, label, lc, minLc, tier) {
+export function formatLine(passed, label, lc, minLc, tier) {
   const mark = passed ? '✓' : '✗';
   const lcStr = lc.toFixed(1).padStart(6);
   const tail = passed
@@ -402,4 +402,7 @@ function main() {
   process.exit(failCount === 0 ? 0 : 1);
 }
 
-main();
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  main();
+}


### PR DESCRIPTION
## Summary

Adds `.claude/agents/contrast-auditor.md` — a Claude Code subagent wrapping `yarn audit:contrast`. Parses APCA failures from `formatLine`'s stdout, looks up the current shade reference per failing semantic token, and proposes the minimum reroute candidate with role-conflict cross-references from `.claude/rules/color-shades.md`. The script stays the gate; the agent's proposal is always a candidate the user verifies by re-running the audit.

- **Streaming header tracker** — the active `─── … ───` section header applies to every subsequent `✗` line until the next header; handles single-file (`base-slate-light.json`) and cross-file (`base-slate-light.json ↔ focus-default-light.json`) forms.
- **Lc-sign rule** — `Lc > 0` (fg darker than bg) → step fg darker (higher shade); `Lc < 0` (fg lighter than bg) → step fg lighter (lower shade). The palette-uniform L grid is informational; the sign rule alone picks direction.
- **Four reroute cases:**
  - **A** — palette-shade ref (`{slate.500}`) → one-shade step
  - **B** — leaf primitive (`{white}` / `{black}`) → re-point to tinted shade or move bg side
  - **C** — focus primitive (literal hex) → target L from grid; designer picks the new hex
  - **D** — chart-categorical → both step-within-palette and palette-swap options, surfacing the hue-rotation tradeoff per `tokens.md § Data viz`
- **Role-conflict check** — grep `color-shades.md` for the proposed shade's row, read the theme-matching column, surface collisions in the Notes column (advisory, not blocking).
- **Structural-error discriminator** — anchored on exit ≠ 0 + zero `✗` lines in stdout, not stderr regex (Node wraps thrown messages with `Error:` prefix).
- **`Bash`/`Read`/`Grep` only** — no Edit/Write, per acceptance criteria. Agent proposes, human merges.

Mirrors the just-shipped `storybook-coverage-reviewer` pattern: thin natural-language surface over a deterministic Node script.

## GitHub Issue

Closes #74

## Test Plan

- [x] `yarn audit:contrast` exits 0 on this branch (`Checked 440 pairs — 440 passed, 0 failed.`)
- [x] `yarn prettier --check .claude/agents/contrast-auditor.md` passes
- [ ] Manually invoke the agent ("audit contrast") on a green tree — confirm it reports `✓ Contrast clean — 440 pairs passed`
- [ ] Force a failure (e.g., temporarily edit `base-slate-light.json` to point `foreground` at `{slate.50}`), invoke the agent, confirm the markdown table renders correctly with the Lc-sign-driven reroute proposal and role-conflict note
- [ ] Revert the forced failure; confirm green again

## Council-tracked v1.1 follow-ups (out of scope)

- Fixture test pinning `formatLine`'s output contract (sibling pattern: `audit-storybook-coverage.test.js`)
- Proposer-as-library refactor (`packages/core/scripts/lib/contrast-proposer.js` + agent shells in via `node -e`) — revisit if regex parsing proves brittle in practice