### PR TITLE
feat(tokens): alpha-based neutral foregrounds (composite on any surface)

### DIFF
--- a/apps/docs/public/themes/base-gray.css
+++ b/apps/docs/public/themes/base-gray.css
@@ -2,13 +2,13 @@
 
 html {
   --nx-color-background: var(--nx-color-white-base);
-  --nx-color-foreground: var(--nx-color-gray-950);
+  --nx-color-foreground: var(--nx-color-black-a900);
   --nx-color-background-hover: var(--nx-color-gray-50);
   --nx-color-background-hover-alpha: var(--nx-color-gray-a100);
   --nx-color-background-active: var(--nx-color-gray-100);
   --nx-color-muted: var(--nx-color-gray-50);
-  --nx-color-muted-foreground: var(--nx-color-gray-500);
-  --nx-color-muted-foreground-subtle: var(--nx-color-gray-400);
+  --nx-color-muted-foreground: var(--nx-color-black-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-black-a500);
   --nx-color-disabled: var(--nx-color-gray-50);
   --nx-color-disabled-foreground: var(--nx-color-gray-400);
   --nx-color-container: var(--nx-color-white-base);
@@ -28,7 +28,7 @@ html {
   --nx-color-nav-item-active: var(--nx-color-gray-300);
   --nx-color-nav-border: var(--nx-color-gray-200);
   --nx-color-overlay: var(--nx-color-gray-a700);
-  --nx-color-border-default: var(--nx-color-gray-200);
+  --nx-color-border-default: var(--nx-color-black-a300);
   --nx-color-border-default-alpha: var(--nx-color-gray-a200);
   --nx-color-border-active: var(--nx-color-gray-400);
   --nx-color-border-disabled: var(--nx-color-gray-50);
@@ -82,13 +82,13 @@ html {
 
 html.dark {
   --nx-color-background: var(--nx-color-gray-900);
-  --nx-color-foreground: var(--nx-color-white-base);
+  --nx-color-foreground: var(--nx-color-white-a900);
   --nx-color-background-hover: var(--nx-color-gray-800);
   --nx-color-background-hover-alpha: var(--nx-color-gray-a100);
   --nx-color-background-active: var(--nx-color-gray-950);
   --nx-color-muted: var(--nx-color-gray-800);
-  --nx-color-muted-foreground: var(--nx-color-gray-300);
-  --nx-color-muted-foreground-subtle: var(--nx-color-gray-300);
+  --nx-color-muted-foreground: var(--nx-color-white-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-white-a600);
   --nx-color-disabled: var(--nx-color-gray-950);
   --nx-color-disabled-foreground: var(--nx-color-gray-300);
   --nx-color-container: var(--nx-color-gray-800);
@@ -108,7 +108,7 @@ html.dark {
   --nx-color-nav-item-active: var(--nx-color-gray-800);
   --nx-color-nav-border: var(--nx-color-gray-800);
   --nx-color-overlay: var(--nx-color-gray-a800);
-  --nx-color-border-default: var(--nx-color-gray-700);
+  --nx-color-border-default: var(--nx-color-white-a400);
   --nx-color-border-default-alpha: var(--nx-color-gray-a300);
   --nx-color-border-active: var(--nx-color-gray-400);
   --nx-color-border-disabled: var(--nx-color-gray-950);

--- a/apps/docs/public/themes/base-neutral.css
+++ b/apps/docs/public/themes/base-neutral.css
@@ -2,13 +2,13 @@
 
 html {
   --nx-color-background: var(--nx-color-white-base);
-  --nx-color-foreground: var(--nx-color-neutral-950);
+  --nx-color-foreground: var(--nx-color-black-a900);
   --nx-color-background-hover: var(--nx-color-neutral-50);
   --nx-color-background-hover-alpha: var(--nx-color-neutral-a100);
   --nx-color-background-active: var(--nx-color-neutral-100);
   --nx-color-muted: var(--nx-color-neutral-50);
-  --nx-color-muted-foreground: var(--nx-color-neutral-500);
-  --nx-color-muted-foreground-subtle: var(--nx-color-neutral-400);
+  --nx-color-muted-foreground: var(--nx-color-black-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-black-a500);
   --nx-color-disabled: var(--nx-color-neutral-50);
   --nx-color-disabled-foreground: var(--nx-color-neutral-400);
   --nx-color-container: var(--nx-color-white-base);
@@ -28,7 +28,7 @@ html {
   --nx-color-nav-item-active: var(--nx-color-neutral-300);
   --nx-color-nav-border: var(--nx-color-neutral-200);
   --nx-color-overlay: var(--nx-color-neutral-a700);
-  --nx-color-border-default: var(--nx-color-neutral-200);
+  --nx-color-border-default: var(--nx-color-black-a300);
   --nx-color-border-default-alpha: var(--nx-color-neutral-a200);
   --nx-color-border-active: var(--nx-color-neutral-400);
   --nx-color-border-disabled: var(--nx-color-neutral-50);
@@ -82,13 +82,13 @@ html {
 
 html.dark {
   --nx-color-background: var(--nx-color-neutral-900);
-  --nx-color-foreground: var(--nx-color-white-base);
+  --nx-color-foreground: var(--nx-color-white-a900);
   --nx-color-background-hover: var(--nx-color-neutral-800);
   --nx-color-background-hover-alpha: var(--nx-color-neutral-a100);
   --nx-color-background-active: var(--nx-color-neutral-950);
   --nx-color-muted: var(--nx-color-neutral-800);
-  --nx-color-muted-foreground: var(--nx-color-neutral-300);
-  --nx-color-muted-foreground-subtle: var(--nx-color-neutral-300);
+  --nx-color-muted-foreground: var(--nx-color-white-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-white-a600);
   --nx-color-disabled: var(--nx-color-neutral-950);
   --nx-color-disabled-foreground: var(--nx-color-neutral-300);
   --nx-color-container: var(--nx-color-neutral-800);
@@ -108,7 +108,7 @@ html.dark {
   --nx-color-nav-item-active: var(--nx-color-neutral-800);
   --nx-color-nav-border: var(--nx-color-neutral-800);
   --nx-color-overlay: var(--nx-color-neutral-a800);
-  --nx-color-border-default: var(--nx-color-neutral-700);
+  --nx-color-border-default: var(--nx-color-white-a400);
   --nx-color-border-default-alpha: var(--nx-color-neutral-a300);
   --nx-color-border-active: var(--nx-color-neutral-400);
   --nx-color-border-disabled: var(--nx-color-neutral-950);

--- a/apps/docs/public/themes/base-slate.css
+++ b/apps/docs/public/themes/base-slate.css
@@ -2,13 +2,13 @@
 
 html {
   --nx-color-background: var(--nx-color-white-base);
-  --nx-color-foreground: var(--nx-color-slate-950);
+  --nx-color-foreground: var(--nx-color-black-a900);
   --nx-color-background-hover: var(--nx-color-slate-50);
   --nx-color-background-hover-alpha: var(--nx-color-slate-a100);
   --nx-color-background-active: var(--nx-color-slate-100);
   --nx-color-muted: var(--nx-color-slate-50);
-  --nx-color-muted-foreground: var(--nx-color-slate-500);
-  --nx-color-muted-foreground-subtle: var(--nx-color-slate-400);
+  --nx-color-muted-foreground: var(--nx-color-black-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-black-a500);
   --nx-color-disabled: var(--nx-color-slate-50);
   --nx-color-disabled-foreground: var(--nx-color-slate-400);
   --nx-color-container: var(--nx-color-white-base);
@@ -28,7 +28,7 @@ html {
   --nx-color-nav-item-active: var(--nx-color-slate-300);
   --nx-color-nav-border: var(--nx-color-slate-200);
   --nx-color-overlay: var(--nx-color-slate-a700);
-  --nx-color-border-default: var(--nx-color-slate-200);
+  --nx-color-border-default: var(--nx-color-black-a300);
   --nx-color-border-default-alpha: var(--nx-color-slate-a200);
   --nx-color-border-active: var(--nx-color-slate-400);
   --nx-color-border-disabled: var(--nx-color-slate-50);
@@ -82,13 +82,13 @@ html {
 
 html.dark {
   --nx-color-background: var(--nx-color-slate-900);
-  --nx-color-foreground: var(--nx-color-white-base);
+  --nx-color-foreground: var(--nx-color-white-a900);
   --nx-color-background-hover: var(--nx-color-slate-800);
   --nx-color-background-hover-alpha: var(--nx-color-slate-a100);
   --nx-color-background-active: var(--nx-color-slate-950);
   --nx-color-muted: var(--nx-color-slate-800);
-  --nx-color-muted-foreground: var(--nx-color-slate-300);
-  --nx-color-muted-foreground-subtle: var(--nx-color-slate-300);
+  --nx-color-muted-foreground: var(--nx-color-white-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-white-a600);
   --nx-color-disabled: var(--nx-color-slate-950);
   --nx-color-disabled-foreground: var(--nx-color-slate-300);
   --nx-color-container: var(--nx-color-slate-800);
@@ -108,7 +108,7 @@ html.dark {
   --nx-color-nav-item-active: var(--nx-color-slate-800);
   --nx-color-nav-border: var(--nx-color-slate-800);
   --nx-color-overlay: var(--nx-color-slate-a800);
-  --nx-color-border-default: var(--nx-color-slate-700);
+  --nx-color-border-default: var(--nx-color-white-a400);
   --nx-color-border-default-alpha: var(--nx-color-slate-a300);
   --nx-color-border-active: var(--nx-color-slate-400);
   --nx-color-border-disabled: var(--nx-color-slate-950);

--- a/apps/docs/public/themes/base-stone.css
+++ b/apps/docs/public/themes/base-stone.css
@@ -2,13 +2,13 @@
 
 html {
   --nx-color-background: var(--nx-color-white-base);
-  --nx-color-foreground: var(--nx-color-stone-950);
+  --nx-color-foreground: var(--nx-color-black-a900);
   --nx-color-background-hover: var(--nx-color-stone-50);
   --nx-color-background-hover-alpha: var(--nx-color-stone-a100);
   --nx-color-background-active: var(--nx-color-stone-100);
   --nx-color-muted: var(--nx-color-stone-50);
-  --nx-color-muted-foreground: var(--nx-color-stone-500);
-  --nx-color-muted-foreground-subtle: var(--nx-color-stone-400);
+  --nx-color-muted-foreground: var(--nx-color-black-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-black-a500);
   --nx-color-disabled: var(--nx-color-stone-50);
   --nx-color-disabled-foreground: var(--nx-color-stone-400);
   --nx-color-container: var(--nx-color-white-base);
@@ -28,7 +28,7 @@ html {
   --nx-color-nav-item-active: var(--nx-color-stone-300);
   --nx-color-nav-border: var(--nx-color-stone-200);
   --nx-color-overlay: var(--nx-color-stone-a700);
-  --nx-color-border-default: var(--nx-color-stone-200);
+  --nx-color-border-default: var(--nx-color-black-a300);
   --nx-color-border-default-alpha: var(--nx-color-stone-a200);
   --nx-color-border-active: var(--nx-color-stone-400);
   --nx-color-border-disabled: var(--nx-color-stone-50);
@@ -82,13 +82,13 @@ html {
 
 html.dark {
   --nx-color-background: var(--nx-color-stone-900);
-  --nx-color-foreground: var(--nx-color-white-base);
+  --nx-color-foreground: var(--nx-color-white-a900);
   --nx-color-background-hover: var(--nx-color-stone-800);
   --nx-color-background-hover-alpha: var(--nx-color-stone-a100);
   --nx-color-background-active: var(--nx-color-stone-950);
   --nx-color-muted: var(--nx-color-stone-800);
-  --nx-color-muted-foreground: var(--nx-color-stone-300);
-  --nx-color-muted-foreground-subtle: var(--nx-color-stone-300);
+  --nx-color-muted-foreground: var(--nx-color-white-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-white-a600);
   --nx-color-disabled: var(--nx-color-stone-950);
   --nx-color-disabled-foreground: var(--nx-color-stone-300);
   --nx-color-container: var(--nx-color-stone-800);
@@ -108,7 +108,7 @@ html.dark {
   --nx-color-nav-item-active: var(--nx-color-stone-800);
   --nx-color-nav-border: var(--nx-color-stone-800);
   --nx-color-overlay: var(--nx-color-stone-a800);
-  --nx-color-border-default: var(--nx-color-stone-700);
+  --nx-color-border-default: var(--nx-color-white-a400);
   --nx-color-border-default-alpha: var(--nx-color-stone-a300);
   --nx-color-border-active: var(--nx-color-stone-400);
   --nx-color-border-disabled: var(--nx-color-stone-950);

--- a/apps/docs/public/themes/base-zinc.css
+++ b/apps/docs/public/themes/base-zinc.css
@@ -2,13 +2,13 @@
 
 html {
   --nx-color-background: var(--nx-color-white-base);
-  --nx-color-foreground: var(--nx-color-zinc-950);
+  --nx-color-foreground: var(--nx-color-black-a900);
   --nx-color-background-hover: var(--nx-color-zinc-50);
   --nx-color-background-hover-alpha: var(--nx-color-zinc-a100);
   --nx-color-background-active: var(--nx-color-zinc-100);
   --nx-color-muted: var(--nx-color-zinc-50);
-  --nx-color-muted-foreground: var(--nx-color-zinc-500);
-  --nx-color-muted-foreground-subtle: var(--nx-color-zinc-400);
+  --nx-color-muted-foreground: var(--nx-color-black-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-black-a500);
   --nx-color-disabled: var(--nx-color-zinc-50);
   --nx-color-disabled-foreground: var(--nx-color-zinc-400);
   --nx-color-container: var(--nx-color-white-base);
@@ -28,7 +28,7 @@ html {
   --nx-color-nav-item-active: var(--nx-color-zinc-300);
   --nx-color-nav-border: var(--nx-color-zinc-200);
   --nx-color-overlay: var(--nx-color-zinc-a700);
-  --nx-color-border-default: var(--nx-color-zinc-200);
+  --nx-color-border-default: var(--nx-color-black-a300);
   --nx-color-border-default-alpha: var(--nx-color-zinc-a200);
   --nx-color-border-active: var(--nx-color-zinc-400);
   --nx-color-border-disabled: var(--nx-color-zinc-50);
@@ -82,13 +82,13 @@ html {
 
 html.dark {
   --nx-color-background: var(--nx-color-zinc-900);
-  --nx-color-foreground: var(--nx-color-white-base);
+  --nx-color-foreground: var(--nx-color-white-a900);
   --nx-color-background-hover: var(--nx-color-zinc-800);
   --nx-color-background-hover-alpha: var(--nx-color-zinc-a100);
   --nx-color-background-active: var(--nx-color-zinc-950);
   --nx-color-muted: var(--nx-color-zinc-800);
-  --nx-color-muted-foreground: var(--nx-color-zinc-300);
-  --nx-color-muted-foreground-subtle: var(--nx-color-zinc-300);
+  --nx-color-muted-foreground: var(--nx-color-white-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-white-a600);
   --nx-color-disabled: var(--nx-color-zinc-950);
   --nx-color-disabled-foreground: var(--nx-color-zinc-300);
   --nx-color-container: var(--nx-color-zinc-800);
@@ -108,7 +108,7 @@ html.dark {
   --nx-color-nav-item-active: var(--nx-color-zinc-800);
   --nx-color-nav-border: var(--nx-color-zinc-800);
   --nx-color-overlay: var(--nx-color-zinc-a800);
-  --nx-color-border-default: var(--nx-color-zinc-700);
+  --nx-color-border-default: var(--nx-color-white-a400);
   --nx-color-border-default-alpha: var(--nx-color-zinc-a300);
   --nx-color-border-active: var(--nx-color-zinc-400);
   --nx-color-border-disabled: var(--nx-color-zinc-950);

--- a/apps/docs/public/themes/globals.css
+++ b/apps/docs/public/themes/globals.css
@@ -32,13 +32,13 @@
 
   /* Semantic tokens */
   --color-background: var(--nx-color-white-base);
-  --color-foreground: var(--nx-color-slate-950);
+  --color-foreground: var(--nx-color-black-a900);
   --color-background-hover: var(--nx-color-slate-50);
   --color-background-hover-alpha: var(--nx-color-slate-a100);
   --color-background-active: var(--nx-color-slate-100);
   --color-muted: var(--nx-color-slate-50);
-  --color-muted-foreground: var(--nx-color-slate-500);
-  --color-muted-foreground-subtle: var(--nx-color-slate-400);
+  --color-muted-foreground: var(--nx-color-black-a600);
+  --color-muted-foreground-subtle: var(--nx-color-black-a500);
   --color-disabled: var(--nx-color-slate-50);
   --color-disabled-foreground: var(--nx-color-slate-400);
   --color-container: var(--nx-color-white-base);
@@ -58,7 +58,7 @@
   --color-nav-item-active: var(--nx-color-slate-300);
   --color-nav-border: var(--nx-color-slate-200);
   --color-overlay: var(--nx-color-slate-a700);
-  --color-border-default: var(--nx-color-slate-200);
+  --color-border-default: var(--nx-color-black-a300);
   --color-border-default-alpha: var(--nx-color-slate-a200);
   --color-border-active: var(--nx-color-slate-400);
   --color-border-disabled: var(--nx-color-slate-50);

--- a/apps/playground/public/themes/base-gray.css
+++ b/apps/playground/public/themes/base-gray.css
@@ -2,13 +2,13 @@
 
 html {
   --nx-color-background: var(--nx-color-white-base);
-  --nx-color-foreground: var(--nx-color-gray-950);
+  --nx-color-foreground: var(--nx-color-black-a900);
   --nx-color-background-hover: var(--nx-color-gray-50);
   --nx-color-background-hover-alpha: var(--nx-color-gray-a100);
   --nx-color-background-active: var(--nx-color-gray-100);
   --nx-color-muted: var(--nx-color-gray-50);
-  --nx-color-muted-foreground: var(--nx-color-gray-500);
-  --nx-color-muted-foreground-subtle: var(--nx-color-gray-400);
+  --nx-color-muted-foreground: var(--nx-color-black-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-black-a500);
   --nx-color-disabled: var(--nx-color-gray-50);
   --nx-color-disabled-foreground: var(--nx-color-gray-400);
   --nx-color-container: var(--nx-color-white-base);
@@ -28,7 +28,7 @@ html {
   --nx-color-nav-item-active: var(--nx-color-gray-300);
   --nx-color-nav-border: var(--nx-color-gray-200);
   --nx-color-overlay: var(--nx-color-gray-a700);
-  --nx-color-border-default: var(--nx-color-gray-200);
+  --nx-color-border-default: var(--nx-color-black-a300);
   --nx-color-border-default-alpha: var(--nx-color-gray-a200);
   --nx-color-border-active: var(--nx-color-gray-400);
   --nx-color-border-disabled: var(--nx-color-gray-50);
@@ -82,13 +82,13 @@ html {
 
 html.dark {
   --nx-color-background: var(--nx-color-gray-900);
-  --nx-color-foreground: var(--nx-color-white-base);
+  --nx-color-foreground: var(--nx-color-white-a900);
   --nx-color-background-hover: var(--nx-color-gray-800);
   --nx-color-background-hover-alpha: var(--nx-color-gray-a100);
   --nx-color-background-active: var(--nx-color-gray-950);
   --nx-color-muted: var(--nx-color-gray-800);
-  --nx-color-muted-foreground: var(--nx-color-gray-300);
-  --nx-color-muted-foreground-subtle: var(--nx-color-gray-300);
+  --nx-color-muted-foreground: var(--nx-color-white-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-white-a600);
   --nx-color-disabled: var(--nx-color-gray-950);
   --nx-color-disabled-foreground: var(--nx-color-gray-300);
   --nx-color-container: var(--nx-color-gray-800);
@@ -108,7 +108,7 @@ html.dark {
   --nx-color-nav-item-active: var(--nx-color-gray-800);
   --nx-color-nav-border: var(--nx-color-gray-800);
   --nx-color-overlay: var(--nx-color-gray-a800);
-  --nx-color-border-default: var(--nx-color-gray-700);
+  --nx-color-border-default: var(--nx-color-white-a400);
   --nx-color-border-default-alpha: var(--nx-color-gray-a300);
   --nx-color-border-active: var(--nx-color-gray-400);
   --nx-color-border-disabled: var(--nx-color-gray-950);

--- a/apps/playground/public/themes/base-neutral.css
+++ b/apps/playground/public/themes/base-neutral.css
@@ -2,13 +2,13 @@
 
 html {
   --nx-color-background: var(--nx-color-white-base);
-  --nx-color-foreground: var(--nx-color-neutral-950);
+  --nx-color-foreground: var(--nx-color-black-a900);
   --nx-color-background-hover: var(--nx-color-neutral-50);
   --nx-color-background-hover-alpha: var(--nx-color-neutral-a100);
   --nx-color-background-active: var(--nx-color-neutral-100);
   --nx-color-muted: var(--nx-color-neutral-50);
-  --nx-color-muted-foreground: var(--nx-color-neutral-500);
-  --nx-color-muted-foreground-subtle: var(--nx-color-neutral-400);
+  --nx-color-muted-foreground: var(--nx-color-black-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-black-a500);
   --nx-color-disabled: var(--nx-color-neutral-50);
   --nx-color-disabled-foreground: var(--nx-color-neutral-400);
   --nx-color-container: var(--nx-color-white-base);
@@ -28,7 +28,7 @@ html {
   --nx-color-nav-item-active: var(--nx-color-neutral-300);
   --nx-color-nav-border: var(--nx-color-neutral-200);
   --nx-color-overlay: var(--nx-color-neutral-a700);
-  --nx-color-border-default: var(--nx-color-neutral-200);
+  --nx-color-border-default: var(--nx-color-black-a300);
   --nx-color-border-default-alpha: var(--nx-color-neutral-a200);
   --nx-color-border-active: var(--nx-color-neutral-400);
   --nx-color-border-disabled: var(--nx-color-neutral-50);
@@ -82,13 +82,13 @@ html {
 
 html.dark {
   --nx-color-background: var(--nx-color-neutral-900);
-  --nx-color-foreground: var(--nx-color-white-base);
+  --nx-color-foreground: var(--nx-color-white-a900);
   --nx-color-background-hover: var(--nx-color-neutral-800);
   --nx-color-background-hover-alpha: var(--nx-color-neutral-a100);
   --nx-color-background-active: var(--nx-color-neutral-950);
   --nx-color-muted: var(--nx-color-neutral-800);
-  --nx-color-muted-foreground: var(--nx-color-neutral-300);
-  --nx-color-muted-foreground-subtle: var(--nx-color-neutral-300);
+  --nx-color-muted-foreground: var(--nx-color-white-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-white-a600);
   --nx-color-disabled: var(--nx-color-neutral-950);
   --nx-color-disabled-foreground: var(--nx-color-neutral-300);
   --nx-color-container: var(--nx-color-neutral-800);
@@ -108,7 +108,7 @@ html.dark {
   --nx-color-nav-item-active: var(--nx-color-neutral-800);
   --nx-color-nav-border: var(--nx-color-neutral-800);
   --nx-color-overlay: var(--nx-color-neutral-a800);
-  --nx-color-border-default: var(--nx-color-neutral-700);
+  --nx-color-border-default: var(--nx-color-white-a400);
   --nx-color-border-default-alpha: var(--nx-color-neutral-a300);
   --nx-color-border-active: var(--nx-color-neutral-400);
   --nx-color-border-disabled: var(--nx-color-neutral-950);

--- a/apps/playground/public/themes/base-slate.css
+++ b/apps/playground/public/themes/base-slate.css
@@ -2,13 +2,13 @@
 
 html {
   --nx-color-background: var(--nx-color-white-base);
-  --nx-color-foreground: var(--nx-color-slate-950);
+  --nx-color-foreground: var(--nx-color-black-a900);
   --nx-color-background-hover: var(--nx-color-slate-50);
   --nx-color-background-hover-alpha: var(--nx-color-slate-a100);
   --nx-color-background-active: var(--nx-color-slate-100);
   --nx-color-muted: var(--nx-color-slate-50);
-  --nx-color-muted-foreground: var(--nx-color-slate-500);
-  --nx-color-muted-foreground-subtle: var(--nx-color-slate-400);
+  --nx-color-muted-foreground: var(--nx-color-black-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-black-a500);
   --nx-color-disabled: var(--nx-color-slate-50);
   --nx-color-disabled-foreground: var(--nx-color-slate-400);
   --nx-color-container: var(--nx-color-white-base);
@@ -28,7 +28,7 @@ html {
   --nx-color-nav-item-active: var(--nx-color-slate-300);
   --nx-color-nav-border: var(--nx-color-slate-200);
   --nx-color-overlay: var(--nx-color-slate-a700);
-  --nx-color-border-default: var(--nx-color-slate-200);
+  --nx-color-border-default: var(--nx-color-black-a300);
   --nx-color-border-default-alpha: var(--nx-color-slate-a200);
   --nx-color-border-active: var(--nx-color-slate-400);
   --nx-color-border-disabled: var(--nx-color-slate-50);
@@ -82,13 +82,13 @@ html {
 
 html.dark {
   --nx-color-background: var(--nx-color-slate-900);
-  --nx-color-foreground: var(--nx-color-white-base);
+  --nx-color-foreground: var(--nx-color-white-a900);
   --nx-color-background-hover: var(--nx-color-slate-800);
   --nx-color-background-hover-alpha: var(--nx-color-slate-a100);
   --nx-color-background-active: var(--nx-color-slate-950);
   --nx-color-muted: var(--nx-color-slate-800);
-  --nx-color-muted-foreground: var(--nx-color-slate-300);
-  --nx-color-muted-foreground-subtle: var(--nx-color-slate-300);
+  --nx-color-muted-foreground: var(--nx-color-white-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-white-a600);
   --nx-color-disabled: var(--nx-color-slate-950);
   --nx-color-disabled-foreground: var(--nx-color-slate-300);
   --nx-color-container: var(--nx-color-slate-800);
@@ -108,7 +108,7 @@ html.dark {
   --nx-color-nav-item-active: var(--nx-color-slate-800);
   --nx-color-nav-border: var(--nx-color-slate-800);
   --nx-color-overlay: var(--nx-color-slate-a800);
-  --nx-color-border-default: var(--nx-color-slate-700);
+  --nx-color-border-default: var(--nx-color-white-a400);
   --nx-color-border-default-alpha: var(--nx-color-slate-a300);
   --nx-color-border-active: var(--nx-color-slate-400);
   --nx-color-border-disabled: var(--nx-color-slate-950);

--- a/apps/playground/public/themes/base-stone.css
+++ b/apps/playground/public/themes/base-stone.css
@@ -2,13 +2,13 @@
 
 html {
   --nx-color-background: var(--nx-color-white-base);
-  --nx-color-foreground: var(--nx-color-stone-950);
+  --nx-color-foreground: var(--nx-color-black-a900);
   --nx-color-background-hover: var(--nx-color-stone-50);
   --nx-color-background-hover-alpha: var(--nx-color-stone-a100);
   --nx-color-background-active: var(--nx-color-stone-100);
   --nx-color-muted: var(--nx-color-stone-50);
-  --nx-color-muted-foreground: var(--nx-color-stone-500);
-  --nx-color-muted-foreground-subtle: var(--nx-color-stone-400);
+  --nx-color-muted-foreground: var(--nx-color-black-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-black-a500);
   --nx-color-disabled: var(--nx-color-stone-50);
   --nx-color-disabled-foreground: var(--nx-color-stone-400);
   --nx-color-container: var(--nx-color-white-base);
@@ -28,7 +28,7 @@ html {
   --nx-color-nav-item-active: var(--nx-color-stone-300);
   --nx-color-nav-border: var(--nx-color-stone-200);
   --nx-color-overlay: var(--nx-color-stone-a700);
-  --nx-color-border-default: var(--nx-color-stone-200);
+  --nx-color-border-default: var(--nx-color-black-a300);
   --nx-color-border-default-alpha: var(--nx-color-stone-a200);
   --nx-color-border-active: var(--nx-color-stone-400);
   --nx-color-border-disabled: var(--nx-color-stone-50);
@@ -82,13 +82,13 @@ html {
 
 html.dark {
   --nx-color-background: var(--nx-color-stone-900);
-  --nx-color-foreground: var(--nx-color-white-base);
+  --nx-color-foreground: var(--nx-color-white-a900);
   --nx-color-background-hover: var(--nx-color-stone-800);
   --nx-color-background-hover-alpha: var(--nx-color-stone-a100);
   --nx-color-background-active: var(--nx-color-stone-950);
   --nx-color-muted: var(--nx-color-stone-800);
-  --nx-color-muted-foreground: var(--nx-color-stone-300);
-  --nx-color-muted-foreground-subtle: var(--nx-color-stone-300);
+  --nx-color-muted-foreground: var(--nx-color-white-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-white-a600);
   --nx-color-disabled: var(--nx-color-stone-950);
   --nx-color-disabled-foreground: var(--nx-color-stone-300);
   --nx-color-container: var(--nx-color-stone-800);
@@ -108,7 +108,7 @@ html.dark {
   --nx-color-nav-item-active: var(--nx-color-stone-800);
   --nx-color-nav-border: var(--nx-color-stone-800);
   --nx-color-overlay: var(--nx-color-stone-a800);
-  --nx-color-border-default: var(--nx-color-stone-700);
+  --nx-color-border-default: var(--nx-color-white-a400);
   --nx-color-border-default-alpha: var(--nx-color-stone-a300);
   --nx-color-border-active: var(--nx-color-stone-400);
   --nx-color-border-disabled: var(--nx-color-stone-950);

--- a/apps/playground/public/themes/base-zinc.css
+++ b/apps/playground/public/themes/base-zinc.css
@@ -2,13 +2,13 @@
 
 html {
   --nx-color-background: var(--nx-color-white-base);
-  --nx-color-foreground: var(--nx-color-zinc-950);
+  --nx-color-foreground: var(--nx-color-black-a900);
   --nx-color-background-hover: var(--nx-color-zinc-50);
   --nx-color-background-hover-alpha: var(--nx-color-zinc-a100);
   --nx-color-background-active: var(--nx-color-zinc-100);
   --nx-color-muted: var(--nx-color-zinc-50);
-  --nx-color-muted-foreground: var(--nx-color-zinc-500);
-  --nx-color-muted-foreground-subtle: var(--nx-color-zinc-400);
+  --nx-color-muted-foreground: var(--nx-color-black-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-black-a500);
   --nx-color-disabled: var(--nx-color-zinc-50);
   --nx-color-disabled-foreground: var(--nx-color-zinc-400);
   --nx-color-container: var(--nx-color-white-base);
@@ -28,7 +28,7 @@ html {
   --nx-color-nav-item-active: var(--nx-color-zinc-300);
   --nx-color-nav-border: var(--nx-color-zinc-200);
   --nx-color-overlay: var(--nx-color-zinc-a700);
-  --nx-color-border-default: var(--nx-color-zinc-200);
+  --nx-color-border-default: var(--nx-color-black-a300);
   --nx-color-border-default-alpha: var(--nx-color-zinc-a200);
   --nx-color-border-active: var(--nx-color-zinc-400);
   --nx-color-border-disabled: var(--nx-color-zinc-50);
@@ -82,13 +82,13 @@ html {
 
 html.dark {
   --nx-color-background: var(--nx-color-zinc-900);
-  --nx-color-foreground: var(--nx-color-white-base);
+  --nx-color-foreground: var(--nx-color-white-a900);
   --nx-color-background-hover: var(--nx-color-zinc-800);
   --nx-color-background-hover-alpha: var(--nx-color-zinc-a100);
   --nx-color-background-active: var(--nx-color-zinc-950);
   --nx-color-muted: var(--nx-color-zinc-800);
-  --nx-color-muted-foreground: var(--nx-color-zinc-300);
-  --nx-color-muted-foreground-subtle: var(--nx-color-zinc-300);
+  --nx-color-muted-foreground: var(--nx-color-white-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-white-a600);
   --nx-color-disabled: var(--nx-color-zinc-950);
   --nx-color-disabled-foreground: var(--nx-color-zinc-300);
   --nx-color-container: var(--nx-color-zinc-800);
@@ -108,7 +108,7 @@ html.dark {
   --nx-color-nav-item-active: var(--nx-color-zinc-800);
   --nx-color-nav-border: var(--nx-color-zinc-800);
   --nx-color-overlay: var(--nx-color-zinc-a800);
-  --nx-color-border-default: var(--nx-color-zinc-700);
+  --nx-color-border-default: var(--nx-color-white-a400);
   --nx-color-border-default-alpha: var(--nx-color-zinc-a300);
   --nx-color-border-active: var(--nx-color-zinc-400);
   --nx-color-border-disabled: var(--nx-color-zinc-950);

--- a/apps/playground/public/themes/globals.css
+++ b/apps/playground/public/themes/globals.css
@@ -32,13 +32,13 @@
 
   /* Semantic tokens */
   --color-background: var(--nx-color-white-base);
-  --color-foreground: var(--nx-color-slate-950);
+  --color-foreground: var(--nx-color-black-a900);
   --color-background-hover: var(--nx-color-slate-50);
   --color-background-hover-alpha: var(--nx-color-slate-a100);
   --color-background-active: var(--nx-color-slate-100);
   --color-muted: var(--nx-color-slate-50);
-  --color-muted-foreground: var(--nx-color-slate-500);
-  --color-muted-foreground-subtle: var(--nx-color-slate-400);
+  --color-muted-foreground: var(--nx-color-black-a600);
+  --color-muted-foreground-subtle: var(--nx-color-black-a500);
   --color-disabled: var(--nx-color-slate-50);
   --color-disabled-foreground: var(--nx-color-slate-400);
   --color-container: var(--nx-color-white-base);
@@ -58,7 +58,7 @@
   --color-nav-item-active: var(--nx-color-slate-300);
   --color-nav-border: var(--nx-color-slate-200);
   --color-overlay: var(--nx-color-slate-a700);
-  --color-border-default: var(--nx-color-slate-200);
+  --color-border-default: var(--nx-color-black-a300);
   --color-border-default-alpha: var(--nx-color-slate-a200);
   --color-border-active: var(--nx-color-slate-400);
   --color-border-disabled: var(--nx-color-slate-50);

--- a/apps/playground/src/styles/globals.css
+++ b/apps/playground/src/styles/globals.css
@@ -32,13 +32,13 @@
 
   /* Semantic tokens */
   --color-background: var(--nx-color-white-base);
-  --color-foreground: var(--nx-color-slate-950);
+  --color-foreground: var(--nx-color-black-a900);
   --color-background-hover: var(--nx-color-slate-50);
   --color-background-hover-alpha: var(--nx-color-slate-a100);
   --color-background-active: var(--nx-color-slate-100);
   --color-muted: var(--nx-color-slate-50);
-  --color-muted-foreground: var(--nx-color-slate-500);
-  --color-muted-foreground-subtle: var(--nx-color-slate-400);
+  --color-muted-foreground: var(--nx-color-black-a600);
+  --color-muted-foreground-subtle: var(--nx-color-black-a500);
   --color-disabled: var(--nx-color-slate-50);
   --color-disabled-foreground: var(--nx-color-slate-400);
   --color-container: var(--nx-color-white-base);
@@ -58,7 +58,7 @@
   --color-nav-item-active: var(--nx-color-slate-300);
   --color-nav-border: var(--nx-color-slate-200);
   --color-overlay: var(--nx-color-slate-a700);
-  --color-border-default: var(--nx-color-slate-200);
+  --color-border-default: var(--nx-color-black-a300);
   --color-border-default-alpha: var(--nx-color-slate-a200);
   --color-border-active: var(--nx-color-slate-400);
   --color-border-disabled: var(--nx-color-slate-50);

--- a/packages/core/scripts/audit-contrast.js
+++ b/packages/core/scripts/audit-contrast.js
@@ -179,34 +179,57 @@ function buildPrimitiveHexMap() {
   return map;
 }
 
-function resolveToSrgbInts(value, primitiveMap) {
+// Composite an 8-digit (alpha) hex over an opaque backdrop → opaque sRGB ints.
+function blendAlphaOver(hex8, bgInts) {
+  const h = hex8.slice(1);
+  const a = parseInt(h.slice(6, 8), 16) / 255;
+  const mix = (i) =>
+    Math.round(
+      parseInt(h.slice(i * 2, i * 2 + 2), 16) * a + bgInts[i] * (1 - a)
+    );
+  return [mix(0), mix(1), mix(2)];
+}
+
+function resolveToSrgbInts(value, primitiveMap, bgInts) {
   if (typeof value !== 'string') {
     throw new Error(
       `audit-contrast: expected string color value, got ${typeof value}`
     );
   }
 
+  let hex;
+  let shade;
+  let palette;
   const refMatch = value.match(REF_RE);
   if (refMatch) {
-    const refPath = refMatch[1];
-    const primitive = primitiveMap.get(refPath);
+    const primitive = primitiveMap.get(refMatch[1]);
     if (!primitive) {
       throw new Error(`audit-contrast: unresolved reference "${value}"`);
     }
-    const shade = primitive.path[primitive.path.length - 1];
-    const palette = primitive.path[primitive.path.length - 2];
-    return hexToSrgbInts(
-      primitive.value,
-      isPaletteShadeKey(shade) ? shade : undefined,
-      isPaletteShadeKey(shade) ? palette : undefined
-    );
+    hex = primitive.value;
+    shade = primitive.path[primitive.path.length - 1];
+    palette = primitive.path[primitive.path.length - 2];
+  } else if (value.startsWith('#')) {
+    hex = value;
+  } else {
+    throw new Error(`audit-contrast: unrecognized color value "${value}"`);
   }
 
-  if (value.startsWith('#')) {
-    return hexToSrgbInts(value);
+  // Alpha foreground (8-digit hex): composite over the backdrop before scoring.
+  if (/^#[0-9a-fA-F]{8}$/.test(hex)) {
+    if (!bgInts) {
+      throw new Error(
+        `audit-contrast: alpha colour "${hex}" needs a backdrop to composite against`
+      );
+    }
+    return blendAlphaOver(hex, bgInts);
   }
 
-  throw new Error(`audit-contrast: unrecognized color value "${value}"`);
+  return hexToSrgbInts(
+    hex,
+    isPaletteShadeKey(shade) ? shade : undefined,
+    isPaletteShadeKey(shade) ? palette : undefined
+  );
 }
 
 function findTokenValue(fileData, tokenPath) {
@@ -258,8 +281,9 @@ function auditPairs(fgData, bgData, fileName, pairs, primitiveMap) {
       );
     }
 
-    const fgInts = resolveToSrgbInts(fgValue, primitiveMap);
+    // Resolve the backdrop first so an alpha foreground can composite over it.
     const bgInts = resolveToSrgbInts(bgValue, primitiveMap);
+    const fgInts = resolveToSrgbInts(fgValue, primitiveMap, bgInts);
     const lc = computeLc(fgInts, bgInts);
     const passed = Math.abs(lc) >= minLc;
 

--- a/packages/core/tokens/semantic/base-gray-dark.json
+++ b/packages/core/tokens/semantic/base-gray-dark.json
@@ -4,7 +4,7 @@
     "$type": "color"
   },
   "foreground": {
-    "$value": "{white.base}",
+    "$value": "{white.a900}",
     "$type": "color"
   },
   "background-hover": {
@@ -24,12 +24,12 @@
     "$type": "color"
   },
   "muted-foreground": {
-    "$value": "{gray.300}",
+    "$value": "{white.a600}",
     "$type": "color",
     "$description": "It’s a gray that softens contrast so primary content stands forward."
   },
   "muted-foreground-subtle": {
-    "$value": "{gray.300}",
+    "$value": "{white.a600}",
     "$type": "color",
     "$description": "Tertiary text tier below muted-foreground — helper text, captions, divider labels."
   },
@@ -111,7 +111,7 @@
   },
   "border": {
     "default": {
-      "$value": "{gray.700}",
+      "$value": "{white.a400}",
       "$type": "color"
     },
     "default-alpha": {

--- a/packages/core/tokens/semantic/base-gray-light.json
+++ b/packages/core/tokens/semantic/base-gray-light.json
@@ -4,7 +4,7 @@
     "$type": "color"
   },
   "foreground": {
-    "$value": "{gray.950}",
+    "$value": "{black.a900}",
     "$type": "color"
   },
   "background-hover": {
@@ -24,12 +24,12 @@
     "$type": "color"
   },
   "muted-foreground": {
-    "$value": "{gray.500}",
+    "$value": "{black.a600}",
     "$type": "color",
     "$description": "It’s a gray that softens contrast so primary content stands forward."
   },
   "muted-foreground-subtle": {
-    "$value": "{gray.400}",
+    "$value": "{black.a500}",
     "$type": "color",
     "$description": "Tertiary text tier below muted-foreground — helper text, captions, divider labels."
   },
@@ -111,7 +111,7 @@
   },
   "border": {
     "default": {
-      "$value": "{gray.200}",
+      "$value": "{black.a300}",
       "$type": "color"
     },
     "default-alpha": {

--- a/packages/core/tokens/semantic/base-neutral-dark.json
+++ b/packages/core/tokens/semantic/base-neutral-dark.json
@@ -4,7 +4,7 @@
     "$type": "color"
   },
   "foreground": {
-    "$value": "{white.base}",
+    "$value": "{white.a900}",
     "$type": "color"
   },
   "background-hover": {
@@ -24,12 +24,12 @@
     "$type": "color"
   },
   "muted-foreground": {
-    "$value": "{neutral.300}",
+    "$value": "{white.a600}",
     "$type": "color",
     "$description": "It’s a gray that softens contrast so primary content stands forward."
   },
   "muted-foreground-subtle": {
-    "$value": "{neutral.300}",
+    "$value": "{white.a600}",
     "$type": "color",
     "$description": "Tertiary text tier below muted-foreground — helper text, captions, divider labels."
   },
@@ -111,7 +111,7 @@
   },
   "border": {
     "default": {
-      "$value": "{neutral.700}",
+      "$value": "{white.a400}",
       "$type": "color"
     },
     "default-alpha": {

--- a/packages/core/tokens/semantic/base-neutral-light.json
+++ b/packages/core/tokens/semantic/base-neutral-light.json
@@ -4,7 +4,7 @@
     "$type": "color"
   },
   "foreground": {
-    "$value": "{neutral.950}",
+    "$value": "{black.a900}",
     "$type": "color"
   },
   "background-hover": {
@@ -24,12 +24,12 @@
     "$type": "color"
   },
   "muted-foreground": {
-    "$value": "{neutral.500}",
+    "$value": "{black.a600}",
     "$type": "color",
     "$description": "It’s a gray that softens contrast so primary content stands forward."
   },
   "muted-foreground-subtle": {
-    "$value": "{neutral.400}",
+    "$value": "{black.a500}",
     "$type": "color",
     "$description": "Tertiary text tier below muted-foreground — helper text, captions, divider labels."
   },
@@ -111,7 +111,7 @@
   },
   "border": {
     "default": {
-      "$value": "{neutral.200}",
+      "$value": "{black.a300}",
       "$type": "color"
     },
     "default-alpha": {

--- a/packages/core/tokens/semantic/base-slate-dark.json
+++ b/packages/core/tokens/semantic/base-slate-dark.json
@@ -4,7 +4,7 @@
     "$type": "color"
   },
   "foreground": {
-    "$value": "{white.base}",
+    "$value": "{white.a900}",
     "$type": "color"
   },
   "background-hover": {
@@ -24,12 +24,12 @@
     "$type": "color"
   },
   "muted-foreground": {
-    "$value": "{slate.300}",
+    "$value": "{white.a600}",
     "$type": "color",
     "$description": "It’s a gray that softens contrast so primary content stands forward."
   },
   "muted-foreground-subtle": {
-    "$value": "{slate.300}",
+    "$value": "{white.a600}",
     "$type": "color",
     "$description": "Tertiary text tier below muted-foreground — helper text, captions, divider labels."
   },
@@ -111,7 +111,7 @@
   },
   "border": {
     "default": {
-      "$value": "{slate.700}",
+      "$value": "{white.a400}",
       "$type": "color"
     },
     "default-alpha": {

--- a/packages/core/tokens/semantic/base-slate-light.json
+++ b/packages/core/tokens/semantic/base-slate-light.json
@@ -4,7 +4,7 @@
     "$type": "color"
   },
   "foreground": {
-    "$value": "{slate.950}",
+    "$value": "{black.a900}",
     "$type": "color"
   },
   "background-hover": {
@@ -24,12 +24,12 @@
     "$type": "color"
   },
   "muted-foreground": {
-    "$value": "{slate.500}",
+    "$value": "{black.a600}",
     "$type": "color",
     "$description": "It’s a gray that softens contrast so primary content stands forward."
   },
   "muted-foreground-subtle": {
-    "$value": "{slate.400}",
+    "$value": "{black.a500}",
     "$type": "color",
     "$description": "Tertiary text tier below muted-foreground — helper text, captions, divider labels."
   },
@@ -111,7 +111,7 @@
   },
   "border": {
     "default": {
-      "$value": "{slate.200}",
+      "$value": "{black.a300}",
       "$type": "color"
     },
     "default-alpha": {

--- a/packages/core/tokens/semantic/base-stone-dark.json
+++ b/packages/core/tokens/semantic/base-stone-dark.json
@@ -4,7 +4,7 @@
     "$type": "color"
   },
   "foreground": {
-    "$value": "{white.base}",
+    "$value": "{white.a900}",
     "$type": "color"
   },
   "background-hover": {
@@ -24,12 +24,12 @@
     "$type": "color"
   },
   "muted-foreground": {
-    "$value": "{stone.300}",
+    "$value": "{white.a600}",
     "$type": "color",
     "$description": "It’s a gray that softens contrast so primary content stands forward."
   },
   "muted-foreground-subtle": {
-    "$value": "{stone.300}",
+    "$value": "{white.a600}",
     "$type": "color",
     "$description": "Tertiary text tier below muted-foreground — helper text, captions, divider labels."
   },
@@ -111,7 +111,7 @@
   },
   "border": {
     "default": {
-      "$value": "{stone.700}",
+      "$value": "{white.a400}",
       "$type": "color"
     },
     "default-alpha": {

--- a/packages/core/tokens/semantic/base-stone-light.json
+++ b/packages/core/tokens/semantic/base-stone-light.json
@@ -4,7 +4,7 @@
     "$type": "color"
   },
   "foreground": {
-    "$value": "{stone.950}",
+    "$value": "{black.a900}",
     "$type": "color"
   },
   "background-hover": {
@@ -24,12 +24,12 @@
     "$type": "color"
   },
   "muted-foreground": {
-    "$value": "{stone.500}",
+    "$value": "{black.a600}",
     "$type": "color",
     "$description": "It’s a gray that softens contrast so primary content stands forward."
   },
   "muted-foreground-subtle": {
-    "$value": "{stone.400}",
+    "$value": "{black.a500}",
     "$type": "color",
     "$description": "Tertiary text tier below muted-foreground — helper text, captions, divider labels."
   },
@@ -111,7 +111,7 @@
   },
   "border": {
     "default": {
-      "$value": "{stone.200}",
+      "$value": "{black.a300}",
       "$type": "color"
     },
     "default-alpha": {

--- a/packages/core/tokens/semantic/base-zinc-dark.json
+++ b/packages/core/tokens/semantic/base-zinc-dark.json
@@ -4,7 +4,7 @@
     "$type": "color"
   },
   "foreground": {
-    "$value": "{white.base}",
+    "$value": "{white.a900}",
     "$type": "color"
   },
   "background-hover": {
@@ -24,12 +24,12 @@
     "$type": "color"
   },
   "muted-foreground": {
-    "$value": "{zinc.300}",
+    "$value": "{white.a600}",
     "$type": "color",
     "$description": "It’s a gray that softens contrast so primary content stands forward."
   },
   "muted-foreground-subtle": {
-    "$value": "{zinc.300}",
+    "$value": "{white.a600}",
     "$type": "color",
     "$description": "Tertiary text tier below muted-foreground — helper text, captions, divider labels."
   },
@@ -111,7 +111,7 @@
   },
   "border": {
     "default": {
-      "$value": "{zinc.700}",
+      "$value": "{white.a400}",
       "$type": "color"
     },
     "default-alpha": {

--- a/packages/core/tokens/semantic/base-zinc-light.json
+++ b/packages/core/tokens/semantic/base-zinc-light.json
@@ -4,7 +4,7 @@
     "$type": "color"
   },
   "foreground": {
-    "$value": "{zinc.950}",
+    "$value": "{black.a900}",
     "$type": "color"
   },
   "background-hover": {
@@ -24,12 +24,12 @@
     "$type": "color"
   },
   "muted-foreground": {
-    "$value": "{zinc.500}",
+    "$value": "{black.a600}",
     "$type": "color",
     "$description": "It’s a gray that softens contrast so primary content stands forward."
   },
   "muted-foreground-subtle": {
-    "$value": "{zinc.400}",
+    "$value": "{black.a500}",
     "$type": "color",
     "$description": "Tertiary text tier below muted-foreground — helper text, captions, divider labels."
   },
@@ -111,7 +111,7 @@
   },
   "border": {
     "default": {
-      "$value": "{zinc.200}",
+      "$value": "{black.a300}",
       "$type": "color"
     },
     "default-alpha": {

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -27,13 +27,13 @@
 
   /* Semantic tokens */
   --color-background: var(--nx-color-white-base);
-  --color-foreground: var(--nx-color-stone-950);
+  --color-foreground: var(--nx-color-black-a900);
   --color-background-hover: var(--nx-color-stone-50);
   --color-background-hover-alpha: var(--nx-color-stone-a100);
   --color-background-active: var(--nx-color-stone-100);
   --color-muted: var(--nx-color-stone-50);
-  --color-muted-foreground: var(--nx-color-stone-500);
-  --color-muted-foreground-subtle: var(--nx-color-stone-400);
+  --color-muted-foreground: var(--nx-color-black-a600);
+  --color-muted-foreground-subtle: var(--nx-color-black-a500);
   --color-disabled: var(--nx-color-stone-50);
   --color-disabled-foreground: var(--nx-color-stone-400);
   --color-container: var(--nx-color-white-base);
@@ -53,7 +53,7 @@
   --color-nav-item-active: var(--nx-color-stone-300);
   --color-nav-border: var(--nx-color-stone-200);
   --color-overlay: var(--nx-color-stone-a700);
-  --color-border-default: var(--nx-color-stone-200);
+  --color-border-default: var(--nx-color-black-a300);
   --color-border-default-alpha: var(--nx-color-stone-a200);
   --color-border-active: var(--nx-color-stone-400);
   --color-border-disabled: var(--nx-color-stone-50);
@@ -241,13 +241,13 @@
 /* ===== DARK MODE ===== */
 .dark {
   --nx-color-background: var(--nx-color-stone-900);
-  --nx-color-foreground: var(--nx-color-white-base);
+  --nx-color-foreground: var(--nx-color-white-a900);
   --nx-color-background-hover: var(--nx-color-stone-800);
   --nx-color-background-hover-alpha: var(--nx-color-stone-a100);
   --nx-color-background-active: var(--nx-color-stone-950);
   --nx-color-muted: var(--nx-color-stone-800);
-  --nx-color-muted-foreground: var(--nx-color-stone-300);
-  --nx-color-muted-foreground-subtle: var(--nx-color-stone-300);
+  --nx-color-muted-foreground: var(--nx-color-white-a600);
+  --nx-color-muted-foreground-subtle: var(--nx-color-white-a600);
   --nx-color-disabled: var(--nx-color-stone-950);
   --nx-color-disabled-foreground: var(--nx-color-stone-300);
   --nx-color-container: var(--nx-color-stone-800);
@@ -267,7 +267,7 @@
   --nx-color-nav-item-active: var(--nx-color-stone-800);
   --nx-color-nav-border: var(--nx-color-stone-800);
   --nx-color-overlay: var(--nx-color-stone-a800);
-  --nx-color-border-default: var(--nx-color-stone-700);
+  --nx-color-border-default: var(--nx-color-white-a400);
   --nx-color-border-default-alpha: var(--nx-color-stone-a300);
   --nx-color-border-active: var(--nx-color-stone-400);
   --nx-color-border-disabled: var(--nx-color-stone-950);


### PR DESCRIPTION
## Summary

Re-points the neutral foregrounds + default border from solid greys (`slate-950/500/400/200`) to **pure black-alpha (light) / white-alpha (dark)**, so text and borders **composite onto whatever surface they sit on** — the Notion/Figma "looks right everywhere" quality. A fixed cool-slate `muted-foreground` floats on a tinted callout; transparent black takes the callout's own hue.

- `foreground` → `black/white.a900`, `muted-foreground` → `.a600`, `muted-foreground-subtle` → `.a500`, `border-default` → `.a300` (light) / `.a400` (dark). Uses the **existing** black/white alpha primitives — no new tokens.
- **Audit change:** `audit-contrast` now pre-blends an alpha foreground over its backdrop before APCA (resolve bg first → composite → score), so the gate reads the **composited** colour, not the raw translucent one (which has no contrast).

Model is **pure black/white alpha** (not base-tinted) — it composites cleanest on arbitrary tints, and each base's character now lives in its surfaces, which the alpha text inherits.

## GitHub Issue
N/A — follow-on from the neutrals benchmark (the highest-impact lever).

## Test Plan
- [x] `audit:contrast` — **440/440** (composited via the new pre-blend)
- [x] `audit:colorblind` — **0 findings**
- [x] `@nexus/core` typecheck + unit tests pass (incl. `audit-contrast.test.js`)
- [ ] **Component visual review (Storybook)** — this changes *every* neutral text / border / icon system-wide. The audit confirms contrast holds; the visual result across components should be eyeballed before merge. Brand text on brand fills (button labels) stays solid — this is neutral text/borders only.

Concept demo (local, untracked): `reports/alpha-foreground.html` — solid vs alpha on every surface.

> Independent of #248 (hue-aware grid); both touch `base-*.json` + `nexus.css` but on different tokens, so they merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)