### PR TITLE
test(tokens): cover alpha compositing + hue-aware grid; guard chromatic coverage

### DIFF
--- a/packages/core/scripts/__tests__/audit-contrast.test.js
+++ b/packages/core/scripts/__tests__/audit-contrast.test.js
@@ -1,6 +1,37 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatLine } from '../audit-contrast.js';
+import { blendAlphaOver, formatLine } from '../audit-contrast.js';
+
+// The over-operator behind alpha-foreground contrast scoring (#249): an
+// 8-digit hex is composited onto its resolved backdrop before APCA reads it.
+// The full audit exercises this only transitively, so these pin the math
+// directly — a swapped operand or a /256-vs-/255 slip would still "pass
+// 440/440" as long as every real pair stayed above threshold. Expected
+// triples are hand-computed: out = round(fg·a + bg·(1−a)) per channel,
+// with a = byte / 255.
+describe('blendAlphaOver', () => {
+  it('composites 50%-alpha black over white to mid grey (round(255·(1−128/255)) = 127)', () => {
+    expect(blendAlphaOver('#00000080', [255, 255, 255])).toEqual([
+      127, 127, 127,
+    ]);
+  });
+
+  it('composites 50%-alpha white over black to mid grey (round(255·128/255) = 128)', () => {
+    expect(blendAlphaOver('#ffffff80', [0, 0, 0])).toEqual([128, 128, 128]);
+  });
+
+  it('ignores the backdrop when the foreground is fully opaque (a = 1)', () => {
+    expect(blendAlphaOver('#000000ff', [255, 255, 255])).toEqual([0, 0, 0]);
+  });
+
+  it('returns the backdrop unchanged when the foreground is fully transparent (a = 0)', () => {
+    expect(blendAlphaOver('#ffffff00', [10, 20, 30])).toEqual([10, 20, 30]);
+  });
+
+  it('blends each channel independently (red over blue at 50%)', () => {
+    expect(blendAlphaOver('#ff000080', [0, 0, 255])).toEqual([128, 0, 127]);
+  });
+});
 
 // Pins the textual contract `contrast-auditor` agent's parser relies on:
 // 2-space prefix + mark + label padded to 48 + ` Lc ` + 6-char Lc + tail.

--- a/packages/core/scripts/__tests__/perceptual-grid.test.js
+++ b/packages/core/scripts/__tests__/perceptual-grid.test.js
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -6,6 +9,7 @@ import {
   hexToSrgbInts,
   isPaletteShadeKey,
   PERCEPTUAL_L_GRID,
+  PERCEPTUAL_L_GRID_HUE,
 } from '../lib/perceptual-grid.js';
 
 const OKLCH_RE = /^oklch\(([-\d.]+) ([-\d.]+) ([-\d.]+)(?: \/ ([\d.]+))?\)$/;
@@ -97,6 +101,36 @@ describe('hexToOklchPinned', () => {
     expect(parsed.c).toBeGreaterThan(0.09);
     expect(parsed.c).toBeLessThan(0.11);
   });
+
+  // A re-pitched chromatic palette pins L to its own hue curve, not the flat
+  // grid (0.553 at shade 500). Before this, only blue.500 was asserted — a
+  // corrupted green/yellow/red band would have shipped silently. Hexes are the
+  // real shade-500 source values from color.json; L is name-driven so the flat
+  // assertion is what catches a regression to the un-tuned grid.
+  const HUE_CURVE_BANDS = [
+    { palette: 'green', hex: '#569947', curveL: 0.72 },
+    { palette: 'yellow', hex: '#facc15', curveL: 0.8 },
+    { palette: 'red', hex: '#d6455b', curveL: 0.637 },
+  ];
+  for (const { palette, hex, curveL } of HUE_CURVE_BANDS) {
+    it(`pins ${palette}.500 to its hue-curve L (${curveL}), not the flat grid`, () => {
+      const { l } = parseOklch(hexToOklchPinned(hex, '500', palette));
+      expect(l).toBeCloseTo(curveL, 3);
+      expect(l).not.toBeCloseTo(PERCEPTUAL_L_GRID['500'], 3);
+    });
+  }
+
+  it('selects the curve by palette NAME — same hex, listed vs unlisted palette', () => {
+    // Opt-in is by name: "blue" has a hue curve, the surface "slate" does not.
+    // Same hex + shade, only the name differs — the listed palette takes its
+    // curve (0.623), the unlisted one falls back to the flat grid (0.553).
+    expect(
+      parseOklch(hexToOklchPinned('#3b82f6', '500', 'blue')).l
+    ).toBeCloseTo(0.623, 3);
+    expect(
+      parseOklch(hexToOklchPinned('#3b82f6', '500', 'slate')).l
+    ).toBeCloseTo(PERCEPTUAL_L_GRID['500'], 3);
+  });
 });
 
 describe('hexToOklchMechanical', () => {
@@ -157,5 +191,42 @@ describe('P3 gamut clip warning', () => {
   it('does not warn on shades within P3 at their pinned L', () => {
     hexToOklchPinned('#3b82f6', '500');
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('hue curve ↔ color.json coverage', () => {
+  it('every chromatic palette in color.json has a hue-curve entry', () => {
+    // The hue curve is opted into by palette NAME (PERCEPTUAL_L_GRID_HUE[name]),
+    // so a chromatic palette added to color.json but forgotten here silently
+    // falls back to the flat grid — re-muddying it (the bug #248 fixed). Guard
+    // it: anything with real chroma at shade 500 must have a curve. Measured
+    // split at shade 500 (via the pipeline's own mechanical conversion): the 5
+    // non-chromatic palettes top out at chroma 0.041 (slate); the 17 chromatics
+    // start at 0.123 (teal). 0.08 sits midway in that gap, margin on both sides.
+    const CHROMATIC_C_MIN = 0.08;
+    const OKLCH_C = /^oklch\([-\d.]+ ([-\d.]+)/;
+    const chromaOf = (hex) =>
+      Number(OKLCH_C.exec(hexToOklchMechanical(hex))[1]);
+
+    // color.json is keyed by palette name at the top level (no wrapper object):
+    // { green: { '500': { $value } }, … }. Iterate those entries directly.
+    const dir = path.dirname(fileURLToPath(import.meta.url));
+    const palettes = JSON.parse(
+      fs.readFileSync(
+        path.join(dir, '../../tokens/primitives/color.json'),
+        'utf8'
+      )
+    );
+
+    const untuned = [];
+    for (const [name, shades] of Object.entries(palettes)) {
+      const hex = shades?.['500']?.$value;
+      if (typeof hex !== 'string' || !hex.startsWith('#')) continue;
+      if (chromaOf(hex) > CHROMATIC_C_MIN && !(name in PERCEPTUAL_L_GRID_HUE)) {
+        untuned.push(name);
+      }
+    }
+
+    expect(untuned).toEqual([]);
   });
 });

--- a/packages/core/scripts/audit-contrast.js
+++ b/packages/core/scripts/audit-contrast.js
@@ -180,7 +180,7 @@ function buildPrimitiveHexMap() {
 }
 
 // Composite an 8-digit (alpha) hex over an opaque backdrop → opaque sRGB ints.
-function blendAlphaOver(hex8, bgInts) {
+export function blendAlphaOver(hex8, bgInts) {
   const h = hex8.slice(1);
   const a = parseInt(h.slice(6, 8), 16) / 255;
   const mix = (i) =>


### PR DESCRIPTION
## Summary

Follow-ups from the council review of the palette-chroma arc (#248–#254). The contrast gate and unit suites were already green, but a council pass found two new pieces of logic almost unasserted and one latent trap with no guard. Tests only, plus one inert `export` — no behavior change.

- **Alpha compositing (`blendAlphaOver`, from #249).** Export it from `audit-contrast.js` and pin the over-operator math directly — 5 cases incl. the `a=0` / `a=1` boundaries and per-channel independence. The full audit only exercised it transitively, so a swapped operand or a `/256`-vs-`/255` slip could still pass 440/440 as long as every real pair stayed above threshold.
- **Hue-aware grid bands (from #248).** Assert `green` / `yellow` / `red`.500 each pin to their own hue-curve L (not the flat `0.553`), against the **real** `color.json` source hexes; add a by-name selection test (same hex, listed `blue` → curve `0.623` vs unlisted surface `slate` → flat `0.553`). Previously only `blue.500` was asserted.
- **Chromatic-coverage guard (latent trap from the review).** The hue curve is opted into by **palette name**, so a chromatic palette added to `color.json` but forgotten in `perceptual-grid-hue.json` would silently fall back to the flat grid — re-muddying it (the exact bug #248 fixed). New test fails if any palette with real chroma (> 0.08 at shade 500) lacks a curve entry. All 17 shipped chromatics currently have curves (`without_curve = NONE`); the threshold sits in the measured gap — 5 surface palettes top out at chroma 0.041 (slate), 17 chromatics start at 0.123 (teal). **Mutation-verified**: removing `green` from the hue grid makes it fail (`expected [ 'green' ] to deeply equal []`).

## GitHub Issue

No tracked issue — direct follow-ups from the post-merge council review of #248–#254 (per `no-follow-up-deferral`, fixed in their own PR). Context: `reports/council-pr-248-254.md` on `main`.

## Test Plan

- [x] `node packages/core/scripts/audit-contrast.js` → **440/440 pass** (the `export` is behaviorally inert)
- [x] `vitest run --project=unit` (full project, as CI runs it) → **390 passed, 1 skipped**; CI green on this branch
- [x] Added tests present & passing: 5 `blendAlphaOver` + 3 hue-curve band + 1 by-name selection + 1 coverage guard
- [x] Coverage guard **mutation-tested**: removing a chromatic palette from the hue grid turns it red
- [x] `prettier --check` + `eslint` clean on all 3 changed files