### PR TITLE
feat(tokens): author 7 per-mode semantic spacing files

### DIFF
--- a/packages/core/tokens/semantic/spacing-luma.json
+++ b/packages/core/tokens/semantic/spacing-luma.json
@@ -1,0 +1,352 @@
+{
+  "spacing": {
+    "0": {
+      "$value": {
+        "value": 0,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "1": {
+      "$value": {
+        "value": 4,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "2": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "3": {
+      "$value": {
+        "value": 12,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "4": {
+      "$value": {
+        "value": 16,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "5": {
+      "$value": {
+        "value": 20,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "6": {
+      "$value": {
+        "value": 24,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "7": {
+      "$value": {
+        "value": 28,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "8": {
+      "$value": {
+        "value": 32,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "9": {
+      "$value": {
+        "value": 36,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "10": {
+      "$value": {
+        "value": 40,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "11": {
+      "$value": {
+        "value": 44,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "12": {
+      "$value": {
+        "value": 48,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "14": {
+      "$value": {
+        "value": 56,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "16": {
+      "$value": {
+        "value": 64,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "20": {
+      "$value": {
+        "value": 80,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "24": {
+      "$value": {
+        "value": 96,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "28": {
+      "$value": {
+        "value": 112,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "32": {
+      "$value": {
+        "value": 128,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "36": {
+      "$value": {
+        "value": 144,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "40": {
+      "$value": {
+        "value": 160,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "44": {
+      "$value": {
+        "value": 176,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "48": {
+      "$value": {
+        "value": 192,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "52": {
+      "$value": {
+        "value": 208,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "56": {
+      "$value": {
+        "value": 224,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "60": {
+      "$value": {
+        "value": 240,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "64": {
+      "$value": {
+        "value": 256,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "72": {
+      "$value": {
+        "value": 288,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "80": {
+      "$value": {
+        "value": 320,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "96": {
+      "$value": {
+        "value": 384,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "0_5": {
+      "$value": {
+        "value": 2,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "1_5": {
+      "$value": {
+        "value": 6,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "2_5": {
+      "$value": {
+        "value": 10,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "3_5": {
+      "$value": {
+        "value": 14,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "control": {
+    "h": {
+      "sm": {
+        "$value": {
+          "value": 32,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 36,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 44,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "padding-x": {
+      "sm": {
+        "$value": {
+          "value": 14,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 20,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 36,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "padding-y": {
+      "sm": {
+        "$value": {
+          "value": 8,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 10,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 14,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "gap": {
+      "$value": {
+        "value": 10,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "container": {
+    "p": {
+      "$value": {
+        "value": 28,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "gap": {
+      "$value": {
+        "value": 20,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "layout": {
+    "section-gap": {
+      "$value": {
+        "value": 40,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "stack-gap": {
+      "$value": {
+        "value": 10,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  }
+}

--- a/packages/core/tokens/semantic/spacing-luma.json
+++ b/packages/core/tokens/semantic/spacing-luma.json
@@ -243,21 +243,21 @@
     "h": {
       "sm": {
         "$value": {
-          "value": 32,
+          "value": 28,
           "unit": "px"
         },
         "$type": "dimension"
       },
       "md": {
         "$value": {
-          "value": 36,
+          "value": 32,
           "unit": "px"
         },
         "$type": "dimension"
       },
       "lg": {
         "$value": {
-          "value": 44,
+          "value": 40,
           "unit": "px"
         },
         "$type": "dimension"
@@ -266,21 +266,21 @@
     "padding-x": {
       "sm": {
         "$value": {
-          "value": 14,
+          "value": 12,
           "unit": "px"
         },
         "$type": "dimension"
       },
       "md": {
         "$value": {
-          "value": 20,
+          "value": 16,
           "unit": "px"
         },
         "$type": "dimension"
       },
       "lg": {
         "$value": {
-          "value": 36,
+          "value": 32,
           "unit": "px"
         },
         "$type": "dimension"
@@ -289,21 +289,21 @@
     "padding-y": {
       "sm": {
         "$value": {
-          "value": 8,
+          "value": 6,
           "unit": "px"
         },
         "$type": "dimension"
       },
       "md": {
         "$value": {
-          "value": 10,
+          "value": 8,
           "unit": "px"
         },
         "$type": "dimension"
       },
       "lg": {
         "$value": {
-          "value": 14,
+          "value": 12,
           "unit": "px"
         },
         "$type": "dimension"
@@ -311,7 +311,7 @@
     },
     "gap": {
       "$value": {
-        "value": 10,
+        "value": 8,
         "unit": "px"
       },
       "$type": "dimension"

--- a/packages/core/tokens/semantic/spacing-lyra.json
+++ b/packages/core/tokens/semantic/spacing-lyra.json
@@ -1,0 +1,352 @@
+{
+  "spacing": {
+    "0": {
+      "$value": {
+        "value": 0,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "1": {
+      "$value": {
+        "value": 4,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "2": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "3": {
+      "$value": {
+        "value": 12,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "4": {
+      "$value": {
+        "value": 16,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "5": {
+      "$value": {
+        "value": 20,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "6": {
+      "$value": {
+        "value": 24,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "7": {
+      "$value": {
+        "value": 30,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "8": {
+      "$value": {
+        "value": 32,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "9": {
+      "$value": {
+        "value": 36,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "10": {
+      "$value": {
+        "value": 42,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "11": {
+      "$value": {
+        "value": 48,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "12": {
+      "$value": {
+        "value": 48,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "14": {
+      "$value": {
+        "value": 60,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "16": {
+      "$value": {
+        "value": 64,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "20": {
+      "$value": {
+        "value": 80,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "24": {
+      "$value": {
+        "value": 96,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "28": {
+      "$value": {
+        "value": 120,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "32": {
+      "$value": {
+        "value": 128,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "36": {
+      "$value": {
+        "value": 144,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "40": {
+      "$value": {
+        "value": 160,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "44": {
+      "$value": {
+        "value": 180,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "48": {
+      "$value": {
+        "value": 192,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "52": {
+      "$value": {
+        "value": 210,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "56": {
+      "$value": {
+        "value": 224,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "60": {
+      "$value": {
+        "value": 240,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "64": {
+      "$value": {
+        "value": 256,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "72": {
+      "$value": {
+        "value": 288,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "80": {
+      "$value": {
+        "value": 320,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "96": {
+      "$value": {
+        "value": 384,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "0_5": {
+      "$value": {
+        "value": 2,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "1_5": {
+      "$value": {
+        "value": 6,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "2_5": {
+      "$value": {
+        "value": 10,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "3_5": {
+      "$value": {
+        "value": 15,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "control": {
+    "h": {
+      "sm": {
+        "$value": {
+          "value": 28,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 32,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 40,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "padding-x": {
+      "sm": {
+        "$value": {
+          "value": 12,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 16,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 32,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "padding-y": {
+      "sm": {
+        "$value": {
+          "value": 6,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 8,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 12,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "gap": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "container": {
+    "p": {
+      "$value": {
+        "value": 24,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "gap": {
+      "$value": {
+        "value": 16,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "layout": {
+    "section-gap": {
+      "$value": {
+        "value": 32,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "stack-gap": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  }
+}

--- a/packages/core/tokens/semantic/spacing-maia.json
+++ b/packages/core/tokens/semantic/spacing-maia.json
@@ -1,0 +1,352 @@
+{
+  "spacing": {
+    "0": {
+      "$value": {
+        "value": 0,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "1": {
+      "$value": {
+        "value": 4,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "2": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "3": {
+      "$value": {
+        "value": 14,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "4": {
+      "$value": {
+        "value": 18,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "5": {
+      "$value": {
+        "value": 22,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "6": {
+      "$value": {
+        "value": 28,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "7": {
+      "$value": {
+        "value": 32,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "8": {
+      "$value": {
+        "value": 36,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "9": {
+      "$value": {
+        "value": 40,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "10": {
+      "$value": {
+        "value": 44,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "11": {
+      "$value": {
+        "value": 48,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "12": {
+      "$value": {
+        "value": 52,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "14": {
+      "$value": {
+        "value": 60,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "16": {
+      "$value": {
+        "value": 68,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "20": {
+      "$value": {
+        "value": 84,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "24": {
+      "$value": {
+        "value": 100,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "28": {
+      "$value": {
+        "value": 116,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "32": {
+      "$value": {
+        "value": 132,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "36": {
+      "$value": {
+        "value": 148,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "40": {
+      "$value": {
+        "value": 164,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "44": {
+      "$value": {
+        "value": 180,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "48": {
+      "$value": {
+        "value": 196,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "52": {
+      "$value": {
+        "value": 212,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "56": {
+      "$value": {
+        "value": 228,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "60": {
+      "$value": {
+        "value": 244,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "64": {
+      "$value": {
+        "value": 260,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "72": {
+      "$value": {
+        "value": 292,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "80": {
+      "$value": {
+        "value": 324,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "96": {
+      "$value": {
+        "value": 388,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "0_5": {
+      "$value": {
+        "value": 2,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "1_5": {
+      "$value": {
+        "value": 6,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "2_5": {
+      "$value": {
+        "value": 11,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "3_5": {
+      "$value": {
+        "value": 16,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "control": {
+    "h": {
+      "sm": {
+        "$value": {
+          "value": 32,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 36,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 44,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "padding-x": {
+      "sm": {
+        "$value": {
+          "value": 14,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 20,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 36,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "padding-y": {
+      "sm": {
+        "$value": {
+          "value": 8,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 10,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 14,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "gap": {
+      "$value": {
+        "value": 10,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "container": {
+    "p": {
+      "$value": {
+        "value": 28,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "gap": {
+      "$value": {
+        "value": 20,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "layout": {
+    "section-gap": {
+      "$value": {
+        "value": 40,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "stack-gap": {
+      "$value": {
+        "value": 10,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  }
+}

--- a/packages/core/tokens/semantic/spacing-mira.json
+++ b/packages/core/tokens/semantic/spacing-mira.json
@@ -1,0 +1,352 @@
+{
+  "spacing": {
+    "0": {
+      "$value": {
+        "value": 0,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "1": {
+      "$value": {
+        "value": 4,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "2": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "3": {
+      "$value": {
+        "value": 12,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "4": {
+      "$value": {
+        "value": 16,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "5": {
+      "$value": {
+        "value": 20,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "6": {
+      "$value": {
+        "value": 24,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "7": {
+      "$value": {
+        "value": 28,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "8": {
+      "$value": {
+        "value": 32,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "9": {
+      "$value": {
+        "value": 36,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "10": {
+      "$value": {
+        "value": 40,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "11": {
+      "$value": {
+        "value": 44,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "12": {
+      "$value": {
+        "value": 48,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "14": {
+      "$value": {
+        "value": 56,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "16": {
+      "$value": {
+        "value": 64,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "20": {
+      "$value": {
+        "value": 80,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "24": {
+      "$value": {
+        "value": 96,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "28": {
+      "$value": {
+        "value": 112,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "32": {
+      "$value": {
+        "value": 128,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "36": {
+      "$value": {
+        "value": 144,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "40": {
+      "$value": {
+        "value": 160,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "44": {
+      "$value": {
+        "value": 176,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "48": {
+      "$value": {
+        "value": 192,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "52": {
+      "$value": {
+        "value": 208,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "56": {
+      "$value": {
+        "value": 224,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "60": {
+      "$value": {
+        "value": 240,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "64": {
+      "$value": {
+        "value": 256,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "72": {
+      "$value": {
+        "value": 288,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "80": {
+      "$value": {
+        "value": 320,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "96": {
+      "$value": {
+        "value": 384,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "0_5": {
+      "$value": {
+        "value": 2,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "1_5": {
+      "$value": {
+        "value": 6,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "2_5": {
+      "$value": {
+        "value": 10,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "3_5": {
+      "$value": {
+        "value": 14,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "control": {
+    "h": {
+      "sm": {
+        "$value": {
+          "value": 28,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 32,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 40,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "padding-x": {
+      "sm": {
+        "$value": {
+          "value": 12,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 16,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 32,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "padding-y": {
+      "sm": {
+        "$value": {
+          "value": 6,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 8,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 12,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "gap": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "container": {
+    "p": {
+      "$value": {
+        "value": 24,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "gap": {
+      "$value": {
+        "value": 16,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "layout": {
+    "section-gap": {
+      "$value": {
+        "value": 32,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "stack-gap": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  }
+}

--- a/packages/core/tokens/semantic/spacing-nova.json
+++ b/packages/core/tokens/semantic/spacing-nova.json
@@ -1,0 +1,352 @@
+{
+  "spacing": {
+    "0": {
+      "$value": {
+        "value": 0,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "1": {
+      "$value": {
+        "value": 4,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "2": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "3": {
+      "$value": {
+        "value": 10,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "4": {
+      "$value": {
+        "value": 14,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "5": {
+      "$value": {
+        "value": 18,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "6": {
+      "$value": {
+        "value": 22,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "7": {
+      "$value": {
+        "value": 26,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "8": {
+      "$value": {
+        "value": 30,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "9": {
+      "$value": {
+        "value": 34,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "10": {
+      "$value": {
+        "value": 38,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "11": {
+      "$value": {
+        "value": 42,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "12": {
+      "$value": {
+        "value": 46,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "14": {
+      "$value": {
+        "value": 52,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "16": {
+      "$value": {
+        "value": 60,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "20": {
+      "$value": {
+        "value": 76,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "24": {
+      "$value": {
+        "value": 92,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "28": {
+      "$value": {
+        "value": 108,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "32": {
+      "$value": {
+        "value": 124,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "36": {
+      "$value": {
+        "value": 140,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "40": {
+      "$value": {
+        "value": 156,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "44": {
+      "$value": {
+        "value": 172,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "48": {
+      "$value": {
+        "value": 188,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "52": {
+      "$value": {
+        "value": 204,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "56": {
+      "$value": {
+        "value": 220,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "60": {
+      "$value": {
+        "value": 236,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "64": {
+      "$value": {
+        "value": 252,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "72": {
+      "$value": {
+        "value": 284,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "80": {
+      "$value": {
+        "value": 316,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "96": {
+      "$value": {
+        "value": 380,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "0_5": {
+      "$value": {
+        "value": 2,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "1_5": {
+      "$value": {
+        "value": 6,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "2_5": {
+      "$value": {
+        "value": 9,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "3_5": {
+      "$value": {
+        "value": 12,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "control": {
+    "h": {
+      "sm": {
+        "$value": {
+          "value": 24,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 28,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 36,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "padding-x": {
+      "sm": {
+        "$value": {
+          "value": 10,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 12,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 28,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "padding-y": {
+      "sm": {
+        "$value": {
+          "value": 4,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 6,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 10,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "gap": {
+      "$value": {
+        "value": 6,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "container": {
+    "p": {
+      "$value": {
+        "value": 20,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "gap": {
+      "$value": {
+        "value": 12,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "layout": {
+    "section-gap": {
+      "$value": {
+        "value": 28,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "stack-gap": {
+      "$value": {
+        "value": 6,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  }
+}

--- a/packages/core/tokens/semantic/spacing-sera.json
+++ b/packages/core/tokens/semantic/spacing-sera.json
@@ -1,0 +1,352 @@
+{
+  "spacing": {
+    "0": {
+      "$value": {
+        "value": 0,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "1": {
+      "$value": {
+        "value": 4,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "2": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "3": {
+      "$value": {
+        "value": 12,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "4": {
+      "$value": {
+        "value": 16,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "5": {
+      "$value": {
+        "value": 20,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "6": {
+      "$value": {
+        "value": 24,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "7": {
+      "$value": {
+        "value": 28,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "8": {
+      "$value": {
+        "value": 32,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "9": {
+      "$value": {
+        "value": 36,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "10": {
+      "$value": {
+        "value": 40,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "11": {
+      "$value": {
+        "value": 44,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "12": {
+      "$value": {
+        "value": 48,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "14": {
+      "$value": {
+        "value": 56,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "16": {
+      "$value": {
+        "value": 64,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "20": {
+      "$value": {
+        "value": 80,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "24": {
+      "$value": {
+        "value": 96,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "28": {
+      "$value": {
+        "value": 112,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "32": {
+      "$value": {
+        "value": 128,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "36": {
+      "$value": {
+        "value": 144,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "40": {
+      "$value": {
+        "value": 160,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "44": {
+      "$value": {
+        "value": 176,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "48": {
+      "$value": {
+        "value": 192,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "52": {
+      "$value": {
+        "value": 208,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "56": {
+      "$value": {
+        "value": 224,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "60": {
+      "$value": {
+        "value": 240,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "64": {
+      "$value": {
+        "value": 256,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "72": {
+      "$value": {
+        "value": 288,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "80": {
+      "$value": {
+        "value": 320,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "96": {
+      "$value": {
+        "value": 384,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "0_5": {
+      "$value": {
+        "value": 2,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "1_5": {
+      "$value": {
+        "value": 6,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "2_5": {
+      "$value": {
+        "value": 10,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "3_5": {
+      "$value": {
+        "value": 14,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "control": {
+    "h": {
+      "sm": {
+        "$value": {
+          "value": 36,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 44,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 56,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "padding-x": {
+      "sm": {
+        "$value": {
+          "value": 16,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 24,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 40,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "padding-y": {
+      "sm": {
+        "$value": {
+          "value": 10,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 12,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 16,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "gap": {
+      "$value": {
+        "value": 12,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "container": {
+    "p": {
+      "$value": {
+        "value": 40,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "gap": {
+      "$value": {
+        "value": 24,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "layout": {
+    "section-gap": {
+      "$value": {
+        "value": 56,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "stack-gap": {
+      "$value": {
+        "value": 16,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  }
+}

--- a/packages/core/tokens/semantic/spacing-vega.json
+++ b/packages/core/tokens/semantic/spacing-vega.json
@@ -1,0 +1,352 @@
+{
+  "spacing": {
+    "0": {
+      "$value": {
+        "value": 0,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "1": {
+      "$value": {
+        "value": 4,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "2": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "3": {
+      "$value": {
+        "value": 12,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "4": {
+      "$value": {
+        "value": 16,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "5": {
+      "$value": {
+        "value": 20,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "6": {
+      "$value": {
+        "value": 24,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "7": {
+      "$value": {
+        "value": 28,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "8": {
+      "$value": {
+        "value": 32,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "9": {
+      "$value": {
+        "value": 36,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "10": {
+      "$value": {
+        "value": 40,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "11": {
+      "$value": {
+        "value": 44,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "12": {
+      "$value": {
+        "value": 48,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "14": {
+      "$value": {
+        "value": 56,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "16": {
+      "$value": {
+        "value": 64,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "20": {
+      "$value": {
+        "value": 80,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "24": {
+      "$value": {
+        "value": 96,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "28": {
+      "$value": {
+        "value": 112,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "32": {
+      "$value": {
+        "value": 128,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "36": {
+      "$value": {
+        "value": 144,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "40": {
+      "$value": {
+        "value": 160,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "44": {
+      "$value": {
+        "value": 176,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "48": {
+      "$value": {
+        "value": 192,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "52": {
+      "$value": {
+        "value": 208,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "56": {
+      "$value": {
+        "value": 224,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "60": {
+      "$value": {
+        "value": 240,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "64": {
+      "$value": {
+        "value": 256,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "72": {
+      "$value": {
+        "value": 288,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "80": {
+      "$value": {
+        "value": 320,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "96": {
+      "$value": {
+        "value": 384,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "0_5": {
+      "$value": {
+        "value": 2,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "1_5": {
+      "$value": {
+        "value": 6,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "2_5": {
+      "$value": {
+        "value": 10,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "3_5": {
+      "$value": {
+        "value": 14,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "control": {
+    "h": {
+      "sm": {
+        "$value": {
+          "value": 28,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 32,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 40,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "padding-x": {
+      "sm": {
+        "$value": {
+          "value": 12,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 16,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 32,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "padding-y": {
+      "sm": {
+        "$value": {
+          "value": 6,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "md": {
+        "$value": {
+          "value": 8,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 12,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
+    },
+    "gap": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "container": {
+    "p": {
+      "$value": {
+        "value": 24,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "gap": {
+      "$value": {
+        "value": 16,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  },
+  "layout": {
+    "section-gap": {
+      "$value": {
+        "value": 32,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    },
+    "stack-gap": {
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      },
+      "$type": "dimension"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Creates the 7 per-mode semantic spacing files at `packages/core/tokens/semantic/spacing-{vega,lyra,maia,mira,nova,luma,sera}.json`. Each file owns 48 keys (34 numeric + 14 role) with **direct px values** in DTCG object-form dimensions — no `{N}` references.

- **5 existing modes** (Vega/Lyra/Maia/Mira/Nova): numeric scale preserved 1:1 from `packages/core/tokens/primitives/size/size-{mode}.json` for pixel-identity. Mira numeric = Vega (current primitives are byte-identical). Role values: Vega derived from current `button.tsx` / `card.tsx` / `dialog.tsx` utility classes; per-mode variance Maia +2 to +4 / Nova −2 to −4 / Lyra = Mira = Vega.
- **2 new modes** (Luma/Sera): proposed defaults, designer to validate. Numeric scale = Vega's (avoids canonical-step-set collisions in the high range; designer can refine numeric scale later). Luma roles = "Vega controls + Maia containers/layout" (compact controls, breathing room between sections — distinct from both Vega and Maia at the role-profile level); Sera roles = Vega +4 to +24 (substantially more spacious).
- All 98 role values across 7 modes land in the canonical step set.
- Files are **dormant** — the build still reads `semantic/spacing.json`. `collectSpacingTokens()` switch is owned by #119.

JSON structure puts `control` / `container` / `layout` at the JSON top level (no `space/` wrapper) so emission lands at `--control-h-sm`, `--container-p`, `--layout-section-gap` — matching the issue's "no `--space-` prefix" requirement.

### Vega role baseline

| Role | Vega px | Source |
|------|---------|--------|
| `control-h-{sm,md,lg}` | 28 / 32 / 40 | derived from Button padding + line-height |
| `control-padding-x-{sm,md,lg}` | 12 / 16 / 32 | Button `nx:px-{3,4,8}` |
| `control-padding-y-{sm,md,lg}` | 6 / 8 / 12 | Button `nx:py-{1.5,2,3}` |
| `control-gap` | 8 | Button base `nx:gap-2` |
| `container-p` | 24 | Card / Dialog `nx:p-6` |
| `container-gap` | 16 | Dialog `nx:gap-4` |
| `layout-section-gap` | 32 | industry standard |
| `layout-stack-gap` | 8 | industry standard |

### Luma vs Maia (post-review)

Initial draft had Luma's 14 role values byte-identical to Maia's. Revised so Luma's profile is "Vega controls + Maia containers/layout":

| Role | Vega | Maia | Luma |
|------|------|------|------|
| `control-h-{sm,md,lg}` | 28 / 32 / 40 | 32 / 36 / 44 | **28 / 32 / 40** (Vega) |
| `control-padding-x-{sm,md,lg}` | 12 / 16 / 32 | 14 / 20 / 36 | **12 / 16 / 32** (Vega) |
| `control-padding-y-{sm,md,lg}` | 6 / 8 / 12 | 8 / 10 / 14 | **6 / 8 / 12** (Vega) |
| `control-gap` | 8 | 10 | **8** (Vega) |
| `container-p` | 24 | 28 | **28** (Maia) |
| `container-gap` | 16 | 20 | **20** (Maia) |
| `layout-section-gap` | 32 | 40 | **40** (Maia) |
| `layout-stack-gap` | 8 | 10 | **10** (Maia) |

Luma differs from Maia in 10 of 14 roles. Designer will refine further if the "compact controls, breathing layout" archetype isn't the desired Luma identity.

## GitHub Issue

Closes #118

## Test Plan

- [x] All 7 files have identical 48-key sets — verified with a leaf-walker mirroring `extractTokens()` from `scripts/utils.js`
- [x] Pixel-identity for all 5 existing modes vs `primitives/size/size-{mode}.json` (34 keys × 5 modes verified)
- [x] DTCG dimension shape valid across all 7 files (every leaf is `{value: number, unit: "px"}` + `$type: "dimension"`)
- [x] All 14 role tokens per mode in the canonical step set
- [x] Luma role profile distinct from Maia (`cmp` confirms; 10 of 14 roles differ)
- [x] Prettier clean
- [x] Existing `yarn workspace @nexus/core build:tailwind` still produces the same output — new files are dormant until #119

## Notes & Open Items

- **Canonical-step-set tension acknowledged**: the 5 existing modes' numeric scales carry pre-existing off-canonical values (Vega 176/208/240/288; Nova 9/10/14/18/...; Maia 11/14/18/22/...; Lyra 30/42/48-dup/60/180/210/15). Preserved verbatim to satisfy "pixel-identical" + "values match current primitive files" acceptance criteria. The eventual `spacing-tokens.md` reconciliation (allow-list / softened prose) is owned by #125; the #127 lint allow-list is derivable from the shipped data when #127 is authored.
- **Lyra `spacing-11 == spacing-12 == 48px` collision** is pre-existing in `size-lyra.json` and is preserved.
- **Luma/Sera numeric = Vega numeric** is a deliberate choice — distinct numeric scales for new modes that snap to canonical would cause collisions in the high range. Density differentiation lives in role tokens, which means consumers writing raw numeric utilities (`nx:p-6`) in Mira/Luma/Sera get the same value as Vega; density only fires through role tokens (`nx:p-container`, `nx:px-control`). This contract is the spec #127 lint will codify when authored.
- **JSON format = object dimension (`{value, unit}`)** to match all existing DTCG dimension primitives in the repo (size, radius, borderwidth, breakpoints, focus). The rule's example uses string form for readability; both parse correctly via `formatTokenValue` so either would work — picked object for consistency.
- **Sera role-delta range** is +4 to +24 (e.g., `padding-y` +4, `layout.section-gap` +24), not +6 to +16 as an earlier draft stated.
- **Utility-naming for `nx:px-control-md`** (architect's forward-compat concern): the emitted variable from `control.padding-x.md` is `--control-padding-x-md`, not in Tailwind's `--padding-x-*` namespace. The mapping to `nx:px-control-md` is owned by #119 (per its spec: "Register the new role-named tokens in `@theme` so Tailwind generates utilities (`nx:h-control-md`, `nx:px-control-md`, …) automatically"). #119 will land either flattened CSS variable names or custom `@utility` declarations; the JSON shape here is dormant data until that decision lands and can be reshaped if needed.

Unblocks #119 / #121 / #126 / #127 / #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)