### PR TITLE
feat(components): add label component

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,6 +52,7 @@
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",

--- a/packages/react/src/components/ui/Label.stories.tsx
+++ b/packages/react/src/components/ui/Label.stories.tsx
@@ -35,20 +35,10 @@ export const WithInput: Story = {
 
 export const Disabled: Story = {
   render: () => (
-    <div className="nx:flex nx:flex-col nx:gap-4">
-      {/* peer-disabled: label follows a disabled sibling control */}
-      <div className="nx:flex nx:items-center nx:gap-2">
-        <input type="checkbox" id="terms" disabled className="nx:peer" />
-        <Label htmlFor="terms">Accept terms (peer-disabled)</Label>
-      </div>
-      {/* group-disabled: an ancestor field group carries data-disabled */}
-      <div
-        className="nx:group nx:flex nx:flex-col nx:gap-2"
-        data-disabled="true"
-      >
-        <Label htmlFor="full-name">Name (group-disabled)</Label>
-        <Input id="full-name" disabled placeholder="Disabled field" />
-      </div>
+    // The label dims when its `nx:peer` sibling control is disabled.
+    <div className="nx:flex nx:items-center nx:gap-2">
+      <input type="checkbox" id="terms" disabled className="nx:peer" />
+      <Label htmlFor="terms">Accept terms</Label>
     </div>
   ),
 };
@@ -110,10 +100,6 @@ export const AllVariants: Story = {
           aria-label="Unavailable option"
         />
         <Label>Peer-disabled</Label>
-      </span>
-
-      <span className="nx:group nx:flex" data-disabled="true">
-        <Label>Group-disabled</Label>
       </span>
     </div>
   ),

--- a/packages/react/src/components/ui/Label.stories.tsx
+++ b/packages/react/src/components/ui/Label.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { Input } from './input';
+import { Label } from './label';
+
+const meta: Meta<typeof Label> = {
+  title: 'Components/Label',
+  component: Label,
+  args: {
+    children: 'Email',
+  },
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Label>;
+
+// ============================================
+// BASIC STORIES
+// ============================================
+
+export const Default: Story = {};
+
+export const WithInput: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-2">
+      <Label htmlFor="email">Email</Label>
+      <Input id="email" type="email" placeholder="you@example.com" />
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-4">
+      {/* peer-disabled: label follows a disabled sibling control */}
+      <div className="nx:flex nx:items-center nx:gap-2">
+        <input type="checkbox" id="terms" disabled className="nx:peer" />
+        <Label htmlFor="terms">Accept terms (peer-disabled)</Label>
+      </div>
+      {/* group-disabled: an ancestor field group carries data-disabled */}
+      <div
+        className="nx:group nx:flex nx:flex-col nx:gap-2"
+        data-disabled="true"
+      >
+        <Label htmlFor="full-name">Name (group-disabled)</Label>
+        <Input id="full-name" disabled placeholder="Disabled field" />
+      </div>
+    </div>
+  ),
+};
+
+// ============================================
+// INTERACTION TESTS
+// ============================================
+
+export const ClickInteraction: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-2">
+      <Label htmlFor="click-email">Email address</Label>
+      <Input id="click-email" type="email" placeholder="you@example.com" />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const label = canvas.getByText('Email address');
+    const input = canvas.getByRole('textbox');
+
+    // Clicking the label moves focus to its associated control
+    await expect(input).not.toHaveFocus();
+    await userEvent.click(label);
+    await expect(input).toHaveFocus();
+  },
+};
+
+export const WithDataAttributes: Story = {
+  args: {
+    children: 'Field label',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const label = canvas.getByText('Field label');
+
+    await expect(label).toHaveAttribute('data-slot', 'label');
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-4">
+      <Label>Default label</Label>
+
+      <Label>
+        <input type="checkbox" aria-label="Nested checkbox" />
+        With nested control
+      </Label>
+
+      <span className="nx:flex nx:items-center nx:gap-2">
+        <input
+          type="checkbox"
+          disabled
+          className="nx:peer"
+          aria-label="Unavailable option"
+        />
+        <Label>Peer-disabled</Label>
+      </span>
+
+      <span className="nx:group nx:flex" data-disabled="true">
+        <Label>Group-disabled</Label>
+      </span>
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/label.tsx
+++ b/packages/react/src/components/ui/label.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+
+import * as LabelPrimitive from '@radix-ui/react-label';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * LabelProps
+ *
+ * Props for the Label component.
+ */
+interface LabelProps extends React.ComponentProps<typeof LabelPrimitive.Root> {}
+
+/**
+ * Label
+ *
+ * An accessible caption for a form control. Associate it with a control via
+ * `htmlFor` (matching the control's `id`) so clicking the label focuses or
+ * toggles that control. Dims automatically when a sibling `nx:peer` control is
+ * disabled.
+ *
+ * @example
+ * ```tsx
+ * <Label htmlFor="email">Email</Label>
+ * <Input id="email" type="email" />
+ * ```
+ */
+function Label({ className, ...props }: LabelProps) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        // nexus-allow-numeric: icon gap between label text and a nested control
+        'nx:flex nx:items-center nx:gap-2 nx:select-none nx:text-sm nx:font-medium nx:leading-none nx:text-foreground',
+        'nx:peer-disabled:cursor-not-allowed nx:peer-disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label, type LabelProps };

--- a/packages/react/src/components/ui/label.tsx
+++ b/packages/react/src/components/ui/label.tsx
@@ -15,9 +15,9 @@ interface LabelProps extends React.ComponentProps<typeof LabelPrimitive.Root> {}
  * Label
  *
  * An accessible caption for a form control. Associate it with a control via
- * `htmlFor` (matching the control's `id`) so clicking the label focuses or
- * toggles that control. Dims automatically when a sibling `nx:peer` control is
- * disabled.
+ * `htmlFor` (matching the control's `id`) so clicking the label focuses (or
+ * toggles, for a checkbox/radio) that control. Dims automatically when a
+ * sibling `nx:peer` control is disabled.
  *
  * @example
  * ```tsx

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -18,6 +18,7 @@ export * from '@/components/ui/card';
 export * from '@/components/ui/dialog';
 export * from '@/components/ui/dropdown-menu';
 export * from '@/components/ui/input';
+export * from '@/components/ui/label';
 export * from '@/components/ui/select';
 export * from '@/components/ui/switch';
 export * from '@/components/ui/tabs';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,6 +1058,13 @@
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.1"
 
+"@radix-ui/react-label@^2.1.7":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-2.1.8.tgz#d93b7c063ef2ea034df143a2464bfc0548e4b7e5"
+  integrity sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.4"
+
 "@radix-ui/react-menu@2.1.16":
   version "2.1.16"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-menu/-/react-menu-2.1.16.tgz#528a5a973c3a7413d3d49eb9ccd229aa52402911"


### PR DESCRIPTION
## Summary

- Adapt shadcn/ui `label` into `@nexus/react` as a first-class Nexus component — a Radix `@radix-ui/react-label` wrapper.
- Semantic `nx:` tokens, `data-slot="label"`, `peer-disabled` field-association styling, and the standard component bar.
- Exports `Label` + `LabelProps`; barrel-exported from `src/index.ts`.
- Stories: Default, WithInput (`htmlFor` wiring), Disabled (peer-disabled), ClickInteraction (label → input focus), WithDataAttributes (play-fn), AllVariants.

### Divergences from the shadcn source (intentional)

- **Dropped `group-data-[disabled=true]:*`** — it supports a Field-group wrapper that doesn't exist in Nexus yet (form is #176). Per `project-stage.md` (no forward-looking code) and #162's remaps listing only `peer-disabled`. Add it back with the form component if needed.
- **Raw `nx:text-sm nx:font-medium nx:leading-none`** rather than the `nx:typography-label-default` composite — matches shadcn's exact type treatment (`leading-none` differs from the composite's line-height). #162 permitted either.

## GitHub Issue

Closes #162

## Test Plan

- [x] `yarn workspace @nexus/react audit:storybook-coverage --component label` — exit 0 (0 missing, 0 drift)
- [x] `yarn workspace @nexus/react typecheck` — clean
- [x] `yarn lint` — clean
- [x] `yarn test:storybook` — 283/283 passed (Label 6/6); a11y automatic

🤖 Generated with [Claude Code](https://claude.com/claude-code)