### PR TITLE
feat(components): add separator component

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,6 +54,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/packages/react/src/components/ui/Separator.stories.tsx
+++ b/packages/react/src/components/ui/Separator.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+
+import { Separator } from './separator';
+
+const meta: Meta<typeof Separator> = {
+  title: 'Components/Separator',
+  component: Separator,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Separator>;
+
+// ============================================
+// BASIC STORIES
+// ============================================
+
+// Horizontal is the default orientation — a full-width 1px rule.
+export const Default: Story = {};
+
+export const Vertical: Story = {
+  // A vertical rule stretches to its parent's height — the row sets `nx:h-5`.
+  render: () => (
+    <div className="nx:flex nx:h-5 nx:items-center nx:gap-3 nx:text-sm nx:text-foreground">
+      <span>Docs</span>
+      <Separator orientation="vertical" />
+      <span>Source</span>
+      <Separator orientation="vertical" />
+      <span>Issues</span>
+    </div>
+  ),
+};
+
+export const InContext: Story = {
+  render: () => (
+    <div className="nx:max-w-xs nx:rounded-lg nx:border nx:border-border-default nx:bg-container nx:p-4">
+      <div className="nx:flex nx:flex-col nx:gap-1">
+        <span className="nx:text-sm nx:font-medium nx:text-container-foreground">
+          Radix Primitives
+        </span>
+        <span className="nx:text-sm nx:text-muted-foreground">
+          An open-source UI component library.
+        </span>
+      </div>
+      <Separator className="nx:my-4" />
+      <div className="nx:flex nx:h-5 nx:items-center nx:gap-3 nx:text-sm nx:text-muted-foreground">
+        <span>Blog</span>
+        <Separator orientation="vertical" />
+        <span>Docs</span>
+        <Separator orientation="vertical" />
+        <span>Source</span>
+      </div>
+    </div>
+  ),
+};
+
+// ============================================
+// ATTRIBUTE TESTS
+// ============================================
+
+export const WithDataAttributes: Story = {
+  // `decorative={false}` exposes the semantic `separator` role — the default
+  // decorative separator renders `role="none"`, so it isn't query-able by role.
+  args: { decorative: false },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const separator = canvas.getByRole('separator');
+
+    await expect(separator).toHaveAttribute('data-slot', 'separator');
+    await expect(separator).toHaveAttribute('data-orientation', 'horizontal');
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-6 nx:text-sm nx:text-foreground">
+      <div className="nx:flex nx:flex-col nx:gap-2">
+        <span className="nx:text-muted-foreground">Horizontal</span>
+        <Separator />
+      </div>
+      <div className="nx:flex nx:h-5 nx:items-center nx:gap-3">
+        <span className="nx:text-muted-foreground">Vertical</span>
+        <Separator orientation="vertical" />
+        <span>before</span>
+        <Separator orientation="vertical" />
+        <span>after</span>
+      </div>
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/separator.tsx
+++ b/packages/react/src/components/ui/separator.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+
+import * as SeparatorPrimitive from '@radix-ui/react-separator';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * SeparatorProps
+ *
+ * Props for the Separator component.
+ */
+interface SeparatorProps extends React.ComponentProps<
+  typeof SeparatorPrimitive.Root
+> {}
+
+/**
+ * Separator
+ *
+ * A visual divider between content — a thin rule along one axis. Horizontal by
+ * default; pass `orientation="vertical"` inside a flex row (the parent needs a
+ * defined cross-axis size, since a vertical rule stretches to `h-full`).
+ * Decorative by default, so it's hidden from assistive tech; pass
+ * `decorative={false}` when the rule marks a genuine semantic boundary between
+ * groups (it then exposes a `separator` role).
+ *
+ * @example
+ * ```tsx
+ * <Separator />
+ * ```
+ *
+ * @example
+ * ```tsx
+ * <div className="nx:flex nx:h-5 nx:items-center nx:gap-3">
+ *   <span>Docs</span>
+ *   <Separator orientation="vertical" />
+ *   <span>Source</span>
+ * </div>
+ * ```
+ */
+function Separator({
+  className,
+  orientation = 'horizontal',
+  decorative = true,
+  ...props
+}: SeparatorProps) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        'nx:shrink-0 nx:bg-border-default',
+        'nx:data-[orientation=horizontal]:h-px nx:data-[orientation=horizontal]:w-full',
+        'nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-px',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator, type SeparatorProps };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -20,6 +20,7 @@ export * from '@/components/ui/dropdown-menu';
 export * from '@/components/ui/input';
 export * from '@/components/ui/label';
 export * from '@/components/ui/select';
+export * from '@/components/ui/separator';
 export * from '@/components/ui/switch';
 export * from '@/components/ui/tabs';
 export * from '@/components/ui/tooltip';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1177,6 +1177,13 @@
     aria-hidden "^1.2.4"
     react-remove-scroll "^2.6.3"
 
+"@radix-ui/react-separator@^1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-separator/-/react-separator-1.1.8.tgz#24f871fbf9630af316d0c14cbc7519a6e33aa11e"
+  integrity sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.4"
+
 "@radix-ui/react-slot@1.2.3":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.3.tgz#502d6e354fc847d4169c3bc5f189de777f68cfe1"


### PR DESCRIPTION
## Summary

- Adapt shadcn/ui `separator` into `@nexus/react` — a thin `@radix-ui/react-separator` wrapper following the established Radix-wrapper archetype (`switch.tsx` / `label.tsx`).
- Semantic `nx:` tokens only: `bg-border` → `nx:bg-border-default`; orientation-driven sizing (`h-px`/`w-full` horizontal, `h-full`/`w-px` vertical) via `data-[orientation=…]` selectors.
- `data-slot="separator"`; `orientation` defaults to `horizontal`, `decorative` defaults to `true` (decorative ⇒ `role="none"`; `decorative={false}` ⇒ semantic `separator` role).
- Exports `Separator` + `SeparatorProps`; barrel-exported from `src/index.ts`.
- New dep: `@radix-ui/react-separator@^1.1.8`. No new icons. base-variants opt-in: no (per issue).
- No focus ring / `asChild` / `py-control` — separator is a non-focusable decorative element.

## GitHub Issue

Closes #163

## Test Plan

- [x] `yarn workspace @nexus/react typecheck` — clean
- [x] `eslint` on `separator.tsx` + `Separator.stories.tsx` — 0 errors / 0 warnings
- [x] `yarn workspace @nexus/react audit:storybook-coverage --component separator` — 0 missing, 0 drift (3 expected display-gate info entries)
- [x] Story tests (chromium) — 5/5 pass incl. `WithDataAttributes` play-fn (asserts `data-slot` + `data-orientation` via the semantic `separator` role) and automatic a11y
- [ ] Reviewer: visual check of Horizontal / Vertical / InContext / AllVariants in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)