### PR TITLE
[10/12] feat(scripts): JSON schema validation for spacing mode files

### DIFF
--- a/.claude/rules/spacing-tokens.md
+++ b/.claude/rules/spacing-tokens.md
@@ -1,6 +1,6 @@
 # Spacing Token Architecture Rules
 
-> **Partial implementation status (post-#124).** The build pipeline now reads per-mode `semantic/spacing-{mode}.json` files and emits direct-px `[data-style="X"]` blocks; the `--nx-size-*` primitive layer is gone, `collectSpacingTokens` returns the per-mode shape, and `nx:px-control-*` / `nx:py-control-*` / `nx:p-container` / `nx:gap-layout-*` utilities are generated. The role-to-component coupling table below reflects shipped code as of #123 and #124. Still pending: `validate-spacing-modes.js` schema validator (#126), `nexus/canonical-spacing-steps` and `nexus/prefer-role-utilities` lint rules (#127), the `audit:figma-parity` wire-up for size category (#128), and the canonical-step-set reconciliation noted under "Open Items" in PR #223. Treat sections in this file as the **spec the build now satisfies**, except for the items listed above.
+> **Partial implementation status (post-#126).** The build pipeline now reads per-mode `semantic/spacing-{mode}.json` files and emits direct-px `[data-style="X"]` blocks; the `--nx-size-*` primitive layer is gone, `collectSpacingTokens` returns the per-mode shape, and `nx:px-control-*` / `nx:py-control-*` / `nx:p-container` / `nx:gap-layout-*` utilities are generated. The role-to-component coupling table below reflects shipped code as of #123 and #124. Schema validation (cross-mode key-set parity) ships via `validate-spacing-modes.js` (#126) and is gated in pre-commit and CI. Still pending: `nexus/canonical-spacing-steps` and `nexus/prefer-role-utilities` lint rules (#127), the `audit:figma-parity` wire-up for size category (#128), and the canonical-step-set reconciliation noted under "Open Items" in PR #223. Treat sections in this file as the **spec the build now satisfies**, except for the items listed above.
 
 > Companion to `tokens.md`. Spacing has a different architecture than color, typography, radius, etc. — there is **no primitive size layer**. This file documents that decision, the rules that replace what primitives used to enforce, and the authoring patterns that follow from it.
 
@@ -174,22 +174,29 @@ Load these into context when generating Nexus FE code:
 
 A density mode is a complete spacing scale — numeric steps plus the `control` / `container` / `layout` role bundles. Adding one is mechanical once the design decisions are made.
 
-1. **Author the JSON.** Copy `packages/core/tokens/semantic/spacing-vega.json` to `spacing-{mode}.json` and edit values for the new mode's design intent. Do not add or remove keys — every mode file must carry the same key set so the schema validator (once #126 lands) accepts it.
+1. **Author the JSON.** Copy `packages/core/tokens/semantic/spacing-vega.json` to `spacing-{mode}.json` and edit values for the new mode's design intent. Do not add or remove keys — every mode file must carry the same key set so the schema validator accepts it.
 2. **Register the mode in both `SPACING_MODES` tuples.** The tuple is duplicated, not cross-imported, so both files need the new entry:
    - `apps/playground/src/hooks/useTheme.ts` — the playground theme switcher source-of-truth.
    - `packages/react/src/stories/spacing-modes.tsx` — the React-workspace tuple consumed by component story sentinels.
 
    Storybook's `Style` toolbar picks up the new mode automatically — `packages/react/.storybook/preview.tsx` spreads `[...SPACING_MODES]` into its `globalTypes.style.toolbar.items`.
 
-3. **Validate.** Run `yarn validate:spacing-modes` once that script lands (#126). Until then, the cross-mode CSS-variable-name parity assertion in `generate-tailwind-package.test.js` is the indirect gate — `yarn test:unit` (from the repo root) will fail if the new mode emits a different variable name set than Vega.
+3. **Validate.** Run `yarn validate:spacing-modes` to confirm the new mode file shares the same key set as the others; the script reports any missing or extra paths and exits non-zero on drift. The cross-mode CSS-variable-name parity assertion in `generate-tailwind-package.test.js` is a second-tier check — `yarn test:unit` catches the same shape of drift after regen.
 4. **Regenerate the emitted CSS.** Run `yarn tokens:tailwind` (per-mode CSS bundle for the `@nexus/tailwind` package) followed by `yarn tokens:modular` (which also runs `sync-playground-themes.js` to keep playground theme files in sync).
 5. **Sanity-check.** Open Storybook, switch to the new mode in the `Style` toolbar, and confirm a few migrated components (Button, Card, Dialog) render the expected per-mode padding.
 
-## Schema validation _(planned — #126)_
+## Schema validation
 
-CI **will** enforce that all 7 mode files have **identical key sets**. The schema is to be generated from `spacing-vega.json` (the canonical default) and applied to all other modes. A mode file with missing or extra keys will fail the build.
+CI enforces that all 7 mode files have **identical key sets** via `packages/core/scripts/validate-spacing-modes.js`. The script reads the Vega key set as the canonical baseline and validates the other six against it; a mode file with missing or extra leaf paths fails the build with the offending paths reported on stderr.
 
-Planned implementation: `scripts/validate-spacing-modes.js` reads the Vega key set and validates the other six against it. Will run in pre-commit hook and CI. Tracked by #126. Until it lands, parity is enforced indirectly by the cross-mode CSS-variable-name parity assertion in `generate-tailwind-package.test.js`.
+A "leaf path" is determined by the DTCG token contract: a node carrying both `$value` and `$type` is a leaf, and its dotted path enters the key set. Sibling keys starting with `$` (e.g. `$meta`, `$description`) are skipped. A typo like `value:` (no `$`) won't slip through — the walker keeps descending past that branch and contributes nothing, so the parity check still catches the missing token.
+
+The validator runs in two places:
+
+- **Pre-commit** — when any `packages/core/tokens/semantic/spacing-*.json` is staged, lint-staged fires `yarn validate:spacing-modes` ahead of the commit.
+- **CI** — the `audit-tokens` job runs it before token regeneration, so a broken mode-file set fails fast without burning time on downstream audits.
+
+Exit codes mirror `audit-figma-parity`: `0` (match), `1` (drift), `2` (config error — missing baseline, unknown mode file, malformed JSON). Pure-function diffing logic (`leafPathsOf`, `diffKeySets`, `validateModes`, `formatFindings`) is unit-tested in `packages/core/scripts/__tests__/validate-spacing-modes.test.js`; the real-files smoke test in `spacing-modes.test.js` calls into the same `validateModes` entry point.
 
 ## Lint rules _(planned — #127)_
 
@@ -271,8 +278,9 @@ The two-tier per-mode architecture described above landed across the [Spacing to
 - **#124** — roll out role-named utilities to the remaining 12 components.
 - **PR #130** — populate this file's role-coupling table with the audit-grounded 14-role version; sync the FE brief.
 - **#230** — add `--control-gap-{sm,md,lg}` per-size gap roles (the `control.gap` token splits from a single value into a size-keyed bundle).
+- **#126** — ship `validate-spacing-modes.js` schema validator; wire to pre-commit (lint-staged) and CI (`audit-tokens` job, before regen).
 
-Still ahead on the same milestone: #126 (schema validator), #127 (lint rules), #128 (figma-parity wire-up for size).
+Still ahead on the same milestone: #127 (lint rules), #128 (figma-parity wire-up for size).
 
 ## When to revisit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,12 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      # Run BEFORE the regen step so the build doesn't run on a broken
+      # mode-file set. Validator is stdlib-only and runs in well under a
+      # second — fail-fast for the cheapest possible signal.
+      - name: Validate spacing mode files
+        run: yarn validate:spacing-modes
+
       - name: Regenerate token outputs (tailwind + modular + colorblind SVG)
         id: regen
         run: |

--- a/package.json
+++ b/package.json
@@ -83,6 +83,9 @@
     ],
     "*.{json,md,css}": [
       "prettier --write"
+    ],
+    "packages/core/tokens/semantic/spacing-*.json": [
+      "yarn validate:spacing-modes"
     ]
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "audit:contrast": "yarn workspace @nexus/core audit:contrast",
     "audit:figma-parity": "yarn workspace @nexus/core audit:figma-parity",
     "audit:storybook-coverage": "yarn workspace @nexus/react audit:storybook-coverage",
+    "validate:spacing-modes": "yarn workspace @nexus/core validate:spacing-modes",
     "playground": "cd apps/playground && yarn dev",
     "size-limit": "size-limit",
     "prepare": "husky"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,8 @@
     "audit:class-refs": "node scripts/audit-class-refs.js",
     "audit:colorblind": "node scripts/audit-colorblind.js",
     "audit:figma-parity": "node scripts/audit-figma-parity.js",
-    "generate:colorblind-svg": "node scripts/generate-colorblind-svg.js"
+    "generate:colorblind-svg": "node scripts/generate-colorblind-svg.js",
+    "validate:spacing-modes": "node scripts/validate-spacing-modes.js"
   },
   "dependencies": {
     "apca-w3": "^0.1.9",

--- a/packages/core/scripts/__tests__/spacing-modes.test.js
+++ b/packages/core/scripts/__tests__/spacing-modes.test.js
@@ -3,15 +3,17 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
+import { CANONICAL_MODES, validateModes } from '../validate-spacing-modes.js';
+
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const SEMANTIC_DIR = path.resolve(TEST_DIR, '..', '..', 'tokens', 'semantic');
 
-// Spacing ships exactly seven canonical modes per `.claude/rules/spacing-tokens.md`.
-// The generator filesystem-discovers them via the `spacing-{mode}.json`
-// pattern, so adding an unintentional 8th file (or losing one) would
-// silently emit/drop a `[data-style="..."]` block.
-const EXPECTED_MODES = ['luma', 'lyra', 'maia', 'mira', 'nova', 'sera', 'vega'];
-
+// This file is the vitest-side smoke test for the real spacing-{mode}.json
+// content on disk. It complements the pure-function unit tests in
+// validate-spacing-modes.test.js (which run against synthetic data) by
+// exercising the same validator entry point against the actual checked-in
+// files. The CLI gate (yarn validate:spacing-modes in CI and pre-commit) is
+// the production enforcement; this test gives Vitest-level signal too.
 describe('spacing modes', () => {
   it('ships exactly the seven canonical modes', () => {
     const modes = fs
@@ -20,53 +22,25 @@ describe('spacing modes', () => {
       .map((name) => name.slice('spacing-'.length, -'.json'.length))
       .sort();
 
-    expect(modes).toEqual(EXPECTED_MODES);
+    expect(modes).toEqual([...CANONICAL_MODES].sort());
   });
 
-  // Each spacing-{mode}.json carries the same key set — the build assumes
-  // this (and #125's validator will codify it at the schema layer). The test
-  // here is a coarse JSON-shape guarantee on top of the build-side
-  // cross-mode variable-name parity test in generate-tailwind-package.test.js.
-  it('all 7 mode files declare the same JSON path set at the leaves', () => {
-    function collectLeafPaths(node, pathParts) {
-      const paths = [];
-      function walk(n, p) {
-        if (
-          typeof n === 'object' &&
-          n !== null &&
-          '$value' in n &&
-          '$type' in n
-        ) {
-          paths.push(p.join('.'));
-          return;
-        }
-        if (typeof n === 'object' && n !== null) {
-          for (const [key, value] of Object.entries(n)) {
-            if (key.startsWith('$')) continue;
-            walk(value, [...p, key]);
-          }
-        }
-      }
-      walk(node, pathParts);
-      return paths;
-    }
-
-    const modePaths = {};
-    for (const mode of EXPECTED_MODES) {
+  it('all 7 mode files share the same leaf-path key set (vega as baseline)', () => {
+    const modeDataMap = new Map();
+    for (const mode of CANONICAL_MODES) {
       const data = JSON.parse(
         fs.readFileSync(path.join(SEMANTIC_DIR, `spacing-${mode}.json`), 'utf8')
       );
-      modePaths[mode] = new Set(collectLeafPaths(data, []));
+      modeDataMap.set(mode, data);
     }
 
-    const vegaPaths = modePaths.vega;
-    expect(vegaPaths.size).toBeGreaterThan(0);
-    for (const mode of EXPECTED_MODES) {
-      if (mode === 'vega') continue;
-      expect(
-        [...modePaths[mode]].sort(),
-        `spacing-${mode}.json diverges from spacing-vega.json key set`
-      ).toEqual([...vegaPaths].sort());
-    }
+    const findings = validateModes(modeDataMap);
+    const drift = findings.filter(
+      (f) => f.missing.length > 0 || f.extra.length > 0
+    );
+    expect(
+      drift,
+      `Spacing mode files diverge from baseline. Run \`yarn validate:spacing-modes\` for the full report.`
+    ).toEqual([]);
   });
 });

--- a/packages/core/scripts/__tests__/validate-spacing-modes.test.js
+++ b/packages/core/scripts/__tests__/validate-spacing-modes.test.js
@@ -1,9 +1,15 @@
-import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  assertCanonicalModeSet,
   BASELINE_MODE,
   CANONICAL_MODES,
+  ConfigError,
   diffKeySets,
+  discoverModes,
   formatFindings,
   leafPathsOf,
   validateModes,
@@ -287,5 +293,86 @@ describe('formatFindings', () => {
     );
     expect(out).toContain('baseline: lyra');
     expect(out).toContain('in spacing-lyra.json but not in spacing-maia.json');
+  });
+});
+
+describe('discoverModes', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'discover-modes-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const touch = (name) => fs.writeFileSync(path.join(tmpDir, name), '{}');
+
+  it('returns the matching mode names sorted alphabetically', () => {
+    touch('spacing-vega.json');
+    touch('spacing-luma.json');
+    touch('spacing-maia.json');
+    expect(discoverModes(tmpDir)).toEqual(['luma', 'maia', 'vega']);
+  });
+
+  it('ignores files that do not match the spacing-<mode>.json pattern', () => {
+    touch('spacing-vega.json');
+    touch('base-slate-light.json');
+    touch('spacing-vega.json.bak');
+    touch('Spacing-vega.json');
+    touch('spacing-Vega.json');
+    touch('spacing-vega-extra.json');
+    touch('spacing-.json');
+    touch('README.md');
+    expect(discoverModes(tmpDir)).toEqual(['vega']);
+  });
+
+  it('returns an empty list when the directory has no matching files', () => {
+    touch('README.md');
+    expect(discoverModes(tmpDir)).toEqual([]);
+  });
+});
+
+describe('assertCanonicalModeSet', () => {
+  it('does not throw when the discovered set equals the canonical set', () => {
+    expect(() => assertCanonicalModeSet([...CANONICAL_MODES])).not.toThrow();
+  });
+
+  it('does not depend on input order', () => {
+    expect(() =>
+      assertCanonicalModeSet([...CANONICAL_MODES].reverse())
+    ).not.toThrow();
+  });
+
+  it('throws a ConfigError naming unexpected (alien) mode files', () => {
+    const discovered = [...CANONICAL_MODES, 'foo'];
+    expect(() => assertCanonicalModeSet(discovered)).toThrow(ConfigError);
+    expect(() => assertCanonicalModeSet(discovered)).toThrow(
+      /unexpected mode file\(s\): foo/
+    );
+  });
+
+  it('throws a ConfigError naming missing canonical modes', () => {
+    const discovered = CANONICAL_MODES.filter((m) => m !== 'lyra');
+    expect(() => assertCanonicalModeSet(discovered)).toThrow(ConfigError);
+    expect(() => assertCanonicalModeSet(discovered)).toThrow(
+      /missing canonical mode\(s\): lyra/
+    );
+  });
+
+  it('reports both unexpected and missing modes in one message', () => {
+    const discovered = CANONICAL_MODES.filter((m) => m !== 'lyra').concat([
+      'foo',
+      'bar',
+    ]);
+    try {
+      assertCanonicalModeSet(discovered);
+      throw new Error('expected ConfigError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConfigError);
+      expect(err.message).toMatch(/unexpected mode file\(s\): bar, foo/);
+      expect(err.message).toMatch(/missing canonical mode\(s\): lyra/);
+    }
   });
 });

--- a/packages/core/scripts/__tests__/validate-spacing-modes.test.js
+++ b/packages/core/scripts/__tests__/validate-spacing-modes.test.js
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BASELINE_MODE,
+  CANONICAL_MODES,
+  diffKeySets,
+  formatFindings,
+  leafPathsOf,
+  validateModes,
+} from '../validate-spacing-modes.js';
+
+const dim = (n) => ({ $value: { value: n, unit: 'px' }, $type: 'dimension' });
+
+describe('CANONICAL_MODES', () => {
+  it('is the 7-mode set per .claude/rules/spacing-tokens.md', () => {
+    expect([...CANONICAL_MODES].sort()).toEqual([
+      'luma',
+      'lyra',
+      'maia',
+      'mira',
+      'nova',
+      'sera',
+      'vega',
+    ]);
+  });
+
+  it('contains the baseline', () => {
+    expect(CANONICAL_MODES).toContain(BASELINE_MODE);
+  });
+});
+
+describe('leafPathsOf', () => {
+  it('returns sorted dotted paths for flat token nodes', () => {
+    const data = { spacing: { 0: dim(0), 1: dim(4), 2: dim(8) } };
+    expect(leafPathsOf(data)).toEqual(['spacing.0', 'spacing.1', 'spacing.2']);
+  });
+
+  it('walks 3+ level deep nesting (e.g. control.padding-x.sm)', () => {
+    const data = {
+      control: {
+        'padding-x': { sm: dim(12), md: dim(16), lg: dim(32) },
+        gap: { sm: dim(6) },
+      },
+    };
+    expect(leafPathsOf(data)).toEqual([
+      'control.gap.sm',
+      'control.padding-x.lg',
+      'control.padding-x.md',
+      'control.padding-x.sm',
+    ]);
+  });
+
+  it('skips $-prefixed metadata keys at any level', () => {
+    const data = {
+      $meta: { capturedAt: '2026-05-27' },
+      spacing: {
+        $description: 'numeric scale',
+        0: dim(0),
+        1: dim(4),
+      },
+    };
+    expect(leafPathsOf(data)).toEqual(['spacing.0', 'spacing.1']);
+  });
+
+  it('returns a leaf only when BOTH $value and $type are present', () => {
+    // A typo `value:` (no $) doesn't make this a leaf — the walker keeps
+    // descending and finds nothing token-shaped underneath.
+    const typo = {
+      spacing: { 0: { value: { value: 0, unit: 'px' }, $type: 'dimension' } },
+    };
+    expect(leafPathsOf(typo)).toEqual([]);
+
+    // Same for $value without $type
+    const noType = {
+      spacing: { 0: { $value: { value: 0, unit: 'px' } } },
+    };
+    expect(leafPathsOf(noType)).toEqual([]);
+  });
+
+  it('treats malformed $value as a valid leaf for path purposes', () => {
+    // Key-set parity is about which paths exist, not about $value shape.
+    // A $value that is a string (not a dimension object) is still a leaf.
+    const data = {
+      spacing: { 0: { $value: 'not-a-dimension', $type: 'dimension' } },
+    };
+    expect(leafPathsOf(data)).toEqual(['spacing.0']);
+  });
+
+  it('returns an empty list for an empty object', () => {
+    expect(leafPathsOf({})).toEqual([]);
+  });
+
+  it('handles non-object / null nodes without throwing', () => {
+    expect(leafPathsOf(null)).toEqual([]);
+    // Null sub-trees are skipped rather than walked.
+    expect(leafPathsOf({ spacing: null, control: { md: dim(8) } })).toEqual([
+      'control.md',
+    ]);
+  });
+});
+
+describe('diffKeySets', () => {
+  it('returns empty arrays for identical inputs', () => {
+    const paths = ['a', 'b', 'c'];
+    expect(diffKeySets(paths, paths)).toEqual({ missing: [], extra: [] });
+  });
+
+  it('returns empty arrays for both empty inputs', () => {
+    expect(diffKeySets([], [])).toEqual({ missing: [], extra: [] });
+  });
+
+  it('reports a key present in baseline but absent from mode as missing', () => {
+    const baseline = ['a', 'b', 'c'];
+    const mode = ['a', 'c'];
+    expect(diffKeySets(baseline, mode)).toEqual({
+      missing: ['b'],
+      extra: [],
+    });
+  });
+
+  it('reports a key present in mode but absent from baseline as extra', () => {
+    const baseline = ['a', 'b'];
+    const mode = ['a', 'b', 'c'];
+    expect(diffKeySets(baseline, mode)).toEqual({
+      missing: [],
+      extra: ['c'],
+    });
+  });
+
+  it('reports interleaved missing and extra in the same diff', () => {
+    const baseline = ['a', 'b', 'c'];
+    const mode = ['a', 'd', 'e'];
+    expect(diffKeySets(baseline, mode)).toEqual({
+      missing: ['b', 'c'],
+      extra: ['d', 'e'],
+    });
+  });
+
+  it('sorts missing and extra arrays for stable output', () => {
+    const baseline = ['zeta', 'alpha', 'mu'];
+    const mode = ['theta', 'beta'];
+    expect(diffKeySets(baseline, mode)).toEqual({
+      missing: ['alpha', 'mu', 'zeta'],
+      extra: ['beta', 'theta'],
+    });
+  });
+
+  it('treats an entirely-missing mode as all-baseline-keys-missing', () => {
+    expect(diffKeySets(['a', 'b', 'c'], [])).toEqual({
+      missing: ['a', 'b', 'c'],
+      extra: [],
+    });
+  });
+});
+
+describe('validateModes', () => {
+  it('returns an empty findings list when all modes match the baseline', () => {
+    const data = { spacing: { 0: dim(0), 1: dim(4) } };
+    const modeMap = new Map([
+      ['vega', data],
+      ['lyra', data],
+      ['maia', data],
+    ]);
+    const findings = validateModes(modeMap);
+    expect(findings).toHaveLength(2);
+    for (const f of findings) {
+      expect(f.missing).toEqual([]);
+      expect(f.extra).toEqual([]);
+    }
+  });
+
+  it('skips the baseline mode in the output', () => {
+    const data = { spacing: { 0: dim(0) } };
+    const modeMap = new Map([
+      ['vega', data],
+      ['lyra', data],
+    ]);
+    expect(validateModes(modeMap).map((f) => f.mode)).toEqual(['lyra']);
+  });
+
+  it('reports per-mode drift for multiple diverging modes', () => {
+    const baseline = { spacing: { 0: dim(0), 1: dim(4), 2: dim(8) } };
+    const luma = { spacing: { 0: dim(0), 2: dim(8) } }; // missing spacing.1
+    const lyra = { spacing: { 0: dim(0), 1: dim(4), 2: dim(8), 3: dim(12) } }; // extra spacing.3
+    const modeMap = new Map([
+      ['vega', baseline],
+      ['luma', luma],
+      ['lyra', lyra],
+    ]);
+    const findings = validateModes(modeMap);
+    expect(findings).toEqual([
+      { mode: 'luma', missing: ['spacing.1'], extra: [] },
+      { mode: 'lyra', missing: [], extra: ['spacing.3'] },
+    ]);
+  });
+
+  it('sorts findings by mode name for stable output', () => {
+    const data = { spacing: { 0: dim(0) } };
+    const modeMap = new Map([
+      ['vega', data],
+      ['sera', data],
+      ['nova', data],
+      ['luma', data],
+    ]);
+    expect(validateModes(modeMap).map((f) => f.mode)).toEqual([
+      'luma',
+      'nova',
+      'sera',
+    ]);
+  });
+
+  it('reports every non-baseline mode as drifting when the baseline itself has a stray key', () => {
+    // If vega gets a new key the other modes haven't picked up yet, every
+    // non-baseline mode reports it as missing — the validator surfaces the
+    // drift symmetrically rather than special-casing the baseline.
+    const vega = { spacing: { 0: dim(0), 99: dim(396) } };
+    const clean = { spacing: { 0: dim(0) } };
+    const modeMap = new Map([
+      ['vega', vega],
+      ['lyra', clean],
+      ['maia', clean],
+    ]);
+    const findings = validateModes(modeMap);
+    expect(findings).toEqual([
+      { mode: 'lyra', missing: ['spacing.99'], extra: [] },
+      { mode: 'maia', missing: ['spacing.99'], extra: [] },
+    ]);
+  });
+
+  it('throws when the baseline mode is absent from the input map', () => {
+    const modeMap = new Map([['lyra', { spacing: { 0: dim(0) } }]]);
+    expect(() => validateModes(modeMap)).toThrow(
+      /baseline mode "vega" not found/
+    );
+  });
+
+  it('honours a custom baseline argument', () => {
+    const data = { spacing: { 0: dim(0) } };
+    const modeMap = new Map([
+      ['lyra', data],
+      ['maia', data],
+    ]);
+    expect(validateModes(modeMap, 'lyra').map((f) => f.mode)).toEqual(['maia']);
+  });
+});
+
+describe('formatFindings', () => {
+  it('renders a ✓ line for a clean mode', () => {
+    const out = formatFindings([{ mode: 'lyra', missing: [], extra: [] }]);
+    expect(out).toContain('✓ spacing-lyra.json (matches baseline)');
+  });
+
+  it('renders a ✗ line with missing-path details for a mode with missing keys', () => {
+    const out = formatFindings([
+      { mode: 'luma', missing: ['spacing.4'], extra: [] },
+    ]);
+    expect(out).toContain('✗ spacing-luma.json (1 missing, 0 extra)');
+    expect(out).toContain('missing: spacing.4');
+    expect(out).toContain('in spacing-vega.json but not in spacing-luma.json');
+  });
+
+  it('renders a ✗ line with extra-path details for a mode with extra keys', () => {
+    const out = formatFindings([
+      { mode: 'lyra', missing: [], extra: ['spacing.99'] },
+    ]);
+    expect(out).toContain('✗ spacing-lyra.json (0 missing, 1 extra)');
+    expect(out).toContain('extra:');
+    expect(out).toContain('spacing.99');
+  });
+
+  it('renders both kinds in a single report and includes the baseline name in the header', () => {
+    const out = formatFindings([
+      { mode: 'luma', missing: ['spacing.1'], extra: [] },
+      { mode: 'lyra', missing: [], extra: ['spacing.99'] },
+      { mode: 'maia', missing: [], extra: [] },
+    ]);
+    expect(out).toContain('baseline: vega');
+    expect(out).toContain('spacing-luma.json (1 missing, 0 extra)');
+    expect(out).toContain('spacing-lyra.json (0 missing, 1 extra)');
+    expect(out).toContain('spacing-maia.json (matches baseline)');
+  });
+
+  it('uses the custom baseline name when provided', () => {
+    const out = formatFindings(
+      [{ mode: 'maia', missing: ['spacing.1'], extra: [] }],
+      'lyra'
+    );
+    expect(out).toContain('baseline: lyra');
+    expect(out).toContain('in spacing-lyra.json but not in spacing-maia.json');
+  });
+});

--- a/packages/core/scripts/validate-spacing-modes.js
+++ b/packages/core/scripts/validate-spacing-modes.js
@@ -1,0 +1,222 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SEMANTIC_DIR = path.resolve(__dirname, '..', 'tokens', 'semantic');
+
+export const BASELINE_MODE = 'vega';
+
+// The seven canonical density modes per .claude/rules/spacing-tokens.md.
+// An unknown filename (e.g. spacing-foo.json) or a missing canonical mode
+// is a structural error (exit 2), not key drift (exit 1).
+export const CANONICAL_MODES = [
+  'luma',
+  'lyra',
+  'maia',
+  'mira',
+  'nova',
+  'sera',
+  'vega',
+];
+
+const EXIT_OK = 0;
+const EXIT_DRIFT = 1;
+const EXIT_CONFIG = 2;
+
+class ConfigError extends Error {}
+
+/**
+ * Walk a DTCG token tree and return sorted leaf paths as dotted strings.
+ *
+ * A "leaf" is a node carrying BOTH $value and $type (the DTCG token contract).
+ * Sibling keys starting with `$` (metadata like $meta, $description) are
+ * skipped. A typo like `value:` (no $) won't slip through — its parent won't
+ * be recognised as a leaf, so the walker keeps descending and the typo'd
+ * branch contributes nothing.
+ *
+ * Deliberately not delegated to utils.js#extractTokens: that helper is
+ * token-aware and may grow to handle refs / $extensions, which would silently
+ * shift what counts as "a key" here. This validator wants the most minimal
+ * possible definition of a leaf path.
+ */
+export function leafPathsOf(modeData) {
+  const paths = [];
+  function walk(node, parts) {
+    if (!node || typeof node !== 'object') return;
+    if ('$value' in node && '$type' in node) {
+      paths.push(parts.join('.'));
+      return;
+    }
+    for (const [key, value] of Object.entries(node)) {
+      if (key.startsWith('$')) continue;
+      walk(value, [...parts, key]);
+    }
+  }
+  walk(modeData, []);
+  return paths.sort();
+}
+
+/**
+ * Per-mode key-set parity check.
+ *
+ * Output shape is intentionally per-mode (one row per non-baseline file)
+ * with two drift arrays, rather than the discriminated-union { kind, path }
+ * shape used by audit-figma-parity. Different problem: figma-parity diffs
+ * values at known paths; this validator diffs key sets across mode files.
+ *
+ * @returns {{ missing: string[], extra: string[] }}
+ *   missing — paths in baseline but absent from mode
+ *   extra   — paths in mode but absent from baseline
+ */
+export function diffKeySets(baselinePaths, modePaths) {
+  const baselineSet = new Set(baselinePaths);
+  const modeSet = new Set(modePaths);
+  return {
+    missing: baselinePaths.filter((p) => !modeSet.has(p)).sort(),
+    extra: modePaths.filter((p) => !baselineSet.has(p)).sort(),
+  };
+}
+
+/**
+ * @param {Map<string, object>} modeDataMap  mode name → parsed JSON
+ * @param {string} baseline                  default 'vega'
+ * @returns {{ mode: string, missing: string[], extra: string[] }[]}
+ *   one entry per non-baseline mode, sorted by mode name
+ * @throws when the baseline mode is absent from the map
+ */
+export function validateModes(modeDataMap, baseline = BASELINE_MODE) {
+  const baselineData = modeDataMap.get(baseline);
+  if (!baselineData) {
+    throw new ConfigError(`baseline mode "${baseline}" not found in input`);
+  }
+  const baselinePaths = leafPathsOf(baselineData);
+  const results = [];
+  for (const [mode, data] of modeDataMap) {
+    if (mode === baseline) continue;
+    const diff = diffKeySets(baselinePaths, leafPathsOf(data));
+    results.push({ mode, ...diff });
+  }
+  return results.sort((a, b) => a.mode.localeCompare(b.mode));
+}
+
+/**
+ * Format a per-mode findings list into a human-readable multi-line report.
+ * Only non-empty findings (a mode with at least one missing or extra path)
+ * are emitted as failure lines; clean modes get a ✓ line.
+ */
+export function formatFindings(findings, baseline = BASELINE_MODE) {
+  const lines = [];
+  lines.push(`─── validate-spacing-modes (baseline: ${baseline}) ───`);
+  for (const { mode, missing, extra } of findings) {
+    if (missing.length === 0 && extra.length === 0) {
+      lines.push(`  ✓ spacing-${mode}.json (matches baseline)`);
+      continue;
+    }
+    lines.push(
+      `  ✗ spacing-${mode}.json (${missing.length} missing, ${extra.length} extra)`
+    );
+    for (const p of missing) {
+      lines.push(
+        `      missing: ${p} (in spacing-${baseline}.json but not in spacing-${mode}.json)`
+      );
+    }
+    for (const p of extra) {
+      lines.push(
+        `      extra:   ${p} (in spacing-${mode}.json but not in spacing-${baseline}.json)`
+      );
+    }
+  }
+  return lines.join('\n');
+}
+
+function discoverModes(semanticDir) {
+  const entries = fs.readdirSync(semanticDir);
+  const found = [];
+  for (const name of entries) {
+    const match = name.match(/^spacing-([a-z]+)\.json$/);
+    if (match) found.push(match[1]);
+  }
+  return found.sort();
+}
+
+function assertCanonicalModeSet(discoveredModes) {
+  const discoveredSet = new Set(discoveredModes);
+  const canonicalSet = new Set(CANONICAL_MODES);
+  const unexpected = [...discoveredSet].filter((m) => !canonicalSet.has(m));
+  const missing = [...canonicalSet].filter((m) => !discoveredSet.has(m));
+  if (unexpected.length > 0 || missing.length > 0) {
+    const parts = [];
+    if (unexpected.length > 0) {
+      parts.push(`unexpected mode file(s): ${unexpected.sort().join(', ')}`);
+    }
+    if (missing.length > 0) {
+      parts.push(`missing canonical mode(s): ${missing.sort().join(', ')}`);
+    }
+    throw new ConfigError(
+      `spacing-*.json file set does not match canonical modes.\n  ${parts.join('\n  ')}\n  Canonical: ${CANONICAL_MODES.join(', ')}\n  See .claude/rules/spacing-tokens.md`
+    );
+  }
+}
+
+function readModeOrFail(mode) {
+  const filePath = path.join(SEMANTIC_DIR, `spacing-${mode}.json`);
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    throw new ConfigError(`failed to read ${filePath}: ${err.message}`);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new ConfigError(`failed to parse ${filePath}: ${err.message}`);
+  }
+}
+
+function main() {
+  try {
+    const discovered = discoverModes(SEMANTIC_DIR);
+    assertCanonicalModeSet(discovered);
+
+    const modeDataMap = new Map();
+    for (const mode of discovered) {
+      modeDataMap.set(mode, readModeOrFail(mode));
+    }
+
+    const findings = validateModes(modeDataMap);
+    const hasDrift = findings.some(
+      (f) => f.missing.length > 0 || f.extra.length > 0
+    );
+
+    if (hasDrift) {
+      process.stderr.write(formatFindings(findings) + '\n');
+      process.stderr.write(
+        `\n✗ Spacing mode files diverge from baseline (${BASELINE_MODE}).\n`
+      );
+      process.stderr.write(
+        `  Fix: add the missing keys or remove the extras so every mode file has the same key set.\n`
+      );
+      process.stderr.write(
+        `  See .claude/rules/spacing-tokens.md → Schema validation.\n`
+      );
+      process.exit(EXIT_DRIFT);
+    }
+
+    process.stdout.write(formatFindings(findings) + '\n');
+    process.stdout.write(
+      `\n✓ All ${discovered.length} spacing mode files share the same key set.\n`
+    );
+    process.exit(EXIT_OK);
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      process.stderr.write(`Error: ${err.message}\n`);
+      process.exit(EXIT_CONFIG);
+    }
+    throw err;
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/packages/core/scripts/validate-spacing-modes.js
+++ b/packages/core/scripts/validate-spacing-modes.js
@@ -24,7 +24,7 @@ const EXIT_OK = 0;
 const EXIT_DRIFT = 1;
 const EXIT_CONFIG = 2;
 
-class ConfigError extends Error {}
+export class ConfigError extends Error {}
 
 /**
  * Walk a DTCG token tree and return sorted leaf paths as dotted strings.
@@ -34,11 +34,6 @@ class ConfigError extends Error {}
  * skipped. A typo like `value:` (no $) won't slip through — its parent won't
  * be recognised as a leaf, so the walker keeps descending and the typo'd
  * branch contributes nothing.
- *
- * Deliberately not delegated to utils.js#extractTokens: that helper is
- * token-aware and may grow to handle refs / $extensions, which would silently
- * shift what counts as "a key" here. This validator wants the most minimal
- * possible definition of a leaf path.
  */
 export function leafPathsOf(modeData) {
   const paths = [];
@@ -59,11 +54,6 @@ export function leafPathsOf(modeData) {
 
 /**
  * Per-mode key-set parity check.
- *
- * Output shape is intentionally per-mode (one row per non-baseline file)
- * with two drift arrays, rather than the discriminated-union { kind, path }
- * shape used by audit-figma-parity. Different problem: figma-parity diffs
- * values at known paths; this validator diffs key sets across mode files.
  *
  * @returns {{ missing: string[], extra: string[] }}
  *   missing — paths in baseline but absent from mode
@@ -130,7 +120,7 @@ export function formatFindings(findings, baseline = BASELINE_MODE) {
   return lines.join('\n');
 }
 
-function discoverModes(semanticDir) {
+export function discoverModes(semanticDir) {
   const entries = fs.readdirSync(semanticDir);
   const found = [];
   for (const name of entries) {
@@ -140,7 +130,7 @@ function discoverModes(semanticDir) {
   return found.sort();
 }
 
-function assertCanonicalModeSet(discoveredModes) {
+export function assertCanonicalModeSet(discoveredModes) {
   const discoveredSet = new Set(discoveredModes);
   const canonicalSet = new Set(CANONICAL_MODES);
   const unexpected = [...discoveredSet].filter((m) => !canonicalSet.has(m));


### PR DESCRIPTION
## Summary

- New `packages/core/scripts/validate-spacing-modes.js` enforces that all 7 `spacing-{mode}.json` files share an identical leaf-path key set, with `spacing-vega.json` as the canonical baseline.
- Dedicated DTCG walker (a leaf must have both `$value` AND `$type`; `$`-prefixed keys are skipped). A typo like `value:` doesn't slip through — the walker keeps descending past that branch.
- Canonical-mode-set check: alien `spacing-foo.json` or a missing canonical mode → exit 2 (config error), distinct from key drift (exit 1).
- Wired to **pre-commit** (lint-staged on `packages/core/tokens/semantic/spacing-*.json`) and **CI** (new step in the `audit-tokens` job, before token regen so the build never runs on a broken mode-file set).
- `spacing-modes.test.js` refactored to use the validator's exported `CANONICAL_MODES` + `validateModes` — one source of truth for both the mode-count check and the key-set parity check.
- `.claude/rules/spacing-tokens.md` § Schema validation flips from `_(planned — #126)_` to shipped; migration history row added.

## GitHub Issue

Closes #126

## Test Plan

- [x] `yarn validate:spacing-modes` exits 0 on this branch
- [x] Negative test: introduced drift on `spacing-luma.json` (added stray key + removed existing key) → exit 1 with full report on stderr including missing/extra paths; restored cleanly
- [x] `yarn test:unit` — 336/336 pass (validator's 28 new tests + spacing-modes' refactored 2 tests included)
- [x] `yarn lint` clean
- [x] `yarn format:check` clean
- [x] `yarn workspace @nexus/core typecheck` clean
- [ ] CI green (will verify post-push)

### Test coverage

Pure-function unit tests cover:

- `leafPathsOf` — flat, deeply nested (3+ levels via `control.padding-x.sm`), `$`-prefixed metadata skipping, the `$value`+`$type` leaf contract (typo'd `value:` doesn't slip through), malformed `$value` (still a valid leaf for path purposes), empty object, null nodes
- `diffKeySets` — identical, both empty, missing-only, extra-only, interleaved missing+extra, sort stability, entirely-missing mode
- `validateModes` — clean input, multi-mode drift, baseline-skipped-in-output, sort stability, vega-self-drift (baseline has a stray key — every other mode reports it as missing), missing-baseline throws, custom baseline arg
- `formatFindings` — ✓ for clean modes, ✗ with missing-path details, ✗ with extra-path details, combined report, custom baseline name

Vitest-side smoke test in `spacing-modes.test.js` runs `validateModes` against the real on-disk files.

## Implementation notes

- Exit codes mirror `audit-figma-parity`: `0` (match), `1` (drift), `2` (config error — missing baseline, unknown mode file, malformed JSON).
- The plan deliberately doesn't reuse `extractTokens` from `utils.js`: that helper is token-aware and may grow to handle refs / `$extensions`, which would silently shift what counts as "a key" here. The validator uses the minimal possible leaf definition.
- The output shape is per-mode (`{ mode, missing[], extra[] }`) rather than the discriminated-union `{ kind, path }` used by `audit-figma-parity` — different problem, different natural unit.
- `lint-staged` 16 passes matched files in a single `spawn` call (`getSpawnedTask.js:172` — `args.concat(files)`). The validator ignores positional args (it discovers files itself), so the appended paths are inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)