### PR TITLE
chore(testing): extract dimensional regression-sentinel helpers for component migrations

### DIFF
--- a/packages/react/src/components/ui/Button.stories.tsx
+++ b/packages/react/src/components/ui/Button.stories.tsx
@@ -3,6 +3,10 @@ import { IconRocket, IconStar } from '@tabler/icons-react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { SPACING_MODES } from '../../stories/spacing-modes';
+import {
+  expectHeightPinned,
+  expectModeCascadeWorks,
+} from '../../stories/test-utils';
 
 import { Button } from './button';
 
@@ -520,7 +524,7 @@ export const ModesProduceDifferentHeights: Story = {
     docs: {
       description: {
         story:
-          'Regression sentinel for the `data-style` cascade and the role-utility resolver. Buttons scoped to different modes must render at different heights — a typo like `nx:py-control-mdd` would silently fall back to intrinsic and all three buttons would match. The assertion checks only that not all heights are equal; specific ordering between modes is a design contract, not a code contract.',
+          'Regression sentinel for the `data-style` cascade and the role-utility resolver. A Button scoped to `nova` (compact) must render shorter than the same Button scoped to `sera` (breathy) — a typo like `nx:py-control-mdd` would silently fall back to intrinsic and both would match. Pair-wise (not a 3-mode chain) so a designer retune of any single mode does not break this test — only a broken cascade does.',
       },
     },
   },
@@ -529,28 +533,17 @@ export const ModesProduceDifferentHeights: Story = {
       <div data-style="nova" data-testid="mode-host-nova">
         <Button>btn</Button>
       </div>
-      <div data-style="vega" data-testid="mode-host-vega">
-        <Button>btn</Button>
-      </div>
       <div data-style="sera" data-testid="mode-host-sera">
         <Button>btn</Button>
       </div>
     </div>
   ),
   play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const heightOf = (testId: string) => {
-      const host = canvas.getByTestId(testId);
-      const button = host.querySelector('button');
-      if (!button) throw new Error(`button not found in ${testId}`);
-      return button.getBoundingClientRect().height;
-    };
-
-    const novaH = heightOf('mode-host-nova');
-    const vegaH = heightOf('mode-host-vega');
-    const seraH = heightOf('mode-host-sera');
-
-    expect(new Set([novaH, vegaH, seraH]).size).toBeGreaterThan(1);
+    expectModeCascadeWorks(
+      within(canvasElement),
+      'mode-host-nova',
+      'mode-host-sera'
+    );
   },
 };
 
@@ -574,11 +567,7 @@ export const VegaDefaultHeightPinned: Story = {
     </div>
   ),
   play: async ({ canvasElement }) => {
-    // Wait for Inter to load — fallback metrics would skew the measurement.
-    await document.fonts.ready;
-    const canvas = within(canvasElement);
-    const button = canvas.getByRole('button');
-    await expect(button.getBoundingClientRect().height).toBeCloseTo(36, 0);
+    await expectHeightPinned(within(canvasElement), 'vega-host', 36);
   },
 };
 

--- a/packages/react/src/stories/test-utils.ts
+++ b/packages/react/src/stories/test-utils.ts
@@ -6,7 +6,7 @@ const DEFAULT_CONTROL_SELECTOR =
 type Canvas = ReturnType<typeof within>;
 
 /**
- * Pixel-rounded height of the first focusable control inside a host element
+ * Pixel-rounded height of the single focusable control inside a host element
  * identified by `data-testid`. If the host element itself matches the selector
  * (e.g. `data-testid` placed directly on a `<button>`), measures the host;
  * otherwise looks for a single descendant match. Throws descriptively when no
@@ -18,11 +18,11 @@ export function getControlHeight(
   testId: string,
   selector = DEFAULT_CONTROL_SELECTOR
 ): number {
-  const host = canvas.getByTestId(testId);
+  const host: HTMLElement = canvas.getByTestId(testId);
   if (host.matches(selector)) {
     return Math.round(host.getBoundingClientRect().height);
   }
-  const controls = host.querySelectorAll(selector) as NodeListOf<HTMLElement>;
+  const controls = host.querySelectorAll<HTMLElement>(selector);
   if (controls.length > 1) {
     throw new Error(
       `Found ${controls.length} controls matching \`${selector}\` inside [data-testid="${testId}"] — measurement is ambiguous`
@@ -39,11 +39,12 @@ export function getControlHeight(
 
 /**
  * Cascade-regression sentinel — asserts that a control rendered under two
- * different `data-style` mode scopes resolves to different heights. Pair-wise
- * (not a 3-mode chain) so designer retunes of any single mode do not break
- * the test — only a broken cascade does. Consumers in different components
- * can pick different pairs (`nova`+`sera`, `nova`+`maia`, …) to spread
- * coverage across the 7 modes.
+ * different `data-style` mode scopes resolves to different heights, with the
+ * first arg's height strictly less than the second. Pass the smaller-padding
+ * mode first (e.g. `nova` before `sera`). Pair-wise (not a 3-mode chain) so
+ * designer retunes of any single mode do not break the test — only a broken
+ * cascade does. Consumers in different components can pick different pairs
+ * (`nova`+`sera`, `nova`+`maia`, …) to spread coverage across the 7 modes.
  */
 export function expectModeCascadeWorks(
   canvas: Canvas,

--- a/packages/react/src/stories/test-utils.ts
+++ b/packages/react/src/stories/test-utils.ts
@@ -1,0 +1,71 @@
+import { expect, type within } from 'storybook/test';
+
+const DEFAULT_CONTROL_SELECTOR =
+  'button, input, [role="combobox"], [role="tab"]';
+
+type Canvas = ReturnType<typeof within>;
+
+/**
+ * Pixel-rounded height of the first focusable control inside a host element
+ * identified by `data-testid`. If the host element itself matches the selector
+ * (e.g. `data-testid` placed directly on a `<button>`), measures the host;
+ * otherwise looks for a single descendant match. Throws descriptively when no
+ * control matches or when multiple controls match — both are story-shape bugs
+ * that should fail loud, not silently use the first hit.
+ */
+export function getControlHeight(
+  canvas: Canvas,
+  testId: string,
+  selector = DEFAULT_CONTROL_SELECTOR
+): number {
+  const host = canvas.getByTestId(testId);
+  if (host.matches(selector)) {
+    return Math.round(host.getBoundingClientRect().height);
+  }
+  const controls = host.querySelectorAll(selector) as NodeListOf<HTMLElement>;
+  if (controls.length > 1) {
+    throw new Error(
+      `Found ${controls.length} controls matching \`${selector}\` inside [data-testid="${testId}"] — measurement is ambiguous`
+    );
+  }
+  const control = controls[0];
+  if (!control) {
+    throw new Error(
+      `No control matching \`${selector}\` found inside [data-testid="${testId}"]`
+    );
+  }
+  return Math.round(control.getBoundingClientRect().height);
+}
+
+/**
+ * Cascade-regression sentinel — asserts that a control rendered under two
+ * different `data-style` mode scopes resolves to different heights. Pair-wise
+ * (not a 3-mode chain) so designer retunes of any single mode do not break
+ * the test — only a broken cascade does. Consumers in different components
+ * can pick different pairs (`nova`+`sera`, `nova`+`maia`, …) to spread
+ * coverage across the 7 modes.
+ */
+export function expectModeCascadeWorks(
+  canvas: Canvas,
+  smallerModeTestId: string,
+  largerModeTestId: string
+): void {
+  const smaller = getControlHeight(canvas, smallerModeTestId);
+  const larger = getControlHeight(canvas, largerModeTestId);
+  expect(smaller).toBeLessThan(larger);
+}
+
+/**
+ * Contract pin — asserts that a control rendered under a specific `data-style`
+ * scope hits an exact pixel height. Awaits `document.fonts.ready` first; Inter
+ * fallback metrics would skew the measurement.
+ */
+export async function expectHeightPinned(
+  canvas: Canvas,
+  testId: string,
+  expectedPx: number
+): Promise<void> {
+  await document.fonts.ready;
+  const actual = getControlHeight(canvas, testId);
+  expect(actual).toBe(expectedPx);
+}


### PR DESCRIPTION
## Summary

- Extracts the three dimensional-regression patterns from `Button.stories.tsx` into a reusable helper at `packages/react/src/stories/test-utils.ts` — `getControlHeight`, `expectModeCascadeWorks`, `expectHeightPinned` — so the 10 component migrations in #124 each consume the helpers instead of duplicating ~50 LOC of inline test code.
- Bakes in the three review fixes from #231: `Math.round` + `toBe(N)` instead of `toBe` on raw `getBoundingClientRect()` (sub-pixel flake); `void` return on the cascade assertion so a dead `await` is a type error; pair-wise (not 3-mode chain) so designer retunes of any single mode do not break the test.
- Refactors Button's `ModesProduceDifferentHeights` to a `nova`+`sera` pair (was nova/vega/sera trio) and Button's `VegaDefaultHeightPinned` to a single `expectHeightPinned` call. Net `+11 / −22` in the consumer.

## Helper-side refinements beyond the issue spec

Three additions surfaced during the council audit, all kept the API tight:

- `host.matches(selector)` handles `data-testid` placed directly on a control as well as on a wrapper.
- Ambiguity throw on multiple matches — silent first-hit was a debugging trap.
- TypeScript-correct under `noUncheckedIndexedAccess`: guard clauses on length, then on the resolved element.

The `toBeCloseTo(N, 0)` from the spec was dropped in favour of `Math.round` + `toBe(N)` — after rounding, the integer input means `toBeCloseTo(N, 0)` only passes for exactly `N` (diff is 0 or ≥ 1; tolerance is < 0.5). Equivalent semantics, simpler read.

## GitHub Issue

Closes #232

## Test Plan

- [x] `yarn workspace @nexus/react typecheck` clean
- [x] `yarn lint` clean (`--max-warnings 0`)
- [x] `yarn test:storybook` — 250/250 tests passing (Button: 29/29)
- [x] `yarn workspace @nexus/react audit:storybook-coverage --component button` — no gaps
- [x] `ModesProduceDifferentHeights` and `VegaDefaultHeightPinned` continue to pass post-refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)