### PR TITLE
feat(playground): demo spacing role utilities

### DIFF
--- a/apps/playground/src/components/ComponentShowcase.tsx
+++ b/apps/playground/src/components/ComponentShowcase.tsx
@@ -1,4 +1,5 @@
 import { IconShowcase } from './IconShowcase';
+import { PlaygroundIcon } from './PlaygroundIcon';
 
 // Reusable section component
 function Section({
@@ -221,6 +222,90 @@ export function ComponentShowcase() {
             <SpacingBar name="10" className="nx:w-10" />
             <SpacingBar name="12" className="nx:w-12" />
             <SpacingBar name="16" className="nx:w-16" />
+          </div>
+        </Section>
+
+        {/* Role Utilities Section */}
+        <Section
+          title="Role Utilities"
+          description="Per-mode tokens that drive component-internal spacing — switch the Spacing axis to see them flex"
+        >
+          <div className="nx:space-y-6">
+            {/* Controls */}
+            <div className="nx:space-y-2">
+              <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+                Controls — h-control-*, px-control-*, py-control-*, gap-control
+              </span>
+              <div className="nx:flex nx:flex-wrap nx:items-center nx:gap-3">
+                <button className="nx:inline-flex nx:items-center nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:text-sm nx:font-medium nx:h-control-sm nx:px-control-sm nx:py-control-sm nx:gap-control">
+                  <PlaygroundIcon name="search" size={14} />
+                  <span>Small</span>
+                </button>
+                <button className="nx:inline-flex nx:items-center nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:text-sm nx:font-medium nx:h-control-md nx:px-control-md nx:py-control-md nx:gap-control">
+                  <PlaygroundIcon name="check" size={14} />
+                  <span>Medium</span>
+                </button>
+                <button className="nx:inline-flex nx:items-center nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:text-sm nx:font-medium nx:h-control-lg nx:px-control-lg nx:py-control-lg nx:gap-control">
+                  <PlaygroundIcon name="chevron-down" size={16} />
+                  <span>Large</span>
+                </button>
+              </div>
+            </div>
+
+            {/* Container */}
+            <div className="nx:space-y-2">
+              <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+                Container — p-container, gap-container
+              </span>
+              <div className="nx:bg-container nx:border nx:border-border-default nx:rounded-lg nx:flex nx:flex-col nx:p-container nx:gap-container">
+                <h4 className="nx:text-foreground nx:font-medium">
+                  Card header
+                </h4>
+                <p className="nx:text-sm nx:text-muted-foreground">
+                  Card body — interior padding and the gap between siblings both
+                  scale with the active Spacing mode.
+                </p>
+                <div className="nx:flex nx:flex-wrap nx:gap-2">
+                  <button className="nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:px-3 nx:py-1.5 nx:text-sm nx:font-medium">
+                    Confirm
+                  </button>
+                  <button className="nx:border nx:border-border-default nx:bg-background nx:rounded-md nx:px-3 nx:py-1.5 nx:text-sm nx:font-medium">
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {/* Layout */}
+            <div className="nx:space-y-2">
+              <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+                Layout — gap-layout-section, gap-layout-stack
+              </span>
+              <div className="nx:flex nx:flex-col nx:gap-layout-section nx:bg-muted nx:rounded-lg nx:p-4">
+                <div className="nx:flex nx:flex-col nx:gap-layout-stack">
+                  <span className="nx:text-xs nx:font-semibold nx:text-foreground">
+                    Section A
+                  </span>
+                  <span className="nx:text-sm nx:text-muted-foreground">
+                    Stack item one
+                  </span>
+                  <span className="nx:text-sm nx:text-muted-foreground">
+                    Stack item two
+                  </span>
+                </div>
+                <div className="nx:flex nx:flex-col nx:gap-layout-stack">
+                  <span className="nx:text-xs nx:font-semibold nx:text-foreground">
+                    Section B
+                  </span>
+                  <span className="nx:text-sm nx:text-muted-foreground">
+                    Stack item one
+                  </span>
+                  <span className="nx:text-sm nx:text-muted-foreground">
+                    Stack item two
+                  </span>
+                </div>
+              </div>
+            </div>
           </div>
         </Section>
 

--- a/apps/playground/src/components/ComponentShowcase.tsx
+++ b/apps/playground/src/components/ComponentShowcase.tsx
@@ -282,28 +282,22 @@ export function ComponentShowcase() {
                 Layout — gap-layout-section, gap-layout-stack
               </span>
               <div className="nx:flex nx:flex-col nx:gap-layout-section nx:bg-muted nx:rounded-lg nx:p-4">
-                <div className="nx:flex nx:flex-col nx:gap-layout-stack">
-                  <span className="nx:text-xs nx:font-semibold nx:text-foreground">
-                    Section A
-                  </span>
-                  <span className="nx:text-sm nx:text-muted-foreground">
-                    Stack item one
-                  </span>
-                  <span className="nx:text-sm nx:text-muted-foreground">
-                    Stack item two
-                  </span>
-                </div>
-                <div className="nx:flex nx:flex-col nx:gap-layout-stack">
-                  <span className="nx:text-xs nx:font-semibold nx:text-foreground">
-                    Section B
-                  </span>
-                  <span className="nx:text-sm nx:text-muted-foreground">
-                    Stack item one
-                  </span>
-                  <span className="nx:text-sm nx:text-muted-foreground">
-                    Stack item two
-                  </span>
-                </div>
+                {['Section A', 'Section B'].map((label) => (
+                  <div
+                    key={label}
+                    className="nx:flex nx:flex-col nx:gap-layout-stack"
+                  >
+                    <span className="nx:text-xs nx:font-semibold nx:text-foreground">
+                      {label}
+                    </span>
+                    <span className="nx:text-sm nx:text-muted-foreground">
+                      Stack item one
+                    </span>
+                    <span className="nx:text-sm nx:text-muted-foreground">
+                      Stack item two
+                    </span>
+                  </div>
+                ))}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Adds a **Role Utilities** section to `apps/playground/src/components/ComponentShowcase.tsx` between Spacing Scale and Icons, with three subsections — Controls / Container / Layout — that collectively reference all 14 spacing role utilities (`nx:h-control-{sm,md,lg}`, `nx:px-control-{sm,md,lg}`, `nx:py-control-{sm,md,lg}`, `nx:gap-control`, `nx:p-container`, `nx:gap-container`, `nx:gap-layout-{section,stack}`).
- This is the first source-side use of these utilities anywhere in the repo. Pre-change, Tailwind v4 was tree-shaking the `@utility` declarations in `spacing-utilities.css` because nothing in source referenced them; the built bundle had **zero** matches for any role utility name. Post-change, all 14 class selectors are emitted (CSS bundle: 63.37KB → 64.49KB).
- Each subsection follows the role-to-component-coupling table in `.claude/rules/spacing-tokens.md` exactly. Controls use `h-control-* + px-control-* + py-control-* + gap-control` on three `inline-flex` primary buttons with icons sized (14/14/16) to fit the 16px content area produced by `border-box + height + padding-y`. Container is a flex-column card using `p-container + gap-container`. Layout is two `flex-column` groups separated by `gap-layout-section`, each containing items separated by `gap-layout-stack`.
- Negative verification: no `nx:w-container-*` / `nx:h-control-h-*` smear utilities emitted — PR #224's deliberate `@theme` exclusion of role tokens still holds.

## GitHub Issue

Closes #120

## Test Plan

Build-time gates (all clean):

- [x] `npx eslint apps/playground/src/components/ComponentShowcase.tsx --max-warnings 0`
- [x] `yarn workspace @nexus/playground typecheck`
- [x] `yarn workspace @nexus/playground build`
- [x] Positive grep — 14/14 role utility class selectors emitted in `dist/assets/*.css`
- [x] Negative grep — 0 token-name smears (no `nx:w-container`, `nx:h-control-h`, etc.)
- [x] `yarn lint` (full repo)

Runtime gates (Playwright MCP driving Chromium against `yarn dev` on `localhost:5173`):

- [x] Computed-style readout matches per-mode JSON byte-for-byte for all 7 modes (vega / lyra / mira / nova / maia / luma / sera)
- [x] Lyra ≡ Mira ≡ Vega empirically confirmed at every measured property (intentional per #127)
- [x] Switching the Spacing dropdown from Vega → Sera flips `<html data-style>` and computed styles update through the cascade with no page reload
- [x] Dark-mode toggle coexists with `data-style` — colors swap, spacing axis untouched (button height stays 32px, container padding stays 24px)
- [x] Base palette swap (slate → stone) preserves spacing — only hue shifts

Full verification log with the per-mode computed-style table: https://github.com/nexuslabs-ai/nexus/issues/120#issuecomment-4546710975

## Notes

- **Scope alignment with #120 AC.** PR #224 already shipped the literal AC of #120 (`useTheme.ts` data-style switch, `SPACING_MODES` 7-mode list, removal of `size-*.css`) — its body called the remainder *"playground deeper integration"*. This PR is that follow-through: making the 14 role utilities visible/emitted and proving the cascade end-to-end.
- **Does NOT pre-claim #123 work.** Issue #123 migrates the actual `<Button>` CVA variants in `packages/react/src/components/ui/button.tsx` and adds a per-row `data-style` `AllModes` Storybook story. This PR touches only `apps/playground/` and uses raw `<button>` HTML; `Button.tsx` and `Button.stories.tsx` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)