### PR TITLE
feat(tokens): add --control-gap-{sm,md,lg} per-size gap roles

### DIFF
--- a/.claude/rules/spacing-tokens.md
+++ b/.claude/rules/spacing-tokens.md
@@ -70,7 +70,11 @@ Every mode file MUST contain the same set of keys — enforced by JSON schema va
       "md": { "$value": { "value": 8, "unit": "px" }, "$type": "dimension" },
       "lg": { "$value": { "value": 12, "unit": "px" }, "$type": "dimension" }
     },
-    "gap": { "$value": { "value": 8, "unit": "px" }, "$type": "dimension" }
+    "gap": {
+      "sm": { "$value": { "value": 6, "unit": "px" }, "$type": "dimension" },
+      "md": { "$value": { "value": 8, "unit": "px" }, "$type": "dimension" },
+      "lg": { "$value": { "value": 10, "unit": "px" }, "$type": "dimension" }
+    }
   },
   "container": {
     "p": { "$value": { "value": 24, "unit": "px" }, "$type": "dimension" },
@@ -149,8 +153,8 @@ These are the px values the design system has chosen as its scale. Any value out
 ### For component authors writing JSX
 
 - **Use numeric utilities (`nx:p-2`, `nx:gap-4`, `nx:h-9`)** for layout-level and ad-hoc spacing inside components. They shift with mode automatically.
-- **Use role-named utilities (`nx:px-control-md`, `nx:py-control-md`, `nx:p-container`, `nx:gap-layout-section`)** for component-internal spacing that has a clear semantic role. Control utilities carry an explicit size suffix (`-sm`, `-md`, `-lg`); container/layout utilities have no size suffix.
-- **Mix freely.** A Button can use `nx:px-control-md nx:py-control-md nx:gap-2` — padding follows the control role, gap is a structural numeric choice.
+- **Use role-named utilities (`nx:px-control-md`, `nx:py-control-md`, `nx:gap-control-md`, `nx:p-container`, `nx:gap-layout-section`)** for component-internal spacing that has a clear semantic role. Control utilities carry an explicit size suffix (`-sm`, `-md`, `-lg`); container/layout utilities have no size suffix.
+- **Mix freely.** A Button uses `nx:px-control-md nx:py-control-md nx:gap-control-md` for its internal semantic spacing at md; a toolbar wrapping multiple Buttons reaches for `nx:gap-2` to space them apart — role tokens express component-internal intent, numeric utilities space components in context.
 - **No `control-h` token.** Control heights are intrinsic — they emerge from `py-control-{size}` + the control's content (text line-height or icon size). The earlier `--control-h-*` axis was over-specified (both `h` and `py` set together meant the visual padding eaten by content overflow didn't match the designer's `py` value). Cross-control alignment is achieved by Button / Input / Select / Tabs / Badge sharing the same `py-control-{size}` and same text-size body.
 - ❌ Don't write raw px values (`style={{ padding: '10px' }}`). Always go through a token.
 - ❌ Don't use `nx:p-[5px]` arbitrary-value escape hatches. If the canonical set doesn't have what you need, propose the change to the set.
@@ -185,24 +189,24 @@ Components should use specific roles for specific spacing decisions. This table 
 
 > **Status: target state, not current code.** Button / Input / Select / Tabs / Badge currently use numeric `nx:p-N` utilities; #123 is the migration that moves them onto these role tokens. Read this table as the post-#123 contract that `nexus/prefer-role-utilities` (#127) will enforce — not as a description of what's shipped today.
 
-| Component                                | Role used for                     | Tokens                                                              |
-| ---------------------------------------- | --------------------------------- | ------------------------------------------------------------------- |
-| Button (default)                         | padding-x, padding-y, gap         | `--control-padding-x-md`, `--control-padding-y-md`, `--control-gap` |
-| Button (sm)                              | padding-x, padding-y              | `--control-padding-x-sm`, `--control-padding-y-sm`                  |
-| Button (lg)                              | padding-x, padding-y              | `--control-padding-x-lg`, `--control-padding-y-lg`                  |
-| Button (icon)                            | square padding (numeric)          | `nx:p-2.5` (10px, canonical step) — see note below                  |
-| Input (default)                          | padding-x, padding-y              | `--control-padding-x-md`, `--control-padding-y-md`                  |
-| Select trigger                           | padding-x, padding-y, gap         | `--control-padding-x-md`, `--control-padding-y-md`, `--control-gap` |
-| Tabs trigger                             | padding-x, padding-y (sm/md)      | `--control-padding-x-{sm,md}`, `--control-padding-y-{sm,md}`        |
-| Tooltip                                  | padding-x, padding-y              | `--control-padding-x-sm`, `--control-padding-y-sm`                  |
-| Badge / Chip                             | padding-x, padding-y (sm)         | `--control-padding-x-sm`, `--control-padding-y-sm`                  |
-| Card                                     | interior padding, gap             | `--container-p`, `--container-gap`                                  |
-| Card header                              | container padding                 | `--container-p` (sub-element offsets use numeric `spacing-N`)       |
-| Dialog                                   | interior padding, gap             | `--container-p`, `--container-gap`                                  |
-| Avatar                                   | (uses sizing tokens, not spacing) | N/A — see `nx:size-*` numeric utilities                             |
-| Section between blocks                   | vertical gap                      | `--layout-section-gap`                                              |
-| Stack utility                            | gap between siblings              | `--layout-stack-gap`                                                |
-| Page gutter, inline groups, layout-level | (no named role yet)               | Use numeric `spacing-N` from canonical step set                     |
+| Component                                | Role used for                     | Tokens                                                                 |
+| ---------------------------------------- | --------------------------------- | ---------------------------------------------------------------------- |
+| Button (default)                         | padding-x, padding-y, gap         | `--control-padding-x-md`, `--control-padding-y-md`, `--control-gap-md` |
+| Button (sm)                              | padding-x, padding-y, gap         | `--control-padding-x-sm`, `--control-padding-y-sm`, `--control-gap-sm` |
+| Button (lg)                              | padding-x, padding-y, gap         | `--control-padding-x-lg`, `--control-padding-y-lg`, `--control-gap-lg` |
+| Button (icon)                            | square padding (numeric)          | `nx:p-2.5` (10px, canonical step) — see note below                     |
+| Input (default)                          | padding-x, padding-y              | `--control-padding-x-md`, `--control-padding-y-md`                     |
+| Select trigger                           | padding-x, padding-y, gap         | `--control-padding-x-md`, `--control-padding-y-md`, `--control-gap-md` |
+| Tabs trigger                             | padding-x, padding-y (sm/md)      | `--control-padding-x-{sm,md}`, `--control-padding-y-{sm,md}`           |
+| Tooltip                                  | padding-x, padding-y              | `--control-padding-x-sm`, `--control-padding-y-sm`                     |
+| Badge / Chip                             | padding-x, padding-y (sm)         | `--control-padding-x-sm`, `--control-padding-y-sm`                     |
+| Card                                     | interior padding, gap             | `--container-p`, `--container-gap`                                     |
+| Card header                              | container padding                 | `--container-p` (sub-element offsets use numeric `spacing-N`)          |
+| Dialog                                   | interior padding, gap             | `--container-p`, `--container-gap`                                     |
+| Avatar                                   | (uses sizing tokens, not spacing) | N/A — see `nx:size-*` numeric utilities                                |
+| Section between blocks                   | vertical gap                      | `--layout-section-gap`                                                 |
+| Stack utility                            | gap between siblings              | `--layout-stack-gap`                                                   |
+| Page gutter, inline groups, layout-level | (no named role yet)               | Use numeric `spacing-N` from canonical step set                        |
 
 When a new component is authored, the author adds a row to this table.
 

--- a/.claude/rules/spacing-tokens.md
+++ b/.claude/rules/spacing-tokens.md
@@ -95,6 +95,8 @@ Every mode file MUST contain the same set of keys — enforced by JSON schema va
 
 Top-level keys are `spacing` (numeric scale), `control`, `container`, `layout` — flat siblings, no enclosing wrapper. `$value` is a DTCG `{ value, unit }` dimension object.
 
+> **Placeholder values for `control.gap.{sm,md,lg}`.** The `md` value of each mode is the pre-#230 single `control.gap` value; `sm` and `lg` are seeded with the formula `sm = md − 2`, `lg = md + 2`, snapped to the canonical step set. These are placeholders pending designer tuning — the formula encodes intent (a single density step away from `md` in either direction), not a final design call. Retuning per-mode is fine and expected; the schema only requires the three keys to exist with canonical values.
+
 ### Emitted CSS
 
 The build emits one CSS block per mode, all in a single bundle:

--- a/apps/playground/public/themes/globals.css
+++ b/apps/playground/public/themes/globals.css
@@ -282,7 +282,9 @@
   --nx-control-padding-y-sm: 6px;
   --nx-control-padding-y-md: 8px;
   --nx-control-padding-y-lg: 12px;
-  --nx-control-gap: 8px;
+  --nx-control-gap-sm: 6px;
+  --nx-control-gap-md: 8px;
+  --nx-control-gap-lg: 10px;
   --nx-container-p: 24px;
   --nx-container-gap: 16px;
   --nx-layout-section-gap: 32px;
@@ -330,7 +332,9 @@
   --nx-control-padding-y-sm: 6px;
   --nx-control-padding-y-md: 8px;
   --nx-control-padding-y-lg: 12px;
-  --nx-control-gap: 8px;
+  --nx-control-gap-sm: 6px;
+  --nx-control-gap-md: 8px;
+  --nx-control-gap-lg: 10px;
   --nx-container-p: 28px;
   --nx-container-gap: 20px;
   --nx-layout-section-gap: 40px;
@@ -378,7 +382,9 @@
   --nx-control-padding-y-sm: 6px;
   --nx-control-padding-y-md: 8px;
   --nx-control-padding-y-lg: 12px;
-  --nx-control-gap: 8px;
+  --nx-control-gap-sm: 6px;
+  --nx-control-gap-md: 8px;
+  --nx-control-gap-lg: 10px;
   --nx-container-p: 24px;
   --nx-container-gap: 16px;
   --nx-layout-section-gap: 32px;
@@ -426,7 +432,9 @@
   --nx-control-padding-y-sm: 8px;
   --nx-control-padding-y-md: 10px;
   --nx-control-padding-y-lg: 14px;
-  --nx-control-gap: 10px;
+  --nx-control-gap-sm: 8px;
+  --nx-control-gap-md: 10px;
+  --nx-control-gap-lg: 12px;
   --nx-container-p: 28px;
   --nx-container-gap: 20px;
   --nx-layout-section-gap: 40px;
@@ -474,7 +482,9 @@
   --nx-control-padding-y-sm: 6px;
   --nx-control-padding-y-md: 8px;
   --nx-control-padding-y-lg: 12px;
-  --nx-control-gap: 8px;
+  --nx-control-gap-sm: 6px;
+  --nx-control-gap-md: 8px;
+  --nx-control-gap-lg: 10px;
   --nx-container-p: 24px;
   --nx-container-gap: 16px;
   --nx-layout-section-gap: 32px;
@@ -522,7 +532,9 @@
   --nx-control-padding-y-sm: 4px;
   --nx-control-padding-y-md: 6px;
   --nx-control-padding-y-lg: 10px;
-  --nx-control-gap: 6px;
+  --nx-control-gap-sm: 4px;
+  --nx-control-gap-md: 6px;
+  --nx-control-gap-lg: 8px;
   --nx-container-p: 20px;
   --nx-container-gap: 12px;
   --nx-layout-section-gap: 28px;
@@ -570,7 +582,9 @@
   --nx-control-padding-y-sm: 10px;
   --nx-control-padding-y-md: 12px;
   --nx-control-padding-y-lg: 16px;
-  --nx-control-gap: 12px;
+  --nx-control-gap-sm: 10px;
+  --nx-control-gap-md: 12px;
+  --nx-control-gap-lg: 14px;
   --nx-container-p: 40px;
   --nx-container-gap: 24px;
   --nx-layout-section-gap: 56px;

--- a/apps/playground/public/themes/spacing-utilities.css
+++ b/apps/playground/public/themes/spacing-utilities.css
@@ -30,8 +30,16 @@
   padding-bottom: var(--nx-control-padding-y-lg);
 }
 
-@utility gap-control {
-  gap: var(--nx-control-gap);
+@utility gap-control-sm {
+  gap: var(--nx-control-gap-sm);
+}
+
+@utility gap-control-md {
+  gap: var(--nx-control-gap-md);
+}
+
+@utility gap-control-lg {
+  gap: var(--nx-control-gap-lg);
 }
 
 @utility p-container {

--- a/apps/playground/src/components/ComponentShowcase.tsx
+++ b/apps/playground/src/components/ComponentShowcase.tsx
@@ -234,18 +234,18 @@ export function ComponentShowcase() {
             {/* Controls */}
             <div className="nx:space-y-2">
               <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
-                Controls — px-control-*, py-control-*, gap-control
+                Controls — px-control-*, py-control-*, gap-control-*
               </span>
               <div className="nx:flex nx:flex-wrap nx:items-center nx:gap-3">
-                <button className="nx:inline-flex nx:items-center nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:text-sm nx:font-medium nx:px-control-sm nx:py-control-sm nx:gap-control">
+                <button className="nx:inline-flex nx:items-center nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:text-sm nx:font-medium nx:px-control-sm nx:py-control-sm nx:gap-control-sm">
                   <PlaygroundIcon name="search" size={14} />
                   <span>Small</span>
                 </button>
-                <button className="nx:inline-flex nx:items-center nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:text-sm nx:font-medium nx:px-control-md nx:py-control-md nx:gap-control">
+                <button className="nx:inline-flex nx:items-center nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:text-sm nx:font-medium nx:px-control-md nx:py-control-md nx:gap-control-md">
                   <PlaygroundIcon name="check" size={14} />
                   <span>Medium</span>
                 </button>
-                <button className="nx:inline-flex nx:items-center nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:text-sm nx:font-medium nx:px-control-lg nx:py-control-lg nx:gap-control">
+                <button className="nx:inline-flex nx:items-center nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:text-sm nx:font-medium nx:px-control-lg nx:py-control-lg nx:gap-control-lg">
                   <PlaygroundIcon name="chevron-down" size={16} />
                   <span>Large</span>
                 </button>

--- a/apps/playground/src/styles/globals.css
+++ b/apps/playground/src/styles/globals.css
@@ -282,7 +282,9 @@
   --nx-control-padding-y-sm: 6px;
   --nx-control-padding-y-md: 8px;
   --nx-control-padding-y-lg: 12px;
-  --nx-control-gap: 8px;
+  --nx-control-gap-sm: 6px;
+  --nx-control-gap-md: 8px;
+  --nx-control-gap-lg: 10px;
   --nx-container-p: 24px;
   --nx-container-gap: 16px;
   --nx-layout-section-gap: 32px;
@@ -330,7 +332,9 @@
   --nx-control-padding-y-sm: 6px;
   --nx-control-padding-y-md: 8px;
   --nx-control-padding-y-lg: 12px;
-  --nx-control-gap: 8px;
+  --nx-control-gap-sm: 6px;
+  --nx-control-gap-md: 8px;
+  --nx-control-gap-lg: 10px;
   --nx-container-p: 28px;
   --nx-container-gap: 20px;
   --nx-layout-section-gap: 40px;
@@ -378,7 +382,9 @@
   --nx-control-padding-y-sm: 6px;
   --nx-control-padding-y-md: 8px;
   --nx-control-padding-y-lg: 12px;
-  --nx-control-gap: 8px;
+  --nx-control-gap-sm: 6px;
+  --nx-control-gap-md: 8px;
+  --nx-control-gap-lg: 10px;
   --nx-container-p: 24px;
   --nx-container-gap: 16px;
   --nx-layout-section-gap: 32px;
@@ -426,7 +432,9 @@
   --nx-control-padding-y-sm: 8px;
   --nx-control-padding-y-md: 10px;
   --nx-control-padding-y-lg: 14px;
-  --nx-control-gap: 10px;
+  --nx-control-gap-sm: 8px;
+  --nx-control-gap-md: 10px;
+  --nx-control-gap-lg: 12px;
   --nx-container-p: 28px;
   --nx-container-gap: 20px;
   --nx-layout-section-gap: 40px;
@@ -474,7 +482,9 @@
   --nx-control-padding-y-sm: 6px;
   --nx-control-padding-y-md: 8px;
   --nx-control-padding-y-lg: 12px;
-  --nx-control-gap: 8px;
+  --nx-control-gap-sm: 6px;
+  --nx-control-gap-md: 8px;
+  --nx-control-gap-lg: 10px;
   --nx-container-p: 24px;
   --nx-container-gap: 16px;
   --nx-layout-section-gap: 32px;
@@ -522,7 +532,9 @@
   --nx-control-padding-y-sm: 4px;
   --nx-control-padding-y-md: 6px;
   --nx-control-padding-y-lg: 10px;
-  --nx-control-gap: 6px;
+  --nx-control-gap-sm: 4px;
+  --nx-control-gap-md: 6px;
+  --nx-control-gap-lg: 8px;
   --nx-container-p: 20px;
   --nx-container-gap: 12px;
   --nx-layout-section-gap: 28px;
@@ -570,7 +582,9 @@
   --nx-control-padding-y-sm: 10px;
   --nx-control-padding-y-md: 12px;
   --nx-control-padding-y-lg: 16px;
-  --nx-control-gap: 12px;
+  --nx-control-gap-sm: 10px;
+  --nx-control-gap-md: 12px;
+  --nx-control-gap-lg: 14px;
   --nx-container-p: 40px;
   --nx-container-gap: 24px;
   --nx-layout-section-gap: 56px;

--- a/apps/playground/src/styles/spacing-utilities.css
+++ b/apps/playground/src/styles/spacing-utilities.css
@@ -30,8 +30,16 @@
   padding-bottom: var(--nx-control-padding-y-lg);
 }
 
-@utility gap-control {
-  gap: var(--nx-control-gap);
+@utility gap-control-sm {
+  gap: var(--nx-control-gap-sm);
+}
+
+@utility gap-control-md {
+  gap: var(--nx-control-gap-md);
+}
+
+@utility gap-control-lg {
+  gap: var(--nx-control-gap-lg);
 }
 
 @utility p-container {

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -430,7 +430,7 @@ describe('generateTailwindPackage', () => {
     ).toBe(true);
   });
 
-  it('spacing-utilities.css declares all 11 role utilities with correct property bindings', () => {
+  it('spacing-utilities.css declares all 13 role utilities with correct property bindings', () => {
     // Each @utility binds the right CSS property to the right --nx-* variable.
     // A buggy emitter could pass "utility exists" tests but bind the wrong
     // var (e.g. px-control-sm reading --nx-control-padding-x-md).

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -465,7 +465,21 @@ describe('generateTailwindPackage', () => {
         prop: 'padding-top',
         cssVar: 'nx-control-padding-y-lg',
       },
-      { utility: 'gap-control', prop: 'gap', cssVar: 'nx-control-gap' },
+      {
+        utility: 'gap-control-sm',
+        prop: 'gap',
+        cssVar: 'nx-control-gap-sm',
+      },
+      {
+        utility: 'gap-control-md',
+        prop: 'gap',
+        cssVar: 'nx-control-gap-md',
+      },
+      {
+        utility: 'gap-control-lg',
+        prop: 'gap',
+        cssVar: 'nx-control-gap-lg',
+      },
       { utility: 'p-container', prop: 'padding', cssVar: 'nx-container-p' },
       { utility: 'gap-container', prop: 'gap', cssVar: 'nx-container-gap' },
       {
@@ -480,7 +494,7 @@ describe('generateTailwindPackage', () => {
       },
     ];
 
-    expect(ROLE_UTILITY_BINDINGS).toHaveLength(11);
+    expect(ROLE_UTILITY_BINDINGS).toHaveLength(13);
     for (const { utility, prop, cssVar } of ROLE_UTILITY_BINDINGS) {
       const block = extractBlock(spacingUtilitiesCSS, `@utility ${utility}`);
       expect(block, `@utility ${utility} body`).toMatch(
@@ -514,7 +528,9 @@ describe('generateTailwindPackage', () => {
         //   [role, '<x>-gap']     → gap-<role>-<x>
         const [role, second, third] = pathParts;
         if (third !== undefined) {
-          const prefix = { 'padding-x': 'px', 'padding-y': 'py' }[second];
+          const prefix = { 'padding-x': 'px', 'padding-y': 'py', gap: 'gap' }[
+            second
+          ];
           expected.add(`${prefix}-${role}-${third}`);
         } else if (second === 'gap') {
           expected.add(`gap-${role}`);

--- a/packages/core/scripts/__tests__/utils.test.js
+++ b/packages/core/scripts/__tests__/utils.test.js
@@ -821,9 +821,19 @@ describe('utils', () => {
           value: '12px',
         },
         {
-          cssName: 'control-gap',
-          path: ['control', 'gap'],
+          cssName: 'control-gap-sm',
+          path: ['control', 'gap', 'sm'],
+          value: '6px',
+        },
+        {
+          cssName: 'control-gap-md',
+          path: ['control', 'gap', 'md'],
           value: '8px',
+        },
+        {
+          cssName: 'control-gap-lg',
+          path: ['control', 'gap', 'lg'],
+          value: '10px',
         },
         {
           cssName: 'container-p',
@@ -848,7 +858,7 @@ describe('utils', () => {
       ];
       const { css, count } = generateSpacingRoleUtilitiesCSS(canonical);
 
-      expect(count).toBe(7);
+      expect(count).toBe(9);
       // Each utility name follows the role-and-property convention; the var
       // reference is the prefixed form, so it matches what per-mode blocks
       // declare.
@@ -859,7 +869,13 @@ describe('utils', () => {
         /@utility py-control-lg \{[^}]*padding-top: var\(--nx-control-padding-y-lg\);[^}]*padding-bottom: var\(--nx-control-padding-y-lg\);/
       );
       expect(css).toMatch(
-        /@utility gap-control \{[^}]*gap: var\(--nx-control-gap\);/
+        /@utility gap-control-sm \{[^}]*gap: var\(--nx-control-gap-sm\);/
+      );
+      expect(css).toMatch(
+        /@utility gap-control-md \{[^}]*gap: var\(--nx-control-gap-md\);/
+      );
+      expect(css).toMatch(
+        /@utility gap-control-lg \{[^}]*gap: var\(--nx-control-gap-lg\);/
       );
       expect(css).toMatch(
         /@utility p-container \{[^}]*padding: var\(--nx-container-p\);/

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -926,16 +926,20 @@ export function generateSpacingModesCSS(modesByName, opts = {}) {
  * properties the utility should set. Hand-maintained because the suffix →
  * property mapping is a CSS-design decision, not derivable from JSON.
  *
- * Three-segment paths only — two-segment paths (`container.p`, `control.gap`,
- * `layout.section-gap`) are handled inline in `deriveRoleUtility`.
+ * Three-segment paths only — two-segment paths (`container.p`,
+ * `container.gap`, `layout.section-gap`) are handled inline in
+ * `deriveRoleUtility`. `gap` lives here for the 3-segment `control.gap.{size}`
+ * shape; the 2-segment `container.gap` form predates per-size and stays on
+ * the inline branch.
  *
  * Adding a new three-segment family (e.g. `m` → `margin`) means adding one
- * row here. The set of role tokens themselves is JSON-driven — see
- * `generateSpacingRoleUtilitiesCSS`.
+ * row here AND one row in `FAMILY_TO_UTILITY_PREFIX`. The set of role tokens
+ * themselves is JSON-driven — see `generateSpacingRoleUtilitiesCSS`.
  */
 const SUFFIX_TO_PROPERTIES = {
   'padding-x': ['padding-left', 'padding-right'],
   'padding-y': ['padding-top', 'padding-bottom'],
+  gap: ['gap'],
 };
 
 /**
@@ -944,7 +948,7 @@ const SUFFIX_TO_PROPERTIES = {
  * Naming convention — `<property-shorthand>-<role>[-<size>]`:
  *   `control.padding-x.sm`    → utility `px-control-sm`,       padding-inline
  *   `control.padding-y.lg`    → utility `py-control-lg`,       padding-block
- *   `control.gap`             → utility `gap-control`,         gap
+ *   `control.gap.md`          → utility `gap-control-md`,      gap
  *   `container.p`             → utility `p-container`,         padding
  *   `container.gap`           → utility `gap-container`,       gap
  *   `layout.section-gap`      → utility `gap-layout-section`,  gap
@@ -1007,12 +1011,23 @@ function deriveRoleUtility(tokenPath) {
   );
 }
 
-// Three-segment-only helper: `gap` and `p` two-segment paths are handled
-// inline in `deriveRoleUtility` and never reach here.
+// Three-segment-only helper: the 2-segment `container.p` / `container.gap` /
+// `layout.<x>-gap` paths are handled inline in `deriveRoleUtility` and never
+// reach here. Keep this map in lockstep with `SUFFIX_TO_PROPERTIES` — every
+// 3-segment family needs both an entry there (CSS properties) and here
+// (utility-name prefix).
+const FAMILY_TO_UTILITY_PREFIX = {
+  'padding-x': 'px',
+  'padding-y': 'py',
+  gap: 'gap',
+};
+
 function familyToUtilityPrefix(family) {
-  if (family === 'padding-x') return 'px';
-  if (family === 'padding-y') return 'py';
-  throw new Error(`familyToUtilityPrefix: unknown family "${family}"`);
+  const prefix = FAMILY_TO_UTILITY_PREFIX[family];
+  if (prefix === undefined) {
+    throw new Error(`familyToUtilityPrefix: unknown family "${family}"`);
+  }
+  return prefix;
 }
 
 /**

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -922,24 +922,20 @@ export function generateSpacingModesCSS(modesByName, opts = {}) {
 }
 
 /**
- * Maps the family segment of a three-segment role-token path to the CSS
- * properties the utility should set. Hand-maintained because the suffix →
- * property mapping is a CSS-design decision, not derivable from JSON.
+ * Three-segment family registry. Each row defines one CSS-design decision —
+ * what utility prefix to emit and which CSS properties to set — for one
+ * family segment of a `[role, family, size]` role-token path. The 2-segment
+ * paths (`container.p`, `container.gap`, `layout.<x>-gap`) are handled
+ * inline in `deriveRoleUtility` and do not go through this map.
  *
- * Three-segment paths only — two-segment paths (`container.p`,
- * `container.gap`, `layout.section-gap`) are handled inline in
- * `deriveRoleUtility`. `gap` lives here for the 3-segment `control.gap.{size}`
- * shape; the 2-segment `container.gap` form predates per-size and stays on
- * the inline branch.
- *
- * Adding a new three-segment family (e.g. `m` → `margin`) means adding one
- * row here AND one row in `FAMILY_TO_UTILITY_PREFIX`. The set of role tokens
- * themselves is JSON-driven — see `generateSpacingRoleUtilitiesCSS`.
+ * Adding a new 3-segment family (e.g. `m` → `margin`) means adding one row
+ * here. The set of role tokens themselves is JSON-driven — see
+ * `generateSpacingRoleUtilitiesCSS`.
  */
-const SUFFIX_TO_PROPERTIES = {
-  'padding-x': ['padding-left', 'padding-right'],
-  'padding-y': ['padding-top', 'padding-bottom'],
-  gap: ['gap'],
+const FAMILY_TO_UTILITY = {
+  'padding-x': { prefix: 'px', properties: ['padding-left', 'padding-right'] },
+  'padding-y': { prefix: 'py', properties: ['padding-top', 'padding-bottom'] },
+  gap: { prefix: 'gap', properties: ['gap'] },
 };
 
 /**
@@ -966,7 +962,7 @@ const SUFFIX_TO_PROPERTIES = {
  */
 function deriveRoleUtility(tokenPath) {
   // Path forms we handle:
-  //   [role, suffix]             — e.g. ['container', 'p'], ['control', 'gap']
+  //   [role, suffix]             — e.g. ['container', 'p'], ['container', 'gap']
   //   [role, family, size]       — e.g. ['control', 'padding-x', 'md']
   //   [role, 'X-gap']            — e.g. ['layout', 'section-gap'] (composite suffix)
   if (tokenPath.length < 2 || tokenPath.length > 3) {
@@ -976,18 +972,20 @@ function deriveRoleUtility(tokenPath) {
   }
   const [role, second, third] = tokenPath;
 
-  // Three-segment path: [role, family, size]. family ∈ {padding-x, padding-y}.
+  // Three-segment path: [role, family, size]. family ∈ {padding-x, padding-y, gap}.
   if (third !== undefined) {
     const family = second;
     const size = third;
-    const properties = SUFFIX_TO_PROPERTIES[family];
-    if (!properties) {
+    const entry = FAMILY_TO_UTILITY[family];
+    if (!entry) {
       throw new Error(
-        `deriveRoleUtility: unknown family "${family}" in path [${tokenPath.join('.')}] — extend SUFFIX_TO_PROPERTIES`
+        `deriveRoleUtility: unknown family "${family}" in path [${tokenPath.join('.')}] — extend FAMILY_TO_UTILITY`
       );
     }
-    const prefix = familyToUtilityPrefix(family);
-    return { utilityName: `${prefix}-${role}-${size}`, properties };
+    return {
+      utilityName: `${entry.prefix}-${role}-${size}`,
+      properties: entry.properties,
+    };
   }
 
   // Two-segment path: [role, suffix].
@@ -1009,25 +1007,6 @@ function deriveRoleUtility(tokenPath) {
   throw new Error(
     `deriveRoleUtility: unhandled path shape [${tokenPath.join('.')}] — extend deriveRoleUtility cases`
   );
-}
-
-// Three-segment-only helper: the 2-segment `container.p` / `container.gap` /
-// `layout.<x>-gap` paths are handled inline in `deriveRoleUtility` and never
-// reach here. Keep this map in lockstep with `SUFFIX_TO_PROPERTIES` — every
-// 3-segment family needs both an entry there (CSS properties) and here
-// (utility-name prefix).
-const FAMILY_TO_UTILITY_PREFIX = {
-  'padding-x': 'px',
-  'padding-y': 'py',
-  gap: 'gap',
-};
-
-function familyToUtilityPrefix(family) {
-  const prefix = FAMILY_TO_UTILITY_PREFIX[family];
-  if (prefix === undefined) {
-    throw new Error(`familyToUtilityPrefix: unknown family "${family}"`);
-  }
-  return prefix;
 }
 
 /**

--- a/packages/core/tokens/semantic/spacing-luma.json
+++ b/packages/core/tokens/semantic/spacing-luma.json
@@ -287,7 +287,6 @@
       }
     },
     "gap": {
-      "$description": "Placeholders pending designer tuning — sm = md − 2, lg = md + 2 around each mode's existing md gap, kept on canonical spacing steps.",
       "sm": {
         "$value": {
           "value": 6,

--- a/packages/core/tokens/semantic/spacing-luma.json
+++ b/packages/core/tokens/semantic/spacing-luma.json
@@ -287,6 +287,7 @@
       }
     },
     "gap": {
+      "$description": "Placeholders pending designer tuning — sm = md − 2, lg = md + 2 around each mode's existing md gap, kept on canonical spacing steps.",
       "sm": {
         "$value": {
           "value": 6,

--- a/packages/core/tokens/semantic/spacing-luma.json
+++ b/packages/core/tokens/semantic/spacing-luma.json
@@ -287,11 +287,27 @@
       }
     },
     "gap": {
-      "$value": {
-        "value": 8,
-        "unit": "px"
+      "sm": {
+        "$value": {
+          "value": 6,
+          "unit": "px"
+        },
+        "$type": "dimension"
       },
-      "$type": "dimension"
+      "md": {
+        "$value": {
+          "value": 8,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 10,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
     }
   },
   "container": {

--- a/packages/core/tokens/semantic/spacing-lyra.json
+++ b/packages/core/tokens/semantic/spacing-lyra.json
@@ -287,7 +287,6 @@
       }
     },
     "gap": {
-      "$description": "Placeholders pending designer tuning — sm = md − 2, lg = md + 2 around each mode's existing md gap, kept on canonical spacing steps.",
       "sm": {
         "$value": {
           "value": 6,

--- a/packages/core/tokens/semantic/spacing-lyra.json
+++ b/packages/core/tokens/semantic/spacing-lyra.json
@@ -287,6 +287,7 @@
       }
     },
     "gap": {
+      "$description": "Placeholders pending designer tuning — sm = md − 2, lg = md + 2 around each mode's existing md gap, kept on canonical spacing steps.",
       "sm": {
         "$value": {
           "value": 6,

--- a/packages/core/tokens/semantic/spacing-lyra.json
+++ b/packages/core/tokens/semantic/spacing-lyra.json
@@ -287,11 +287,27 @@
       }
     },
     "gap": {
-      "$value": {
-        "value": 8,
-        "unit": "px"
+      "sm": {
+        "$value": {
+          "value": 6,
+          "unit": "px"
+        },
+        "$type": "dimension"
       },
-      "$type": "dimension"
+      "md": {
+        "$value": {
+          "value": 8,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 10,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
     }
   },
   "container": {

--- a/packages/core/tokens/semantic/spacing-maia.json
+++ b/packages/core/tokens/semantic/spacing-maia.json
@@ -287,7 +287,6 @@
       }
     },
     "gap": {
-      "$description": "Placeholders pending designer tuning — sm = md − 2, lg = md + 2 around each mode's existing md gap, kept on canonical spacing steps.",
       "sm": {
         "$value": {
           "value": 8,

--- a/packages/core/tokens/semantic/spacing-maia.json
+++ b/packages/core/tokens/semantic/spacing-maia.json
@@ -287,11 +287,27 @@
       }
     },
     "gap": {
-      "$value": {
-        "value": 10,
-        "unit": "px"
+      "sm": {
+        "$value": {
+          "value": 8,
+          "unit": "px"
+        },
+        "$type": "dimension"
       },
-      "$type": "dimension"
+      "md": {
+        "$value": {
+          "value": 10,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 12,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
     }
   },
   "container": {

--- a/packages/core/tokens/semantic/spacing-maia.json
+++ b/packages/core/tokens/semantic/spacing-maia.json
@@ -287,6 +287,7 @@
       }
     },
     "gap": {
+      "$description": "Placeholders pending designer tuning — sm = md − 2, lg = md + 2 around each mode's existing md gap, kept on canonical spacing steps.",
       "sm": {
         "$value": {
           "value": 8,

--- a/packages/core/tokens/semantic/spacing-mira.json
+++ b/packages/core/tokens/semantic/spacing-mira.json
@@ -287,7 +287,6 @@
       }
     },
     "gap": {
-      "$description": "Placeholders pending designer tuning — sm = md − 2, lg = md + 2 around each mode's existing md gap, kept on canonical spacing steps.",
       "sm": {
         "$value": {
           "value": 6,

--- a/packages/core/tokens/semantic/spacing-mira.json
+++ b/packages/core/tokens/semantic/spacing-mira.json
@@ -287,6 +287,7 @@
       }
     },
     "gap": {
+      "$description": "Placeholders pending designer tuning — sm = md − 2, lg = md + 2 around each mode's existing md gap, kept on canonical spacing steps.",
       "sm": {
         "$value": {
           "value": 6,

--- a/packages/core/tokens/semantic/spacing-mira.json
+++ b/packages/core/tokens/semantic/spacing-mira.json
@@ -287,11 +287,27 @@
       }
     },
     "gap": {
-      "$value": {
-        "value": 8,
-        "unit": "px"
+      "sm": {
+        "$value": {
+          "value": 6,
+          "unit": "px"
+        },
+        "$type": "dimension"
       },
-      "$type": "dimension"
+      "md": {
+        "$value": {
+          "value": 8,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 10,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
     }
   },
   "container": {

--- a/packages/core/tokens/semantic/spacing-nova.json
+++ b/packages/core/tokens/semantic/spacing-nova.json
@@ -287,6 +287,7 @@
       }
     },
     "gap": {
+      "$description": "Placeholders pending designer tuning — sm = md − 2, lg = md + 2 around each mode's existing md gap, kept on canonical spacing steps.",
       "sm": {
         "$value": {
           "value": 4,

--- a/packages/core/tokens/semantic/spacing-nova.json
+++ b/packages/core/tokens/semantic/spacing-nova.json
@@ -287,7 +287,6 @@
       }
     },
     "gap": {
-      "$description": "Placeholders pending designer tuning — sm = md − 2, lg = md + 2 around each mode's existing md gap, kept on canonical spacing steps.",
       "sm": {
         "$value": {
           "value": 4,

--- a/packages/core/tokens/semantic/spacing-nova.json
+++ b/packages/core/tokens/semantic/spacing-nova.json
@@ -287,11 +287,27 @@
       }
     },
     "gap": {
-      "$value": {
-        "value": 6,
-        "unit": "px"
+      "sm": {
+        "$value": {
+          "value": 4,
+          "unit": "px"
+        },
+        "$type": "dimension"
       },
-      "$type": "dimension"
+      "md": {
+        "$value": {
+          "value": 6,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 8,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
     }
   },
   "container": {

--- a/packages/core/tokens/semantic/spacing-sera.json
+++ b/packages/core/tokens/semantic/spacing-sera.json
@@ -287,11 +287,27 @@
       }
     },
     "gap": {
-      "$value": {
-        "value": 12,
-        "unit": "px"
+      "sm": {
+        "$value": {
+          "value": 10,
+          "unit": "px"
+        },
+        "$type": "dimension"
       },
-      "$type": "dimension"
+      "md": {
+        "$value": {
+          "value": 12,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 14,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
     }
   },
   "container": {

--- a/packages/core/tokens/semantic/spacing-sera.json
+++ b/packages/core/tokens/semantic/spacing-sera.json
@@ -287,7 +287,6 @@
       }
     },
     "gap": {
-      "$description": "Placeholders pending designer tuning — sm = md − 2, lg = md + 2 around each mode's existing md gap, kept on canonical spacing steps.",
       "sm": {
         "$value": {
           "value": 10,

--- a/packages/core/tokens/semantic/spacing-sera.json
+++ b/packages/core/tokens/semantic/spacing-sera.json
@@ -287,6 +287,7 @@
       }
     },
     "gap": {
+      "$description": "Placeholders pending designer tuning — sm = md − 2, lg = md + 2 around each mode's existing md gap, kept on canonical spacing steps.",
       "sm": {
         "$value": {
           "value": 10,

--- a/packages/core/tokens/semantic/spacing-vega.json
+++ b/packages/core/tokens/semantic/spacing-vega.json
@@ -287,7 +287,6 @@
       }
     },
     "gap": {
-      "$description": "Placeholders pending designer tuning — sm = md − 2, lg = md + 2 around each mode's existing md gap, kept on canonical spacing steps.",
       "sm": {
         "$value": {
           "value": 6,

--- a/packages/core/tokens/semantic/spacing-vega.json
+++ b/packages/core/tokens/semantic/spacing-vega.json
@@ -287,6 +287,7 @@
       }
     },
     "gap": {
+      "$description": "Placeholders pending designer tuning — sm = md − 2, lg = md + 2 around each mode's existing md gap, kept on canonical spacing steps.",
       "sm": {
         "$value": {
           "value": 6,

--- a/packages/core/tokens/semantic/spacing-vega.json
+++ b/packages/core/tokens/semantic/spacing-vega.json
@@ -287,11 +287,27 @@
       }
     },
     "gap": {
-      "$value": {
-        "value": 8,
-        "unit": "px"
+      "sm": {
+        "$value": {
+          "value": 6,
+          "unit": "px"
+        },
+        "$type": "dimension"
       },
-      "$type": "dimension"
+      "md": {
+        "$value": {
+          "value": 8,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      },
+      "lg": {
+        "$value": {
+          "value": 10,
+          "unit": "px"
+        },
+        "$type": "dimension"
+      }
     }
   },
   "container": {

--- a/packages/react/src/components/ui/button.tsx
+++ b/packages/react/src/components/ui/button.tsx
@@ -7,7 +7,7 @@ import { IconLoader2 } from '@/lib/icons';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'nx:inline-flex nx:items-center nx:justify-center nx:gap-2 nx:rounded-md nx:text-sm nx:font-medium nx:whitespace-nowrap nx:transition-colors nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:pointer-events-none nx:disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+  'nx:inline-flex nx:items-center nx:justify-center nx:rounded-md nx:text-sm nx:font-medium nx:whitespace-nowrap nx:transition-colors nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:pointer-events-none nx:disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -23,9 +23,9 @@ const buttonVariants = cva(
         link: 'nx:text-primary-subtle-foreground nx:underline-offset-4 nx:hover:underline',
       },
       size: {
-        default: 'nx:px-control-md nx:py-control-md',
-        sm: 'nx:px-control-sm nx:py-control-sm nx:text-xs',
-        lg: 'nx:px-control-lg nx:py-control-lg',
+        default: 'nx:px-control-md nx:py-control-md nx:gap-control-md',
+        sm: 'nx:px-control-sm nx:py-control-sm nx:gap-control-sm nx:text-xs',
+        lg: 'nx:px-control-lg nx:py-control-lg nx:gap-control-lg',
         icon: 'nx:p-2.5',
       },
     },

--- a/packages/react/src/lib/utils.test.ts
+++ b/packages/react/src/lib/utils.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { cn } from './utils';
+
+describe('cn — gap class group', () => {
+  it('collapses two per-size gap-control utilities to the last one wins', () => {
+    expect(cn('nx:gap-control-sm', 'nx:gap-control-md')).toBe(
+      'nx:gap-control-md'
+    );
+  });
+
+  it('collapses a per-size gap-control against a native gap utility', () => {
+    expect(cn('nx:gap-control-md', 'nx:gap-2')).toBe('nx:gap-2');
+  });
+});

--- a/packages/react/src/lib/utils.test.ts
+++ b/packages/react/src/lib/utils.test.ts
@@ -3,13 +3,14 @@ import { describe, expect, it } from 'vitest';
 import { cn } from './utils';
 
 describe('cn — gap class group', () => {
-  it('collapses two per-size gap-control utilities to the last one wins', () => {
+  it('collapses two per-size gap-control utilities with last-one-wins semantics', () => {
     expect(cn('nx:gap-control-sm', 'nx:gap-control-md')).toBe(
       'nx:gap-control-md'
     );
   });
 
-  it('collapses a per-size gap-control against a native gap utility', () => {
+  it('collapses a per-size gap-control against a native gap utility in both orders', () => {
     expect(cn('nx:gap-control-md', 'nx:gap-2')).toBe('nx:gap-2');
+    expect(cn('nx:gap-2', 'nx:gap-control-md')).toBe('nx:gap-control-md');
   });
 });

--- a/packages/react/src/lib/utils.test.ts
+++ b/packages/react/src/lib/utils.test.ts
@@ -1,6 +1,9 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-import { cn } from './utils';
+import { cn, ROLE_CLASS_GROUPS } from './utils';
 
 describe('cn — gap class group', () => {
   it('collapses two per-size gap-control utilities with last-one-wins semantics', () => {
@@ -12,5 +15,23 @@ describe('cn — gap class group', () => {
   it('collapses a per-size gap-control against a native gap utility in both orders', () => {
     expect(cn('nx:gap-control-md', 'nx:gap-2')).toBe('nx:gap-2');
     expect(cn('nx:gap-2', 'nx:gap-control-md')).toBe('nx:gap-control-md');
+  });
+});
+
+describe('cn — role-utility class group parity', () => {
+  it('classGroups cover exactly the role utilities emitted by @nexus/core', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const spacingUtilitiesCss = readFileSync(
+      resolve(here, '../../../tailwind/spacing-utilities.css'),
+      'utf8'
+    );
+    const emitted = new Set(
+      [...spacingUtilitiesCss.matchAll(/@utility ([a-z-]+) \{/g)].map(
+        (m) => m[1]
+      )
+    );
+    const configured = new Set(Object.values(ROLE_CLASS_GROUPS).flat());
+
+    expect([...configured].sort()).toEqual([...emitted].sort());
   });
 });

--- a/packages/react/src/lib/utils.ts
+++ b/packages/react/src/lib/utils.ts
@@ -9,7 +9,9 @@ const twMerge = extendTailwindMerge({
       px: ['px-control-sm', 'px-control-md', 'px-control-lg'],
       py: ['py-control-sm', 'py-control-md', 'py-control-lg'],
       gap: [
-        'gap-control',
+        'gap-control-sm',
+        'gap-control-md',
+        'gap-control-lg',
         'gap-container',
         'gap-layout-section',
         'gap-layout-stack',

--- a/packages/react/src/lib/utils.ts
+++ b/packages/react/src/lib/utils.ts
@@ -1,23 +1,34 @@
 import { type ClassValue, clsx } from 'clsx';
 import { extendTailwindMerge } from 'tailwind-merge';
 
+/**
+ * Tailwind-merge class groups for Nexus role utilities. Hand-mirrors the
+ * `@utility` set emitted from canonical-mode role tokens by `@nexus/core`
+ * (see `packages/tailwind/spacing-utilities.css`). The parity test in
+ * `utils.test.ts` pins this set to that file so a new role utility cannot
+ * silently drop out of `cn()`'s last-wins collapse.
+ *
+ * Not re-exported from the package's public entry — internal coupling only.
+ */
+export const ROLE_CLASS_GROUPS = {
+  px: ['px-control-sm', 'px-control-md', 'px-control-lg'],
+  py: ['py-control-sm', 'py-control-md', 'py-control-lg'],
+  gap: [
+    'gap-control-sm',
+    'gap-control-md',
+    'gap-control-lg',
+    'gap-container',
+    'gap-layout-section',
+    'gap-layout-stack',
+  ],
+  p: ['p-container'],
+};
+
 /** Tailwind-merge configured with `nx:` prefix and Nexus role-utility class groups. */
 const twMerge = extendTailwindMerge({
   prefix: 'nx',
   extend: {
-    classGroups: {
-      px: ['px-control-sm', 'px-control-md', 'px-control-lg'],
-      py: ['py-control-sm', 'py-control-md', 'py-control-lg'],
-      gap: [
-        'gap-control-sm',
-        'gap-control-md',
-        'gap-control-lg',
-        'gap-container',
-        'gap-layout-section',
-        'gap-layout-stack',
-      ],
-      p: ['p-container'],
-    },
+    classGroups: ROLE_CLASS_GROUPS,
   },
 });
 

--- a/packages/react/src/stories/Spacing.stories.tsx
+++ b/packages/react/src/stories/Spacing.stories.tsx
@@ -7,6 +7,7 @@ import spacingMira from '../../../core/tokens/semantic/spacing-mira.json';
 import spacingNova from '../../../core/tokens/semantic/spacing-nova.json';
 import spacingSera from '../../../core/tokens/semantic/spacing-sera.json';
 import spacingVega from '../../../core/tokens/semantic/spacing-vega.json';
+import { IconCheck } from '../lib/icons';
 
 import { SPACING_MODES, type SpacingMode } from './spacing-modes';
 
@@ -215,7 +216,7 @@ export const ActiveMode: Story = {
     docs: {
       description: {
         story:
-          'Live render of role-named utilities under the active `data-style` mode (controlled by the **Style** toolbar). Switching modes resizes the boxes; numeric utilities like `nx:p-4` are byte-identical across modes today, so only role utilities (`nx:px-control-*`, `nx:py-control-*`, `nx:gap-control`, `nx:p-container`, `nx:gap-layout-*`) reveal the per-mode variance. Try `nova` (compact), `vega` (default), `maia` (relaxed), `sera` (most breathing).',
+          'Live render of role-named utilities under the active `data-style` mode (controlled by the **Style** toolbar). Switching modes resizes the boxes; numeric utilities like `nx:p-4` are byte-identical across modes today, so only role utilities (`nx:px-control-*`, `nx:py-control-*`, `nx:gap-control-*`, `nx:p-container`, `nx:gap-layout-*`) reveal the per-mode variance. Try `nova` (compact), `vega` (default), `maia` (relaxed), `sera` (most breathing).',
       },
     },
   },
@@ -236,7 +237,7 @@ export const ActiveMode: Story = {
         <h3 className="nx:text-foreground nx:typography-heading-xsmall nx:font-mono">
           nx:px-control-* / nx:py-control-*
         </h3>
-        <div className="nx:flex nx:items-end nx:gap-control">
+        <div className="nx:flex nx:items-end nx:gap-4">
           <div className="nx:px-control-sm nx:py-control-sm nx:inline-flex nx:items-center nx:rounded-md nx:bg-primary-background nx:text-primary-foreground nx:typography-label-small">
             sm
           </div>
@@ -246,6 +247,35 @@ export const ActiveMode: Story = {
           <div className="nx:px-control-lg nx:py-control-lg nx:inline-flex nx:items-center nx:rounded-md nx:bg-primary-background nx:text-primary-foreground nx:typography-label-default">
             lg
           </div>
+        </div>
+      </section>
+
+      <section className="nx:flex nx:flex-col nx:gap-3">
+        <h3 className="nx:text-foreground nx:typography-heading-xsmall nx:font-mono">
+          nx:gap-control-{'{sm,md,lg}'}
+        </h3>
+        <div className="nx:flex nx:items-end nx:gap-4">
+          <button
+            type="button"
+            className="nx:px-control-sm nx:py-control-sm nx:gap-control-sm nx:inline-flex nx:items-center nx:rounded-md nx:bg-primary-background nx:text-primary-foreground nx:typography-label-small"
+          >
+            <IconCheck aria-hidden="true" />
+            sm
+          </button>
+          <button
+            type="button"
+            className="nx:px-control-md nx:py-control-md nx:gap-control-md nx:inline-flex nx:items-center nx:rounded-md nx:bg-primary-background nx:text-primary-foreground nx:typography-label-default"
+          >
+            <IconCheck aria-hidden="true" />
+            md
+          </button>
+          <button
+            type="button"
+            className="nx:px-control-lg nx:py-control-lg nx:gap-control-lg nx:inline-flex nx:items-center nx:rounded-md nx:bg-primary-background nx:text-primary-foreground nx:typography-label-default"
+          >
+            <IconCheck aria-hidden="true" />
+            lg
+          </button>
         </div>
       </section>
 

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -386,7 +386,9 @@
   --nx-control-padding-y-sm: 6px;
   --nx-control-padding-y-md: 8px;
   --nx-control-padding-y-lg: 12px;
-  --nx-control-gap: 8px;
+  --nx-control-gap-sm: 6px;
+  --nx-control-gap-md: 8px;
+  --nx-control-gap-lg: 10px;
   --nx-container-p: 24px;
   --nx-container-gap: 16px;
   --nx-layout-section-gap: 32px;
@@ -434,7 +436,9 @@
   --nx-control-padding-y-sm: 6px;
   --nx-control-padding-y-md: 8px;
   --nx-control-padding-y-lg: 12px;
-  --nx-control-gap: 8px;
+  --nx-control-gap-sm: 6px;
+  --nx-control-gap-md: 8px;
+  --nx-control-gap-lg: 10px;
   --nx-container-p: 28px;
   --nx-container-gap: 20px;
   --nx-layout-section-gap: 40px;
@@ -482,7 +486,9 @@
   --nx-control-padding-y-sm: 6px;
   --nx-control-padding-y-md: 8px;
   --nx-control-padding-y-lg: 12px;
-  --nx-control-gap: 8px;
+  --nx-control-gap-sm: 6px;
+  --nx-control-gap-md: 8px;
+  --nx-control-gap-lg: 10px;
   --nx-container-p: 24px;
   --nx-container-gap: 16px;
   --nx-layout-section-gap: 32px;
@@ -530,7 +536,9 @@
   --nx-control-padding-y-sm: 8px;
   --nx-control-padding-y-md: 10px;
   --nx-control-padding-y-lg: 14px;
-  --nx-control-gap: 10px;
+  --nx-control-gap-sm: 8px;
+  --nx-control-gap-md: 10px;
+  --nx-control-gap-lg: 12px;
   --nx-container-p: 28px;
   --nx-container-gap: 20px;
   --nx-layout-section-gap: 40px;
@@ -578,7 +586,9 @@
   --nx-control-padding-y-sm: 6px;
   --nx-control-padding-y-md: 8px;
   --nx-control-padding-y-lg: 12px;
-  --nx-control-gap: 8px;
+  --nx-control-gap-sm: 6px;
+  --nx-control-gap-md: 8px;
+  --nx-control-gap-lg: 10px;
   --nx-container-p: 24px;
   --nx-container-gap: 16px;
   --nx-layout-section-gap: 32px;
@@ -626,7 +636,9 @@
   --nx-control-padding-y-sm: 4px;
   --nx-control-padding-y-md: 6px;
   --nx-control-padding-y-lg: 10px;
-  --nx-control-gap: 6px;
+  --nx-control-gap-sm: 4px;
+  --nx-control-gap-md: 6px;
+  --nx-control-gap-lg: 8px;
   --nx-container-p: 20px;
   --nx-container-gap: 12px;
   --nx-layout-section-gap: 28px;
@@ -674,7 +686,9 @@
   --nx-control-padding-y-sm: 10px;
   --nx-control-padding-y-md: 12px;
   --nx-control-padding-y-lg: 16px;
-  --nx-control-gap: 12px;
+  --nx-control-gap-sm: 10px;
+  --nx-control-gap-md: 12px;
+  --nx-control-gap-lg: 14px;
   --nx-container-p: 40px;
   --nx-container-gap: 24px;
   --nx-layout-section-gap: 56px;

--- a/packages/tailwind/spacing-utilities.css
+++ b/packages/tailwind/spacing-utilities.css
@@ -30,8 +30,16 @@
   padding-bottom: var(--nx-control-padding-y-lg);
 }
 
-@utility gap-control {
-  gap: var(--nx-control-gap);
+@utility gap-control-sm {
+  gap: var(--nx-control-gap-sm);
+}
+
+@utility gap-control-md {
+  gap: var(--nx-control-gap-md);
+}
+
+@utility gap-control-lg {
+  gap: var(--nx-control-gap-lg);
 }
 
 @utility p-container {


### PR DESCRIPTION
## Summary

- Reshape `control.gap` from a single 2-segment leaf to a 3-segment subtree across all 7 spacing modes (`vega`, `lyra`, `maia`, `mira`, `nova`, `luma`, `sera`), mirroring `padding-x` / `padding-y`. `md` preserves each mode's current `gap` value so default-size Button shows no behavior change; `sm` / `lg` are canonical-step-aligned placeholders (`sm = md − 2`, `lg = md + 2`). Each mode file documents the formula via a `$description` on the `control.gap` group so the placeholder/tuned distinction lives at the JSON, not just in PR-body memory.
- Extend `deriveRoleUtility` in `packages/core/scripts/utils.js`: unify the 3-segment family registry into a single `FAMILY_TO_UTILITY = { 'padding-x': { prefix, properties }, ... }` map (gains `gap → { prefix: 'gap', properties: ['gap'] }`). The 2-segment `if (second === 'gap')` branch stays for `container.gap`, which is still size-less.
- Emit `nx:gap-control-{sm,md,lg}` utilities (3 `@utility` blocks); remove the un-suffixed `nx:gap-control` and `--nx-control-gap` cleanly per `project-stage.md` (no shims).
- Swap Button's base `nx:gap-2` for per-size `nx:gap-control-{sm,md,lg}` matched to each `size` variant — `default` → md, `sm` → sm, `lg` → lg, `icon` unchanged (single child). The Button proof-point now responds to spacing mode at the size the button actually is, which was the whole point of the issue.
- `cn()` twMerge `gap` class group lists the three per-size names. **New** `packages/react/src/lib/utils.test.ts` pins collapse behavior in both directions: per-size last-one-wins (`cn('nx:gap-control-sm','nx:gap-control-md') === 'nx:gap-control-md'`) and commutative cross-group dedupe with native `gap` (`cn('nx:gap-control-md','nx:gap-2') === 'nx:gap-2'` and the inverse `cn('nx:gap-2','nx:gap-control-md') === 'nx:gap-control-md'`).
- `Spacing.stories.tsx` `ActiveMode` adds a new section demonstrating per-size gap with icon+label buttons, so the per-mode variance is visible inside a control. `apps/playground/src/components/ComponentShowcase.tsx` controls swap to size-matched `gap-control-{size}`.
- `.claude/rules/spacing-tokens.md` updated: JSON shape example, coupling table (Button default/sm/lg, Select trigger), and the "Mix freely" example (which previously cited Button + numeric `gap-2`, no longer accurate).

## GitHub Issue

Closes #230

## Test Plan

- [x] `yarn test` — 557/557 passing (+3 `cn()` collapse assertions)
- [x] `yarn typecheck` — clean
- [x] `yarn lint` — clean
- [x] `yarn tokens:tailwind` + `yarn tokens:modular` — regenerated; `nexus.css` has 21 per-mode `--nx-control-gap-{sm,md,lg}` declarations (3 × 7); `spacing-utilities.css` has 3 `@utility gap-control-{sm,md,lg}` blocks; zero un-suffixed `control-gap` / `gap-control` survive
- [x] Storybook Button + Spacing stories render under the new utility set; `ModesProduceDifferentHeights` regression sentinel still passes (heights driven by `py`, not gap)
- [ ] Reviewer: spot-check the Spacing story's new per-size gap section in Storybook across the Style toolbar — `nova` (compact) vs `sera` (most breathing) should show visibly different icon↔text gaps

## Council pre-merge audit

A 3-agent council (principal-architect / sde2 / tester) audited the plan before implementation. Their flagged refinements were folded in:

- **SDE2:** Button must use per-size gap inside each `size` variant, not a base-level `gap-control-md`. (The whole point of the issue.) ✅
- **Tester:** Add `cn()` collapse tests so a wrong twMerge config can't silently regress. ✅
- **Architect:** Unify the family registry into a single `FAMILY_TO_UTILITY` map so adding a new 3-segment family touches one row, not two. ✅

## Out of scope

- **Designer tuning of per-size gap values across modes** — placeholders ship; tuning is a separate task per the issue.
- **Migrating Select / Tabs / Tooltip / Badge to per-size gap** — those land in #124's component-migration epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
