### PR TITLE
fix(docs): single token source — scan @nexus/react instead of importing its prebuilt CSS

### DIFF
--- a/apps/docs/app/globals.css
+++ b/apps/docs/app/globals.css
@@ -1,12 +1,15 @@
-/* Nexus tokens + Tailwind utilities (nx: prefix) */
+/* Nexus design tokens + Tailwind utilities (nx: prefix).
+   @nexus/tailwind is the SINGLE source of token definitions. */
 @import '@nexus/tailwind';
-/* Prebuilt utilities for shipped @nexus/react components.
-   Tailwind 4 doesn't scan node_modules, so utilities used inside the
-   compiled @nexus/react bundle would not be emitted otherwise. */
-@import '@nexus/react/styles.css';
 /* Animations used by Dialog / Dropdown / Select / Tooltip */
 @import 'tw-animate-css';
 
-/* Scan the MDX content dir for nx: utilities (path relative to this file);
-   Tailwind 4 won't emit classes authored only in MDX otherwise. */
+/* Generate the nx: utilities used in MDX content and in the shipped
+   @nexus/react components by scanning their source directly. We deliberately do
+   NOT import @nexus/react's prebuilt CSS: it bundles its own copy of every
+   design token and, imported after @nexus/tailwind, would override the live
+   tokens — and silently go stale whenever tokens change but the package isn't
+   rebuilt. Tailwind 4 skips node_modules, so the component source is pointed at
+   explicitly. Paths are relative to this file. */
 @source '../content';
+@source '../../../packages/react/src';


### PR DESCRIPTION
## Problem

The docs site rendered the **pre-palette-work colors** even though the tokens were correct everywhere. Root cause: `apps/docs/app/globals.css` imported design tokens from **two** places —

1. `@import '@nexus/tailwind'` — the canonical, live tokens, and
2. `@import '@nexus/react/styles.css'` → `packages/react/dist/react.css`, a built artifact that **bundles its own full copy of every `--nx-color-*` token**.

Imported last, the react copy won the cascade. So whenever tokens changed but `@nexus/react` wasn't rebuilt, the docs silently served the stale palette (muted blue, violet zinc, near-grey stone, olive yellow). react.css was only imported for the component *utility classes* (Tailwind 4 doesn't scan `node_modules`) — the bundled tokens were an unwanted side effect.

## Fix (single source of truth)

Drop the `@nexus/react/styles.css` import; instead let the docs' own Tailwind generate the component utilities by scanning the component **source** directly:

```css
@import '@nexus/tailwind';   /* the ONLY token definitions */
@import 'tw-animate-css';
@source '../content';
@source '../../../packages/react/src';
```

Tokens now resolve from exactly one place, so a stale `@nexus/react` build can never override them — and the docs no longer depend on `@nexus/react` being built at all.

## Blast radius (checked)

- **Only `apps/docs` imported react's CSS** — no other app/package does.
- **Playground unaffected** — its `globals.css` is self-contained (own `@theme` + `color.css`); never imported react's CSS.
- **`packages/react/src/exports.test.ts`** only `require.resolve`s `@nexus/react/styles.css` — the export still ships for standalone consumers; test stays green.
- **`@nexus/react` is untouched** → its Storybook/build are unaffected.

## Verified (Playwright + prod build)
- [x] `yarn workspace @nexus/docs build` passes — `@source` emits utilities in production, not just dev
- [x] Nexus `<Button>` fully styled (primary `#0069ec`, correct padding, sharp radius)
- [x] `blue/green/yellow/stone/zinc` render the current palette
- [x] `@nexus/react/styles.css` no longer in the loaded stylesheets — single token source
- [x] no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)