### PR TITLE
[11/12] feat(lint): canonical-spacing-steps + prefer-role-utilities rules

### DIFF
--- a/.claude/rules/spacing-tokens.md
+++ b/.claude/rules/spacing-tokens.md
@@ -1,6 +1,6 @@
 # Spacing Token Architecture Rules
 
-> **Partial implementation status (post-#126).** The build pipeline now reads per-mode `semantic/spacing-{mode}.json` files and emits direct-px `[data-style="X"]` blocks; the `--nx-size-*` primitive layer is gone, `collectSpacingTokens` returns the per-mode shape, and `nx:px-control-*` / `nx:py-control-*` / `nx:p-container` / `nx:gap-layout-*` utilities are generated. The role-to-component coupling table below reflects shipped code as of #123 and #124. Schema validation (cross-mode key-set parity) ships via `validate-spacing-modes.js` (#126) and is gated in pre-commit and CI. Still pending: `nexus/canonical-spacing-steps` and `nexus/prefer-role-utilities` lint rules (#127), the `audit:figma-parity` wire-up for size category (#128), and the canonical-step-set reconciliation noted under "Open Items" in PR #223. Treat sections in this file as the **spec the build now satisfies**, except for the items listed above.
+> **Partial implementation status (post-#127).** The build pipeline now reads per-mode `semantic/spacing-{mode}.json` files and emits direct-px `[data-style="X"]` blocks; the `--nx-size-*` primitive layer is gone, `collectSpacingTokens` returns the per-mode shape, and `nx:px-control-*` / `nx:py-control-*` / `nx:p-container` / `nx:gap-layout-*` utilities are generated. The role-to-component coupling table below reflects shipped code as of #123 and #124. Schema validation (cross-mode key-set parity) ships via `validate-spacing-modes.js` (#126), and the two custom ESLint rules `@nexus/canonical-spacing-steps` and `@nexus/prefer-role-utilities` ship in `packages/eslint-plugin-nexus/` (#127). Both are gated at `error` severity by `yarn lint` in CI and on pre-commit via lint-staged. Still pending: the `audit:figma-parity` wire-up for size category (#128) and the canonical-step-set reconciliation noted under "Open Items" in PR #223 — the rule currently accepts the union of every px value shipped across all 7 mode files (~80 values), wider than the documented 30-step set. Treat sections in this file as the **spec the build now satisfies**, except for the items listed above.
 
 > Companion to `tokens.md`. Spacing has a different architecture than color, typography, radius, etc. — there is **no primitive size layer**. This file documents that decision, the rules that replace what primitives used to enforce, and the authoring patterns that follow from it.
 
@@ -198,14 +198,32 @@ The validator runs in two places:
 
 Exit codes mirror `audit-figma-parity`: `0` (match), `1` (drift), `2` (config error — missing baseline, unknown mode file, malformed JSON). Pure-function diffing logic (`leafPathsOf`, `diffKeySets`, `validateModes`, `formatFindings`) is unit-tested in `packages/core/scripts/__tests__/validate-spacing-modes.test.js`; the real-files smoke test in `spacing-modes.test.js` calls into the same `validateModes` entry point.
 
-## Lint rules _(planned — #127)_
+## Lint rules
 
-Two ESLint/Stylelint rules **will** guard the architecture:
+Two custom ESLint rules guard the architecture. Both ship in `packages/eslint-plugin-nexus/` (workspace `@nexus/eslint-plugin`) and are wired into the root `eslint.config.js` at `error` severity.
 
-1. **`nexus/canonical-spacing-steps`** — flags any spacing value in `spacing-*.json` mode files outside the canonical step set. Configurable via the canonical step list in this rule file.
-2. **`nexus/prefer-role-utilities`** — flags raw numeric utilities (`nx:p-N`, `nx:h-N`, `nx:gap-N`) in `packages/react/src/components/ui/*.tsx` files when a role-named utility would apply. Reads the role-to-component coupling table (see below). Allow-list with `// nexus-allow-numeric: reason` comment.
+### `@nexus/canonical-spacing-steps`
 
-Both rules are tracked by #127. Until they land, the architecture is enforced through review.
+Flags any px value in `packages/core/tokens/semantic/spacing-*.json` that is not in the canonical step set. The canonical set lives in `packages/eslint-plugin-nexus/src/canonical-step-set.json` and is the **union** of every px value currently shipped across the 7 mode files (~80 values). Refresh via `yarn workspace @nexus/eslint-plugin refresh:canonical-set` when a mode file legitimately introduces a new value — the refresh is deliberate; pre-commit does not auto-regenerate.
+
+The rule walks the JSONC AST via `'JSONProperty[key.value="$value"] > JSONObjectExpression'`, extracts `(value, unit)` from the DTCG dimension shape, and reports values not in the set. Non-px units are skipped. Negative values flag as off-grid via `JSONUnaryExpression` handling. The aspirational 30-step set documented above is narrower than the shipped union; reconciliation is tracked under PR #223's "Open Items" — until then, the rule prevents **new** drift without forcing snap-to-grid for existing values.
+
+### `@nexus/prefer-role-utilities`
+
+Flags raw numeric padding / gap utilities in `packages/react/src/components/ui/*.tsx` (excluding `*.stories.tsx`) where a role utility exists per the coupling table. Specifically: `nx:(p|px|py|gap)-N` and any modifier-prefixed variant (`nx:hover:p-4`, `nx:dark:hover:p-4`). `nx:(p|px|py|gap)-0` is not flagged — there is no role for "no padding". Out-of-scope prefixes (`pt`, `pb`, `m*`, `h*`, `w*`, `size-*`, `gap-x`, `gap-y`) are silent because no role token exists for them; the rule grows when role families grow.
+
+#### Allowlist syntax
+
+When a raw numeric is intentional, annotate the line **immediately above** the literal:
+
+```tsx
+// nexus-allow-numeric: chip rhythm — Badge note in spacing-tokens.md
+className: 'nx:px-2 nx:py-0.5',
+```
+
+The comment text after the colon is free-form; keep it terse and cite the rule note that justifies the deviation. Only `Line` comments are honoured (not block comments, not trailing same-line). Multiple matches on the next line are silenced by a single comment.
+
+The shipped components all carry such annotations where the role-coupling table calls for numerics (Alert callout rhythm, Accordion item-tier, Badge chip rhythm, Button icon density-stable hit-target, sub-element offsets in Card / Dialog, item-tier menu rows in DropdownMenu / Select, Input px-numeric, Tabs `sm` sub-control). See those files for live examples.
 
 ## Role-to-component coupling table
 
@@ -279,8 +297,9 @@ The two-tier per-mode architecture described above landed across the [Spacing to
 - **PR #130** — populate this file's role-coupling table with the audit-grounded 14-role version; sync the FE brief.
 - **#230** — add `--control-gap-{sm,md,lg}` per-size gap roles (the `control.gap` token splits from a single value into a size-keyed bundle).
 - **#126** — ship `validate-spacing-modes.js` schema validator; wire to pre-commit (lint-staged) and CI (`audit-tokens` job, before regen).
+- **#127** — ship `@nexus/eslint-plugin` (`packages/eslint-plugin-nexus/`) with `canonical-spacing-steps` and `prefer-role-utilities`; wire both into root `eslint.config.js` at `error`; sweep the 10 UI components to annotate intentional raw-numeric sites with `// nexus-allow-numeric:` comments.
 
-Still ahead on the same milestone: #127 (lint rules), #128 (figma-parity wire-up for size).
+Still ahead on the same milestone: #128 (figma-parity wire-up for size).
 
 ## When to revisit
 

--- a/.claude/rules/spacing-tokens.md
+++ b/.claude/rules/spacing-tokens.md
@@ -227,9 +227,9 @@ The shipped components all carry such annotations where the role-coupling table 
 
 ## Role-to-component coupling table
 
-Components should use specific roles for specific spacing decisions. This table is authoritative; lint rule #2 references it.
+Components should use specific roles for specific spacing decisions. This table is authoritative; the `@nexus/prefer-role-utilities` rule references it.
 
-> **Status: shipped (#123, #124).** Button, Input, Select, Tabs, Badge, and the remaining containers/internal components (Card, Dialog, Alert, Accordion, plus DropdownMenu / Tooltip / Tabs internals) now use these role tokens. The table is authoritative for current code; `nexus/prefer-role-utilities` (#127) will mechanically enforce it once that lint rule lands.
+> **Status: shipped (#123, #124).** Button, Input, Select, Tabs, Badge, and the remaining containers/internal components (Card, Dialog, Alert, Accordion, plus DropdownMenu / Tooltip / Tabs internals) now use these role tokens. The table is authoritative for current code; `@nexus/prefer-role-utilities` (#127) mechanically enforces it.
 
 | Component                                | Role used for                          | Tokens                                                                             |
 | ---------------------------------------- | -------------------------------------- | ---------------------------------------------------------------------------------- |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,12 @@ jobs:
       - name: Validate spacing mode files
         run: yarn validate:spacing-modes
 
+      # Guard against drift between the committed canonical-step-set.json
+      # and the live union across spacing-*.json. Same fail-fast tier as
+      # the validator above — stdlib-only, sub-second.
+      - name: Check canonical step set freshness
+        run: yarn workspace @nexus/eslint-plugin refresh:canonical-set --check
+
       - name: Regenerate token outputs (tailwind + modular + colorblind SVG)
         id: regen
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,9 +118,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .eslintcache
-          key: eslint-${{ runner.os }}-${{ hashFiles('yarn.lock', 'eslint.config.js') }}-${{ github.sha }}
+          key: eslint-${{ runner.os }}-${{ hashFiles('yarn.lock', 'eslint.config.js', 'packages/eslint-plugin-nexus/src/**') }}-${{ github.sha }}
           restore-keys: |
-            eslint-${{ runner.os }}-${{ hashFiles('yarn.lock', 'eslint.config.js') }}-
+            eslint-${{ runner.os }}-${{ hashFiles('yarn.lock', 'eslint.config.js', 'packages/eslint-plugin-nexus/src/**') }}-
             eslint-${{ runner.os }}-
 
       - name: Lint

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,12 @@
 import js from '@eslint/js';
+import nexusPlugin from '@nexus/eslint-plugin';
 import prettierConfig from 'eslint-config-prettier';
 import jsxA11yPlugin from 'eslint-plugin-jsx-a11y';
 import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import globals from 'globals';
+import * as jsoncParser from 'jsonc-eslint-parser';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
@@ -198,6 +200,33 @@ export default tseslint.config(
         'error',
         { allowInterfaces: 'with-single-extends' },
       ],
+    },
+  },
+
+  // Nexus: prefer role-named spacing utilities over raw numerics in UI components.
+  // Stories opt out — demo grids legitimately mix numeric utilities for layout chrome.
+  {
+    files: ['packages/react/src/components/ui/**/*.{ts,tsx}'],
+    ignores: ['packages/react/src/components/ui/**/*.stories.tsx'],
+    plugins: {
+      '@nexus': nexusPlugin,
+    },
+    rules: {
+      '@nexus/prefer-role-utilities': 'error',
+    },
+  },
+
+  // Nexus: gate px values in spacing mode files to the canonical step set.
+  {
+    files: ['packages/core/tokens/semantic/spacing-*.json'],
+    languageOptions: {
+      parser: jsoncParser,
+    },
+    plugins: {
+      '@nexus': nexusPlugin,
+    },
+    rules: {
+      '@nexus/canonical-spacing-steps': 'error',
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
       "prettier --write"
     ],
     "packages/core/tokens/semantic/spacing-*.json": [
-      "yarn validate:spacing-modes"
+      "yarn validate:spacing-modes",
+      "eslint --fix --no-warn-ignored"
     ]
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   ],
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@nexus/eslint-plugin": "*",
     "@size-limit/preset-small-lib": "^12.0.0",
     "@storybook/addon-vitest": "^10.1.11",
     "@vitest/browser": "4.0.18",
@@ -60,6 +61,7 @@
     "globals": "^16.5.0",
     "husky": "^9.1.7",
     "jsdom": "^27.3.0",
+    "jsonc-eslint-parser": "^3.1.0",
     "lint-staged": "^16.2.7",
     "playwright": "^1.57.0",
     "prettier": "^3.7.4",

--- a/packages/eslint-plugin-nexus/README.md
+++ b/packages/eslint-plugin-nexus/README.md
@@ -1,0 +1,32 @@
+# @nexus/eslint-plugin
+
+Custom ESLint rules that backfill what the deleted `--nx-size-*` primitive layer used to enforce.
+
+## Rules
+
+### `@nexus/canonical-spacing-steps`
+
+Flags any px value in `packages/core/tokens/semantic/spacing-*.json` that is not in the canonical step set. The canonical set is the union of every px value currently shipped across the 7 mode files; see `src/canonical-step-set.json`. Refresh that file when a mode file legitimately introduces a new value.
+
+Requires `jsonc-eslint-parser`. Wired in the root `eslint.config.js` to target spacing mode files only.
+
+### `@nexus/prefer-role-utilities`
+
+Flags raw numeric padding / gap utilities (`nx:p-N`, `nx:px-N`, `nx:py-N`, `nx:gap-N`) in `packages/react/src/components/ui/*.tsx` (excluding `*.stories.tsx`) where a role-named utility would apply per the coupling table in `.claude/rules/spacing-tokens.md`.
+
+`nx:(p|px|py|gap)-0` is not flagged — there is no role for "no padding".
+
+#### Allowlist
+
+When a raw numeric is intentional (chip rhythm, sub-element offset, item-tier menu rows, etc.), annotate the line **immediately above** with:
+
+```tsx
+// nexus-allow-numeric: chip rhythm — Badge note in spacing-tokens.md
+className: 'nx:px-2 nx:py-0.5',
+```
+
+The comment text after the colon is free-form; keep it terse and cite the rule note that justifies the deviation.
+
+## Source of truth
+
+The role-to-component coupling table and the canonical step set live in `.claude/rules/spacing-tokens.md`. This plugin enforces what that document specifies.

--- a/packages/eslint-plugin-nexus/__tests__/canonical-spacing-steps.test.js
+++ b/packages/eslint-plugin-nexus/__tests__/canonical-spacing-steps.test.js
@@ -1,0 +1,138 @@
+import { ESLint, RuleTester } from 'eslint';
+import * as jsoncParser from 'jsonc-eslint-parser';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../src/index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const semanticDir = resolve(
+  __dirname,
+  '..',
+  '..',
+  'core',
+  'tokens',
+  'semantic'
+);
+const fixturesDir = resolve(__dirname, 'fixtures');
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parser: jsoncParser },
+});
+
+const rule = plugin.rules['canonical-spacing-steps'];
+
+const validValue = (n) => `{
+  "spacing": {
+    "x": { "$value": { "value": ${n}, "unit": "px" }, "$type": "dimension" }
+  }
+}`;
+
+const invalidValue = (n) => ({
+  code: validValue(n),
+  errors: [{ messageId: 'offGrid' }],
+});
+
+ruleTester.run('canonical-spacing-steps', rule, {
+  valid: [
+    // Canonical (in-set) values
+    validValue(0),
+    validValue(2),
+    validValue(4),
+    validValue(16),
+    validValue(24),
+    validValue(80),
+    validValue(384),
+    // Off-doc-grid but in shipped union — accepted because canonical set = union
+    validValue(11), // maia
+    validValue(176), // vega
+    validValue(380), // nova
+    validValue(388), // maia
+    // Non-px units are out of scope for this rule
+    `{ "spacing": { "x": { "$value": { "value": 1, "unit": "rem" }, "$type": "dimension" } } }`,
+    // $-prefixed siblings must be ignored (matches validate-spacing-modes walker)
+    `{
+      "spacing": {
+        "$meta": { "capturedAt": "2026-05-27" },
+        "$description": "test",
+        "4": { "$value": { "value": 16, "unit": "px" }, "$type": "dimension" }
+      }
+    }`,
+    // Color tokens (string $value) — selector doesn't match JSONObjectExpression
+    `{ "color": { "slate": { "500": { "$value": "#64748b", "$type": "color" } } } }`,
+    // FontWeight tokens (number $value) — selector doesn't match
+    `{ "font": { "weight": { "$value": 600, "$type": "fontWeight" } } }`,
+    // Malformed leaf (missing unit) — silently skipped; validate-spacing-modes owns structural drift
+    `{ "spacing": { "x": { "$value": { "value": 13 }, "$type": "dimension" } } }`,
+  ],
+  invalid: [
+    invalidValue(1), // odd-pixel
+    invalidValue(5),
+    invalidValue(13),
+    invalidValue(17),
+    invalidValue(23),
+    invalidValue(99),
+    // Multiple off-grid values report independently
+    {
+      code: `{
+        "spacing": {
+          "a": { "$value": { "value": 13, "unit": "px" }, "$type": "dimension" },
+          "b": { "$value": { "value": 17, "unit": "px" }, "$type": "dimension" }
+        }
+      }`,
+      errors: [{ messageId: 'offGrid' }, { messageId: 'offGrid' }],
+    },
+    // Negative px value (JSONUnaryExpression) flagged as off-grid
+    {
+      code: `{ "spacing": { "x": { "$value": { "value": -4, "unit": "px" }, "$type": "dimension" } } }`,
+      errors: [{ messageId: 'offGrid' }],
+    },
+  ],
+});
+
+describe('canonical-spacing-steps — real-file smoke test', () => {
+  const modes = ['vega', 'lyra', 'maia', 'mira', 'nova', 'luma', 'sera'];
+  for (const mode of modes) {
+    it(`reports zero findings on spacing-${mode}.json`, async () => {
+      const eslint = new ESLint({
+        overrideConfigFile: true,
+        overrideConfig: {
+          files: ['**/*.json'],
+          languageOptions: { parser: jsoncParser },
+          plugins: { '@nexus': plugin },
+          rules: { '@nexus/canonical-spacing-steps': 'error' },
+        },
+      });
+      const filePath = resolve(semanticDir, `spacing-${mode}.json`);
+      const code = readFileSync(filePath, 'utf8');
+      const messages = await eslint.lintText(code, { filePath });
+      expect(messages[0].errorCount).toBe(0);
+    });
+  }
+});
+
+describe('canonical-spacing-steps — bad-fixture smoke test', () => {
+  it('reports the expected off-grid values on bad-canonical-spacing.json', async () => {
+    const eslint = new ESLint({
+      overrideConfigFile: true,
+      overrideConfig: {
+        files: ['**/*.json'],
+        languageOptions: { parser: jsoncParser },
+        plugins: { '@nexus': plugin },
+        rules: { '@nexus/canonical-spacing-steps': 'error' },
+      },
+    });
+    const filePath = resolve(fixturesDir, 'bad-canonical-spacing.json');
+    const code = readFileSync(filePath, 'utf8');
+    const messages = await eslint.lintText(code, { filePath });
+    const findings = messages[0].messages
+      .map((m) => m.message.match(/^(-?\d+)px/)?.[1])
+      .filter(Boolean);
+    expect(findings).toEqual(['13', '17', '23']);
+  });
+});

--- a/packages/eslint-plugin-nexus/__tests__/fixtures/bad-canonical-spacing.json
+++ b/packages/eslint-plugin-nexus/__tests__/fixtures/bad-canonical-spacing.json
@@ -1,0 +1,16 @@
+{
+  "spacing": {
+    "off-3": {
+      "$value": { "value": 13, "unit": "px" },
+      "$type": "dimension"
+    },
+    "off-5": {
+      "$value": { "value": 17, "unit": "px" },
+      "$type": "dimension"
+    },
+    "off-7": {
+      "$value": { "value": 23, "unit": "px" },
+      "$type": "dimension"
+    }
+  }
+}

--- a/packages/eslint-plugin-nexus/__tests__/fixtures/bad-prefer-role.tsx
+++ b/packages/eslint-plugin-nexus/__tests__/fixtures/bad-prefer-role.tsx
@@ -1,0 +1,8 @@
+// Fixture: every line below is an intentional rule violation used by
+// __tests__/prefer-role-utilities.test.js to assert the bad-fixture smoke
+// path. Do not annotate with // nexus-allow-numeric — that is the point.
+const _a = 'nx:p-4';
+const _b = 'nx:px-2 nx:py-2';
+const _c = 'nx:gap-4';
+const _d = 'nx:p-2.5';
+const _e = 'nx:hover:p-4';

--- a/packages/eslint-plugin-nexus/__tests__/prefer-role-utilities.test.js
+++ b/packages/eslint-plugin-nexus/__tests__/prefer-role-utilities.test.js
@@ -1,0 +1,131 @@
+import { ESLint, RuleTester } from 'eslint';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import tseslint from 'typescript-eslint';
+import { describe, expect, it } from 'vitest';
+
+import plugin from '../src/index.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(__dirname, 'fixtures');
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tseslint.parser,
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+const rule = plugin.rules['prefer-role-utilities'];
+
+ruleTester.run('prefer-role-utilities', rule, {
+  valid: [
+    // Role utilities are the goal
+    `const x = 'nx:p-container';`,
+    `const x = 'nx:px-control-md';`,
+    `const x = 'nx:py-control-sm';`,
+    `const x = 'nx:gap-control-lg';`,
+    `const x = 'nx:gap-container';`,
+    `const x = 'nx:gap-layout-section';`,
+    // n=0 has no role equivalent — never flagged
+    `const x = 'nx:p-0';`,
+    `const x = 'nx:px-0 nx:py-0 nx:gap-0';`,
+    // Other utility prefixes (pt, pb, ps, m*, h*, w*, size-*, gap-x, gap-y) are out of scope
+    `const x = 'nx:pt-4 nx:pb-2 nx:ps-1 nx:mt-4 nx:mx-2 nx:h-10 nx:w-full nx:size-5 nx:gap-x-2 nx:gap-y-4';`,
+    // CSS var arbitrary values are not numeric utilities
+    `const x = 'nx:p-(--focus-offset)';`,
+    // Arbitrary-value escape hatches are out of scope
+    `const x = 'nx:p-[5px]';`,
+    // Allowlist comment one line above silences all matches on the next line
+    `// nexus-allow-numeric: chip rhythm\nconst x = 'nx:px-2 nx:py-0.5 nx:gap-1';`,
+    // Non-string literal — rule skips
+    `const x = 4;`,
+    `const x = true;`,
+    // Template literals (dynamic interpolation) — rule skips
+    'const size = 4; const x = `nx:p-${size}`;',
+  ],
+  invalid: [
+    // Basic raw numeric
+    {
+      code: `const x = 'nx:p-4';`,
+      errors: [{ messageId: 'preferRole' }],
+    },
+    // Multiple matches in one string each fire
+    {
+      code: `const x = 'nx:p-4 nx:px-2 nx:gap-2';`,
+      errors: [
+        { messageId: 'preferRole' },
+        { messageId: 'preferRole' },
+        { messageId: 'preferRole' },
+      ],
+    },
+    // Decimal numeric (e.g. Button icon's p-2.5)
+    {
+      code: `const x = 'nx:p-2.5';`,
+      errors: [{ messageId: 'preferRole' }],
+    },
+    // Responsive / state prefix chain
+    {
+      code: `const x = 'nx:hover:p-4';`,
+      errors: [{ messageId: 'preferRole' }],
+    },
+    {
+      code: `const x = 'nx:dark:hover:p-4';`,
+      errors: [{ messageId: 'preferRole' }],
+    },
+    // Inside cn()-style call expression (still a Literal arg)
+    {
+      code: `const x = cn('nx:gap-4', 'nx:p-container');`,
+      errors: [{ messageId: 'preferRole' }],
+    },
+    // Inside JSX attribute value
+    {
+      code: `const X = <div className="nx:p-4" />;`,
+      errors: [{ messageId: 'preferRole' }],
+      languageOptions: {
+        parser: tseslint.parser,
+        parserOptions: { ecmaFeatures: { jsx: true } },
+      },
+    },
+    // Allowlist comment on a different (non-adjacent) line does NOT silence
+    {
+      code: `// nexus-allow-numeric: other\n\nconst x = 'nx:p-4';`,
+      errors: [{ messageId: 'preferRole' }],
+    },
+    // Same-line trailing comment does NOT silence
+    {
+      code: `const x = 'nx:p-4'; // nexus-allow-numeric: nope`,
+      errors: [{ messageId: 'preferRole' }],
+    },
+  ],
+});
+
+describe('prefer-role-utilities — bad-fixture smoke test', () => {
+  it('reports five findings on bad-prefer-role.tsx (one per raw-numeric line)', async () => {
+    const eslint = new ESLint({
+      overrideConfigFile: true,
+      overrideConfig: {
+        files: ['**/*.tsx'],
+        languageOptions: {
+          parser: tseslint.parser,
+          ecmaVersion: 2022,
+          sourceType: 'module',
+        },
+        plugins: { '@nexus': plugin },
+        rules: { '@nexus/prefer-role-utilities': 'error' },
+      },
+    });
+    const filePath = resolve(fixturesDir, 'bad-prefer-role.tsx');
+    const code = readFileSync(filePath, 'utf8');
+    const messages = await eslint.lintText(code, { filePath });
+    // Lines 4 (p-4), 5 (px-2, py-2 — two findings), 6 (gap-4), 7 (p-2.5), 8 (hover:p-4)
+    expect(messages[0].errorCount).toBe(6);
+    const ids = messages[0].messages.map((m) => m.messageId);
+    expect(new Set(ids)).toEqual(new Set(['preferRole']));
+  });
+});

--- a/packages/eslint-plugin-nexus/__tests__/prefer-role-utilities.test.js
+++ b/packages/eslint-plugin-nexus/__tests__/prefer-role-utilities.test.js
@@ -1,5 +1,5 @@
 import { ESLint, RuleTester } from 'eslint';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import tseslint from 'typescript-eslint';
@@ -9,6 +9,15 @@ import plugin from '../src/index.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixturesDir = resolve(__dirname, 'fixtures');
+const uiComponentsDir = resolve(
+  __dirname,
+  '..',
+  '..',
+  'react',
+  'src',
+  'components',
+  'ui'
+);
 
 RuleTester.describe = describe;
 RuleTester.it = it;
@@ -103,6 +112,34 @@ ruleTester.run('prefer-role-utilities', rule, {
       errors: [{ messageId: 'preferRole' }],
     },
   ],
+});
+
+describe('prefer-role-utilities — real-file smoke test', () => {
+  const componentFiles = readdirSync(uiComponentsDir).filter(
+    (name) => /^[a-z][a-z0-9-]*\.tsx$/.test(name) // lowercase = implementation; PascalCase = stories
+  );
+  it.each(componentFiles)(
+    'reports zero findings on %s (after Phase 7 annotations)',
+    async (name) => {
+      const eslint = new ESLint({
+        overrideConfigFile: true,
+        overrideConfig: {
+          files: ['**/*.tsx'],
+          languageOptions: {
+            parser: tseslint.parser,
+            ecmaVersion: 2022,
+            sourceType: 'module',
+          },
+          plugins: { '@nexus': plugin },
+          rules: { '@nexus/prefer-role-utilities': 'error' },
+        },
+      });
+      const filePath = resolve(uiComponentsDir, name);
+      const code = readFileSync(filePath, 'utf8');
+      const messages = await eslint.lintText(code, { filePath });
+      expect(messages[0].errorCount).toBe(0);
+    }
+  );
 });
 
 describe('prefer-role-utilities — bad-fixture smoke test', () => {

--- a/packages/eslint-plugin-nexus/package.json
+++ b/packages/eslint-plugin-nexus/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@nexus/eslint-plugin",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Custom ESLint rules for the Nexus design system",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "files": [
+    "src"
+  ],
+  "dependencies": {
+    "jsonc-eslint-parser": "^3.1.0"
+  },
+  "license": "MIT"
+}

--- a/packages/eslint-plugin-nexus/package.json
+++ b/packages/eslint-plugin-nexus/package.json
@@ -11,6 +11,9 @@
   "files": [
     "src"
   ],
+  "scripts": {
+    "refresh:canonical-set": "node scripts/refresh-canonical-set.js"
+  },
   "dependencies": {
     "jsonc-eslint-parser": "^3.1.0"
   },

--- a/packages/eslint-plugin-nexus/scripts/refresh-canonical-set.js
+++ b/packages/eslint-plugin-nexus/scripts/refresh-canonical-set.js
@@ -37,7 +37,7 @@ function collectPxValues(node, out) {
   }
 }
 
-function main() {
+function computeUnion() {
   const files = fs
     .readdirSync(SEMANTIC_DIR)
     .filter((name) => /^spacing-[a-z]+\.json$/.test(name))
@@ -57,15 +57,56 @@ function main() {
     );
     collectPxValues(data, union);
   }
-  const sorted = [...union].sort((a, b) => a - b);
+  return { files, sorted: [...union].sort((a, b) => a - b) };
+}
+
+function arraysEqual(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function main() {
+  const check = process.argv.includes('--check');
+  const { files, sorted } = computeUnion();
 
   const existing = fs.existsSync(OUTPUT_PATH)
     ? JSON.parse(fs.readFileSync(OUTPUT_PATH, 'utf8'))
     : null;
 
+  if (check) {
+    if (!existing) {
+      process.stderr.write(
+        `Error: ${OUTPUT_PATH} is missing. Run \`yarn workspace @nexus/eslint-plugin refresh:canonical-set\` and commit the result.\n`
+      );
+      process.exit(1);
+    }
+    const committed = Array.isArray(existing.values) ? existing.values : [];
+    if (arraysEqual(committed, sorted)) {
+      process.stdout.write(
+        `✓ canonical-step-set.json matches the live union (${sorted.length} values across ${files.length} modes).\n`
+      );
+      process.exit(0);
+    }
+    const committedSet = new Set(committed);
+    const liveSet = new Set(sorted);
+    const missing = sorted.filter((n) => !committedSet.has(n));
+    const extra = committed.filter((n) => !liveSet.has(n));
+    process.stderr.write(
+      `Error: canonical-step-set.json is stale.\n` +
+        (missing.length
+          ? `  missing from committed: ${missing.join(', ')}\n`
+          : '') +
+        (extra.length
+          ? `  no longer in any mode file: ${extra.join(', ')}\n`
+          : '') +
+        `Refresh via \`yarn workspace @nexus/eslint-plugin refresh:canonical-set\` and commit the result.\n`
+    );
+    process.exit(1);
+  }
+
   const out = {
     $comment: existing?.$comment ?? defaultComment(),
-    unit: 'px',
     values: sorted,
   };
 
@@ -86,7 +127,7 @@ function main() {
 }
 
 function defaultComment() {
-  return 'Union of every px value shipped across packages/core/tokens/semantic/spacing-{vega,lyra,maia,mira,nova,luma,sera}.json. Regenerate via `yarn workspace @nexus/eslint-plugin refresh:canonical-set`.';
+  return 'Union of every px value shipped across packages/core/tokens/semantic/spacing-{vega,lyra,maia,mira,nova,luma,sera}.json. Regenerate via `yarn workspace @nexus/eslint-plugin refresh:canonical-set`. The aspirational 30-step set in .claude/rules/spacing-tokens.md is narrower; reconciliation tracked separately.';
 }
 
 main();

--- a/packages/eslint-plugin-nexus/scripts/refresh-canonical-set.js
+++ b/packages/eslint-plugin-nexus/scripts/refresh-canonical-set.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SEMANTIC_DIR = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'core',
+  'tokens',
+  'semantic'
+);
+const OUTPUT_PATH = path.resolve(
+  __dirname,
+  '..',
+  'src',
+  'canonical-step-set.json'
+);
+
+function collectPxValues(node, out) {
+  if (!node || typeof node !== 'object') return;
+  if (
+    node.$type === 'dimension' &&
+    node.$value &&
+    typeof node.$value === 'object' &&
+    node.$value.unit === 'px' &&
+    typeof node.$value.value === 'number'
+  ) {
+    out.add(node.$value.value);
+    return;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key.startsWith('$')) continue;
+    collectPxValues(value, out);
+  }
+}
+
+function main() {
+  const files = fs
+    .readdirSync(SEMANTIC_DIR)
+    .filter((name) => /^spacing-[a-z]+\.json$/.test(name))
+    .sort();
+
+  if (files.length === 0) {
+    process.stderr.write(
+      `Error: no spacing-*.json files found in ${SEMANTIC_DIR}\n`
+    );
+    process.exit(2);
+  }
+
+  const union = new Set();
+  for (const name of files) {
+    const data = JSON.parse(
+      fs.readFileSync(path.join(SEMANTIC_DIR, name), 'utf8')
+    );
+    collectPxValues(data, union);
+  }
+  const sorted = [...union].sort((a, b) => a - b);
+
+  const existing = fs.existsSync(OUTPUT_PATH)
+    ? JSON.parse(fs.readFileSync(OUTPUT_PATH, 'utf8'))
+    : null;
+
+  const out = {
+    $comment: existing?.$comment ?? defaultComment(),
+    unit: 'px',
+    values: sorted,
+  };
+
+  const next = JSON.stringify(out, null, 2) + '\n';
+  const prev = existing ? JSON.stringify(existing, null, 2) + '\n' : null;
+
+  if (prev === next) {
+    process.stdout.write(
+      `✓ canonical-step-set.json is up to date (${sorted.length} values across ${files.length} modes).\n`
+    );
+    process.exit(0);
+  }
+
+  fs.writeFileSync(OUTPUT_PATH, next);
+  process.stdout.write(
+    `✓ canonical-step-set.json refreshed (${sorted.length} values across ${files.length} modes).\n`
+  );
+}
+
+function defaultComment() {
+  return 'Union of every px value shipped across packages/core/tokens/semantic/spacing-{vega,lyra,maia,mira,nova,luma,sera}.json. Regenerate via `yarn workspace @nexus/eslint-plugin refresh:canonical-set`.';
+}
+
+main();

--- a/packages/eslint-plugin-nexus/src/canonical-step-set.json
+++ b/packages/eslint-plugin-nexus/src/canonical-step-set.json
@@ -1,6 +1,5 @@
 {
-  "$comment": "Union of every px value shipped across packages/core/tokens/semantic/spacing-{vega,lyra,maia,mira,nova,luma,sera}.json. Regenerate via `yarn workspace @nexus/eslint-plugin refresh:canonical-set`. The aspirational 30-step set in .claude/rules/spacing-tokens.md narrower; reconciliation tracked separately.",
-  "unit": "px",
+  "$comment": "Union of every px value shipped across packages/core/tokens/semantic/spacing-{vega,lyra,maia,mira,nova,luma,sera}.json. Regenerate via `yarn workspace @nexus/eslint-plugin refresh:canonical-set`. The aspirational 30-step set in .claude/rules/spacing-tokens.md is narrower; reconciliation tracked separately.",
   "values": [
     0, 2, 4, 6, 8, 9, 10, 11, 12, 14, 15, 16, 18, 20, 22, 24, 26, 28, 30, 32,
     34, 36, 38, 40, 42, 44, 46, 48, 52, 56, 60, 64, 68, 76, 80, 84, 92, 96, 100,

--- a/packages/eslint-plugin-nexus/src/canonical-step-set.json
+++ b/packages/eslint-plugin-nexus/src/canonical-step-set.json
@@ -1,0 +1,11 @@
+{
+  "$comment": "Union of every px value shipped across packages/core/tokens/semantic/spacing-{vega,lyra,maia,mira,nova,luma,sera}.json. Regenerate via `yarn workspace @nexus/eslint-plugin refresh:canonical-set`. The aspirational 30-step set in .claude/rules/spacing-tokens.md narrower; reconciliation tracked separately.",
+  "unit": "px",
+  "values": [
+    0, 2, 4, 6, 8, 9, 10, 11, 12, 14, 15, 16, 18, 20, 22, 24, 26, 28, 30, 32,
+    34, 36, 38, 40, 42, 44, 46, 48, 52, 56, 60, 64, 68, 76, 80, 84, 92, 96, 100,
+    108, 112, 116, 120, 124, 128, 132, 140, 144, 148, 156, 160, 164, 172, 176,
+    180, 188, 192, 196, 204, 208, 210, 212, 220, 224, 228, 236, 240, 244, 252,
+    256, 260, 284, 288, 292, 316, 320, 324, 380, 384, 388
+  ]
+}

--- a/packages/eslint-plugin-nexus/src/index.js
+++ b/packages/eslint-plugin-nexus/src/index.js
@@ -1,0 +1,16 @@
+import canonicalSpacingSteps from './rules/canonical-spacing-steps.js';
+import preferRoleUtilities from './rules/prefer-role-utilities.js';
+
+const plugin = {
+  meta: {
+    name: '@nexus/eslint-plugin',
+    version: '0.0.1',
+  },
+  rules: {
+    'canonical-spacing-steps': canonicalSpacingSteps,
+    'prefer-role-utilities': preferRoleUtilities,
+  },
+};
+
+export default plugin;
+export const { rules } = plugin;

--- a/packages/eslint-plugin-nexus/src/rules/canonical-spacing-steps.js
+++ b/packages/eslint-plugin-nexus/src/rules/canonical-spacing-steps.js
@@ -1,0 +1,17 @@
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow px values in spacing mode files outside the canonical step set',
+    },
+    schema: [],
+    messages: {
+      offGrid:
+        '{{value}}px is not in the canonical spacing step set. Allowed: {{allowed}}. See .claude/rules/spacing-tokens.md.',
+    },
+  },
+  create() {
+    return {};
+  },
+};

--- a/packages/eslint-plugin-nexus/src/rules/canonical-spacing-steps.js
+++ b/packages/eslint-plugin-nexus/src/rules/canonical-spacing-steps.js
@@ -1,3 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const canonical = JSON.parse(
+  readFileSync(join(__dirname, '..', 'canonical-step-set.json'), 'utf8')
+);
+const allowed = new Set(canonical.values);
+
+function summarizeAllowed(set) {
+  const arr = [...set].sort((a, b) => a - b);
+  if (arr.length <= 10) return arr.join(', ');
+  return `${arr.slice(0, 6).join(', ')}, … ${arr[arr.length - 1]} (${arr.length} total)`;
+}
+
+function readNumericLiteral(node) {
+  if (!node) return null;
+  if (node.type === 'JSONLiteral' && typeof node.value === 'number') {
+    return node.value;
+  }
+  if (
+    node.type === 'JSONUnaryExpression' &&
+    node.operator === '-' &&
+    node.argument?.type === 'JSONLiteral' &&
+    typeof node.argument.value === 'number'
+  ) {
+    return -node.argument.value;
+  }
+  return null;
+}
+
 export default {
   meta: {
     type: 'problem',
@@ -8,10 +40,35 @@ export default {
     schema: [],
     messages: {
       offGrid:
-        '{{value}}px is not in the canonical spacing step set. Allowed: {{allowed}}. See .claude/rules/spacing-tokens.md.',
+        '{{value}}px is not in the canonical spacing step set. Allowed: {{allowed}}. Refresh src/canonical-step-set.json via `yarn workspace @nexus/eslint-plugin refresh:canonical-set` if a mode file legitimately introduces a new value. See .claude/rules/spacing-tokens.md.',
     },
   },
-  create() {
-    return {};
+  create(context) {
+    return {
+      'JSONProperty[key.value="$value"] > JSONObjectExpression'(node) {
+        let valueProp, unitProp;
+        for (const prop of node.properties) {
+          if (prop.type !== 'JSONProperty') continue;
+          const key = prop.key?.value;
+          if (key === 'value') valueProp = prop.value;
+          else if (key === 'unit') unitProp = prop.value;
+        }
+        if (!unitProp || unitProp.type !== 'JSONLiteral') return;
+        if (unitProp.value !== 'px') return;
+
+        const n = readNumericLiteral(valueProp);
+        if (n === null) return;
+        if (allowed.has(n)) return;
+
+        context.report({
+          node: valueProp,
+          messageId: 'offGrid',
+          data: {
+            value: String(n),
+            allowed: summarizeAllowed(allowed),
+          },
+        });
+      },
+    };
   },
 };

--- a/packages/eslint-plugin-nexus/src/rules/prefer-role-utilities.js
+++ b/packages/eslint-plugin-nexus/src/rules/prefer-role-utilities.js
@@ -1,3 +1,15 @@
+const RAW_NUMERIC_RE =
+  /\bnx:(?:[a-z][a-z0-9-]*:)*(p|px|py|gap)-(\d+(?:\.\d+)?)(?![\w.-])/g;
+
+const ALTERNATIVES = {
+  p: 'nx:p-container',
+  px: 'nx:px-control-{sm,md,lg}',
+  py: 'nx:py-control-{sm,md,lg}',
+  gap: 'nx:gap-control-{sm,md,lg} / nx:gap-container / nx:gap-layout-{section,stack}',
+};
+
+const ALLOW_PREFIX = 'nexus-allow-numeric:';
+
 export default {
   meta: {
     type: 'suggestion',
@@ -11,7 +23,45 @@ export default {
         '"{{raw}}" is a raw numeric utility. Prefer a role utility: {{alternative}}. Add "// nexus-allow-numeric: <reason>" on the prior line if the numeric is intentional.',
     },
   },
-  create() {
-    return {};
+  create(context) {
+    const sourceCode = context.sourceCode;
+    let allowedLines;
+
+    function getAllowedLines() {
+      if (allowedLines !== undefined) return allowedLines;
+      allowedLines = new Set();
+      for (const comment of sourceCode.getAllComments()) {
+        if (comment.type !== 'Line') continue;
+        const text = comment.value.trim();
+        if (!text.startsWith(ALLOW_PREFIX)) continue;
+        allowedLines.add(comment.loc.end.line + 1);
+      }
+      return allowedLines;
+    }
+
+    function check(node, raw) {
+      if (getAllowedLines().has(node.loc.start.line)) return;
+      RAW_NUMERIC_RE.lastIndex = 0;
+      let match;
+      while ((match = RAW_NUMERIC_RE.exec(raw)) !== null) {
+        const [token, prefix, number] = match;
+        if (number === '0') continue;
+        context.report({
+          node,
+          messageId: 'preferRole',
+          data: {
+            raw: token,
+            alternative: ALTERNATIVES[prefix],
+          },
+        });
+      }
+    }
+
+    return {
+      Literal(node) {
+        if (typeof node.value !== 'string') return;
+        check(node, node.value);
+      },
+    };
   },
 };

--- a/packages/eslint-plugin-nexus/src/rules/prefer-role-utilities.js
+++ b/packages/eslint-plugin-nexus/src/rules/prefer-role-utilities.js
@@ -1,0 +1,17 @@
+export default {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer role-named spacing utilities (px-control-*, py-control-*, gap-control-*, p-container, gap-container, gap-layout-*) over raw numerics in UI components.',
+    },
+    schema: [],
+    messages: {
+      preferRole:
+        '"{{raw}}" is a raw numeric utility. Prefer a role utility: {{alternative}}. Add "// nexus-allow-numeric: <reason>" on the prior line if the numeric is intentional.',
+    },
+  },
+  create() {
+    return {};
+  },
+};

--- a/packages/react/src/components/ui/accordion.tsx
+++ b/packages/react/src/components/ui/accordion.tsx
@@ -72,6 +72,7 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
+          // nexus-allow-numeric: item-tier rhythm — Accordion note in spacing-tokens.md
           'nx:flex nx:flex-1 nx:items-center nx:justify-between nx:py-4 nx:text-sm nx:font-medium nx:text-foreground nx:transition-all nx:hover:underline nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:pointer-events-none nx:disabled:opacity-50 nx:[&[data-state=open]>svg]:rotate-180',
           className
         )}

--- a/packages/react/src/components/ui/alert.tsx
+++ b/packages/react/src/components/ui/alert.tsx
@@ -5,6 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const alertVariants = cva(
+  // nexus-allow-numeric: callout rhythm — Alert note in spacing-tokens.md
   'nx:relative nx:w-full nx:rounded-lg nx:border nx:p-4 nx:[&>svg~*]:pl-7 nx:[&>svg+div]:translate-y-[-3px] nx:[&>svg]:absolute nx:[&>svg]:left-4 nx:[&>svg]:top-4 nx:[&>svg]:text-foreground',
   {
     variants: {

--- a/packages/react/src/components/ui/badge.tsx
+++ b/packages/react/src/components/ui/badge.tsx
@@ -6,6 +6,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
+  // nexus-allow-numeric: chip rhythm — Badge note in spacing-tokens.md
   'nx:inline-flex nx:items-center nx:justify-center nx:gap-1 nx:rounded-md nx:whitespace-nowrap nx:transition-colors nx:w-fit',
   {
     variants: {
@@ -188,8 +189,10 @@ function Badge({
     isNumber
       ? 'nx:size-5 nx:rounded-full nx:p-0 nx:typography-label-caps'
       : isCaps
-        ? 'nx:px-2 nx:py-0.5'
-        : 'nx:px-2.5 nx:py-0.5',
+        ? // nexus-allow-numeric: chip rhythm — Badge note in spacing-tokens.md
+          'nx:px-2 nx:py-0.5'
+        : // nexus-allow-numeric: chip rhythm — Badge note in spacing-tokens.md
+          'nx:px-2.5 nx:py-0.5',
     className
   );
 

--- a/packages/react/src/components/ui/button.tsx
+++ b/packages/react/src/components/ui/button.tsx
@@ -26,6 +26,7 @@ const buttonVariants = cva(
         default: 'nx:px-control-md nx:py-control-md nx:gap-control-md',
         sm: 'nx:px-control-sm nx:py-control-sm nx:gap-control-sm nx:text-xs',
         lg: 'nx:px-control-lg nx:py-control-lg nx:gap-control-lg',
+        // nexus-allow-numeric: density-stable square hit-target — Button (icon) note in spacing-tokens.md
         icon: 'nx:p-2.5',
       },
     },

--- a/packages/react/src/components/ui/card.tsx
+++ b/packages/react/src/components/ui/card.tsx
@@ -68,7 +68,11 @@ function CardHeader({ className, ...props }: CardHeaderProps) {
   return (
     <div
       data-slot="card-header"
-      className={cn('nx:flex nx:flex-col nx:gap-1.5 nx:p-container', className)}
+      className={cn(
+        // nexus-allow-numeric: sub-element header rhythm — Card note in spacing-tokens.md
+        'nx:flex nx:flex-col nx:gap-1.5 nx:p-container',
+        className
+      )}
       {...props}
     />
   );
@@ -161,6 +165,7 @@ function CardAction({ className, ...props }: CardActionProps) {
     <div
       data-slot="card-action"
       className={cn(
+        // nexus-allow-numeric: CardAction icon/label rhythm — Card note in spacing-tokens.md
         'nx:absolute nx:right-(--nx-container-p) nx:top-(--nx-container-p) nx:flex nx:items-center nx:gap-2',
         className
       )}
@@ -223,6 +228,7 @@ function CardFooter({ className, ...props }: CardFooterProps) {
     <div
       data-slot="card-footer"
       className={cn(
+        // nexus-allow-numeric: CardFooter sub-element rhythm — Card note in spacing-tokens.md
         'nx:flex nx:items-center nx:gap-2 nx:p-container nx:pt-0',
         className
       )}

--- a/packages/react/src/components/ui/dialog.tsx
+++ b/packages/react/src/components/ui/dialog.tsx
@@ -184,6 +184,7 @@ function DialogHeader({ className, ...props }: DialogHeaderProps) {
     <div
       data-slot="dialog-header"
       className={cn(
+        // nexus-allow-numeric: DialogHeader sub-element rhythm — Dialog note in spacing-tokens.md
         'nx:flex nx:flex-col nx:gap-1.5 nx:text-center nx:sm:text-left',
         className
       )}
@@ -217,6 +218,7 @@ function DialogFooter({ className, ...props }: DialogFooterProps) {
     <div
       data-slot="dialog-footer"
       className={cn(
+        // nexus-allow-numeric: DialogFooter sub-element rhythm at sm — Dialog note in spacing-tokens.md
         'nx:flex nx:flex-col-reverse nx:sm:flex-row nx:sm:justify-end nx:sm:gap-2',
         className
       )}

--- a/packages/react/src/components/ui/dropdown-menu.tsx
+++ b/packages/react/src/components/ui/dropdown-menu.tsx
@@ -90,7 +90,9 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
+        // nexus-allow-numeric: menu item-tier rhythm — DropdownMenu note in spacing-tokens.md
         'nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2',
+        // nexus-allow-numeric: menu item-tier rhythm — DropdownMenu note in spacing-tokens.md
         'nx:rounded-sm nx:px-2 nx:py-control-sm nx:text-sm nx:outline-none',
         'nx:focus:bg-background-hover',
         'nx:data-[state=open]:bg-background-hover',
@@ -130,6 +132,7 @@ function DropdownMenuSubContent({
       className={cn(
         'nx:z-popover nx:min-w-[8rem] nx:overflow-hidden',
         'nx:rounded-md nx:border nx:border-border-default',
+        // nexus-allow-numeric: popover chrome (sub-canonical inner padding) — DropdownMenu note
         'nx:bg-popover nx:p-1 nx:text-popover-foreground nx:shadow-lg',
         'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
         'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
@@ -181,6 +184,7 @@ function DropdownMenuContent({
           'nx:z-popover nx:max-h-(--radix-dropdown-menu-content-available-height)',
           'nx:min-w-[8rem] nx:overflow-x-hidden nx:overflow-y-auto',
           'nx:rounded-md nx:border nx:border-border-default',
+          // nexus-allow-numeric: popover chrome (sub-canonical inner padding) — DropdownMenu note
           'nx:bg-popover nx:p-1 nx:text-popover-foreground nx:shadow-md',
           'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
           'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
@@ -198,6 +202,7 @@ function DropdownMenuContent({
 }
 
 const dropdownMenuItemVariants = cva(
+  // nexus-allow-numeric: menu item-tier rhythm — DropdownMenu note in spacing-tokens.md
   'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2 nx:rounded-sm nx:px-2 nx:py-control-sm nx:text-sm nx:outline-none nx:transition-colors nx:focus:bg-background-hover nx:focus:text-foreground nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
   {
     variants: {
@@ -397,6 +402,7 @@ function DropdownMenuLabel({
       data-slot="dropdown-menu-label"
       data-inset={inset}
       className={cn(
+        // nexus-allow-numeric: menu label item-tier rhythm — DropdownMenu note
         'nx:px-2 nx:py-control-sm nx:text-sm nx:font-semibold',
         inset && 'nx:pl-8',
         className

--- a/packages/react/src/components/ui/input.tsx
+++ b/packages/react/src/components/ui/input.tsx
@@ -17,8 +17,11 @@ const inputVariants = cva(
   {
     variants: {
       size: {
+        // nexus-allow-numeric: Input px stays numeric — Input note in spacing-tokens.md
         default: 'nx:px-3 nx:py-control-md nx:text-sm',
+        // nexus-allow-numeric: Input px stays numeric — Input note in spacing-tokens.md
         sm: 'nx:px-2.5 nx:py-control-sm nx:text-xs',
+        // nexus-allow-numeric: Input px stays numeric — Input note in spacing-tokens.md
         lg: 'nx:px-4 nx:py-control-lg nx:text-base',
       },
     },

--- a/packages/react/src/components/ui/select.tsx
+++ b/packages/react/src/components/ui/select.tsx
@@ -67,6 +67,7 @@ function SelectTrigger({ className, children, ...props }: SelectTriggerProps) {
       className={cn(
         'nx:flex nx:w-full nx:items-center nx:justify-between nx:gap-control-md',
         'nx:rounded-md nx:border nx:border-border-default nx:bg-background',
+        // nexus-allow-numeric: Select trigger px stays numeric — Input/Select note in spacing-tokens.md
         'nx:px-3 nx:py-control-md nx:text-sm',
         'nx:whitespace-nowrap',
         'nx:placeholder:text-muted-foreground',
@@ -98,6 +99,7 @@ function SelectScrollUpButton({
     <SelectPrimitive.ScrollUpButton
       data-slot="select-scroll-up-button"
       className={cn(
+        // nexus-allow-numeric: popover scroll-button chrome — DropdownMenu/Select note
         'nx:flex nx:cursor-default nx:items-center nx:justify-center nx:py-1',
         className
       )}
@@ -121,6 +123,7 @@ function SelectScrollDownButton({
     <SelectPrimitive.ScrollDownButton
       data-slot="select-scroll-down-button"
       className={cn(
+        // nexus-allow-numeric: popover scroll-button chrome — DropdownMenu/Select note
         'nx:flex nx:cursor-default nx:items-center nx:justify-center nx:py-1',
         className
       )}
@@ -181,6 +184,7 @@ function SelectContent({
         <SelectScrollUpButton />
         <SelectPrimitive.Viewport
           className={cn(
+            // nexus-allow-numeric: popover viewport chrome — DropdownMenu/Select note
             'nx:p-1',
             position === 'popper' &&
               'nx:h-(--radix-select-trigger-height) nx:w-full nx:min-w-(--radix-select-trigger-width)'
@@ -221,6 +225,7 @@ function SelectLabel({ className, ...props }: SelectLabelProps) {
     <SelectPrimitive.Label
       data-slot="select-label"
       className={cn(
+        // nexus-allow-numeric: menu label item-tier rhythm — DropdownMenu/Select note
         'nx:px-2 nx:py-control-sm nx:text-sm nx:font-semibold',
         className
       )}

--- a/packages/react/src/components/ui/tabs.tsx
+++ b/packages/react/src/components/ui/tabs.tsx
@@ -52,6 +52,7 @@ function TabsList({ className, ...props }: TabsListProps) {
       data-slot="tabs-list"
       className={cn(
         'nx:inline-flex nx:items-center nx:justify-center',
+        // nexus-allow-numeric: TabsList chrome (sub-canonical inner padding) — Tabs note
         'nx:rounded-md nx:bg-muted nx:p-1',
         className
       )}
@@ -101,6 +102,7 @@ const tabsTriggerVariants = cva(
        * @default "default"
        */
       size: {
+        // nexus-allow-numeric: Tabs sm is sub-control "dense pill" — Tabs note in spacing-tokens.md
         sm: 'nx:px-2 nx:py-1 nx:text-xs',
         default: 'nx:px-control-sm nx:py-control-sm nx:text-sm',
         lg: 'nx:px-control-md nx:py-control-md nx:text-base',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
           include: [
             'packages/**/src/**/*.test.{ts,tsx}',
             'packages/**/scripts/**/*.test.{js,ts}',
+            'packages/eslint-plugin-nexus/__tests__/**/*.test.js',
             // Exclude component tests - they're now in stories
             '!packages/react/src/components/**/*.test.{ts,tsx}',
           ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1976,6 +1976,11 @@ acorn@^8.15.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
+acorn@^8.5.0:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
+  integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
+
 agent-base@^7.1.0, agent-base@^7.1.2:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
@@ -3041,6 +3046,11 @@ eslint-visitor-keys@^4.2.1:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz#4cfea60fe7dd0ad8e816e1ed026c1d5251b512c1"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
+eslint-visitor-keys@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz#9e3c9489697824d2d4ce3a8ad12628f91e9f59be"
+  integrity sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==
+
 eslint@^9.39.2:
   version "9.39.2"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-9.39.2.tgz#cb60e6d16ab234c0f8369a3fe7cc87967faf4b6c"
@@ -3853,6 +3863,15 @@ json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+jsonc-eslint-parser@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jsonc-eslint-parser/-/jsonc-eslint-parser-3.1.0.tgz#ecbd62bdfe8acc299812d0610bff938377987626"
+  integrity sha512-75EA7EWZExL/j+MDKQrRbdzcRI2HOkRlmUw8fZJc1ioqFEOvBsq7Rt+A6yCxOt9w/TYNpkt52gC6nm/g5tFIng==
+  dependencies:
+    acorn "^8.5.0"
+    eslint-visitor-keys "^5.0.0"
+    semver "^7.3.5"
 
 jsonfile@^6.0.1:
   version "6.2.0"
@@ -4820,6 +4839,11 @@ semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.3.5:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.1.tgz#bf4970b5e70fda0686363cc18bfe8805d5ed957e"
+  integrity sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==
 
 semver@^7.6.0, semver@^7.6.2:
   version "7.7.3"


### PR DESCRIPTION
## Summary

Ships two custom ESLint rules in a new `@nexus/eslint-plugin` workspace (`packages/eslint-plugin-nexus/`) that backfill what the deleted `--nx-size-*` primitive layer used to enforce:

- **`@nexus/canonical-spacing-steps`** — flags any px value in `packages/core/tokens/semantic/spacing-*.json` outside the canonical step set. Walks the JSONC AST via `'JSONProperty[key.value="$value"] > JSONObjectExpression'` and extracts `(value, unit)` from the DTCG dimension shape.
- **`@nexus/prefer-role-utilities`** — flags raw `nx:(p|px|py|gap)-N` (with optional modifier prefixes like `nx:hover:p-4`) in `packages/react/src/components/ui/*.tsx` (excluding stories). Skips `N=0` and out-of-scope utility prefixes. Allowlist via `// nexus-allow-numeric: <reason>` on the line immediately above the literal.

Both rules wired at `error` severity in `eslint.config.js`. Pre-commit (lint-staged) and CI (`yarn lint`) catch violations. 10 UI components annotated with allowlist comments where the role-coupling table calls for numerics (Alert callout rhythm, Badge chip rhythm, Button icon hit-target, Input px-numeric, sub-element offsets in Card/Dialog, item-tier menu rows in DropdownMenu/Select, Tabs `sm` sub-control).

### Notable decisions

- Plugin lives at `packages/eslint-plugin-nexus/` (not `tools/`) to match the existing `packages/*` / `apps/*` workspace pattern.
- Canonical set = **union of every px value currently shipped** across all 7 mode files (~80 values), not the documented 30-step set. The doc's narrower set is aspirational; reconciliation is the open item flagged in PR #223. This rule prevents **new** drift today; narrowing is a separate design call.
- Canonical set lives in `src/canonical-step-set.json` (committed). Refresh via `yarn workspace @nexus/eslint-plugin refresh:canonical-set` — deliberate, not auto-regenerated, so adding a new px value to a mode file is a reviewed act.

### Council audit (architect / SDE2 / tester / devops) integrated

- AST visitor uses ESLint selector + defensive guards for non-px units, malformed leaves, negatives (`JSONUnaryExpression`).
- Regex handles responsive/state modifier chains; rejects hyphenated suffixes via lookahead.
- Bad-fixture smoke tests (`__tests__/fixtures/bad-*.{json,tsx}`) prove the rules fire on synthetic input; real-file smoke tests prove they don't fire on shipped sources (regression net the moment the canonical set drifts or a new raw numeric slips in unannotated).
- ESLint cache key in `ci.yml` extended to include `packages/eslint-plugin-nexus/src/**` so rule edits bust the cache.
- lint-staged for `spacing-*.json` adds `eslint --fix --no-warn-ignored` so off-grid values are caught pre-commit, not just in CI.

## GitHub Issue

Closes #127

## Test Plan

- [x] `yarn vitest run --project=unit packages/eslint-plugin-nexus/` — 70 tests pass (32 canonical + 38 prefer-role)
- [x] `yarn typecheck` — clean across all 5 workspaces
- [x] `yarn lint --max-warnings 0` — clean
- [x] Manual: drop `13px` into a temp spacing mode file → rule fires
- [x] Manual: drop `nx:p-4` into a component without allowlist → rule fires
- [x] Manual: same `nx:p-4` with `// nexus-allow-numeric: …` on prior line → silent
- [x] Real-file smoke covers all 13 lowercase `*.tsx` in `packages/react/src/components/ui/` — zero findings after Phase 7 annotations
- [ ] CI lint + tests pass on this PR