### PR TITLE
feat(components): add popover component

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,6 +54,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",

--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -40,6 +40,12 @@
         "KeyboardInteraction": ["TypeInteraction"]
       }
     },
+    {
+      "name": "Popover",
+      "showcase": "AllVariants",
+      "interactions": ["ClickInteraction"],
+      "equivalents": { "ClickInteraction": ["OpenCloseInteraction"] }
+    },
     { "name": "RadioGroup", "showcase": "AllVariants" },
     {
       "name": "Select",

--- a/packages/react/src/components/ui/Popover.stories.tsx
+++ b/packages/react/src/components/ui/Popover.stories.tsx
@@ -1,0 +1,298 @@
+import * as React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { Button } from './button';
+import { Input } from './input';
+import { Label } from './label';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverTrigger,
+} from './popover';
+
+const meta: Meta<typeof Popover> = {
+  title: 'Components/Popover',
+  component: Popover,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Popover>;
+
+// ============================================
+// BASIC STORIES
+// ============================================
+
+export const Default: Story = {
+  render: (_args) => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Open popover</Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <p className="nx:text-sm nx:text-muted-foreground">
+          Place content for the popover here.
+        </p>
+      </PopoverContent>
+    </Popover>
+  ),
+};
+
+export const WithForm: Story = {
+  // Named function + useId so the label/input pairs are uniquely associated.
+  render: function WithFormStory() {
+    const widthId = React.useId();
+    const maxWidthId = React.useId();
+    return (
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button variant="outline">Set dimensions</Button>
+        </PopoverTrigger>
+        <PopoverContent className="nx:w-80">
+          <div className="nx:flex nx:flex-col nx:gap-4">
+            <div className="nx:flex nx:flex-col nx:gap-1.5">
+              <h4 className="nx:text-sm nx:font-medium nx:leading-none">
+                Dimensions
+              </h4>
+              <p className="nx:text-sm nx:text-muted-foreground">
+                Set the dimensions for the layer.
+              </p>
+            </div>
+            <div className="nx:flex nx:flex-col nx:gap-2">
+              <div className="nx:grid nx:grid-cols-3 nx:items-center nx:gap-4">
+                <Label htmlFor={widthId}>Width</Label>
+                <Input
+                  id={widthId}
+                  defaultValue="100%"
+                  className="nx:col-span-2"
+                />
+              </div>
+              <div className="nx:grid nx:grid-cols-3 nx:items-center nx:gap-4">
+                <Label htmlFor={maxWidthId}>Max. width</Label>
+                <Input
+                  id={maxWidthId}
+                  defaultValue="300px"
+                  className="nx:col-span-2"
+                />
+              </div>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    );
+  },
+};
+
+export const Placements: Story = {
+  render: (_args) => (
+    <div className="nx:flex nx:flex-wrap nx:gap-4">
+      {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
+        <Popover key={side}>
+          <PopoverTrigger asChild>
+            <Button variant="outline">side: {side}</Button>
+          </PopoverTrigger>
+          <PopoverContent side={side}>
+            <p className="nx:text-sm">Opens on {side}.</p>
+          </PopoverContent>
+        </Popover>
+      ))}
+      {(['start', 'center', 'end'] as const).map((align) => (
+        <Popover key={align}>
+          <PopoverTrigger asChild>
+            <Button variant="outline">align: {align}</Button>
+          </PopoverTrigger>
+          <PopoverContent align={align}>
+            <p className="nx:text-sm">Aligned {align}.</p>
+          </PopoverContent>
+        </Popover>
+      ))}
+    </div>
+  ),
+};
+
+export const WithAnchor: Story = {
+  render: (_args) => (
+    <Popover>
+      <PopoverAnchor asChild>
+        <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-container nx:text-sm nx:text-muted-foreground">
+          The popover positions against this anchor box.
+        </div>
+      </PopoverAnchor>
+      <div className="nx:mt-4">
+        <PopoverTrigger asChild>
+          <Button variant="outline">Toggle popover</Button>
+        </PopoverTrigger>
+      </div>
+      <PopoverContent>
+        <p className="nx:text-sm">
+          Positioned relative to the anchor box, not the trigger button.
+        </p>
+      </PopoverContent>
+    </Popover>
+  ),
+};
+
+// ============================================
+// INTERACTION TESTS
+// ============================================
+
+export const OpenCloseInteraction: Story = {
+  render: (_args) => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Open popover</Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <p className="nx:text-sm">Popover content</p>
+      </PopoverContent>
+    </Popover>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Open popover' });
+    await expect(trigger).toBeInTheDocument();
+
+    // Open the popover
+    await userEvent.click(trigger);
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="popover-content"]')
+      ).toBeInTheDocument();
+    });
+
+    // Close with Escape
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="popover-content"]')
+      ).toBeNull();
+    });
+  },
+};
+
+export const WithDataAttributes: Story = {
+  render: (_args) => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline">Open popover</Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <p className="nx:text-sm">Popover content</p>
+      </PopoverContent>
+    </Popover>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Open popover' });
+
+    // Open the popover, then assert the content's data-slot hook
+    await userEvent.click(trigger);
+    await waitFor(() => {
+      const content = document.querySelector('[data-slot="popover-content"]');
+      expect(content).toBeInTheDocument();
+    });
+
+    // Clean up so the portal doesn't leak into sibling stories
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="popover-content"]')
+      ).toBeNull();
+    });
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+export const AllVariants: Story = {
+  render: (_args) => (
+    <div className="nx:flex nx:flex-col nx:gap-8">
+      <div>
+        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          Trigger Variants
+        </h3>
+        <div className="nx:flex nx:flex-wrap nx:items-center nx:gap-4">
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline">Outline trigger</Button>
+            </PopoverTrigger>
+            <PopoverContent>
+              <p className="nx:text-sm">Popover content</p>
+            </PopoverContent>
+          </Popover>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="secondary">Secondary trigger</Button>
+            </PopoverTrigger>
+            <PopoverContent>
+              <p className="nx:text-sm">Popover content</p>
+            </PopoverContent>
+          </Popover>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="ghost">Ghost trigger</Button>
+            </PopoverTrigger>
+            <PopoverContent>
+              <p className="nx:text-sm">Popover content</p>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+
+      <div>
+        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          Placements
+        </h3>
+        <div className="nx:flex nx:flex-wrap nx:items-center nx:gap-4">
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline">Top</Button>
+            </PopoverTrigger>
+            <PopoverContent side="top">
+              <p className="nx:text-sm">Top</p>
+            </PopoverContent>
+          </Popover>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline">Right</Button>
+            </PopoverTrigger>
+            <PopoverContent side="right">
+              <p className="nx:text-sm">Right</p>
+            </PopoverContent>
+          </Popover>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline">Bottom</Button>
+            </PopoverTrigger>
+            <PopoverContent side="bottom">
+              <p className="nx:text-sm">Bottom</p>
+            </PopoverContent>
+          </Popover>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline">Left</Button>
+            </PopoverTrigger>
+            <PopoverContent side="left">
+              <p className="nx:text-sm">Left</p>
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+// ============================================
+// A11Y is tested automatically on ALL stories
+// via addon-a11y with test: 'error'
+// ============================================

--- a/packages/react/src/components/ui/popover.tsx
+++ b/packages/react/src/components/ui/popover.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * Popover
+ *
+ * Root component for the popover. Controls open/close state.
+ *
+ * @example
+ * ```tsx
+ * <Popover>
+ *   <PopoverTrigger asChild>
+ *     <Button variant="outline">Open</Button>
+ *   </PopoverTrigger>
+ *   <PopoverContent>Place content for the popover here.</PopoverContent>
+ * </Popover>
+ * ```
+ */
+const Popover = PopoverPrimitive.Root;
+
+/**
+ * PopoverTrigger
+ *
+ * Button that toggles the popover. Use `asChild` to render as your own component.
+ */
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+/**
+ * PopoverAnchor
+ *
+ * Optional element to anchor the popover against, instead of the trigger. Useful
+ * when the popover should position relative to a different element than the one
+ * that opens it.
+ */
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
+/**
+ * PopoverContentProps
+ *
+ * Props for the PopoverContent component.
+ */
+interface PopoverContentProps extends React.ComponentProps<
+  typeof PopoverPrimitive.Content
+> {}
+
+/**
+ * PopoverContent
+ *
+ * The floating content container, anchored to the trigger and portaled to the body.
+ *
+ * @example
+ * ```tsx
+ * <PopoverContent align="start" sideOffset={8}>
+ *   <p>Popover content</p>
+ * </PopoverContent>
+ * ```
+ */
+function PopoverContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ...props
+}: PopoverContentProps) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'nx:z-popover nx:w-72 nx:p-container nx:outline-none',
+          'nx:rounded-md nx:border nx:border-border-default nx:bg-popover nx:text-popover-foreground nx:shadow-md',
+          'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
+          'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
+          'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',
+          'nx:data-[side=bottom]:slide-in-from-top-2 nx:data-[side=left]:slide-in-from-right-2',
+          'nx:data-[side=right]:slide-in-from-left-2 nx:data-[side=top]:slide-in-from-bottom-2',
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+export {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  type PopoverContentProps,
+  PopoverTrigger,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -20,6 +20,7 @@ export * from '@/components/ui/dialog';
 export * from '@/components/ui/dropdown-menu';
 export * from '@/components/ui/input';
 export * from '@/components/ui/label';
+export * from '@/components/ui/popover';
 export * from '@/components/ui/progress';
 export * from '@/components/ui/radio-group';
 export * from '@/components/ui/select';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1103,6 +1103,27 @@
     aria-hidden "^1.2.4"
     react-remove-scroll "^2.6.3"
 
+"@radix-ui/react-popover@^1.1.15":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popover/-/react-popover-1.1.15.tgz#9c852f93990a687ebdc949b2c3de1f37cdc4c5d5"
+  integrity sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-dismissable-layer" "1.1.11"
+    "@radix-ui/react-focus-guards" "1.1.3"
+    "@radix-ui/react-focus-scope" "1.1.7"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-popper" "1.2.8"
+    "@radix-ui/react-portal" "1.1.9"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-slot" "1.2.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.6.3"
+
 "@radix-ui/react-popper@1.2.8":
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.2.8.tgz#a79f39cdd2b09ab9fb50bf95250918422c4d9602"


### PR DESCRIPTION
## Summary

Adapts the shadcn/ui popover into a first-class Nexus component — floating content anchored to a trigger on the popover layer (`[10/17]` of the Phase 1 component epic #161).

- Exports `Popover`, `PopoverTrigger`, `PopoverContent`, `PopoverAnchor`, `PopoverContentProps`; new dep `@radix-ui/react-popover`.
- Mirrors `select.tsx` floating-surface treatment: `nx:z-popover`, `nx:bg-popover` surface, `nx:border-border-default`, `nx:shadow-md`, fade/zoom/slide animations.
- `Trigger`/`Anchor` are bare Radix aliases (focus ring comes from the `asChild` Button), matching Dialog/DropdownMenu/Tooltip; `data-slot="popover-content"` lives on the styled content.
- Padding via the `nx:p-container` role token (not a raw numeric), matching the Dialog archetype.
- Stories: Default, WithForm, Placements, WithAnchor, OpenCloseInteraction + WithDataAttributes (play fns), AllVariants showcase. Opted into base-variants generation (closed-trigger only — portal caveat).

Dropped from the upstream registry: the `origin-(--radix-…)` class (no repo precedent; select zooms fine without it) and the newer `PopoverHeader`/`Title`/`Description` parts (outside this issue's export contract).

## GitHub Issue

Closes #171

## Test Plan

- [x] `audit:storybook-coverage --component popover` — exit 0 (0 missing, 0 drift, 2 expected info)
- [x] `yarn workspace @nexus/react typecheck` — clean
- [x] `yarn lint` (`eslint . --max-warnings 0`) — clean
- [x] `yarn test:storybook Popover` — 8/8 pass across both story files; a11y auto-checked
- [x] `yarn size-limit` — ESM 52.65/56 kB, CSS 6.83/30 kB (combined with progress #265, post-rebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)