### PR TITLE
feat(components): add skeleton component

### DIFF
--- a/packages/react/src/components/ui/Skeleton.stories.tsx
+++ b/packages/react/src/components/ui/Skeleton.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect } from 'storybook/test';
+
+import { Skeleton } from './skeleton';
+
+const meta: Meta<typeof Skeleton> = {
+  title: 'Components/Skeleton',
+  component: Skeleton,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+// ============================================
+// BASIC STORIES
+// ============================================
+
+// A single bar — shape and size come from consumer utilities.
+export const Default: Story = {
+  args: {
+    className: 'nx:h-4 nx:w-48',
+  },
+};
+
+// A circular placeholder for an avatar or icon.
+export const Circle: Story = {
+  args: {
+    className: 'nx:size-12 nx:rounded-full',
+  },
+};
+
+// Stacked lines for a paragraph; the last line is shorter to mimic a ragged
+// final row of text.
+export const TextLines: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-2">
+      <Skeleton className="nx:h-4 nx:w-full" />
+      <Skeleton className="nx:h-4 nx:w-full" />
+      <Skeleton className="nx:h-4 nx:w-4/5" />
+    </div>
+  ),
+};
+
+// A composed "card is loading" layout: a media block over an avatar circle
+// with heading and subtitle lines.
+export const CardSkeleton: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-80 nx:flex-col nx:gap-4">
+      <Skeleton className="nx:h-40 nx:w-full nx:rounded-lg" />
+      <div className="nx:flex nx:items-center nx:gap-3">
+        <Skeleton className="nx:size-10 nx:rounded-full" />
+        <div className="nx:flex nx:flex-1 nx:flex-col nx:gap-2">
+          <Skeleton className="nx:h-4 nx:w-1/2" />
+          <Skeleton className="nx:h-3 nx:w-3/4" />
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+// ============================================
+// ATTRIBUTE TEST
+// ============================================
+
+export const WithDataAttributes: Story = {
+  args: {
+    className: 'nx:h-4 nx:w-48',
+  },
+  play: async ({ canvasElement }) => {
+    const skeleton = canvasElement.querySelector('[data-slot="skeleton"]');
+
+    await expect(skeleton).toBeInTheDocument();
+    await expect(skeleton).toHaveAttribute('data-slot', 'skeleton');
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-6">
+      <Skeleton className="nx:h-4 nx:w-48" />
+      <Skeleton className="nx:size-12 nx:rounded-full" />
+      <div className="nx:flex nx:flex-col nx:gap-2">
+        <Skeleton className="nx:h-4 nx:w-full" />
+        <Skeleton className="nx:h-4 nx:w-4/5" />
+      </div>
+      <div className="nx:flex nx:w-80 nx:flex-col nx:gap-4">
+        <Skeleton className="nx:h-40 nx:w-full nx:rounded-lg" />
+        <div className="nx:flex nx:items-center nx:gap-3">
+          <Skeleton className="nx:size-10 nx:rounded-full" />
+          <div className="nx:flex nx:flex-1 nx:flex-col nx:gap-2">
+            <Skeleton className="nx:h-4 nx:w-1/2" />
+            <Skeleton className="nx:h-3 nx:w-3/4" />
+          </div>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/skeleton.tsx
+++ b/packages/react/src/components/ui/skeleton.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * SkeletonProps
+ *
+ * Props for the Skeleton component.
+ */
+interface SkeletonProps extends React.ComponentProps<'div'> {}
+
+/**
+ * Skeleton
+ *
+ * A pulsing placeholder block for loading states. Render one — or a cluster —
+ * in place of content that hasn't arrived yet to hold the layout and signal
+ * that something is coming. Shape and size come from consumer utilities:
+ * `nx:h-*` / `nx:w-*` for a bar, `nx:size-* nx:rounded-full` for a circle.
+ *
+ * @example
+ * ```tsx
+ * <Skeleton className="nx:h-4 nx:w-48" />
+ * <Skeleton className="nx:size-12 nx:rounded-full" />
+ * ```
+ */
+function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn('nx:animate-pulse nx:rounded-md nx:bg-muted', className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton, type SkeletonProps };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -21,6 +21,7 @@ export * from '@/components/ui/input';
 export * from '@/components/ui/label';
 export * from '@/components/ui/select';
 export * from '@/components/ui/separator';
+export * from '@/components/ui/skeleton';
 export * from '@/components/ui/switch';
 export * from '@/components/ui/tabs';
 export * from '@/components/ui/tooltip';


### PR DESCRIPTION
## Summary

- Adapts shadcn `skeleton` → Nexus: a pulsing placeholder block for loading states — `nx:animate-pulse nx:rounded-md nx:bg-muted`, `data-slot="skeleton"`.
- `bg-accent` → `nx:bg-muted` (Nexus has no `accent` token; per the issue spec).
- Exports `Skeleton` + `SkeletonProps` (extends `div`). Shape/size come from consumer utilities (`nx:h-*` / `nx:w-*`; `nx:rounded-full` for a circle). No new deps.
- Stories: Default, Circle, TextLines, CardSkeleton, WithDataAttributes (play), AllVariants. Non-interactive → deliberately **not** opted into base-variants generation.

## GitHub Issue

Closes #164

## Test Plan

- [x] `yarn workspace @nexus/react typecheck` — clean (Skeleton correctly excluded from base-variants generation)
- [x] `eslint --max-warnings 0` on changed files — clean
- [x] `yarn workspace @nexus/react audit:storybook-coverage --component skeleton` — **exit 0** (0 missing / 0 drift) — the DoD gate
- [x] CSS emission verified in `dist/react.css`: `.nx\:animate-pulse` + `@keyframes pulse`, `nx:bg-muted`, fractional widths, all dimensions
- [ ] `yarn test:storybook` — stalled locally on cold-start browser infra (known worktree sb-vitest issue), **not** a code failure; CI runs the storybook suite (trivial `data-slot` play-fn + a11y on a bare `<div>`) as the authoritative gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)