### PR TITLE
fix(storybook): apply .dark to <html> so portaled components theme in dark mode

### DIFF
--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -1,6 +1,25 @@
-import type { Preview } from '@storybook/react-vite';
+import { useEffect } from 'react';
+
+import type { Decorator, Preview } from '@storybook/react-vite';
 
 import '../src/index.css';
+
+const ThemeDecorator: Decorator = (Story, context) => {
+  const theme = context.globals.theme;
+  const isDocs = context.viewMode === 'docs';
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+  }, [theme]);
+
+  return (
+    <div
+      className={`nx:flex nx:items-center nx:justify-center nx:bg-background nx:text-foreground ${isDocs ? 'nx:py-12' : 'nx:min-h-screen'}`}
+    >
+      <Story />
+    </div>
+  );
+};
 
 const preview: Preview = {
   // Enable autodocs for all stories globally
@@ -62,19 +81,7 @@ const preview: Preview = {
       },
     },
   },
-  decorators: [
-    (Story, context) => {
-      const theme = context.globals.theme;
-      const isDocs = context.viewMode === 'docs';
-      return (
-        <div
-          className={`nx:flex nx:items-center nx:justify-center nx:bg-background nx:text-foreground ${theme === 'dark' ? 'dark' : ''} ${isDocs ? 'nx:py-12' : 'nx:min-h-screen'}`}
-        >
-          <Story />
-        </div>
-      );
-    },
-  ],
+  decorators: [ThemeDecorator],
 };
 
 export default preview;


### PR DESCRIPTION
## Summary

- Move `.dark` from the Storybook decorator's wrapper `<div>` to `document.documentElement` via `useEffect`.
- Radix portals (Dialog, DropdownMenu, Select, Tooltip — current and future) render to `document.body`, outside the wrapper, so they previously ignored the toolbar dark toggle and resolved light tokens in dark mode. With `.dark` on `<html>`, portal subtrees inherit the theme through the normal cascade.
- Decorator extracted to a named `ThemeDecorator: Decorator` so `react-hooks/rules-of-hooks` (configured as `error` in `eslint.config.js`) recognizes the call site as a component.
- `useEffect` is the right escape hatch per `.claude/rules/useeffect-escape-hatch.md` — it syncs an external system (the DOM outside React's tree), not React state.

## GitHub Issue

Closes #137

## Why not `useLayoutEffect`

`useEffect` runs after first paint, so a returning user with `dark` selected will see one frame of light theme before the effect snaps `<html>` to dark on initial load. Acceptable trade-off: `useLayoutEffect` would prevent the flash but blocks paint and adds an SSR-warning footgun (irrelevant for Storybook today, but a maintenance trap). The toolbar-toggle case has no flash either way. If FOUC becomes a complaint, swap in a follow-up.

## What stays unchanged

- Wrapper `nx:bg-background` / `nx:text-foreground` still resolve in both themes — they read `var(--nx-color-*)` which cascades from `<html>`.
- Generated base-variants stories are unaffected: each cell sets `[data-nexus-base="X"]{…}` and `[data-nexus-base="X"].dark{…}` directly on the cell, so CSS variable closest-ancestor inheritance wins regardless of what `<html>` defines.
- `Shadow.Dark` (the only story with per-story `globals: { theme: 'dark' }`) renders dark as before; navigating to a light story flips `<html>` back via the next decorator render.

## Test Plan

- [x] `yarn workspace @nexus/react typecheck` — clean
- [x] `yarn lint` — clean (`eslint . --max-warnings 0` from root)
- [ ] Manual: `Components/Dialog → Default` → toolbar `Dark` → overlay + content render dark
- [ ] Manual: toolbar `Light` → unchanged
- [ ] Manual: docs page (autodocs) → theming still works across multiple stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)