### PR TITLE
feat(components): add form component

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,9 @@
       "eslint --fix --no-warn-ignored"
     ]
   },
+  "//resolutions": "zod is pinned to dedupe @hookform/resolvers' broad peer range (^3.25.0 || ^4.0.0) onto a single v4 copy, so zodResolver() typechecks in Form.stories.tsx. zod is a story-only devDependency and ships in no package bundle.",
   "resolutions": {
-    "minimatch": "^10.1.2"
+    "minimatch": "^10.1.2",
+    "zod": "^4.4.3"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,6 +29,7 @@
     "build-storybook": "yarn generate:base-variants && storybook build"
   },
   "devDependencies": {
+    "@hookform/resolvers": "^5.4.0",
     "@nexus/core": "*",
     "@storybook/addon-a11y": "^10.1.10",
     "@storybook/addon-docs": "^10.1.10",
@@ -38,13 +39,15 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
+    "react-hook-form": "^7.77.0",
     "recharts": "^3.8.1",
     "storybook": "^10.1.10",
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
     "vite": "^7.3.0",
-    "vite-plugin-dts": "^4.5.4"
+    "vite-plugin-dts": "^4.5.4",
+    "zod": "^4.4.3"
   },
   "dependencies": {
     "@nexus/tailwind": "*",
@@ -74,7 +77,13 @@
   },
   "peerDependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-hook-form": "^7.77.0"
+  },
+  "peerDependenciesMeta": {
+    "react-hook-form": {
+      "optional": true
+    }
   },
   "files": [
     "dist"

--- a/packages/react/src/components/ui/Form.stories.tsx
+++ b/packages/react/src/components/ui/Form.stories.tsx
@@ -1,0 +1,286 @@
+import { useForm } from 'react-hook-form';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { z } from 'zod';
+
+import { Button } from './button';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from './form';
+import { Input } from './input';
+
+const signUpSchema = z.object({
+  username: z.string().min(2, 'Username must be at least 2 characters'),
+  email: z.email('Enter a valid email address'),
+});
+
+type SignUpValues = z.infer<typeof signUpSchema>;
+
+/**
+ * A zod-validated sign-up form — the canonical Form composition reused across
+ * the interaction stories. `onSubmit` runs only when validation passes.
+ */
+function SignUpForm({
+  onSubmit,
+}: {
+  onSubmit?: (values: SignUpValues) => void;
+}) {
+  const form = useForm<SignUpValues>({
+    resolver: zodResolver(signUpSchema),
+    defaultValues: { username: '', email: '' },
+  });
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit((values) => onSubmit?.(values))}
+        className="nx:flex nx:flex-col nx:gap-6 nx:w-[360px]"
+      >
+        <FormField
+          control={form.control}
+          name="username"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Username</FormLabel>
+              <FormControl>
+                <Input placeholder="janedoe" {...field} />
+              </FormControl>
+              <FormDescription>Your public display name.</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" placeholder="jane@example.com" {...field} />
+              </FormControl>
+              <FormDescription>Used for sign-in and receipts.</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit">Create account</Button>
+      </form>
+    </Form>
+  );
+}
+
+/**
+ * A single-field form with no resolver — the simplest possible composition.
+ */
+function UsernameForm() {
+  const form = useForm<{ username: string }>({
+    defaultValues: { username: '' },
+  });
+
+  return (
+    <Form {...form}>
+      <div className="nx:w-[360px]">
+        <FormField
+          control={form.control}
+          name="username"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Username</FormLabel>
+              <FormControl>
+                <Input placeholder="janedoe" {...field} />
+              </FormControl>
+              <FormDescription>Your public display name.</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+    </Form>
+  );
+}
+
+/**
+ * Showcase of the field anatomy across its resting configurations: a full
+ * field, a label-plus-control field, and a disabled control. Every field keeps
+ * a description so the control's `aria-describedby` always resolves.
+ */
+function AnatomyForm() {
+  const form = useForm<{
+    full: string;
+    paired: string;
+    locked: string;
+  }>({
+    defaultValues: { full: '', paired: '', locked: 'Read-only value' },
+  });
+
+  return (
+    <Form {...form}>
+      <div className="nx:flex nx:flex-col nx:gap-6 nx:w-[360px]">
+        <FormField
+          control={form.control}
+          name="full"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Label, control, description</FormLabel>
+              <FormControl>
+                <Input placeholder="Standard field" {...field} />
+              </FormControl>
+              <FormDescription>Helper text under the control.</FormDescription>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="paired"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Label and control</FormLabel>
+              <FormControl>
+                <Input placeholder="Compact field" {...field} />
+              </FormControl>
+              <FormDescription>Descriptions remain optional.</FormDescription>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="locked"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Disabled control</FormLabel>
+              <FormControl>
+                <Input disabled {...field} />
+              </FormControl>
+              <FormDescription>The control can be disabled.</FormDescription>
+            </FormItem>
+          )}
+        />
+      </div>
+    </Form>
+  );
+}
+
+const meta = {
+  title: 'Components/Form',
+  component: Form,
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta<typeof Form>;
+
+export default meta;
+
+// Stories drive their own composition through `render`, so args are decoupled
+// from FormProvider's (required) props; `onSubmit` is the only spy they pass.
+type Story = StoryObj<{ onSubmit?: (values: SignUpValues) => void }>;
+
+// ============================================
+// BASIC STORIES
+// ============================================
+
+export const Default: Story = {
+  render: () => <UsernameForm />,
+};
+
+export const BasicValidation: Story = {
+  render: () => <SignUpForm />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Fields are validated with a Zod schema via `zodResolver`. Each FormItem composes a label, control, description, and message; FormMessage renders the resolver error when a field is invalid.',
+      },
+    },
+  },
+};
+
+// ============================================
+// INTERACTION TESTS
+// ============================================
+
+export const SubmitSuccess: Story = {
+  args: { onSubmit: fn() },
+  render: (args) => <SignUpForm onSubmit={args.onSubmit} />,
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.type(canvas.getByLabelText('Username'), 'janedoe');
+    await userEvent.type(canvas.getByLabelText('Email'), 'jane@example.com');
+    await userEvent.click(
+      canvas.getByRole('button', { name: /create account/i })
+    );
+
+    await waitFor(() => expect(args.onSubmit).toHaveBeenCalledTimes(1));
+    await expect(args.onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        username: 'janedoe',
+        email: 'jane@example.com',
+      })
+    );
+  },
+};
+
+export const ShowErrors: Story = {
+  args: { onSubmit: fn() },
+  render: (args) => <SignUpForm onSubmit={args.onSubmit} />,
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Submit with empty fields — the resolver should surface messages.
+    await userEvent.click(
+      canvas.getByRole('button', { name: /create account/i })
+    );
+
+    await waitFor(() =>
+      expect(
+        canvas.getByText('Username must be at least 2 characters')
+      ).toBeInTheDocument()
+    );
+
+    const username = canvas.getByLabelText('Username');
+    await expect(username).toHaveAttribute('aria-invalid', 'true');
+    await expect(args.onSubmit).not.toHaveBeenCalled();
+  },
+};
+
+export const WithDataAttributes: Story = {
+  render: () => <SignUpForm />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const label = canvas.getByText('Username');
+    await expect(label).toHaveAttribute('data-slot', 'form-label');
+
+    const description = canvas.getByText('Your public display name.');
+    await expect(description).toHaveAttribute('data-slot', 'form-description');
+
+    // FormControl wires the control's id + aria-describedby to the FormItem.
+    const input = canvas.getByLabelText('Username');
+    await expect(input).toHaveAttribute('id', label.getAttribute('for'));
+    await expect(input).toHaveAttribute(
+      'aria-describedby',
+      description.getAttribute('id')
+    );
+
+    await expect(
+      canvasElement.querySelector('[data-slot="form-item"]')
+    ).toBeInTheDocument();
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+export const AllVariants: Story = {
+  render: () => <AnatomyForm />,
+};

--- a/packages/react/src/components/ui/form.tsx
+++ b/packages/react/src/components/ui/form.tsx
@@ -1,0 +1,281 @@
+import * as React from 'react';
+import {
+  Controller,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+  FormProvider,
+  useFormContext,
+  useFormState,
+} from 'react-hook-form';
+
+import { Slot } from '@radix-ui/react-slot';
+
+import { Label } from '@/components/ui/label';
+import { cn } from '@/lib/utils';
+
+/**
+ * Form
+ *
+ * Context provider for a react-hook-form instance — a re-export of
+ * `FormProvider`. Spread a `useForm()` return value onto it, then render fields
+ * with `FormField` so the field parts (`FormLabel`, `FormControl`,
+ * `FormDescription`, `FormMessage`) can read the field's state and wire their
+ * `id` / `aria-*` together.
+ *
+ * @example
+ * ```tsx
+ * const form = useForm<Values>({ resolver: zodResolver(schema) });
+ *
+ * <Form {...form}>
+ *   <form onSubmit={form.handleSubmit((values) => save(values))}>
+ *     <FormField
+ *       control={form.control}
+ *       name="username"
+ *       render={({ field }) => (
+ *         <FormItem>
+ *           <FormLabel>Username</FormLabel>
+ *           <FormControl>
+ *             <Input {...field} />
+ *           </FormControl>
+ *           <FormDescription>Your public display name.</FormDescription>
+ *           <FormMessage />
+ *         </FormItem>
+ *       )}
+ *     />
+ *   </form>
+ * </Form>
+ * ```
+ */
+const Form = FormProvider;
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName;
+};
+
+const FormFieldContext = React.createContext<FormFieldContextValue | null>(
+  null
+);
+
+type FormItemContextValue = {
+  id: string;
+};
+
+const FormItemContext = React.createContext<FormItemContextValue | null>(null);
+
+/**
+ * FormField
+ *
+ * Connects a single field to react-hook-form via `Controller` and publishes the
+ * field name so the field parts inside it resolve their state and ids.
+ */
+function FormField<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>(props: ControllerProps<TFieldValues, TName>) {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+}
+
+/**
+ * useFormField
+ *
+ * Reads the active field's validation state plus the `id`s that link its label,
+ * control, description, and message. Must be called inside both a `FormField`
+ * and a `FormItem`.
+ */
+function useFormField() {
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const formContext = useFormContext();
+  const formState = useFormState({ name: fieldContext?.name });
+
+  if (!fieldContext) {
+    throw new Error('useFormField should be used within <FormField>');
+  }
+  if (!itemContext) {
+    throw new Error('useFormField should be used within <FormItem>');
+  }
+
+  const { id } = itemContext;
+  const { getFieldState } = formContext;
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  };
+}
+
+/**
+ * FormItemProps
+ *
+ * Props for the FormItem component.
+ */
+interface FormItemProps extends React.ComponentProps<'div'> {}
+
+/**
+ * FormItem
+ *
+ * Groups one field's label, control, description, and message, and generates
+ * the shared `id` that wires them together.
+ */
+function FormItem({ className, ...props }: FormItemProps) {
+  const id = React.useId();
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        data-slot="form-item"
+        className={cn(
+          // nexus-allow-numeric: vertical rhythm between label, control, description, message
+          'nx:grid nx:gap-2',
+          className
+        )}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  );
+}
+
+/**
+ * FormLabelProps
+ *
+ * Props for the FormLabel component.
+ */
+interface FormLabelProps extends React.ComponentProps<typeof Label> {}
+
+/**
+ * FormLabel
+ *
+ * Label for the field's control. Wired to the control via `htmlFor` and turns
+ * error-coloured when the field is invalid.
+ */
+function FormLabel({ className, ...props }: FormLabelProps) {
+  const { error, formItemId } = useFormField();
+
+  return (
+    <Label
+      data-slot="form-label"
+      data-error={!!error}
+      className={cn('nx:data-[error=true]:text-error-foreground', className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  );
+}
+
+/**
+ * FormControlProps
+ *
+ * Props for the FormControl component.
+ */
+interface FormControlProps extends React.ComponentProps<typeof Slot> {}
+
+/**
+ * FormControl
+ *
+ * Slot that wires the field's control to the surrounding `FormItem` — setting
+ * its `id`, `aria-invalid`, and `aria-describedby` (pointing at the description
+ * and, when invalid, the message).
+ */
+function FormControl(props: FormControlProps) {
+  const { error, formItemId, formDescriptionId, formMessageId } =
+    useFormField();
+
+  return (
+    <Slot
+      data-slot="form-control"
+      id={formItemId}
+      aria-describedby={
+        error ? `${formDescriptionId} ${formMessageId}` : formDescriptionId
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  );
+}
+
+/**
+ * FormDescriptionProps
+ *
+ * Props for the FormDescription component.
+ */
+interface FormDescriptionProps extends React.ComponentProps<'p'> {}
+
+/**
+ * FormDescription
+ *
+ * Helper text for the field, linked to the control via `aria-describedby`.
+ */
+function FormDescription({ className, ...props }: FormDescriptionProps) {
+  const { formDescriptionId } = useFormField();
+
+  return (
+    <p
+      data-slot="form-description"
+      id={formDescriptionId}
+      className={cn('nx:text-sm nx:text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * FormMessageProps
+ *
+ * Props for the FormMessage component.
+ */
+interface FormMessageProps extends React.ComponentProps<'p'> {}
+
+/**
+ * FormMessage
+ *
+ * Validation message for the field. Renders the field's error message, falling
+ * back to its `children`, and renders nothing when there is neither.
+ */
+function FormMessage({ className, children, ...props }: FormMessageProps) {
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error.message ?? '') : children;
+
+  if (!body) {
+    return null;
+  }
+
+  return (
+    <p
+      data-slot="form-message"
+      id={formMessageId}
+      className={cn('nx:text-sm nx:text-error-foreground', className)}
+      {...props}
+    >
+      {body}
+    </p>
+  );
+}
+
+export {
+  Form,
+  FormControl,
+  type FormControlProps,
+  FormDescription,
+  type FormDescriptionProps,
+  FormField,
+  FormItem,
+  type FormItemProps,
+  FormLabel,
+  type FormLabelProps,
+  FormMessage,
+  type FormMessageProps,
+  useFormField,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -20,6 +20,7 @@ export * from '@/components/ui/checkbox';
 export * from '@/components/ui/command';
 export * from '@/components/ui/dialog';
 export * from '@/components/ui/dropdown-menu';
+export * from '@/components/ui/form';
 export * from '@/components/ui/input';
 export * from '@/components/ui/input-otp';
 export * from '@/components/ui/label';

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -28,12 +28,13 @@ export default defineConfig({
       fileName: (format) => `index.${format === 'es' ? 'mjs' : 'js'}`,
     },
     rollupOptions: {
-      external: ['react', 'react-dom', 'react/jsx-runtime'],
+      external: ['react', 'react-dom', 'react/jsx-runtime', 'react-hook-form'],
       output: {
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
           'react/jsx-runtime': 'jsxRuntime',
+          'react-hook-form': 'ReactHookForm',
         },
       },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -514,6 +514,13 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.10.tgz#a2a1e3812d14525f725d011a73eceb41fef5bc1c"
   integrity sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==
 
+"@hookform/resolvers@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-5.4.0.tgz#89ff709a08576766fbef849e5ec60e549a888006"
+  integrity sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==
+  dependencies:
+    "@standard-schema/utils" "^0.3.0"
+
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.1.tgz#17c55ca7d426733fe3c561906b8173c336b40a77"
@@ -5904,6 +5911,11 @@ react-docgen@^8.0.0, react-docgen@^8.0.2:
   dependencies:
     scheduler "^0.27.0"
 
+react-hook-form@^7.77.0:
+  version "7.77.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.77.0.tgz#af7e1d90d00c0418a98cf00b6f9bd5b85587c6fb"
+  integrity sha512-Sslh9YDYc0GDlWT/lxasnIduNo4v3yyvqRGvmGKUre5AFjDs/HV9/OafHGD8d+sB2yoL4UIL9L8X9i0WlZZebg==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -7429,10 +7441,10 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-4.0.2.tgz#bc605eba49ce0fcd598c127fee1c236be3f22918"
   integrity sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==
 
-"zod@^3.25.0 || ^4.0.0":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-4.2.1.tgz#07f0388c7edbfd5f5a2466181cb4adf5b5dbd57b"
-  integrity sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==
+"zod@^3.25.0 || ^4.0.0", zod@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==
 
 zustand@^5.0.9:
   version "5.0.9"


### PR DESCRIPTION
## Summary

- Adapt shadcn/ui `form` into a Nexus component — react-hook-form context + accessible field plumbing.
- Exports `Form` (FormProvider), `FormField` (Controller), `FormItem`, `FormLabel`, `FormControl`, `FormDescription`, `FormMessage`, `useFormField`, and the part prop types.
- `FormControl` wires the control's `id` / `aria-invalid` / `aria-describedby`; `FormLabel` + `FormMessage` use `error-foreground`, `FormDescription` uses `muted-foreground`; `data-slot` per part; `FormItem` stacks its parts with `nx:gap-2`.
- `useFormField` uses live guard clauses (hooks-first, then `<FormField>` / `<FormItem>` checks) instead of shadcn's `{}`-default dead guard.
- Stories with play-fns: `Default`, `BasicValidation` (zod resolver), `SubmitSuccess`, `ShowErrors`, `WithDataAttributes`, `AllVariants`. Not opted into base-variants (per the issue).
- **Deps:** `react-hook-form` is an **optional `peerDependency`** (`peerDependenciesMeta.optional`) — kept in `devDependencies` for the workspace build/stories — and added to vite `rollupOptions.external`, so it is **not bundled** into `dist/index.mjs`. Bundling it would key rhf's React context to a second module instance, so a consumer's own `useForm()` wouldn't match the bundled `Controller`/`useFormContext`. `@hookform/resolvers` + `zod` stay story-only `devDependencies`; `zod` is pinned via a **root `resolutions`** entry (with a `//resolutions` rationale note) to dedupe `@hookform/resolvers`' broad range (`^3.25.0 || ^4.0.0`) so `zodResolver(schema)` typechecks.

## GitHub Issue

Closes #176

## Test Plan

- [x] `yarn workspace @nexus/react typecheck`
- [x] `yarn lint` (`eslint . --max-warnings 0`)
- [x] `yarn workspace @nexus/react audit:storybook-coverage --component form` — 0 missing / 0 drift
- [x] `yarn size-limit` — ESM 66.3 kB (< 68 kB limit, no bump needed); CSS 7.46 kB
- [ ] `yarn test:storybook` — Form play-fns (`SubmitSuccess` / `ShowErrors` / `WithDataAttributes`) exercised in CI; the browser suite doesn't run locally in the worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)
