### PR TITLE
chore(build): address #224 post-merge review findings

### DIFF
--- a/.claude/rules/spacing-tokens.md
+++ b/.claude/rules/spacing-tokens.md
@@ -51,33 +51,48 @@ Every mode file MUST contain the same set of keys — enforced by JSON schema va
 ```json
 {
   "spacing": {
-    "0": { "$value": "0px", "$type": "dimension" },
-    "0_5": { "$value": "2px", "$type": "dimension" },
-    "1": { "$value": "4px", "$type": "dimension" },
-    "2": { "$value": "8px", "$type": "dimension" },
-    "3": { "$value": "12px", "$type": "dimension" },
+    "0": { "$value": { "value": 0, "unit": "px" }, "$type": "dimension" },
+    "1": { "$value": { "value": 4, "unit": "px" }, "$type": "dimension" },
+    "2": { "$value": { "value": 8, "unit": "px" }, "$type": "dimension" },
     "...": "...",
-    "96": { "$value": "384px", "$type": "dimension" }
+    "96": { "$value": { "value": 384, "unit": "px" }, "$type": "dimension" }
   },
-  "space": {
-    "control": {
-      "h-sm": { "$value": "32px", "$type": "dimension" },
-      "h-md": { "$value": "36px", "$type": "dimension" },
-      "h-lg": { "$value": "40px", "$type": "dimension" },
-      "px": { "$value": "10px", "$type": "dimension" },
-      "gap": { "$value": "4px", "$type": "dimension" }
+  "control": {
+    "h": {
+      "sm": { "$value": { "value": 28, "unit": "px" }, "$type": "dimension" },
+      "md": { "$value": { "value": 32, "unit": "px" }, "$type": "dimension" },
+      "lg": { "$value": { "value": 40, "unit": "px" }, "$type": "dimension" }
     },
-    "container": {
-      "p": { "$value": "24px", "$type": "dimension" },
-      "header-py": { "$value": "24px", "$type": "dimension" }
+    "padding-x": {
+      "sm": { "$value": { "value": 12, "unit": "px" }, "$type": "dimension" },
+      "md": { "$value": { "value": 16, "unit": "px" }, "$type": "dimension" },
+      "lg": { "$value": { "value": 32, "unit": "px" }, "$type": "dimension" }
     },
-    "section-gap": { "$value": "32px", "$type": "dimension" },
-    "stack-gap": { "$value": "8px", "$type": "dimension" },
-    "page-gutter": { "$value": "24px", "$type": "dimension" },
-    "inline-gap": { "$value": "8px", "$type": "dimension" }
+    "padding-y": {
+      "sm": { "$value": { "value": 6, "unit": "px" }, "$type": "dimension" },
+      "md": { "$value": { "value": 8, "unit": "px" }, "$type": "dimension" },
+      "lg": { "$value": { "value": 12, "unit": "px" }, "$type": "dimension" }
+    },
+    "gap": { "$value": { "value": 8, "unit": "px" }, "$type": "dimension" }
+  },
+  "container": {
+    "p": { "$value": { "value": 24, "unit": "px" }, "$type": "dimension" },
+    "gap": { "$value": { "value": 16, "unit": "px" }, "$type": "dimension" }
+  },
+  "layout": {
+    "section-gap": {
+      "$value": { "value": 32, "unit": "px" },
+      "$type": "dimension"
+    },
+    "stack-gap": {
+      "$value": { "value": 8, "unit": "px" },
+      "$type": "dimension"
+    }
   }
 }
 ```
+
+Top-level keys are `spacing` (numeric scale), `control`, `container`, `layout` — flat siblings, no enclosing wrapper. `$value` is a DTCG `{ value, unit }` dimension object.
 
 ### Emitted CSS
 
@@ -108,6 +123,12 @@ The build emits one CSS block per mode, all in a single bundle:
 ```
 
 Mode swap = change the `data-style` attribute on `<html>` (or any subtree). CSS variable cascade handles the rest. No rebuild.
+
+### The `data-style` attribute carries spacing density only
+
+`data-style` is the spacing-density attribute. It carries one value at a time (`vega`, `lyra`, `maia`, `mira`, `nova`, `luma`, `sera`) and resolves only the `--nx-spacing-*` / `--nx-control-*` / `--nx-container-*` / `--nx-layout-*` overrides.
+
+If a future per-mode semantic category lands (per-mode color shading, per-mode shadow, etc.), it ships its **own** attribute name (e.g., `data-shadow-mode`, `data-color-density`). `data-style` does not multiplex — the contract is one attribute per per-mode axis, so consumers can compose densities independently (`<div data-style="mira" data-shadow-mode="vega">`) without one attribute meaning two things.
 
 ## The canonical step set
 

--- a/.claude/rules/spacing-tokens.md
+++ b/.claude/rules/spacing-tokens.md
@@ -103,23 +103,22 @@ The build emits one CSS block per mode, all in a single bundle:
 ```css
 :root,
 [data-style='vega'] {
-  --spacing-0: 0px;
-  --spacing-1: 4px;
-  --spacing-2: 8px;
+  --nx-spacing-0: 0px;
+  --nx-spacing-1: 4px;
+  --nx-spacing-2: 8px;
   /* ... */
-  --control-h-md: 36px;
-  --control-padding-x-md: 12px;
-  --control-padding-y-md: 8px;
+  --nx-control-h-md: 32px;
+  --nx-control-padding-x-md: 16px;
+  --nx-control-padding-y-md: 8px;
   /* ... */
 }
 
 [data-style='mira'] {
-  --spacing-1: 3px;
-  --spacing-2: 6px;
+  --nx-spacing-2: 6px;
   /* ... */
-  --control-h-md: 28px;
-  --control-padding-x-md: 8px;
-  --control-padding-y-md: 6px;
+  --nx-control-h-md: 28px;
+  --nx-control-padding-x-md: 12px;
+  --nx-control-padding-y-md: 6px;
   /* ... */
 }
 ```

--- a/.claude/rules/spacing-tokens.md
+++ b/.claude/rules/spacing-tokens.md
@@ -113,8 +113,8 @@ The build emits one CSS block per mode, all in a single bundle:
   /* ... */
 }
 
-[data-style='mira'] {
-  --nx-spacing-2: 6px;
+[data-style='nova'] {
+  --nx-spacing-3: 10px;
   /* ... */
   --nx-control-h-md: 28px;
   --nx-control-padding-x-md: 12px;

--- a/.claude/rules/spacing-tokens.md
+++ b/.claude/rules/spacing-tokens.md
@@ -52,7 +52,9 @@ Every mode file MUST contain the same set of keys — enforced by JSON schema va
 {
   "spacing": {
     "0": { "$value": { "value": 0, "unit": "px" }, "$type": "dimension" },
+    "0_5": { "$value": { "value": 2, "unit": "px" }, "$type": "dimension" },
     "1": { "$value": { "value": 4, "unit": "px" }, "$type": "dimension" },
+    "1_5": { "$value": { "value": 6, "unit": "px" }, "$type": "dimension" },
     "2": { "$value": { "value": 8, "unit": "px" }, "$type": "dimension" },
     "...": "...",
     "96": { "$value": { "value": 384, "unit": "px" }, "$type": "dimension" }

--- a/.claude/rules/tokens.md
+++ b/.claude/rules/tokens.md
@@ -286,7 +286,7 @@ Available options:
 - **Radius**: blunt, sharp, subtle, smooth, mellow
 - **Border Width**: vega, lyra, maia, mira, nova
 
-> **Spacing isn't a CLI flag.** Spacing ships all 7 modes (vega, lyra, maia, mira, nova, luma, sera) in every build; mode swap is via the `data-style="X"` attribute on `<html>` (or any subtree) at runtime — no flag, no rebuild. See `spacing-tokens.md`.
+> **Spacing isn't a per-mode CLI flag.** All 7 modes (vega, lyra, maia, mira, nova, luma, sera) ship in every build — there's no single-mode build. Mode swap is via the `data-style="X"` attribute on `<html>` (or any subtree) at runtime, no rebuild needed. `--spacingDefault=<mode>` is the one related CLI option: it only picks which mode lands under the `:root` cascade default (so a document with no `data-style` attribute resolves to that mode); the other six still emit their `[data-style="X"]` blocks alongside. See `spacing-tokens.md`.
 
 > **Mode distinctness varies by axis.** A mode listed above means the CLI flag is accepted — not that it resolves to unique values. `shadow` is genuinely distinct across all five modes. `typography` ships only three (`nova` / `vega` / `maia`); its `lyra` / `mira` were byte-identical to `vega` and removed. `borderwidth` still exposes five flags, but several are byte-identical copies of `vega` (`borderwidth-lyra` = `borderwidth-mira` = `borderwidth-vega`) — the flag resolves, it just yields the same tokens. Don't read a surviving `lyra` / `mira` flag as a distinct design on every axis.
 

--- a/apps/playground/src/components/ThemeSwitcher.tsx
+++ b/apps/playground/src/components/ThemeSwitcher.tsx
@@ -1,4 +1,12 @@
-import type { ThemeConfig } from '../hooks/useTheme';
+import {
+  BASES,
+  BRANDS,
+  RADIUS_MODES,
+  SPACING_MODES,
+  type ThemeConfig,
+  TOKEN_MODES,
+  TYPOGRAPHY_MODES,
+} from '../hooks/useTheme';
 import {
   type IconLibrary,
   iconLibraryMeta,
@@ -7,39 +15,6 @@ import {
 
 import { PlaygroundIcon } from './PlaygroundIcon';
 
-// Theme options with metadata
-const BASES = [
-  { value: 'slate', label: 'Slate', color: '#64748b' },
-  { value: 'neutral', label: 'Neutral', color: '#737373' },
-  { value: 'zinc', label: 'Zinc', color: '#71717a' },
-  { value: 'gray', label: 'Gray', color: '#6b7280' },
-  { value: 'stone', label: 'Stone', color: '#78716c' },
-] as const;
-
-const BRANDS = [
-  { value: 'blue', label: 'Blue', color: '#3b82f6' },
-  { value: 'gray', label: 'Gray', color: '#6b7280' },
-  { value: 'neutral', label: 'Neutral', color: '#737373' },
-  { value: 'slate', label: 'Slate', color: '#64748b' },
-  { value: 'stone', label: 'Stone', color: '#78716c' },
-] as const;
-
-const TOKEN_MODES = ['vega', 'lyra', 'maia', 'mira', 'nova'] as const;
-// Spacing grew to 7 modes in #119 (luma + sera authored in #118). Mode swap is
-// via the `data-style` attribute on <html>, not a CSS file load.
-const SPACING_MODES = [
-  'vega',
-  'lyra',
-  'maia',
-  'mira',
-  'nova',
-  'luma',
-  'sera',
-] as const;
-// Typography dropped its byte-duplicate lyra/mira modes (PR #157); their theme
-// CSS no longer exists, so the Typography select offers only the 3 real modes.
-const TYPOGRAPHY_MODES = ['nova', 'vega', 'maia'] as const;
-const RADIUS_MODES = ['blunt', 'sharp', 'subtle', 'smooth', 'mellow'] as const;
 const ICON_LIBRARIES = ['tabler', 'lucide', 'phosphor'] as const;
 
 const DEFAULT_THEME: ThemeConfig = {
@@ -76,7 +51,7 @@ function Section({
   );
 }
 
-function ColorSelect({
+function ColorSelect<TValue extends string>({
   id,
   label,
   value,
@@ -85,9 +60,9 @@ function ColorSelect({
 }: {
   id: string;
   label: string;
-  value: string;
-  options: readonly { value: string; label: string; color: string }[];
-  onChange: (value: string) => void;
+  value: TValue;
+  options: readonly { value: TValue; label: string; color: string }[];
+  onChange: (value: TValue) => void;
 }) {
   const selected = options.find((o) => o.value === value);
 
@@ -100,7 +75,7 @@ function ColorSelect({
         <select
           id={id}
           value={value}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={(e) => onChange(e.target.value as TValue)}
           className="nx:appearance-none nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:pl-7 nx:pr-8 nx:py-1.5 nx:text-sm nx:cursor-pointer nx:hover:bg-background-hover nx:transition-colors"
         >
           {options.map((opt) => (
@@ -125,7 +100,7 @@ function ColorSelect({
   );
 }
 
-function TokenSelect({
+function TokenSelect<TValue extends string>({
   id,
   label,
   value,
@@ -134,9 +109,9 @@ function TokenSelect({
 }: {
   id: string;
   label: string;
-  value: string;
-  options: readonly string[];
-  onChange: (value: string) => void;
+  value: TValue;
+  options: readonly TValue[];
+  onChange: (value: TValue) => void;
 }) {
   return (
     <div className="nx:flex nx:items-center nx:justify-between">
@@ -147,7 +122,7 @@ function TokenSelect({
         <select
           id={id}
           value={value}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={(e) => onChange(e.target.value as TValue)}
           className="nx:appearance-none nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:pl-3 nx:pr-8 nx:py-1.5 nx:text-sm nx:cursor-pointer nx:hover:bg-background-hover nx:transition-colors nx:capitalize"
         >
           {options.map((opt) => (

--- a/apps/playground/src/hooks/useTheme.ts
+++ b/apps/playground/src/hooks/useTheme.ts
@@ -1,16 +1,62 @@
 import { useEffect, useState } from 'react';
 
+export const BASES = [
+  { value: 'slate', label: 'Slate', color: '#64748b' },
+  { value: 'neutral', label: 'Neutral', color: '#737373' },
+  { value: 'zinc', label: 'Zinc', color: '#71717a' },
+  { value: 'gray', label: 'Gray', color: '#6b7280' },
+  { value: 'stone', label: 'Stone', color: '#78716c' },
+] as const;
+
+export const BRANDS = [
+  { value: 'blue', label: 'Blue', color: '#3b82f6' },
+  { value: 'gray', label: 'Gray', color: '#6b7280' },
+  { value: 'neutral', label: 'Neutral', color: '#737373' },
+  { value: 'slate', label: 'Slate', color: '#64748b' },
+  { value: 'stone', label: 'Stone', color: '#78716c' },
+] as const;
+
+export const TOKEN_MODES = ['vega', 'lyra', 'maia', 'mira', 'nova'] as const;
+
+// Spacing grew to 7 modes in #119 (luma + sera authored in #118). Mode swap is
+// via the `data-style` attribute on <html>, not a CSS file load.
+export const SPACING_MODES = [
+  'vega',
+  'lyra',
+  'maia',
+  'mira',
+  'nova',
+  'luma',
+  'sera',
+] as const;
+
+// Typography dropped its byte-duplicate lyra/mira modes (PR #157); their theme
+// CSS no longer exists, so only the 3 real modes are listed.
+export const TYPOGRAPHY_MODES = ['nova', 'vega', 'maia'] as const;
+export const RADIUS_MODES = [
+  'blunt',
+  'sharp',
+  'subtle',
+  'smooth',
+  'mellow',
+] as const;
+
+export type Base = (typeof BASES)[number]['value'];
+export type Brand = (typeof BRANDS)[number]['value'];
+export type TokenMode = (typeof TOKEN_MODES)[number];
+export type SpacingMode = (typeof SPACING_MODES)[number];
+export type TypographyMode = (typeof TYPOGRAPHY_MODES)[number];
+export type RadiusMode = (typeof RADIUS_MODES)[number];
+
 export type ThemeConfig = {
-  // Color themes
-  base: string;
-  brand: string;
+  base: Base;
+  brand: Brand;
   dark: boolean;
-  // Design token modes
-  spacing: string;
-  typography: string;
-  shadow: string;
-  radius: string;
-  borderWidth: string;
+  spacing: SpacingMode;
+  typography: TypographyMode;
+  shadow: TokenMode;
+  radius: RadiusMode;
+  borderWidth: TokenMode;
 };
 
 /**
@@ -36,11 +82,9 @@ function loadCSS(href: string, id: string): void {
  */
 export function useTheme() {
   const [theme, setTheme] = useState<ThemeConfig>({
-    // Color themes
     base: 'slate',
     brand: 'blue',
     dark: false,
-    // Design token modes
     spacing: 'vega',
     typography: 'vega',
     shadow: 'vega',
@@ -48,12 +92,10 @@ export function useTheme() {
     borderWidth: 'vega',
   });
 
-  // Load base theme when it changes
   useEffect(() => {
     loadCSS(`/themes/base-${theme.base}.css`, 'base');
   }, [theme.base]);
 
-  // Load brand theme when it changes
   useEffect(() => {
     loadCSS(`/themes/brands-${theme.brand}.css`, 'brand');
   }, [theme.brand]);
@@ -62,27 +104,22 @@ export function useTheme() {
     document.documentElement.setAttribute('data-style', theme.spacing);
   }, [theme.spacing]);
 
-  // Load typography mode when it changes
   useEffect(() => {
     loadCSS(`/themes/typography-${theme.typography}.css`, 'typography');
   }, [theme.typography]);
 
-  // Load shadow mode when it changes
   useEffect(() => {
     loadCSS(`/themes/shadow-${theme.shadow}.css`, 'shadow');
   }, [theme.shadow]);
 
-  // Load radius mode when it changes
   useEffect(() => {
     loadCSS(`/themes/radius-${theme.radius}.css`, 'radius');
   }, [theme.radius]);
 
-  // Load border width mode when it changes
   useEffect(() => {
     loadCSS(`/themes/borderwidth-${theme.borderWidth}.css`, 'borderwidth');
   }, [theme.borderWidth]);
 
-  // Toggle dark class on html element
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme.dark);
   }, [theme.dark]);

--- a/packages/core/scripts/__tests__/utils.test.js
+++ b/packages/core/scripts/__tests__/utils.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   collectBreakpointsTokens,
@@ -727,6 +727,15 @@ describe('utils', () => {
         },
       ]);
     });
+
+    it('throws on a path with an unknown top-level root', () => {
+      const tokens = [
+        { cssName: 'motion-fast', path: ['motion', 'fast'], value: '120ms' },
+      ];
+      expect(() => splitSpacingTokens(tokens)).toThrow(
+        /unknown top-level key "motion"/
+      );
+    });
   });
 
   describe('generateSpacingModesCSS', () => {
@@ -776,6 +785,23 @@ describe('utils', () => {
       expect(() =>
         generateSpacingModesCSS(modes, { defaultMode: 'missing' })
       ).toThrow(/defaultMode "missing"/);
+    });
+
+    it('warns when two numeric tokens in the same mode resolve to the same px', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const duplicateModes = {
+        vega: [
+          { cssName: 'spacing-11', value: '48px' },
+          { cssName: 'spacing-12', value: '48px' },
+        ],
+      };
+      generateSpacingModesCSS(duplicateModes);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /vega — "spacing-12" and "spacing-11" both resolve to 48px/
+        )
+      );
+      warn.mockRestore();
     });
   });
 
@@ -867,6 +893,54 @@ describe('utils', () => {
       const { css, count } = generateSpacingRoleUtilitiesCSS(canonical);
       expect(count).toBe(2);
       expect((css.match(/@utility /g) || []).length).toBe(2);
+    });
+
+    it('throws on a path with 1 segment (too short)', () => {
+      const canonical = [
+        { cssName: 'control', path: ['control'], value: '8px' },
+      ];
+      expect(() => generateSpacingRoleUtilitiesCSS(canonical)).toThrow(
+        /\[control\] has 1 segment\(s\); only 2- or 3-segment role paths are supported/
+      );
+    });
+
+    it('throws on a path with 4 segments (too long)', () => {
+      const canonical = [
+        {
+          cssName: 'control-padding-x-md-responsive',
+          path: ['control', 'padding-x', 'md', 'responsive'],
+          value: '12px',
+        },
+      ];
+      expect(() => generateSpacingRoleUtilitiesCSS(canonical)).toThrow(
+        /has 4 segment\(s\); only 2- or 3-segment role paths are supported/
+      );
+    });
+
+    it('throws on a 3-segment path with an unknown family', () => {
+      const canonical = [
+        {
+          cssName: 'control-margin-x-md',
+          path: ['control', 'margin-x', 'md'],
+          value: '12px',
+        },
+      ];
+      expect(() => generateSpacingRoleUtilitiesCSS(canonical)).toThrow(
+        /unknown family "margin-x"/
+      );
+    });
+
+    it('throws on a 2-segment path with an unhandled suffix', () => {
+      const canonical = [
+        {
+          cssName: 'control-flex',
+          path: ['control', 'flex'],
+          value: '1',
+        },
+      ];
+      expect(() => generateSpacingRoleUtilitiesCSS(canonical)).toThrow(
+        /unhandled path shape \[control\.flex\]/
+      );
     });
   });
 });

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -233,12 +233,6 @@ export const DEFAULT_CONFIG = {
   borderwidth: 'vega',
   focus: 'default',
   'chart-categorical': 'default',
-  // Spacing ships all 7 modes in every build (mode swap is runtime via the
-  // `data-style="X"` attribute). This key only controls which mode lands
-  // under `:root, [data-style="X"]` — i.e. which is the default when no
-  // `data-style` attribute is set on the document. Other modes still emit
-  // their `[data-style="X"]` blocks alongside. Vega is the canonical
-  // baseline per `.claude/rules/spacing-tokens.md`.
   spacingDefault: 'vega',
 };
 
@@ -302,16 +296,16 @@ export function discoverPrimitives(primitivesDir) {
  * - Standalone files: {name}.json (no light/dark suffix)
  *
  * @param {string} semanticDir - Path to semantic directory
- * @returns {object} { themed: { type: { mode: { light, dark } } }, standalone: string[] }
+ * @returns {object} { themed: { type: { mode: { light, dark } } }, standalone: string[], perModeFiles: { category: { mode: filename } } }
  */
 export function discoverSemantics(semanticDir) {
   const result = {
     themed: {},
     standalone: [],
-    // Schema-agnostic bucket for per-mode semantic categories. Today's only
-    // entry is `spacing` (from `spacing-{mode}.json`); a future per-mode
-    // category (e.g., per-mode color shading) would land as a sibling key
-    // here without forking the partition logic.
+    // Bucket for per-mode semantic categories. Keyed by category so a future
+    // per-mode category (e.g. per-mode color shading) lands as a sibling key
+    // here. Detection of new categories still requires a regex branch below —
+    // only `spacing` is wired today.
     perModeFiles: {},
   };
 
@@ -328,7 +322,7 @@ export function discoverSemantics(semanticDir) {
   // `collectSpacingTokens` — they intentionally bypass the generic
   // standalone-dimension scan, which would otherwise emit each file's keys
   // into `@theme` once per mode and last-write-wins.
-  const spacingModePattern = /^spacing-(.+)\.json$/;
+  const spacingModePattern = /^spacing-([a-z]+)\.json$/;
 
   for (const file of files) {
     const spacingMatch = file.match(spacingModePattern);
@@ -724,33 +718,13 @@ export function generateBorderWidthUtilitiesCSS(tokens) {
 // TOKEN COLLECTION FOR @THEME BLOCKS
 // ============================================
 
-/*
- * Spacing has two distinct "default mode" concepts. They look similar and are
- * easy to conflate, but they live at different layers:
- *
- *  - `CANONICAL_SPACING_DEFAULT_MODE` (this constant, hardcoded) drives the
- *    build-time CONTRACT: which mode's numeric subset seeds `@theme` for
- *    Tailwind utility codegen, and which mode's role tokens get `@utility`
- *    declarations emitted. Vega is locked here because tests reference it
- *    (`VEGA_BASELINE` byte-identity lock, drift guard, etc.). Changing this
- *    moves the test surface.
- *
- *  - `config.spacingDefault` (consumer-configurable, defaults to the constant
- *    above) drives the runtime CASCADE DEFAULT: which mode lands under
- *    `:root, [data-style="X"]` so a document with no `data-style` attribute
- *    resolves to that mode. All seven modes still emit; only the `:root`
- *    selector moves.
- *
- * The build emits the same `@utility` set and the same seven per-mode blocks
- * regardless of `spacingDefault`. Only the `:root` half of the dual selector
- * is consumer-pickable.
- */
-
 /**
  * Canonical default spacing mode. Published under `:root, [data-style="vega"]`
  * by the per-mode emitter, and used by the generators to pick the mode whose
- * numeric subset seeds Tailwind's `@theme` block. One constant so the four
- * sites that pick "the default mode" cannot drift.
+ * numeric subset seeds Tailwind's `@theme` block (the build-time contract for
+ * utility codegen and the `VEGA_BASELINE` byte-identity test). Distinct from
+ * `config.spacingDefault`, which only moves the runtime `:root` cascade
+ * default — all seven modes still emit either way.
  */
 export const CANONICAL_SPACING_DEFAULT_MODE = 'vega';
 
@@ -902,15 +876,9 @@ export function generateSpacingModesCSS(modesByName, opts = {}) {
     );
   }
 
-  // Intra-mode duplicate-value warning for numeric tokens. Two `spacing-N`
-  // keys resolving to the same px (e.g. Lyra's `spacing-11 === spacing-12 ===
-  // 48px` from #223) is almost always a design oversight. Cheap to detect
-  // here, expensive to chase later. We key off the `spacing-` cssName prefix
-  // (rather than `token.path`) because the function's documented input shape
-  // is `{cssName, value}[]` — `path` may be absent in some callers/tests.
-  // The strict canonical-step check is deferred to the
-  // `nexus/canonical-spacing-steps` lint rule (#127) — the step set itself
-  // is still being reconciled (see `spacing-tokens.md`).
+  // Intra-mode duplicate-value warning for numeric tokens. Keys off the
+  // `spacing-` cssName prefix because the documented input shape is
+  // `{cssName, value}[]` — `path` may be absent in some callers/tests.
   for (const mode of allModes) {
     const valueByName = new Map();
     for (const token of modesByName[mode]) {

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -233,6 +233,7 @@ export const DEFAULT_CONFIG = {
   borderwidth: 'vega',
   focus: 'default',
   'chart-categorical': 'default',
+  // see CANONICAL_SPACING_DEFAULT_MODE — controls :root cascade only (all 7 modes ship)
   spacingDefault: 'vega',
 };
 


### PR DESCRIPTION
## Summary

Follow-up to PR #224 (merged). Four post-merge review rounds raised findings that didn't make the merge train; this PR addresses them in one commit.

### Architect findings

- `utils.js` — replace freestanding 21-line `CANONICAL_SPACING_DEFAULT_MODE` rationale block with a 6-line JSDoc on the constant itself
- `utils.js` — `discoverSemantics` `@returns` now lists `perModeFiles`; bucket comment reworded to acknowledge regex-coupled detection (not pure schema-agnostic)
- `.claude/rules/tokens.md` — "Spacing isn't a CLI flag" callout rewritten to clarify that all 7 modes ship and `--spacingDefault` picks the `:root` cascade default
- `.claude/rules/spacing-tokens.md` — replace fictional `space.*` / `page-gutter` / `inline-gap` JSON example with the real `spacing` / `control` / `container` / `layout` shape mirroring `spacing-vega.json` (DTCG `{value, unit}` objects)
- `.claude/rules/spacing-tokens.md` — new subsection pinning the `data-style` attribute contract: spacing-density only; future per-mode categories ship their own attribute names (no multiplexing)

### SDE2 findings

- `utils.js` — shrink 6-line `DEFAULT_CONFIG.spacingDefault` tradeoff comment to a one-liner
- `utils.js` — drop "almost always a design oversight" / "deferred to #127" rationale on the duplicate-warn loop; keep one sentence
- `utils.js` — tighten spacing-mode regex to `/^spacing-([a-z]+)\.json$/` (rejects `spacing-foo-bar.json`)
- `useTheme.ts` — drop six "Load X when it changes" restate-the-code comments
- `useTheme.ts` + `ThemeSwitcher.tsx` — move `BASES` / `BRANDS` / `*_MODES` into `useTheme.ts` as named exports; add `Base` / `Brand` / `*Mode` literal-union types; `ThemeConfig` narrows from `string` to literal unions; `ColorSelect` / `TokenSelect` made generic so their `onChange` returns the literal type instead of `string`
- `utils.test.js` — +6 tests covering the three previously-untested throw branches: `splitSpacingTokens` unknown-root, `generateSpacingModesCSS` intra-mode duplicate-warn (console.warn spy), `deriveRoleUtility` length-too-short, length-too-long, unknown-family, unhandled-2-segment (via `generateSpacingRoleUtilitiesCSS`)

## GitHub Issue

Follow-up to #119 (PR #224, merged). No new issue — these are post-merge review findings.

## Test Plan

- [x] `yarn typecheck` — 5 workspaces, clean
- [x] `yarn lint` — 0 warnings
- [x] `yarn test:unit` — 305 unit tests passing (+6 new)
- [x] `yarn workspace @nexus/core audit:contrast` — 440/440 pairs passing (no color tokens touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)