### PR TITLE
feat(components): add table component

### DIFF
--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -53,6 +53,7 @@
     { "name": "Show", "showcase": "AllAxes", "sourceDir": "primitives" },
     { "name": "Hide", "showcase": "AllAxes", "sourceDir": "primitives" },
     { "name": "Switch", "showcase": "AllVariants" },
+    { "name": "Table", "showcase": "AllVariants" },
     {
       "name": "Tabs",
       "showcase": "AllVariants",

--- a/packages/react/src/components/ui/Table.stories.tsx
+++ b/packages/react/src/components/ui/Table.stories.tsx
@@ -1,0 +1,279 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect } from 'storybook/test';
+
+import { Button } from './button';
+import { Checkbox } from './checkbox';
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from './table';
+
+const meta: Meta<typeof Table> = {
+  title: 'Components/Table',
+  component: Table,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Table>;
+
+// Representative fixture: a list of invoices with status, payment method, and
+// amount — the shape a real billing table renders.
+const invoices = [
+  {
+    invoice: 'INV001',
+    status: 'Paid',
+    method: 'Credit Card',
+    amount: '$250.00',
+  },
+  { invoice: 'INV002', status: 'Pending', method: 'PayPal', amount: '$150.00' },
+  {
+    invoice: 'INV003',
+    status: 'Unpaid',
+    method: 'Bank Transfer',
+    amount: '$350.00',
+  },
+  {
+    invoice: 'INV004',
+    status: 'Paid',
+    method: 'Credit Card',
+    amount: '$450.00',
+  },
+  { invoice: 'INV005', status: 'Paid', method: 'PayPal', amount: '$550.00' },
+];
+
+// ============================================
+// BASIC STORIES
+// ============================================
+
+// A basic data table: caption, column headers, and rows of cells. The amount
+// column is right-aligned, as numeric columns usually are.
+export const Default: Story = {
+  render: () => (
+    <Table>
+      <TableCaption>A list of your recent invoices.</TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Method</TableHead>
+          <TableHead className="nx:text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.map((row) => (
+          <TableRow key={row.invoice}>
+            <TableCell className="nx:font-medium">{row.invoice}</TableCell>
+            <TableCell>{row.status}</TableCell>
+            <TableCell>{row.method}</TableCell>
+            <TableCell className="nx:text-right">{row.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+};
+
+// A footer holds a summary row — here, the total across all invoices. The
+// muted fill and medium weight set it apart from the data rows.
+export const WithFooter: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="nx:text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.map((row) => (
+          <TableRow key={row.invoice}>
+            <TableCell className="nx:font-medium">{row.invoice}</TableCell>
+            <TableCell>{row.status}</TableCell>
+            <TableCell className="nx:text-right">{row.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          <TableCell colSpan={2}>Total</TableCell>
+          <TableCell className="nx:text-right">$1,750.00</TableCell>
+        </TableRow>
+      </TableFooter>
+    </Table>
+  ),
+};
+
+// Rows carry a leading checkbox column. Selected rows set
+// `data-state="selected"` for the highlight; the header checkbox is
+// indeterminate because the selection is partial. Every checkbox has an
+// `aria-label` so screen readers announce what it selects.
+export const SelectableRows: Story = {
+  render: () => {
+    const selected = new Set(['INV001', 'INV003']);
+    return (
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>
+              <Checkbox
+                defaultChecked="indeterminate"
+                aria-label="Select all rows"
+              />
+            </TableHead>
+            <TableHead>Invoice</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="nx:text-right">Amount</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {invoices.map((row) => (
+            <TableRow
+              key={row.invoice}
+              data-state={selected.has(row.invoice) ? 'selected' : undefined}
+            >
+              <TableCell>
+                <Checkbox
+                  defaultChecked={selected.has(row.invoice)}
+                  aria-label={`Select ${row.invoice}`}
+                />
+              </TableCell>
+              <TableCell className="nx:font-medium">{row.invoice}</TableCell>
+              <TableCell>{row.status}</TableCell>
+              <TableCell className="nx:text-right">{row.amount}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    );
+  },
+};
+
+// A trailing actions column with per-row controls. Text buttons carry their own
+// accessible names; a real app would wire these to edit/delete handlers.
+export const WithActions: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="nx:text-right">Actions</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.slice(0, 3).map((row) => (
+          <TableRow key={row.invoice}>
+            <TableCell className="nx:font-medium">{row.invoice}</TableCell>
+            <TableCell>{row.status}</TableCell>
+            <TableCell>
+              <div className="nx:flex nx:justify-end nx:gap-2">
+                <Button variant="ghost" size="sm">
+                  Edit
+                </Button>
+                <Button variant="destructive" size="sm">
+                  Delete
+                </Button>
+              </div>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+};
+
+// ============================================
+// ATTRIBUTE TEST
+// ============================================
+
+export const WithDataAttributes: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell>INV001</TableCell>
+          <TableCell>$250.00</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  ),
+  play: async ({ canvasElement }) => {
+    const container = canvasElement.querySelector(
+      '[data-slot="table-container"]'
+    );
+    const table = canvasElement.querySelector('[data-slot="table"]');
+
+    await expect(container).toBeInTheDocument();
+    await expect(table?.tagName).toBe('TABLE');
+
+    // Every structural part carries its own data-slot hook.
+    for (const slot of [
+      'table-header',
+      'table-body',
+      'table-row',
+      'table-head',
+      'table-cell',
+    ]) {
+      await expect(
+        canvasElement.querySelector(`[data-slot="${slot}"]`)
+      ).toBeInTheDocument();
+    }
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// The full anatomy in one table: muted column headers, a selected row, hover
+// highlight, a footer totals row, and a caption.
+export const AllVariants: Story = {
+  render: () => (
+    <Table>
+      <TableCaption>Recent invoices — full table anatomy.</TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Method</TableHead>
+          <TableHead className="nx:text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.slice(0, 4).map((row, i) => (
+          <TableRow
+            key={row.invoice}
+            data-state={i === 1 ? 'selected' : undefined}
+          >
+            <TableCell className="nx:font-medium">{row.invoice}</TableCell>
+            <TableCell>{row.status}</TableCell>
+            <TableCell>{row.method}</TableCell>
+            <TableCell className="nx:text-right">{row.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          <TableCell colSpan={3}>Total</TableCell>
+          <TableCell className="nx:text-right">$1,400.00</TableCell>
+        </TableRow>
+      </TableFooter>
+    </Table>
+  ),
+};

--- a/packages/react/src/components/ui/table.tsx
+++ b/packages/react/src/components/ui/table.tsx
@@ -1,0 +1,240 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * TableProps
+ *
+ * Props for the Table component.
+ */
+interface TableProps extends React.ComponentProps<'table'> {}
+
+/**
+ * Table
+ *
+ * A semantic data table — header, body, optional footer, and rows of cells.
+ * Renders inside a horizontally-scrollable wrapper so wide tables stay usable
+ * on narrow viewports without forcing a page-level scrollbar. Compose with the
+ * sub-components: `TableHeader` / `TableBody` / `TableFooter` wrap `TableRow`s,
+ * which hold `TableHead` (column header) or `TableCell` (data) cells.
+ *
+ * @example
+ * ```tsx
+ * <Table>
+ *   <TableHeader>
+ *     <TableRow>
+ *       <TableHead>Invoice</TableHead>
+ *       <TableHead>Amount</TableHead>
+ *     </TableRow>
+ *   </TableHeader>
+ *   <TableBody>
+ *     <TableRow>
+ *       <TableCell>INV001</TableCell>
+ *       <TableCell>$250.00</TableCell>
+ *     </TableRow>
+ *   </TableBody>
+ * </Table>
+ * ```
+ */
+function Table({ className, ...props }: TableProps) {
+  return (
+    <div data-slot="table-container" className="nx:w-full nx:overflow-x-auto">
+      <table
+        data-slot="table"
+        className={cn('nx:w-full nx:caption-bottom nx:text-sm', className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+/**
+ * TableHeaderProps
+ *
+ * Props for the TableHeader component.
+ */
+interface TableHeaderProps extends React.ComponentProps<'thead'> {}
+
+/**
+ * TableHeader
+ *
+ * The `<thead>` grouping for column-header rows.
+ */
+function TableHeader({ className, ...props }: TableHeaderProps) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn('nx:[&_tr]:border-b', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * TableBodyProps
+ *
+ * Props for the TableBody component.
+ */
+interface TableBodyProps extends React.ComponentProps<'tbody'> {}
+
+/**
+ * TableBody
+ *
+ * The `<tbody>` grouping for data rows. The last row drops its bottom border so
+ * the body doesn't draw a rule against a following footer or the table edge.
+ */
+function TableBody({ className, ...props }: TableBodyProps) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn('nx:[&_tr:last-child]:border-0', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * TableFooterProps
+ *
+ * Props for the TableFooter component.
+ */
+interface TableFooterProps extends React.ComponentProps<'tfoot'> {}
+
+/**
+ * TableFooter
+ *
+ * The `<tfoot>` grouping for a summary/totals row — a muted fill and medium
+ * weight set it apart from the data rows above.
+ */
+function TableFooter({ className, ...props }: TableFooterProps) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        'nx:border-t nx:border-border-default nx:bg-muted nx:font-medium nx:[&>tr]:last:border-b-0',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * TableRowProps
+ *
+ * Props for the TableRow component.
+ */
+interface TableRowProps extends React.ComponentProps<'tr'> {}
+
+/**
+ * TableRow
+ *
+ * A table row. Highlights on hover and when selected — set
+ * `data-state="selected"` to mark a row as part of the current selection.
+ */
+function TableRow({ className, ...props }: TableRowProps) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        'nx:border-b nx:border-border-default nx:transition-colors nx:hover:bg-background-hover nx:data-[state=selected]:bg-muted',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * TableHeadProps
+ *
+ * Props for the TableHead component.
+ */
+interface TableHeadProps extends React.ComponentProps<'th'> {}
+
+/**
+ * TableHead
+ *
+ * A column-header cell (`<th>`). Rendered in muted foreground to sit quietly
+ * above the data it labels.
+ */
+function TableHead({ className, ...props }: TableHeadProps) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        // nexus-allow-numeric: table header cell padding (not a control)
+        'nx:px-2 nx:py-2.5 nx:text-left nx:align-middle nx:font-medium nx:whitespace-nowrap nx:text-muted-foreground nx:[&:has([role=checkbox])]:pr-0 nx:[&>[role=checkbox]]:translate-y-[2px]',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * TableCellProps
+ *
+ * Props for the TableCell component.
+ */
+interface TableCellProps extends React.ComponentProps<'td'> {}
+
+/**
+ * TableCell
+ *
+ * A data cell (`<td>`).
+ */
+function TableCell({ className, ...props }: TableCellProps) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        // nexus-allow-numeric: table cell padding (not a control)
+        'nx:p-2 nx:align-middle nx:whitespace-nowrap nx:[&:has([role=checkbox])]:pr-0 nx:[&>[role=checkbox]]:translate-y-[2px]',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * TableCaptionProps
+ *
+ * Props for the TableCaption component.
+ */
+interface TableCaptionProps extends React.ComponentProps<'caption'> {}
+
+/**
+ * TableCaption
+ *
+ * A caption describing the table. Rendered below the table (`caption-bottom`).
+ */
+function TableCaption({ className, ...props }: TableCaptionProps) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn('nx:mt-4 nx:text-sm nx:text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableBody,
+  type TableBodyProps,
+  TableCaption,
+  type TableCaptionProps,
+  TableCell,
+  type TableCellProps,
+  TableFooter,
+  type TableFooterProps,
+  TableHead,
+  TableHeader,
+  type TableHeaderProps,
+  type TableHeadProps,
+  type TableProps,
+  TableRow,
+  type TableRowProps,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -25,6 +25,7 @@ export * from '@/components/ui/select';
 export * from '@/components/ui/separator';
 export * from '@/components/ui/skeleton';
 export * from '@/components/ui/switch';
+export * from '@/components/ui/table';
 export * from '@/components/ui/tabs';
 export * from '@/components/ui/textarea';
 export * from '@/components/ui/tooltip';


### PR DESCRIPTION
## Summary

- Adapt shadcn's `table` into Nexus semantic table primitives — `Table`, `TableHeader`, `TableBody`, `TableFooter`, `TableRow`, `TableHead`, `TableCell`, `TableCaption` (+ each `*Props`). Pure markup, **no new dependency**.
- Key adaptation decisions:
  - Column headers render in `text-muted-foreground` (Tier-A muted-header style, per issue spec)
  - Header cells are padding-based (`px-2 py-2.5`), not a fixed `h-10`
  - Footer uses solid `bg-muted` (no opacity modifier, per `shadcn-divergences.md`)
  - `border-b`/`border-t` paired with `border-border-default`; dropped dead `relative` and out-of-scope `has-aria-expanded`
  - Kept the checkbox-alignment selectors; `// nexus-allow-numeric:` annotates the two cell-padding lines
  - Opted into the base-variants generator (render-based `AllVariants` showcase)
- Stories: `Default`, `WithFooter`, `SelectableRows`, `WithActions`, `WithDataAttributes` (play), `AllVariants`.

### Note on story names
The issue acceptance lists `BasicData`; this PR ships it as **`Default`** — the `audit:storybook-coverage` DoD gate requires the canonical `Default` name (`BasicData` is not a registered alias and would fail the audit). The `Default` story *is* the basic-data invoice table.

## GitHub Issue

Closes #169

## Test Plan

- [x] `audit:storybook-coverage --component table` — 0 missing, 0 drift (3 interaction names = non-failing info, correct for a non-interactive component)
- [x] `yarn workspace @nexus/react typecheck` — clean (base-variants regenerated with Table)
- [x] `yarn lint` (`eslint . --max-warnings 0`) — clean
- [x] story tests (chromium) — 7 passed, incl. axe a11y on `SelectableRows`/`WithActions`
- [x] `yarn size-limit` — ESM **51.49 / 56 kB**, CSS 6.8 / 30 kB (no bump)
- [x] Rebased onto `origin/main` after #263 (radio-group) — shared append-point files merged cleanly; combined bundle re-measured

🤖 Generated with [Claude Code](https://claude.com/claude-code)