### PR TITLE
[9/12] docs(rules): sync spacing-tokens.md to implemented state

### DIFF
--- a/.claude/rules/figma.md
+++ b/.claude/rules/figma.md
@@ -53,14 +53,14 @@ Under CI (`CI=true` or `CI=1`), the guard hard-fails if git timestamps are unava
 
 ### Categories
 
-| Category      | Status    | Wired by    | Notes                                                                                                     |
-| ------------- | --------- | ----------- | --------------------------------------------------------------------------------------------------------- |
-| `color`       | Supported | #65         | Single-mode (one `color.json`).                                                                           |
-| `spacing`     | Pending   | (#117 epic) | Multi-mode (`semantic/spacing-{vega,lyra,maia,mira,nova,luma,sera}.json`). No primitive layer — per #119. |
-| `radius`      | Pending   | #61         | Multi-mode (`radius-{blunt,sharp,subtle,...}.json`).                                                      |
-| `borderwidth` | Pending   | #61         | Multi-mode (`borderwidth-{vega,lyra,...}.json`).                                                          |
-| `typography`  | Pending   | #62         | Multi-mode composite tokens.                                                                              |
-| `shadow`      | Pending   | #63         | Multi-mode × theme (`shadow-{mode}-{light,dark}.json`).                                                   |
+| Category      | Status    | Wired by | Notes                                                                                                     |
+| ------------- | --------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `color`       | Supported | #65      | Single-mode (one `color.json`).                                                                           |
+| `spacing`     | Pending   | #128     | Multi-mode (`semantic/spacing-{vega,lyra,maia,mira,nova,luma,sera}.json`). No primitive layer — per #119. |
+| `radius`      | Pending   | #61      | Multi-mode (`radius-{blunt,sharp,subtle,...}.json`).                                                      |
+| `borderwidth` | Pending   | #61      | Multi-mode (`borderwidth-{vega,lyra,...}.json`).                                                          |
+| `typography`  | Pending   | #62      | Multi-mode composite tokens.                                                                              |
+| `shadow`      | Pending   | #63      | Multi-mode × theme (`shadow-{mode}-{light,dark}.json`).                                                   |
 
 This table is the single source of truth for the audit's category coverage. The script no longer carries a parallel `PENDING_CATEGORIES` map — running `--category spacing` today fails with an unknown-category error pointing readers back here.
 

--- a/.claude/rules/spacing-tokens.md
+++ b/.claude/rules/spacing-tokens.md
@@ -185,6 +185,21 @@ Two ESLint/Stylelint rules **will** guard the architecture:
 
 Both rules are tracked by #127. Until they land, the architecture is enforced through review.
 
+## How to add a new mode
+
+A density mode is a complete spacing scale — numeric steps plus the `control` / `container` / `layout` role bundles. Adding one is mechanical once the design decisions are made.
+
+1. **Author the JSON.** Copy `packages/core/tokens/semantic/spacing-vega.json` to `spacing-{mode}.json` and edit values for the new mode's design intent. Do not add or remove keys — every mode file must carry the same key set so the schema validator (once #126 lands) accepts it.
+2. **Register the mode in both `SPACING_MODES` tuples.** The tuple is duplicated, not cross-imported, so both files need the new entry:
+   - `apps/playground/src/hooks/useTheme.ts` — the playground theme switcher source-of-truth.
+   - `packages/react/src/stories/spacing-modes.tsx` — the React-workspace tuple consumed by component story sentinels.
+
+   Storybook's `Style` toolbar picks up the new mode automatically — `packages/react/.storybook/preview.tsx` spreads `[...SPACING_MODES]` into its `globalTypes.style.toolbar.items`.
+
+3. **Validate.** Run `yarn validate:spacing-modes` once that script lands (#126). Until then, the cross-mode CSS-variable-name parity assertion in `generate-tailwind-package.test.js` is the indirect gate — `yarn workspace @nexus/core test` will fail if the new mode emits a different variable name set than Vega.
+4. **Regenerate the emitted CSS.** Run `yarn tokens:tailwind` (per-mode CSS bundle for the `@nexus/tailwind` package) followed by `yarn tokens:modular` (which also runs `sync-playground-themes.js` to keep playground theme files in sync).
+5. **Sanity-check.** Open Storybook, switch to the new mode in the `Style` toolbar, and confirm a few migrated components (Button, Card, Dialog) render the expected per-mode padding.
+
 ## Role-to-component coupling table
 
 Components should use specific roles for specific spacing decisions. This table is authoritative; lint rule #2 references it.

--- a/.claude/rules/spacing-tokens.md
+++ b/.claude/rules/spacing-tokens.md
@@ -257,6 +257,23 @@ The Figma side of Nexus mirrors this architecture. Figma Variables for spacing l
 
 The `audit:figma-parity` script **will** compare each mode's Figma collection against the corresponding `spacing-{mode}.json` file — same intent as the existing color audit, but mode-scoped. The `spacing` category is `Pending` in [`figma.md`](figma.md)'s categories table (tracked under the #117 epic); the audit only supports `--category color` today.
 
+## Migration history
+
+The two-tier per-mode architecture described above landed across the [Spacing tokens · Phase 1](https://github.com/nexuslabs-ai/nexus/milestone/5) milestone. In chronological order:
+
+- **#117** — audit existing spacing utilities, finalise the role vocabulary (`control` / `container` / `layout`).
+- **#118** — author the 7 per-mode `semantic/spacing-{mode}.json` files (vega, lyra, maia, mira, nova, luma, sera).
+- **#119** — switch the token build to read per-mode semantic spacing; emit `[data-style="X"]` blocks.
+- **#120** — refactor playground `useTheme` to activate modes via `data-style`; add Luma + Sera to the picker.
+- **#121** — delete the `--nx-size-*` primitive layer (the two-tier shape becomes load-bearing here).
+- **#122** — add the Storybook `style` globalType + decorator so stories can be exercised across every mode.
+- **#123** — migrate Button to role-named utilities (proof point for the role-token migration).
+- **#124** — roll out role-named utilities to the remaining 12 components.
+- **PR #130** — populate this file's role-coupling table with the audit-grounded 14-role version; sync the FE brief.
+- **#230** — add `--control-gap-{sm,md,lg}` per-size gap roles (the `control.gap` token splits from a single value into a size-keyed bundle).
+
+Still ahead on the same milestone: #126 (schema validator), #127 (lint rules), #128 (figma-parity wire-up for size).
+
 ## When to revisit
 
 Architectural decisions are not load-bearing forever. The conditions under which this design would need to be revisited:

--- a/.claude/rules/spacing-tokens.md
+++ b/.claude/rules/spacing-tokens.md
@@ -1,6 +1,6 @@
 # Spacing Token Architecture Rules
 
-> **Partial implementation status (post-#124).** The build pipeline now reads per-mode `semantic/spacing-{mode}.json` files and emits direct-px `[data-style="X"]` blocks; the `--nx-size-*` primitive layer is gone, `collectSpacingTokens` returns the per-mode shape, and `nx:px-control-*` / `nx:py-control-*` / `nx:p-container` / `nx:gap-layout-*` utilities are generated. The role-to-component coupling table below reflects shipped code as of #123 and #124. Still pending: `validate-spacing-modes.js` schema validator (#126), `nexus/canonical-spacing-steps` and `nexus/prefer-role-utilities` lint rules (#127), the `audit:figma-parity` wire-up for size category (#128), and the canonical-step-set reconciliation noted under "Open Items" in PR #223. Treat sections in this file as the **spec the build now satisfies**, except for the validator + lint enforcement which are still ahead.
+> **Partial implementation status (post-#124).** The build pipeline now reads per-mode `semantic/spacing-{mode}.json` files and emits direct-px `[data-style="X"]` blocks; the `--nx-size-*` primitive layer is gone, `collectSpacingTokens` returns the per-mode shape, and `nx:px-control-*` / `nx:py-control-*` / `nx:p-container` / `nx:gap-layout-*` utilities are generated. The role-to-component coupling table below reflects shipped code as of #123 and #124. Still pending: `validate-spacing-modes.js` schema validator (#126), `nexus/canonical-spacing-steps` and `nexus/prefer-role-utilities` lint rules (#127), the `audit:figma-parity` wire-up for size category (#128), and the canonical-step-set reconciliation noted under "Open Items" in PR #223. Treat sections in this file as the **spec the build now satisfies**, except for the items listed above.
 
 > Companion to `tokens.md`. Spacing has a different architecture than color, typography, radius, etc. — there is **no primitive size layer**. This file documents that decision, the rules that replace what primitives used to enforce, and the authoring patterns that follow from it.
 
@@ -170,6 +170,21 @@ Load these into context when generating Nexus FE code:
 3. **Role-named utilities take priority over numeric** when a clear role applies. Button padding → `nx:px-control-md`, not `nx:px-2.5`.
 4. **Mode switching is via `data-style="X"` attribute** on the root or a subtree. To make a component appear in compact density, wrap it in `<div data-style="mira">`.
 
+## How to add a new mode
+
+A density mode is a complete spacing scale — numeric steps plus the `control` / `container` / `layout` role bundles. Adding one is mechanical once the design decisions are made.
+
+1. **Author the JSON.** Copy `packages/core/tokens/semantic/spacing-vega.json` to `spacing-{mode}.json` and edit values for the new mode's design intent. Do not add or remove keys — every mode file must carry the same key set so the schema validator (once #126 lands) accepts it.
+2. **Register the mode in both `SPACING_MODES` tuples.** The tuple is duplicated, not cross-imported, so both files need the new entry:
+   - `apps/playground/src/hooks/useTheme.ts` — the playground theme switcher source-of-truth.
+   - `packages/react/src/stories/spacing-modes.tsx` — the React-workspace tuple consumed by component story sentinels.
+
+   Storybook's `Style` toolbar picks up the new mode automatically — `packages/react/.storybook/preview.tsx` spreads `[...SPACING_MODES]` into its `globalTypes.style.toolbar.items`.
+
+3. **Validate.** Run `yarn validate:spacing-modes` once that script lands (#126). Until then, the cross-mode CSS-variable-name parity assertion in `generate-tailwind-package.test.js` is the indirect gate — `yarn test:unit` (from the repo root) will fail if the new mode emits a different variable name set than Vega.
+4. **Regenerate the emitted CSS.** Run `yarn tokens:tailwind` (per-mode CSS bundle for the `@nexus/tailwind` package) followed by `yarn tokens:modular` (which also runs `sync-playground-themes.js` to keep playground theme files in sync).
+5. **Sanity-check.** Open Storybook, switch to the new mode in the `Style` toolbar, and confirm a few migrated components (Button, Card, Dialog) render the expected per-mode padding.
+
 ## Schema validation _(planned — #126)_
 
 CI **will** enforce that all 7 mode files have **identical key sets**. The schema is to be generated from `spacing-vega.json` (the canonical default) and applied to all other modes. A mode file with missing or extra keys will fail the build.
@@ -184,21 +199,6 @@ Two ESLint/Stylelint rules **will** guard the architecture:
 2. **`nexus/prefer-role-utilities`** — flags raw numeric utilities (`nx:p-N`, `nx:h-N`, `nx:gap-N`) in `packages/react/src/components/ui/*.tsx` files when a role-named utility would apply. Reads the role-to-component coupling table (see below). Allow-list with `// nexus-allow-numeric: reason` comment.
 
 Both rules are tracked by #127. Until they land, the architecture is enforced through review.
-
-## How to add a new mode
-
-A density mode is a complete spacing scale — numeric steps plus the `control` / `container` / `layout` role bundles. Adding one is mechanical once the design decisions are made.
-
-1. **Author the JSON.** Copy `packages/core/tokens/semantic/spacing-vega.json` to `spacing-{mode}.json` and edit values for the new mode's design intent. Do not add or remove keys — every mode file must carry the same key set so the schema validator (once #126 lands) accepts it.
-2. **Register the mode in both `SPACING_MODES` tuples.** The tuple is duplicated, not cross-imported, so both files need the new entry:
-   - `apps/playground/src/hooks/useTheme.ts` — the playground theme switcher source-of-truth.
-   - `packages/react/src/stories/spacing-modes.tsx` — the React-workspace tuple consumed by component story sentinels.
-
-   Storybook's `Style` toolbar picks up the new mode automatically — `packages/react/.storybook/preview.tsx` spreads `[...SPACING_MODES]` into its `globalTypes.style.toolbar.items`.
-
-3. **Validate.** Run `yarn validate:spacing-modes` once that script lands (#126). Until then, the cross-mode CSS-variable-name parity assertion in `generate-tailwind-package.test.js` is the indirect gate — `yarn workspace @nexus/core test` will fail if the new mode emits a different variable name set than Vega.
-4. **Regenerate the emitted CSS.** Run `yarn tokens:tailwind` (per-mode CSS bundle for the `@nexus/tailwind` package) followed by `yarn tokens:modular` (which also runs `sync-playground-themes.js` to keep playground theme files in sync).
-5. **Sanity-check.** Open Storybook, switch to the new mode in the `Style` toolbar, and confirm a few migrated components (Button, Card, Dialog) render the expected per-mode padding.
 
 ## Role-to-component coupling table
 
@@ -255,11 +255,11 @@ When a new component is authored, the author adds a row to this table.
 
 The Figma side of Nexus mirrors this architecture. Figma Variables for spacing live in mode-specific collections (one per mode), each with the same key set as the JSON mode files. There is no Figma "spacing primitives" collection.
 
-The `audit:figma-parity` script **will** compare each mode's Figma collection against the corresponding `spacing-{mode}.json` file — same intent as the existing color audit, but mode-scoped. The `spacing` category is `Pending` in [`figma.md`](figma.md)'s categories table (tracked under the #117 epic); the audit only supports `--category color` today.
+The `audit:figma-parity` script **will** compare each mode's Figma collection against the corresponding `spacing-{mode}.json` file — same intent as the existing color audit, but mode-scoped. The `spacing` category is `Pending` in [`figma.md`](figma.md)'s categories table (tracked by #128); the audit only supports `--category color` today.
 
 ## Migration history
 
-The two-tier per-mode architecture described above landed across the [Spacing tokens · Phase 1](https://github.com/nexuslabs-ai/nexus/milestone/5) milestone. In chronological order:
+The two-tier per-mode architecture described above landed across the [Spacing tokens · Phase 1](https://github.com/nexuslabs-ai/nexus/milestone/5) milestone. In chronological order (issue numbers unless prefixed with `PR`):
 
 - **#117** — audit existing spacing utilities, finalise the role vocabulary (`control` / `container` / `layout`).
 - **#118** — author the 7 per-mode `semantic/spacing-{mode}.json` files (vega, lyra, maia, mira, nova, luma, sera).

--- a/.claude/rules/spacing-tokens.md
+++ b/.claude/rules/spacing-tokens.md
@@ -1,6 +1,6 @@
 # Spacing Token Architecture Rules
 
-> **Partial implementation status (post-#119).** The build pipeline now reads per-mode `semantic/spacing-{mode}.json` files and emits direct-px `[data-style="X"]` blocks; the `--nx-size-*` primitive layer is gone, `collectSpacingTokens` returns the per-mode shape, and `nx:px-control-*` / `nx:py-control-*` / `nx:p-container` / `nx:gap-layout-*` utilities are generated. Still pending: `validate-spacing-modes.js` schema validator (#125), `nexus/canonical-spacing-steps` and `nexus/prefer-role-utilities` lint rules (#127), the role-to-component-coupling enforcement (#128), and the canonical-step-set reconciliation noted under "Open Items" in PR #223. Treat sections in this file as the **spec the build now satisfies**, except for the validator + lint enforcement which are still ahead.
+> **Partial implementation status (post-#124).** The build pipeline now reads per-mode `semantic/spacing-{mode}.json` files and emits direct-px `[data-style="X"]` blocks; the `--nx-size-*` primitive layer is gone, `collectSpacingTokens` returns the per-mode shape, and `nx:px-control-*` / `nx:py-control-*` / `nx:p-container` / `nx:gap-layout-*` utilities are generated. The role-to-component coupling table below reflects shipped code as of #123 and #124. Still pending: `validate-spacing-modes.js` schema validator (#126), `nexus/canonical-spacing-steps` and `nexus/prefer-role-utilities` lint rules (#127), the `audit:figma-parity` wire-up for size category (#128), and the canonical-step-set reconciliation noted under "Open Items" in PR #223. Treat sections in this file as the **spec the build now satisfies**, except for the validator + lint enforcement which are still ahead.
 
 > Companion to `tokens.md`. Spacing has a different architecture than color, typography, radius, etc. — there is **no primitive size layer**. This file documents that decision, the rules that replace what primitives used to enforce, and the authoring patterns that follow from it.
 
@@ -170,11 +170,11 @@ Load these into context when generating Nexus FE code:
 3. **Role-named utilities take priority over numeric** when a clear role applies. Button padding → `nx:px-control-md`, not `nx:px-2.5`.
 4. **Mode switching is via `data-style="X"` attribute** on the root or a subtree. To make a component appear in compact density, wrap it in `<div data-style="mira">`.
 
-## Schema validation _(planned — #125)_
+## Schema validation _(planned — #126)_
 
 CI **will** enforce that all 7 mode files have **identical key sets**. The schema is to be generated from `spacing-vega.json` (the canonical default) and applied to all other modes. A mode file with missing or extra keys will fail the build.
 
-Planned implementation: `scripts/validate-spacing-modes.js` reads the Vega key set and validates the other six against it. Will run in pre-commit hook and CI. Tracked by #125. Until it lands, parity is enforced indirectly by the cross-mode CSS-variable-name parity assertion in `generate-tailwind-package.test.js`.
+Planned implementation: `scripts/validate-spacing-modes.js` reads the Vega key set and validates the other six against it. Will run in pre-commit hook and CI. Tracked by #126. Until it lands, parity is enforced indirectly by the cross-mode CSS-variable-name parity assertion in `generate-tailwind-package.test.js`.
 
 ## Lint rules _(planned — #127)_
 
@@ -204,7 +204,7 @@ A density mode is a complete spacing scale — numeric steps plus the `control` 
 
 Components should use specific roles for specific spacing decisions. This table is authoritative; lint rule #2 references it.
 
-> **Status: target state, not current code.** Button / Input / Select / Tabs / Badge currently use numeric `nx:p-N` utilities; #123 is the migration that moves them onto these role tokens. Read this table as the post-#123 contract that `nexus/prefer-role-utilities` (#127) will enforce — not as a description of what's shipped today.
+> **Status: shipped (#123, #124).** Button, Input, Select, Tabs, Badge, and the remaining containers/internal components (Card, Dialog, Alert, Accordion, plus DropdownMenu / Tooltip / Tabs internals) now use these role tokens. The table is authoritative for current code; `nexus/prefer-role-utilities` (#127) will mechanically enforce it once that lint rule lands.
 
 | Component                                | Role used for                          | Tokens                                                                             |
 | ---------------------------------------- | -------------------------------------- | ---------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

- Add **How to add a new mode** section to `.claude/rules/spacing-tokens.md` — 5 numbered steps (copy `spacing-vega.json`, register the new mode in both `SPACING_MODES` tuples, run validator + token regen, sanity-check in Storybook).
- Add **Migration history** section linking to the [Spacing tokens · Phase 1](https://github.com/nexuslabs-ai/nexus/milestone/5) milestone with a chronological list of the issues that built the architecture (#117–#124, PR #130, #230) plus the three items still ahead (#126, #127, #128).
- Sync stale references throughout the file:
  - 3× `#125` → `#126` (the validator is #126; this PR is #125)
  - Re-aim `(#128)` mention from "role-to-component-coupling enforcement" to its actual scope — the `audit:figma-parity` wire-up for size category
  - Banner anchor `post-#119` → `post-#124` (matches the current shipped state)
  - Rewrite the role-coupling table's **Status: target state, not current code** callout to **Status: shipped (#123, #124)** — Button + the 12 other components have migrated

## Why `tokens.md` is untouched

Issue ACs 1, 2, and 3 (the `tokens.md` items) were already satisfied on `main`:

- `tokens.md:105` already shows `spacing-{mode}.json` in the File Naming table
- `tokens.md:297-301` already drops `--nx-size-4` from the CSS-variable-naming example and carries the no-primitive-layer note
- `tokens.md:105` and `:301` both already point at `spacing-tokens.md`

Re-doing the work would only churn the diff. ACs 4 and 5 (the `spacing-tokens.md` sections) are what this PR adds.

## Out of scope

- `figma.md` — explicitly punted to #128 per the issue body
- The line-3 banner's `PR #223 'Open Items'` reference — caught during review, but reconciling the half-step canonical-set divergence is its own question (vega's JSON has `0_5/1_5/2_5/3_5` which the doc currently disallows)
- The `MEMORY.md` entry calling `spacing-tokens.md` "aspirational" — naturally resolved once this PR merges

## GitHub Issue

Closes #125

## Test Plan

- [ ] `grep '#125' .claude/rules/spacing-tokens.md` returns zero hits
- [ ] `grep '#126' .claude/rules/spacing-tokens.md` returns 5 hits (3 from the sync + 2 from the new "How to add a new mode" section)
- [ ] Milestone URL https://github.com/nexuslabs-ai/nexus/milestone/5 resolves to "Spacing tokens · Phase 1"
- [ ] "How to add a new mode" file paths are real: `apps/playground/src/hooks/useTheme.ts:23`, `packages/react/src/stories/spacing-modes.tsx:5`, `packages/react/.storybook/preview.tsx:100`
- [ ] Internal anchor refs in the file still resolve (no header was renamed, only inserted)