### PR TITLE
fix(react): ship utilities-only CSS so it can't override consumer tokens

### DIFF
--- a/packages/react/.storybook/preview.css
+++ b/packages/react/.storybook/preview.css
@@ -1,0 +1,7 @@
+/* Storybook-only stylesheet: load the full Nexus token set + utilities for
+ * rendering. The shipped component CSS (src/index.css) is utilities-only by
+ * design (tokens come from the consumer's @nexus/tailwind), so Storybook pulls
+ * the tokens in here. Imported via CSS @import (not a JS import) so the Rollup
+ * production build can resolve @nexus/tailwind, whose package entry is a .css. */
+@import '@nexus/tailwind';
+@import 'tw-animate-css';

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -4,7 +4,11 @@ import type { Decorator, Preview } from '@storybook/react-vite';
 
 import { SPACING_MODES, type SpacingMode } from '../src/stories/spacing-modes';
 
-import '../src/index.css';
+// Storybook needs the full token set to render. The shipped component CSS
+// (src/index.css) is utilities-only by design — tokens come from the consumer's
+// @nexus/tailwind — so Storybook imports the tokens directly here.
+import '@nexus/tailwind';
+import 'tw-animate-css';
 
 const ThemeDecorator: Decorator = (Story, context) => {
   const theme = context.globals.theme;

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -6,9 +6,9 @@ import { SPACING_MODES, type SpacingMode } from '../src/stories/spacing-modes';
 
 // Storybook needs the full token set to render. The shipped component CSS
 // (src/index.css) is utilities-only by design — tokens come from the consumer's
-// @nexus/tailwind — so Storybook imports the tokens directly here.
-import '@nexus/tailwind';
-import 'tw-animate-css';
+// @nexus/tailwind — so Storybook loads them via preview.css (a CSS @import, so
+// the production build can resolve @nexus/tailwind's .css package entry).
+import './preview.css';
 
 const ThemeDecorator: Decorator = (Story, context) => {
   const theme = context.globals.theme;

--- a/packages/react/src/index.css
+++ b/packages/react/src/index.css
@@ -1,4 +1,12 @@
-/* Nexus Tailwind theme with nx: prefix */
-@import '@nexus/tailwind';
-/* Radix overlay enter/exit + accordion animations (Dialog, Dropdown, Select, Tooltip). */
+/* @nexus/react component styles.
+ *
+ * Ships UTILITIES ONLY — design tokens are NOT emitted here. We @reference the
+ * Nexus theme so Tailwind can generate utilities against it (and resolve the
+ * composite @utility / @custom-variant definitions) without outputting any
+ * `--color-*` / `--nx-color-*` variables. Consumers supply the tokens by
+ * importing `@nexus/tailwind`; that way importing this file can never re-define
+ * (and thus override / stale-out) a consumer's tokens.
+ */
+@import 'tailwindcss' prefix(nx);
+@reference '@nexus/tailwind';
 @import 'tw-animate-css';


### PR DESCRIPTION
## Summary

`@nexus/react/styles.css` (`dist/react.css`) bundled a **full copy of every design token** — `--color-*` (the `@theme`) + `--nx-color-*` (primitives) + the `.dark { … }` overrides. Imported alongside `@nexus/tailwind`, that copy (loaded last) would **override the consumer's live tokens** and silently go stale whenever tokens changed but `@nexus/react` wasn't rebuilt — exactly the docs bug fixed in #254.

This makes react's CSS ship **utilities only**:

```css
/* src/index.css */
@import 'tailwindcss' prefix(nx);
@reference '@nexus/tailwind';   /* theme available for utility generation — NOT emitted */
@import 'tw-animate-css';
```

`@reference` lets Tailwind generate the component utilities (including composite `@utility` classes like `typography-label-default`) against the Nexus theme **without emitting any token variables**. Tokens are now the consumer's responsibility (via `@nexus/tailwind`), so importing react's CSS can never re-define or stale-out a consumer's tokens.

## ⚠️ Breaking (acceptable pre-production — no external consumers)

`@nexus/react/styles.css` is **no longer self-contained**: consumers must also load `@nexus/tailwind` for tokens. The docs already do this the right way (#254's `@source` pattern). Storybook now imports `@nexus/tailwind` directly for its own token set (functionally identical to what `index.css` loaded before).

## Verified
- [x] `dist/react.css`: utilities present (`bg-primary-background`, `typography-label-default`); **zero** `--color-*` / `--nx-color-*` definitions; no `.dark{}` block. Size 78 KB → 44 KB.
- [x] Storybook renders — its preview now loads the same CSS (`@nexus/tailwind` + `tw-animate-css`) that `index.css` wrapped before; a clean Storybook boot confirmed that exact CSS works.
- [x] `exports.test.ts` (resolves `./styles.css`) unaffected — the export still ships.
- [ ] CI: Test (React) + Build Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)