### PR TITLE
feat(components): add radio-group component

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,6 +54,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",

--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -40,6 +40,7 @@
         "KeyboardInteraction": ["TypeInteraction"]
       }
     },
+    { "name": "RadioGroup", "showcase": "AllVariants" },
     {
       "name": "Select",
       "showcase": "AllVariants",

--- a/packages/react/src/components/ui/RadioGroup.stories.tsx
+++ b/packages/react/src/components/ui/RadioGroup.stories.tsx
@@ -1,0 +1,318 @@
+import * as React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import { Label } from './label';
+import { RadioGroup, RadioGroupItem } from './radio-group';
+
+const meta: Meta<typeof RadioGroup> = {
+  title: 'Components/RadioGroup',
+  component: RadioGroup,
+  args: {
+    onValueChange: fn(),
+  },
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RadioGroup>;
+
+// ============================================
+// BASIC STORIES
+// ============================================
+
+export const Default: Story = {
+  render: (args) => (
+    <RadioGroup {...args} defaultValue="comfortable" aria-label="Density">
+      <div className="nx:flex nx:items-center nx:gap-2">
+        <RadioGroupItem value="default" id="default-default" />
+        <Label htmlFor="default-default">Default</Label>
+      </div>
+      <div className="nx:flex nx:items-center nx:gap-2">
+        <RadioGroupItem value="comfortable" id="default-comfortable" />
+        <Label htmlFor="default-comfortable">Comfortable</Label>
+      </div>
+      <div className="nx:flex nx:items-center nx:gap-2">
+        <RadioGroupItem value="compact" id="default-compact" />
+        <Label htmlFor="default-compact">Compact</Label>
+      </div>
+    </RadioGroup>
+  ),
+};
+
+export const VerticalWithLabels: Story = {
+  render: (args) => (
+    <RadioGroup {...args} defaultValue="starter" aria-label="Plan">
+      <div className="nx:flex nx:items-start nx:gap-3">
+        <RadioGroupItem
+          value="starter"
+          id="vertical-starter"
+          className="nx:mt-0.5"
+        />
+        <div className="nx:grid nx:gap-1">
+          <Label htmlFor="vertical-starter">Starter</Label>
+          <p className="nx:text-sm nx:text-muted-foreground">
+            For individuals getting started.
+          </p>
+        </div>
+      </div>
+      <div className="nx:flex nx:items-start nx:gap-3">
+        <RadioGroupItem value="pro" id="vertical-pro" className="nx:mt-0.5" />
+        <div className="nx:grid nx:gap-1">
+          <Label htmlFor="vertical-pro">Pro</Label>
+          <p className="nx:text-sm nx:text-muted-foreground">
+            For growing teams that need more.
+          </p>
+        </div>
+      </div>
+      <div className="nx:flex nx:items-start nx:gap-3">
+        <RadioGroupItem
+          value="enterprise"
+          id="vertical-enterprise"
+          className="nx:mt-0.5"
+        />
+        <div className="nx:grid nx:gap-1">
+          <Label htmlFor="vertical-enterprise">Enterprise</Label>
+          <p className="nx:text-sm nx:text-muted-foreground">
+            Advanced controls and support.
+          </p>
+        </div>
+      </div>
+    </RadioGroup>
+  ),
+};
+
+export const Horizontal: Story = {
+  render: (args) => (
+    <RadioGroup
+      {...args}
+      defaultValue="md"
+      orientation="horizontal"
+      className="nx:flex nx:gap-4"
+      aria-label="Size"
+    >
+      <div className="nx:flex nx:items-center nx:gap-2">
+        <RadioGroupItem value="sm" id="horizontal-sm" />
+        <Label htmlFor="horizontal-sm">Small</Label>
+      </div>
+      <div className="nx:flex nx:items-center nx:gap-2">
+        <RadioGroupItem value="md" id="horizontal-md" />
+        <Label htmlFor="horizontal-md">Medium</Label>
+      </div>
+      <div className="nx:flex nx:items-center nx:gap-2">
+        <RadioGroupItem value="lg" id="horizontal-lg" />
+        <Label htmlFor="horizontal-lg">Large</Label>
+      </div>
+    </RadioGroup>
+  ),
+};
+
+// ============================================
+// INTERACTION TESTS
+// ============================================
+
+export const Disabled: Story = {
+  render: (args) => (
+    <RadioGroup
+      {...args}
+      defaultValue="one"
+      disabled
+      aria-label="Disabled options"
+    >
+      <div className="nx:flex nx:items-center nx:gap-2">
+        <RadioGroupItem value="one" id="disabled-one" />
+        <Label htmlFor="disabled-one">Option one</Label>
+      </div>
+      <div className="nx:flex nx:items-center nx:gap-2">
+        <RadioGroupItem value="two" id="disabled-two" />
+        <Label htmlFor="disabled-two">Option two</Label>
+      </div>
+    </RadioGroup>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const one = canvas.getByRole('radio', { name: 'Option one' });
+    const two = canvas.getByRole('radio', { name: 'Option two' });
+
+    await expect(one).toBeDisabled();
+    await expect(two).toBeDisabled();
+
+    // Clicking a disabled option does not change the selection
+    await userEvent.click(two);
+    await expect(args.onValueChange).not.toHaveBeenCalled();
+    await expect(two).toHaveAttribute('data-state', 'unchecked');
+  },
+};
+
+export const ClickInteraction: Story = {
+  render: (args) => (
+    <RadioGroup {...args} aria-label="Pick one">
+      <RadioGroupItem value="one" aria-label="Option one" />
+      <RadioGroupItem value="two" aria-label="Option two" />
+      <RadioGroupItem value="three" aria-label="Option three" />
+    </RadioGroup>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const two = canvas.getByRole('radio', { name: 'Option two' });
+    const three = canvas.getByRole('radio', { name: 'Option three' });
+
+    // Nothing is selected initially
+    await expect(two).toHaveAttribute('data-state', 'unchecked');
+
+    // Clicking selects the option
+    await userEvent.click(two);
+    await expect(two).toHaveAttribute('data-state', 'checked');
+    await expect(args.onValueChange).toHaveBeenCalledWith('two');
+
+    // Selecting another option deselects the first (single-select)
+    await userEvent.click(three);
+    await expect(three).toHaveAttribute('data-state', 'checked');
+    await expect(two).toHaveAttribute('data-state', 'unchecked');
+    await expect(args.onValueChange).toHaveBeenCalledWith('three');
+  },
+};
+
+export const KeyboardInteraction: Story = {
+  render: (args) => (
+    <RadioGroup {...args} aria-label="Pick one">
+      <RadioGroupItem value="one" aria-label="Option one" />
+      <RadioGroupItem value="two" aria-label="Option two" />
+      <RadioGroupItem value="three" aria-label="Option three" />
+    </RadioGroup>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const one = canvas.getByRole('radio', { name: 'Option one' });
+    const two = canvas.getByRole('radio', { name: 'Option two' });
+
+    // Tab moves focus into the group, landing on the first item
+    await userEvent.tab();
+    await expect(one).toHaveFocus();
+
+    // Arrow keys move roving focus between options
+    await userEvent.keyboard('{ArrowDown}');
+    await expect(two).toHaveFocus();
+
+    // Space selects the focused option (await the controlled re-render)
+    await userEvent.keyboard(' ');
+    await waitFor(() => expect(two).toHaveAttribute('data-state', 'checked'));
+    await expect(args.onValueChange).toHaveBeenCalledWith('two');
+  },
+};
+
+export const WithDataAttributes: Story = {
+  render: (args) => (
+    <RadioGroup {...args} defaultValue="one" aria-label="Pick one">
+      <RadioGroupItem value="one" aria-label="Option one" />
+      <RadioGroupItem value="two" aria-label="Option two" />
+    </RadioGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const group = canvas.getByRole('radiogroup');
+    await expect(group).toHaveAttribute('data-slot', 'radio-group');
+
+    const one = canvas.getByRole('radio', { name: 'Option one' });
+    const two = canvas.getByRole('radio', { name: 'Option two' });
+    await expect(one).toHaveAttribute('data-slot', 'radio-group-item');
+    await expect(one).toHaveAttribute('data-state', 'checked');
+    await expect(two).toHaveAttribute('data-state', 'unchecked');
+
+    // The filled dot renders only inside the checked item
+    const indicator = one.querySelector('[data-slot="radio-group-indicator"]');
+    await expect(indicator).toBeInTheDocument();
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+export const AllVariants: Story = {
+  // Named function + useId so the id/htmlFor pairs are unique. This showcase is
+  // reused by base-variant generation (rendered once per cell, 10×); static ids
+  // would collide across cells. See testing-react.md § Caveats.
+  render: function AllVariantsShowcase() {
+    const uid = React.useId();
+    return (
+      <div className="nx:flex nx:flex-col nx:gap-8">
+        <div>
+          <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+            States
+          </h3>
+          <div className="nx:flex nx:items-center nx:gap-6">
+            <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
+              <RadioGroup aria-label="Unselected state">
+                <RadioGroupItem value="a" aria-label="Unselected" />
+              </RadioGroup>
+              <span className="nx:text-xs nx:text-muted-foreground">
+                Unselected
+              </span>
+            </div>
+            <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
+              <RadioGroup defaultValue="a" aria-label="Selected state">
+                <RadioGroupItem value="a" aria-label="Selected" />
+              </RadioGroup>
+              <span className="nx:text-xs nx:text-muted-foreground">
+                Selected
+              </span>
+            </div>
+            <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
+              <RadioGroup aria-label="Disabled state">
+                <RadioGroupItem value="a" disabled aria-label="Disabled" />
+              </RadioGroup>
+              <span className="nx:text-xs nx:text-muted-foreground">
+                Disabled
+              </span>
+            </div>
+            <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
+              <RadioGroup defaultValue="a" aria-label="Disabled selected state">
+                <RadioGroupItem
+                  value="a"
+                  disabled
+                  aria-label="Disabled selected"
+                />
+              </RadioGroup>
+              <span className="nx:text-xs nx:text-muted-foreground">
+                Disabled selected
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+            With labels
+          </h3>
+          <RadioGroup defaultValue="comfortable" aria-label="Density">
+            <div className="nx:flex nx:items-center nx:gap-2">
+              <RadioGroupItem value="default" id={`${uid}-default`} />
+              <Label htmlFor={`${uid}-default`}>Default</Label>
+            </div>
+            <div className="nx:flex nx:items-center nx:gap-2">
+              <RadioGroupItem value="comfortable" id={`${uid}-comfortable`} />
+              <Label htmlFor={`${uid}-comfortable`}>Comfortable</Label>
+            </div>
+            <div className="nx:flex nx:items-center nx:gap-2">
+              <RadioGroupItem value="compact" id={`${uid}-compact`} />
+              <Label htmlFor={`${uid}-compact`}>Compact</Label>
+            </div>
+          </RadioGroup>
+        </div>
+      </div>
+    );
+  },
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+// ============================================
+// A11Y is tested automatically on ALL stories
+// via addon-a11y with test: 'error'
+// ============================================

--- a/packages/react/src/components/ui/radio-group.tsx
+++ b/packages/react/src/components/ui/radio-group.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
+
+import { IconCircleFilled } from '@/lib/icons';
+import { cn } from '@/lib/utils';
+
+/**
+ * RadioGroupProps
+ *
+ * Props for the RadioGroup component.
+ */
+interface RadioGroupProps extends React.ComponentProps<
+  typeof RadioGroupPrimitive.Root
+> {}
+
+/**
+ * RadioGroupItemProps
+ *
+ * Props for the RadioGroupItem component.
+ */
+interface RadioGroupItemProps extends React.ComponentProps<
+  typeof RadioGroupPrimitive.Item
+> {}
+
+/**
+ * RadioGroup
+ *
+ * A set of mutually exclusive options where exactly one can be selected. Render
+ * one `RadioGroupItem` per option; Radix handles roving focus and arrow-key
+ * navigation between them. Control the selection with `value` / `onValueChange`,
+ * or set an initial selection with `defaultValue`.
+ *
+ * @example
+ * ```tsx
+ * <RadioGroup defaultValue="comfortable">
+ *   <div className="nx:flex nx:items-center nx:gap-2">
+ *     <RadioGroupItem value="default" id="r-default" />
+ *     <Label htmlFor="r-default">Default</Label>
+ *   </div>
+ *   <div className="nx:flex nx:items-center nx:gap-2">
+ *     <RadioGroupItem value="comfortable" id="r-comfortable" />
+ *     <Label htmlFor="r-comfortable">Comfortable</Label>
+ *   </div>
+ * </RadioGroup>
+ * ```
+ */
+function RadioGroup({ className, ...props }: RadioGroupProps) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn(
+        // nexus-allow-numeric: spacing between options stacked in the group
+        'nx:grid nx:gap-2',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * RadioGroupItem
+ *
+ * A single selectable option within a `RadioGroup`. Pair it with a `Label`
+ * (via matching `id` / `htmlFor`) so the option's text toggles it.
+ */
+function RadioGroupItem({ className, ...props }: RadioGroupItemProps) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        'nx:size-4 nx:shrink-0 nx:cursor-pointer nx:rounded-full nx:border nx:border-border-default nx:bg-background',
+        'nx:transition-colors',
+        'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
+        'nx:disabled:cursor-not-allowed nx:disabled:opacity-50',
+        'nx:data-[state=checked]:border-primary-background',
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="nx:flex nx:items-center nx:justify-center"
+      >
+        <IconCircleFilled className="nx:size-2.5 nx:text-primary-background" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+}
+
+export {
+  RadioGroup,
+  RadioGroupItem,
+  type RadioGroupItemProps,
+  type RadioGroupProps,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -20,6 +20,7 @@ export * from '@/components/ui/dialog';
 export * from '@/components/ui/dropdown-menu';
 export * from '@/components/ui/input';
 export * from '@/components/ui/label';
+export * from '@/components/ui/radio-group';
 export * from '@/components/ui/select';
 export * from '@/components/ui/separator';
 export * from '@/components/ui/skeleton';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,6 +1149,22 @@
   dependencies:
     "@radix-ui/react-slot" "1.2.4"
 
+"@radix-ui/react-radio-group@^1.3.8":
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz#93f102b5b948d602c2f2adb1bc5c347cbaf64bd9"
+  integrity sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-direction" "1.1.1"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-roving-focus" "1.1.11"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-use-previous" "1.1.1"
+    "@radix-ui/react-use-size" "1.1.1"
+
 "@radix-ui/react-roving-focus@1.1.11":
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz#ef54384b7361afc6480dcf9907ef2fedb5080fd9"


### PR DESCRIPTION
## Summary

- Adapt shadcn/ui `radio-group` into a first-class Nexus component: **`RadioGroup`** + **`RadioGroupItem`** (Radix `@radix-ui/react-radio-group`, roving focus / arrow-key navigation).
- Semantic tokens only: unchecked is `border-border-default` on `bg-background`; checked flips the ring to `border-primary-background` and renders a filled `IconCircleFilled` dot in `text-primary-background`. Canonical focus-ring (`outline-focus-default` + tokenised `--focus-offset`); `data-slot` hooks on group / item / indicator; padding-free fixed `size-4` control (mirrors the `switch.tsx` archetype).
- Stories with play-fns: `Default`, `VerticalWithLabels`, `Horizontal`, `Disabled`, `ClickInteraction`, `KeyboardInteraction`, `WithDataAttributes`, `AllVariants`. Opted into base-variants generation.
- Wired: barrel export in `src/index.ts`, dep in `package.json`, entry in `base-variants.config.json`. `IconCircleFilled` already existed — no icon change.

## GitHub Issue

Closes #167

## Test Plan

- [x] `audit:storybook-coverage --component radio-group` — ✓ no gaps (Phase 1 DoD gate)
- [x] `yarn workspace @nexus/react typecheck` — clean (RadioGroup base-variants generates)
- [x] `eslint` (component + stories) — clean
- [ ] `test:storybook` (play-fns + a11y) — **runs in CI**; the local git-worktree browser-vitest connection is environmentally flaky (browser drops at startup, `no tests` executed — not a code failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)