### PR TITLE
feat(components): add sheet component

### DIFF
--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -56,6 +56,12 @@
         "Disabled": ["DisabledInteraction"]
       }
     },
+    {
+      "name": "Sheet",
+      "showcase": "AllVariants",
+      "interactions": ["ClickInteraction", "KeyboardInteraction"],
+      "equivalents": { "ClickInteraction": ["OpenCloseInteraction"] }
+    },
     { "name": "Show", "showcase": "AllAxes", "sourceDir": "primitives" },
     { "name": "Hide", "showcase": "AllAxes", "sourceDir": "primitives" },
     { "name": "Switch", "showcase": "AllVariants" },

--- a/packages/react/src/components/ui/Sheet.stories.tsx
+++ b/packages/react/src/components/ui/Sheet.stories.tsx
@@ -1,0 +1,352 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { Button } from './button';
+import { Input } from './input';
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from './sheet';
+
+const meta: Meta<typeof Sheet> = {
+  title: 'Components/Sheet',
+  component: Sheet,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Sheet>;
+
+const SIDES = ['top', 'right', 'bottom', 'left'] as const;
+
+// ============================================
+// BASIC STORIES (one per side variant)
+// ============================================
+
+export const Default: Story = {
+  render: (_args) => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open Sheet</Button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Sheet Title</SheetTitle>
+          <SheetDescription>
+            This panel slides in from the right edge by default.
+          </SheetDescription>
+        </SheetHeader>
+        <p className="nx:px-4 nx:text-sm nx:text-foreground">
+          Sheet content goes here. You can add any content you need.
+        </p>
+        <SheetFooter>
+          <SheetClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </SheetClose>
+          <Button>Save</Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+export const Left: Story = {
+  render: (_args) => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open Left</Button>
+      </SheetTrigger>
+      <SheetContent side="left">
+        <SheetHeader>
+          <SheetTitle>Navigation</SheetTitle>
+          <SheetDescription>
+            A left sheet is the canonical home for a slide-in nav drawer.
+          </SheetDescription>
+        </SheetHeader>
+        <SheetFooter>
+          <SheetClose asChild>
+            <Button>Close</Button>
+          </SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+export const Top: Story = {
+  render: (_args) => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open Top</Button>
+      </SheetTrigger>
+      <SheetContent side="top">
+        <SheetHeader>
+          <SheetTitle>Announcement</SheetTitle>
+          <SheetDescription>
+            A top sheet drops down across the full width of the viewport.
+          </SheetDescription>
+        </SheetHeader>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+export const Bottom: Story = {
+  render: (_args) => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open Bottom</Button>
+      </SheetTrigger>
+      <SheetContent side="bottom">
+        <SheetHeader>
+          <SheetTitle>Quick actions</SheetTitle>
+          <SheetDescription>
+            A bottom sheet rises from the bottom edge — a common mobile pattern.
+          </SheetDescription>
+        </SheetHeader>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+export const WithForm: Story = {
+  render: (_args) => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button>Edit Profile</Button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Edit Profile</SheetTitle>
+          <SheetDescription>
+            Update your profile here, then save when you are done.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="nx:grid nx:flex-1 nx:gap-4 nx:px-4">
+          <div className="nx:grid nx:gap-1.5">
+            <label htmlFor="sheet-name" className="nx:text-sm nx:font-medium">
+              Name
+            </label>
+            <Input id="sheet-name" defaultValue="John Doe" />
+          </div>
+          <div className="nx:grid nx:gap-1.5">
+            <label
+              htmlFor="sheet-username"
+              className="nx:text-sm nx:font-medium"
+            >
+              Username
+            </label>
+            <Input id="sheet-username" defaultValue="@johndoe" />
+          </div>
+        </div>
+        <SheetFooter>
+          <SheetClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </SheetClose>
+          <Button type="submit">Save changes</Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+// ============================================
+// INTERACTION TESTS
+// ============================================
+
+export const OpenCloseInteraction: Story = {
+  render: (_args) => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open Sheet</Button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Interaction Test</SheetTitle>
+          <SheetDescription>Testing open and close behavior.</SheetDescription>
+        </SheetHeader>
+        <SheetFooter>
+          <SheetClose asChild>
+            <Button>Dismiss</Button>
+          </SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Sheet should not be open initially.
+    const trigger = canvas.getByRole('button', { name: 'Open Sheet' });
+    await expect(trigger).toBeInTheDocument();
+
+    // Open the sheet.
+    await userEvent.click(trigger);
+
+    // Content portals to document.body with role="dialog".
+    const sheet = await within(document.body).findByRole('dialog');
+    await expect(sheet).toBeInTheDocument();
+    await expect(sheet).toHaveAttribute('data-slot', 'sheet-content');
+
+    // Title should be visible.
+    await expect(
+      within(sheet).getByText('Interaction Test')
+    ).toBeInTheDocument();
+
+    // Close via the footer button (the X button also has "Close" sr-only text).
+    await userEvent.click(
+      within(sheet).getByRole('button', { name: 'Dismiss' })
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector('[role="dialog"]')).toBeNull();
+    });
+  },
+};
+
+export const KeyboardInteraction: Story = {
+  render: (_args) => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open Sheet</Button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Keyboard Test</SheetTitle>
+          <SheetDescription>Testing keyboard interactions.</SheetDescription>
+        </SheetHeader>
+        <SheetFooter>
+          <SheetClose asChild>
+            <Button>Close</Button>
+          </SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole('button', { name: 'Open Sheet' });
+    await userEvent.click(trigger);
+
+    const sheet = await within(document.body).findByRole('dialog');
+    await expect(sheet).toBeInTheDocument();
+
+    // Escape closes the sheet.
+    await userEvent.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(document.querySelector('[role="dialog"]')).toBeNull();
+    });
+  },
+};
+
+export const WithDataAttributes: Story = {
+  render: (_args) => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">Open Sheet</Button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Data Attributes</SheetTitle>
+          <SheetDescription>Testing data-slot attributes.</SheetDescription>
+        </SheetHeader>
+        <p className="nx:px-4 nx:text-sm">Content here</p>
+        <SheetFooter>
+          <SheetClose asChild>
+            <Button>Close</Button>
+          </SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole('button', { name: 'Open Sheet' });
+    await userEvent.click(trigger);
+
+    await within(document.body).findByRole('dialog');
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="sheet-overlay"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="sheet-content"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="sheet-header"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="sheet-title"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="sheet-description"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="sheet-footer"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="sheet-close-button"]')
+      ).toBeInTheDocument();
+    });
+
+    // The active side is reflected on the content for CSS / test hooks.
+    await expect(
+      document.querySelector('[data-slot="sheet-content"]')
+    ).toHaveAttribute('data-side', 'right');
+
+    await userEvent.keyboard('{Escape}');
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID (every side)
+// ============================================
+
+export const AllVariants: Story = {
+  render: (_args) => (
+    <div className="nx:flex nx:flex-wrap nx:gap-4">
+      {SIDES.map((side) => (
+        <Sheet key={side}>
+          <SheetTrigger asChild>
+            <Button variant="outline" className="nx:capitalize">
+              {side}
+            </Button>
+          </SheetTrigger>
+          <SheetContent side={side}>
+            <SheetHeader>
+              <SheetTitle className="nx:capitalize">{side} sheet</SheetTitle>
+              <SheetDescription>
+                Slides in from the {side} edge.
+              </SheetDescription>
+            </SheetHeader>
+            <SheetFooter>
+              <SheetClose asChild>
+                <Button>Close</Button>
+              </SheetClose>
+            </SheetFooter>
+          </SheetContent>
+        </Sheet>
+      ))}
+    </div>
+  ),
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+// ============================================
+// A11Y is tested automatically on ALL stories
+// via addon-a11y with test: 'error'
+// ============================================

--- a/packages/react/src/components/ui/sheet.tsx
+++ b/packages/react/src/components/ui/sheet.tsx
@@ -1,0 +1,343 @@
+import * as React from 'react';
+
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { IconX } from '@/lib/icons';
+import { cn } from '@/lib/utils';
+
+/**
+ * Sheet
+ *
+ * Root component for the sheet — a panel that slides in from an edge of the
+ * viewport. Built on Radix Dialog; controls open/close state.
+ *
+ * @example
+ * ```tsx
+ * <Sheet>
+ *   <SheetTrigger asChild>
+ *     <Button>Open Sheet</Button>
+ *   </SheetTrigger>
+ *   <SheetContent side="right">
+ *     <SheetHeader>
+ *       <SheetTitle>Sheet Title</SheetTitle>
+ *       <SheetDescription>Sheet description here.</SheetDescription>
+ *     </SheetHeader>
+ *     <SheetFooter>
+ *       <Button>Save</Button>
+ *     </SheetFooter>
+ *   </SheetContent>
+ * </Sheet>
+ * ```
+ */
+const Sheet = DialogPrimitive.Root;
+
+/**
+ * SheetTrigger
+ *
+ * Button that opens the sheet. Use `asChild` to render as your own component.
+ */
+const SheetTrigger = DialogPrimitive.Trigger;
+
+/**
+ * SheetPortal
+ *
+ * Portals the sheet content to document.body.
+ */
+const SheetPortal = DialogPrimitive.Portal;
+
+/**
+ * SheetClose
+ *
+ * Button that closes the sheet. Use `asChild` to render as your own component.
+ */
+const SheetClose = DialogPrimitive.Close;
+
+/**
+ * SheetOverlayProps
+ *
+ * Props for the SheetOverlay component.
+ */
+interface SheetOverlayProps extends React.ComponentProps<
+  typeof DialogPrimitive.Overlay
+> {}
+
+/**
+ * SheetOverlay
+ *
+ * Semi-transparent overlay behind the sheet content.
+ */
+function SheetOverlay({ className, ...props }: SheetOverlayProps) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        'nx:fixed nx:inset-0 nx:z-modal nx:bg-overlay',
+        'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
+        'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * Per-side positioning and slide motion for the sheet panel. Each side pins the
+ * panel to an edge and slides it fully on/off screen from that edge — the bare
+ * `slide-*` utilities translate by 100% (the spacing-scaled `slide-*-N` forms
+ * resolve to 0 under the Nexus spacing reset, so they would not move).
+ */
+const sheetContentVariants = cva(
+  cn(
+    'nx:fixed nx:z-modal nx:flex nx:flex-col nx:gap-container',
+    'nx:bg-container nx:shadow-lg nx:ease-in-out',
+    'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
+    'nx:data-[state=open]:duration-500 nx:data-[state=closed]:duration-300'
+  ),
+  {
+    variants: {
+      side: {
+        top: cn(
+          'nx:inset-x-0 nx:top-0 nx:h-auto nx:border-b nx:border-border-default',
+          'nx:data-[state=open]:slide-in-from-top nx:data-[state=closed]:slide-out-to-top'
+        ),
+        bottom: cn(
+          'nx:inset-x-0 nx:bottom-0 nx:h-auto nx:border-t nx:border-border-default',
+          'nx:data-[state=open]:slide-in-from-bottom nx:data-[state=closed]:slide-out-to-bottom'
+        ),
+        left: cn(
+          'nx:inset-y-0 nx:left-0 nx:h-full nx:w-3/4 nx:border-r nx:border-border-default nx:sm:max-w-sm',
+          'nx:data-[state=open]:slide-in-from-left nx:data-[state=closed]:slide-out-to-left'
+        ),
+        right: cn(
+          'nx:inset-y-0 nx:right-0 nx:h-full nx:w-3/4 nx:border-l nx:border-border-default nx:sm:max-w-sm',
+          'nx:data-[state=open]:slide-in-from-right nx:data-[state=closed]:slide-out-to-right'
+        ),
+      },
+    },
+    defaultVariants: {
+      side: 'right',
+    },
+  }
+);
+
+/**
+ * SheetContentProps
+ *
+ * Props for the SheetContent component.
+ */
+interface SheetContentProps
+  extends
+    React.ComponentProps<typeof DialogPrimitive.Content>,
+    VariantProps<typeof sheetContentVariants> {
+  /**
+   * Whether to show the close button in the top-right corner.
+   * @default true
+   */
+  showCloseButton?: boolean;
+}
+
+/**
+ * SheetContent
+ *
+ * The sliding panel. Renders inside a portal with an overlay; the `side` prop
+ * picks which edge it slides from (defaults to `right`).
+ *
+ * @example
+ * ```tsx
+ * <SheetContent side="left">
+ *   <SheetHeader>
+ *     <SheetTitle>Navigation</SheetTitle>
+ *   </SheetHeader>
+ * </SheetContent>
+ * ```
+ */
+function SheetContent({
+  className,
+  children,
+  side = 'right',
+  showCloseButton = true,
+  ...props
+}: SheetContentProps) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <DialogPrimitive.Content
+        data-slot="sheet-content"
+        data-side={side}
+        className={cn(sheetContentVariants({ side }), className)}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="sheet-close-button"
+            className={cn(
+              'nx:absolute nx:right-4 nx:top-4 nx:rounded-sm nx:opacity-70',
+              'nx:transition-opacity',
+              'nx:hover:opacity-100',
+              'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
+              'nx:disabled:pointer-events-none',
+              'nx:data-[state=open]:bg-muted nx:data-[state=open]:text-muted-foreground'
+            )}
+          >
+            <IconX className="nx:size-4" />
+            <span className="nx:sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </SheetPortal>
+  );
+}
+
+/**
+ * SheetHeaderProps
+ *
+ * Props for the SheetHeader component.
+ */
+interface SheetHeaderProps extends React.ComponentProps<'div'> {}
+
+/**
+ * SheetHeader
+ *
+ * Container for sheet title and description. Provides consistent spacing.
+ *
+ * @example
+ * ```tsx
+ * <SheetHeader>
+ *   <SheetTitle>Title</SheetTitle>
+ *   <SheetDescription>Description</SheetDescription>
+ * </SheetHeader>
+ * ```
+ */
+function SheetHeader({ className, ...props }: SheetHeaderProps) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn(
+        // nexus-allow-numeric: SheetHeader sub-element rhythm
+        'nx:flex nx:flex-col nx:gap-1.5 nx:p-container',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SheetFooterProps
+ *
+ * Props for the SheetFooter component.
+ */
+interface SheetFooterProps extends React.ComponentProps<'div'> {}
+
+/**
+ * SheetFooter
+ *
+ * Container for sheet action buttons. Pinned to the bottom of the panel.
+ *
+ * @example
+ * ```tsx
+ * <SheetFooter>
+ *   <Button variant="outline">Cancel</Button>
+ *   <Button>Save</Button>
+ * </SheetFooter>
+ * ```
+ */
+function SheetFooter({ className, ...props }: SheetFooterProps) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn(
+        // nexus-allow-numeric: SheetFooter sub-element rhythm
+        'nx:mt-auto nx:flex nx:flex-col nx:gap-2 nx:p-container',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SheetTitleProps
+ *
+ * Props for the SheetTitle component.
+ */
+interface SheetTitleProps extends React.ComponentProps<
+  typeof DialogPrimitive.Title
+> {}
+
+/**
+ * SheetTitle
+ *
+ * The title of the sheet. Should be used within SheetHeader.
+ *
+ * @example
+ * ```tsx
+ * <SheetTitle>Edit Profile</SheetTitle>
+ * ```
+ */
+function SheetTitle({ className, ...props }: SheetTitleProps) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="sheet-title"
+      className={cn(
+        'nx:text-lg nx:font-semibold nx:leading-none nx:tracking-tight',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SheetDescriptionProps
+ *
+ * Props for the SheetDescription component.
+ */
+interface SheetDescriptionProps extends React.ComponentProps<
+  typeof DialogPrimitive.Description
+> {}
+
+/**
+ * SheetDescription
+ *
+ * Supporting text that provides additional context for the sheet.
+ *
+ * @example
+ * ```tsx
+ * <SheetDescription>
+ *   Make changes to your profile here. Click save when you're done.
+ * </SheetDescription>
+ * ```
+ */
+function SheetDescription({ className, ...props }: SheetDescriptionProps) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="sheet-description"
+      className={cn('nx:text-sm nx:text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  type SheetContentProps,
+  sheetContentVariants,
+  SheetDescription,
+  type SheetDescriptionProps,
+  SheetFooter,
+  type SheetFooterProps,
+  SheetHeader,
+  type SheetHeaderProps,
+  SheetOverlay,
+  type SheetOverlayProps,
+  SheetPortal,
+  SheetTitle,
+  type SheetTitleProps,
+  SheetTrigger,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -26,6 +26,7 @@ export * from '@/components/ui/radio-group';
 export * from '@/components/ui/scroll-area';
 export * from '@/components/ui/select';
 export * from '@/components/ui/separator';
+export * from '@/components/ui/sheet';
 export * from '@/components/ui/skeleton';
 export * from '@/components/ui/switch';
 export * from '@/components/ui/table';


### PR DESCRIPTION
## Summary

- Adapt shadcn `sheet` into a first-class Nexus component, built on Radix Dialog (mirrors `dialog.tsx`) — **no new dependency** (reuses `@radix-ui/react-dialog`).
- Add a `side` CVA (`top` / `bottom` / `left` / `right`, default `right`) using the **bare** `slide-*` utilities (100% translate — the spacing-scaled `-N` forms are inert under the Nexus spacing reset).
- Semantic remaps: overlay → `nx:bg-overlay`, surface → `nx:bg-container`, border → `nx:border-border-default`, `nx:z-modal`, `nx:shadow-lg`; close button + focus ring mirror `dialog.tsx`.
- Exports `Sheet`, `SheetTrigger`, `SheetClose`, `SheetPortal`, `SheetOverlay`, `SheetContent`, `SheetHeader`, `SheetFooter`, `SheetTitle`, `SheetDescription` (+ Props + `sheetContentVariants`); wired into `src/index.ts` and opted into base-variants generation.
- Stories: all four sides, `WithForm`, play-fns (`OpenCloseInteraction`, `KeyboardInteraction`, `WithDataAttributes`), and `AllVariants`.

## GitHub Issue

Closes #174

## Test Plan

- [x] `audit:storybook-coverage --component sheet` — 0 missing, 0 drift
- [x] `yarn workspace @nexus/react typecheck` — clean (base-variants story generates & compiles)
- [x] `yarn lint` (`eslint . --max-warnings 0`) — clean
- [ ] `yarn test:storybook` — story play-fns + a11y, **verified by CI** (browser-mode vitest cannot run in a local worktree; confirmed environmental — shipped `dialog` stories fail identically there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)