### PR TITLE
feat(components): add textarea component

### DIFF
--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -59,6 +59,14 @@
         "Disabled": ["WithDisabledTab", "DisabledTabInteraction"]
       }
     },
+    {
+      "name": "Textarea",
+      "showcase": "AllVariants",
+      "equivalents": {
+        "ClickInteraction": ["FocusBlurInteraction"],
+        "KeyboardInteraction": ["TypeInteraction"]
+      }
+    },
     { "name": "Tooltip", "showcase": "AllVariants" }
   ]
 }

--- a/packages/react/src/components/ui/Textarea.stories.tsx
+++ b/packages/react/src/components/ui/Textarea.stories.tsx
@@ -1,0 +1,211 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { Label } from './label';
+import { Textarea } from './textarea';
+
+const meta: Meta<typeof Textarea> = {
+  title: 'Components/Textarea',
+  component: Textarea,
+  decorators: [
+    (Story) => (
+      <div className="nx:w-[400px]">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    onChange: fn(),
+    onFocus: fn(),
+    onBlur: fn(),
+  },
+  argTypes: {
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the textarea is disabled',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Placeholder text',
+    },
+    rows: {
+      control: 'number',
+      description: 'Visible number of text lines',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Textarea>;
+
+// ============================================
+// BASIC STORIES
+// ============================================
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Tell us about yourself...',
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    defaultValue: 'The quick brown fox jumps over the lazy dog.',
+    'aria-label': 'Textarea with value',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: 'Cannot edit this',
+    disabled: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole('textbox');
+
+    await expect(textarea).toBeDisabled();
+  },
+};
+
+export const Invalid: Story = {
+  args: {
+    defaultValue: 'Too short',
+    'aria-invalid': true,
+    'aria-label': 'Invalid bio',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole('textbox');
+
+    await expect(textarea).toHaveAttribute('aria-invalid', 'true');
+  },
+};
+
+export const WithLabel: Story = {
+  render: (args) => (
+    <div className="nx:flex nx:flex-col nx:gap-2">
+      <Label htmlFor="textarea-bio">Bio</Label>
+      <Textarea
+        id="textarea-bio"
+        placeholder="A few words about you"
+        {...args}
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByLabelText('Bio');
+
+    await expect(textarea).toBeInTheDocument();
+  },
+};
+
+// ============================================
+// INTERACTION TESTS
+// ============================================
+
+export const TypeInteraction: Story = {
+  args: {
+    placeholder: 'Type here...',
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole('textbox');
+
+    await userEvent.type(textarea, 'Hello\nWorld');
+
+    await expect(textarea).toHaveValue('Hello\nWorld');
+    await expect(args.onChange).toHaveBeenCalled();
+  },
+};
+
+export const FocusBlurInteraction: Story = {
+  args: {
+    placeholder: 'Focus me...',
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole('textbox');
+
+    await userEvent.click(textarea);
+    await expect(textarea).toHaveFocus();
+    await expect(args.onFocus).toHaveBeenCalled();
+
+    await userEvent.tab();
+    await expect(textarea).not.toHaveFocus();
+    await expect(args.onBlur).toHaveBeenCalled();
+  },
+};
+
+export const WithDataAttributes: Story = {
+  args: {
+    placeholder: 'Test textarea',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole('textbox');
+
+    await expect(textarea).toHaveAttribute('data-slot', 'textarea');
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+export const AllVariants: Story = {
+  render: (_args) => (
+    <div className="nx:flex nx:flex-col nx:gap-8 nx:w-[400px]">
+      <div>
+        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          States
+        </h3>
+        <div className="nx:flex nx:flex-col nx:gap-3">
+          <div className="nx:flex nx:items-start nx:gap-4">
+            <span className="nx:text-xs nx:text-muted-foreground nx:w-16 nx:pt-2">
+              empty
+            </span>
+            <Textarea placeholder="Placeholder text" />
+          </div>
+          <div className="nx:flex nx:items-start nx:gap-4">
+            <span className="nx:text-xs nx:text-muted-foreground nx:w-16 nx:pt-2">
+              filled
+            </span>
+            <Textarea
+              defaultValue="Filled value spanning a couple of lines so the multi-line shape is visible."
+              aria-label="Filled textarea"
+            />
+          </div>
+          <div className="nx:flex nx:items-start nx:gap-4">
+            <span className="nx:text-xs nx:text-muted-foreground nx:w-16 nx:pt-2">
+              disabled
+            </span>
+            <Textarea placeholder="Disabled" disabled />
+          </div>
+          <div className="nx:flex nx:items-start nx:gap-4">
+            <span className="nx:text-xs nx:text-muted-foreground nx:w-16 nx:pt-2">
+              invalid
+            </span>
+            <Textarea
+              defaultValue="Invalid value"
+              aria-invalid
+              aria-label="Invalid textarea"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+// ============================================
+// A11Y is tested automatically on ALL stories
+// via addon-a11y with test: 'error'
+// ============================================

--- a/packages/react/src/components/ui/textarea.tsx
+++ b/packages/react/src/components/ui/textarea.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * TextareaProps
+ *
+ * Props for the Textarea component.
+ */
+interface TextareaProps extends React.ComponentProps<'textarea'> {}
+
+/**
+ * Textarea
+ *
+ * A multi-line text input. Mirrors Input's token, focus, and `aria-invalid`
+ * treatment and accepts all native textarea attributes. Use `rows` (or a
+ * `min-height` override via `className`) to set the initial height.
+ *
+ * @example
+ * ```tsx
+ * <Textarea placeholder="Tell us about yourself..." />
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Invalid state — always-on error border plus an error-coloured focus ring
+ * <Textarea aria-invalid defaultValue="too short" />
+ * ```
+ */
+function Textarea({ className, ...props }: TextareaProps) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        'nx:flex nx:min-h-16 nx:w-full nx:rounded-md nx:border nx:border-border-default',
+        'nx:bg-background nx:text-foreground nx:transition-colors',
+        'nx:placeholder:text-muted-foreground',
+        // nexus-allow-numeric: Textarea px stays numeric (mirrors Input)
+        'nx:px-3 nx:py-control-md nx:text-sm',
+        'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
+        'nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error',
+        'nx:disabled:cursor-not-allowed nx:disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea, type TextareaProps };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -22,6 +22,7 @@ export * from '@/components/ui/label';
 export * from '@/components/ui/select';
 export * from '@/components/ui/switch';
 export * from '@/components/ui/tabs';
+export * from '@/components/ui/textarea';
 export * from '@/components/ui/tooltip';
 
 // Primitives


### PR DESCRIPTION
## Summary

- Adds `Textarea` — a multi-line text input mirroring `input.tsx`'s tokens, focus ring, and `aria-invalid` treatment: `nx:border-border-default`, `nx:bg-background`, `nx:placeholder:text-muted-foreground`, the `outline-focus-default` ring, and an always-on error border + error ring when `aria-invalid`.
- Plain styled `<textarea>` (no size variant); exports `Textarea` + `TextareaProps`; `data-slot="textarea"`.
- `nx:py-control-md` for the density-aware height plus a `nx:min-h-16` floor; numeric `nx:px-3` kept (allow-comment) to mirror Input.
- Stories: Default, Disabled, Invalid, WithLabel, TypeInteraction, FocusBlurInteraction, WithDataAttributes, AllVariants — opted into the per-base showcase via `base-variants.config.json` (Input-style `equivalents`).

Part of #161.

## GitHub Issue

Closes #165

## Test Plan

- [x] `yarn workspace @nexus/react audit:storybook-coverage --component textarea` → no gaps
- [x] `yarn workspace @nexus/react typecheck` → clean
- [x] `eslint` (scoped + pre-commit hook) → clean
- [x] Built CSS (`dist/react.css`) emits `min-h-16`, `py-control-md`, and the focus / `aria-invalid` utilities
- [ ] `test:storybook` play-fns + a11y — verified by CI `Test (React)` (browser dep-optimization stalled locally on the fresh worktree; infra, not code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)