### PR TITLE
chore(tokens): scrub residual size-primitive references

### DIFF
--- a/.claude/rules/figma.md
+++ b/.claude/rules/figma.md
@@ -74,7 +74,7 @@ The snapshot JSON nests by mode so a single capture covers every mode the design
 | Multi-mode    | `--category spacing --mode vega`              | `semantic/spacing-vega.json`               | `snapshot.spacing.vega`      |
 | Mode × theme  | `--category shadow --mode vega --theme light` | `primitives/shadow/shadow-vega-light.json` | `snapshot.shadow.vega.light` |
 
-Each category subtree carries a `$meta` block — at minimum `capturedAt` (ISO date) and `figmaFileName`. The `$`-prefix is DTCG metadata and is skipped by the token walker, so it never appears as a drift finding. For multi-mode categories the `$meta` lives under the mode (e.g., `snapshot.size.vega.$meta`) so each capture timestamps independently.
+Each category subtree carries a `$meta` block — at minimum `capturedAt` (ISO date) and `figmaFileName`. The `$`-prefix is DTCG metadata and is skipped by the token walker, so it never appears as a drift finding. For multi-mode categories the `$meta` lives under the mode (e.g., `snapshot.spacing.vega.$meta`) so each capture timestamps independently.
 
 This is the intended shape for #61/#62/#63 — only the single-mode (color) row is wired today. Each sub-issue PR adds its category to the registry, wires the path resolver for its row's shape, and (for multi-mode) starts reading `args.mode` (and `args.theme` for shadow). The snapshot/CLI shape itself doesn't change between PRs.
 

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -264,6 +264,7 @@ describe('generateTailwindPackage', () => {
     // indicate the deletion was incomplete or the build regressed.
     expect(variablesCSS).not.toMatch(/--nx-size-/);
     expect(nexusCSS).not.toMatch(/--nx-size-/);
+    expect(spacingUtilitiesCSS).not.toMatch(/--nx-size-/);
   });
 
   it('preserves the --spacing-*: initial reset in @theme', () => {

--- a/packages/core/scripts/generate-modular.js
+++ b/packages/core/scripts/generate-modular.js
@@ -74,7 +74,7 @@ function processSinglePrimitive(category, primitiveMap) {
 }
 
 /**
- * Process a primitive category file (size, typography, shadow, radius,
+ * Process a primitive category file (focus, typography, shadow, radius,
  * borderwidth). Throws if the file does not exist.
  */
 function processPrimitiveFile(category, mode, primitiveMap) {
@@ -144,7 +144,7 @@ function generatePrimitivesCSS(distDir, tokens, category) {
 }
 
 /**
- * Generate mode file (size, typography, shadow, radius, borderwidth)
+ * Generate mode file (typography, radius, borderwidth)
  */
 function generateModeCSS(distDir, category, mode, tokens) {
   let css = `/* ${category}: ${mode} */\n\n:root {\n`;

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -142,7 +142,7 @@ export function pathToCssVar(tokenPath, prefix = null) {
  * Convert token path to CSS variable name with optional nx- prefix
  * Used for generating prefixed CSS variables for @nexus/tailwind package
  * @param {string[]} tokenPath - Token path array
- * @param {string|null} categoryPrefix - Optional category prefix (e.g., 'color', 'size')
+ * @param {string|null} categoryPrefix - Optional category prefix (e.g., 'color', 'radius')
  * @param {boolean} useNxPrefix - Whether to add nx- prefix
  * @returns {string} CSS variable name (without --)
  */


### PR DESCRIPTION
## Summary

PR #224 (the [3/12] build switch) absorbed the bulk of #121's work per the no-follow-up-deferral rule: file deletions, the `--size=vega` flag removal, the `DEFAULT_CONFIG.size` removal, the primary regression guard, and most documentation updates. This PR completes the final residue — 4 stale comments + 1 test tightening that PR #224 missed.

- **`.claude/rules/figma.md:77`** — example sentence still referenced the deleted `size` category. The categories table and snapshot-shape table earlier in the file were already updated to `spacing` by PR #224; this brings the example in line.
- **`packages/core/scripts/utils.js:145`** — JSDoc example `(e.g., 'color', 'size')` cited the dead category. Replaced with `'radius'` (single-segment, real primitive category, parallel to what `'size'` used to demonstrate). `'spacing'` would have been misleading since `pathToCssVarPrefixed` never receives `spacing` as a `categoryPrefix` — spacing has no primitive layer and emits unprefixed.
- **`packages/core/scripts/generate-modular.js:77`** — `processPrimitiveFile`'s doc lists categories it processes. Drops stale `size`; also adds missing `focus` (the function is called for `focus` and `shadow` via `generateThemedPrimitiveCSS` at lines 195-205, but the comment omitted it). Final list: `(focus, typography, shadow, radius, borderwidth)`.
- **`packages/core/scripts/generate-modular.js:147`** — `generateModeCSS`'s doc lists categories it processes. Drops stale `size`; also drops `shadow` (shadow modes are all `{name}-light`/`{name}-dark` pairs and route through `generateThemedPrimitiveCSS`, not `generateModeCSS`, which only runs on the `plain` partition). Final list: `(typography, radius, borderwidth)`.
- **`packages/core/scripts/__tests__/generate-tailwind-package.test.js:260`** — Extends the existing `--nx-size-*` regression guard to also assert against `spacing-utilities.css`. The fixture (`spacingUtilitiesCSS`) was already loaded in the test's `beforeAll` but was not referenced in the assertion — defense-in-depth that documents the contract for future migrations.

## GitHub Issue

Closes #121

## Test Plan

Verified locally with the CI `audit-tokens` job equivalents plus standard gates:

- [x] `yarn tokens:tailwind` exits 0
- [x] `yarn tokens:modular` exits 0 (no `packages/core/package.json` drift on this run)
- [x] `yarn workspace @nexus/core generate:colorblind-svg` exits 0
- [x] Freshness check: `git status --porcelain -- packages/tailwind apps/playground/public/themes apps/playground/src/styles packages/core/docs/color-math-colorblind.svg` returns empty
- [x] `yarn workspace @nexus/core audit:contrast` — 440/440 pairs passed
- [x] `yarn workspace @nexus/core audit:colorblind` — 0 findings (14 palettes × 11 shades × 3 deficiencies)
- [x] `yarn workspace @nexus/core audit:class-refs` — 69 files scanned, all semantic refs resolve
- [x] `yarn workspace @nexus/core audit:figma-parity --category color` — 0 drift
- [x] `yarn build` — 4 tasks successful
- [x] `yarn typecheck` — 5 workspaces, no errors
- [x] `yarn lint` — 0 warnings (`--max-warnings 0`)
- [x] `yarn test` — 545/545 tests pass across 53 files