### PR TITLE
feat(components): add sidebar component

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     {
       "name": "@nexus/react (ESM)",
       "path": "packages/react/dist/index.mjs",
-      "limit": "68 kB"
+      "limit": "70 kB"
     },
     {
       "name": "@nexus/react (CSS)",

--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -71,6 +71,11 @@
       "interactions": ["ClickInteraction", "KeyboardInteraction"],
       "equivalents": { "ClickInteraction": ["OpenCloseInteraction"] }
     },
+    {
+      "name": "Sidebar",
+      "showcase": "AllVariants",
+      "interactions": ["ClickInteraction", "KeyboardInteraction"]
+    },
     { "name": "Show", "showcase": "AllAxes", "sourceDir": "primitives" },
     { "name": "Hide", "showcase": "AllAxes", "sourceDir": "primitives" },
     { "name": "Switch", "showcase": "AllVariants" },

--- a/packages/react/src/components/ui/Sidebar.stories.tsx
+++ b/packages/react/src/components/ui/Sidebar.stories.tsx
@@ -1,0 +1,396 @@
+import * as React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  IconCalendar,
+  IconChevronRight,
+  IconFolder,
+  IconHome,
+  IconInbox,
+  IconLayoutGrid,
+  IconSearch,
+  IconSettings,
+  IconUser,
+} from '@tabler/icons-react';
+import { expect, userEvent } from 'storybook/test';
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+} from './sidebar';
+
+const meta: Meta<typeof Sidebar> = {
+  title: 'Components/Sidebar',
+  component: Sidebar,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Sidebar>;
+
+const NAV_ITEMS = [
+  { title: 'Home', icon: IconHome },
+  { title: 'Inbox', icon: IconInbox, badge: '4' },
+  { title: 'Calendar', icon: IconCalendar },
+  { title: 'Search', icon: IconSearch },
+  { title: 'Settings', icon: IconSettings },
+];
+
+/**
+ * The shared nav body used by most stories: a brand row, a "Platform" group of
+ * menu items, and an account footer. `props` flow straight through to `Sidebar`
+ * so each story can pick its `variant` / `collapsible` / `side`.
+ */
+function DemoSidebar(props: React.ComponentProps<typeof Sidebar>) {
+  return (
+    <Sidebar {...props}>
+      <SidebarHeader>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg" tooltip="Acme Inc">
+              <IconLayoutGrid />
+              <span>Acme Inc</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Platform</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {NAV_ITEMS.map((item) => {
+                const Icon = item.icon;
+                return (
+                  <SidebarMenuItem key={item.title}>
+                    <SidebarMenuButton
+                      tooltip={item.title}
+                      isActive={item.title === 'Home'}
+                    >
+                      <Icon />
+                      <span>{item.title}</span>
+                    </SidebarMenuButton>
+                    {item.badge && (
+                      <SidebarMenuBadge>{item.badge}</SidebarMenuBadge>
+                    )}
+                  </SidebarMenuItem>
+                );
+              })}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+      <SidebarFooter>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton tooltip="Account">
+              <IconUser />
+              <span>Account</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+      <SidebarRail />
+    </Sidebar>
+  );
+}
+
+/**
+ * The content region beside the sidebar — a top bar with the toggle plus some
+ * body copy. Kept tall so the docked, full-height sidebar reads naturally.
+ */
+function DemoInset({ children }: { children?: React.ReactNode }) {
+  return (
+    <SidebarInset>
+      <header className="flex h-16 items-center gap-2 border-b border-[var(--nx-color-border-default)] px-4">
+        <SidebarTrigger />
+        <span className="text-sm font-medium">Dashboard</span>
+      </header>
+      <div className="min-h-[20rem] p-4 text-sm text-[var(--nx-color-muted-foreground)]">
+        {children ?? 'Main content area.'}
+      </div>
+    </SidebarInset>
+  );
+}
+
+export const Default: Story = {
+  render: () => (
+    <SidebarProvider>
+      <DemoSidebar />
+      <DemoInset />
+    </SidebarProvider>
+  ),
+};
+
+export const Expanded: Story = {
+  render: () => (
+    <SidebarProvider defaultOpen>
+      <DemoSidebar />
+      <DemoInset />
+    </SidebarProvider>
+  ),
+};
+
+export const Collapsed: Story = {
+  name: 'Collapsed (icon)',
+  render: () => (
+    <SidebarProvider defaultOpen={false}>
+      <DemoSidebar collapsible="icon" />
+      <DemoInset>
+        Collapsed to an icon rail — hover a button to see its tooltip.
+      </DemoInset>
+    </SidebarProvider>
+  ),
+};
+
+export const WithSubmenu: Story = {
+  render: () => (
+    <SidebarProvider>
+      <Sidebar>
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel>Projects</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton isActive>
+                    <IconFolder />
+                    <span>Design System</span>
+                    <IconChevronRight className="nx:ml-auto" />
+                  </SidebarMenuButton>
+                  <SidebarMenuSub>
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton href="#tokens" isActive>
+                        Tokens
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton href="#components">
+                        Components
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton href="#documentation">
+                        Documentation
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                  </SidebarMenuSub>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+          <SidebarSeparator />
+          <SidebarGroup>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton>
+                    <IconInbox />
+                    <span>Inbox</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+        <SidebarRail />
+      </Sidebar>
+      <DemoInset />
+    </SidebarProvider>
+  ),
+};
+
+export const LoadingSkeleton: Story = {
+  render: () => (
+    <SidebarProvider>
+      <Sidebar>
+        <SidebarHeader>
+          <SidebarInput aria-label="Search" placeholder="Search…" />
+        </SidebarHeader>
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel>Loading</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <SidebarMenuItem key={i}>
+                    <SidebarMenuSkeleton showIcon />
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+        <SidebarRail />
+      </Sidebar>
+      <DemoInset />
+    </SidebarProvider>
+  ),
+};
+
+export const MobileDrawer: Story = {
+  parameters: {
+    viewport: { defaultViewport: 'mobile1' },
+  },
+  render: () => (
+    <SidebarProvider>
+      <DemoSidebar />
+      <DemoInset>
+        Below the Standard floor (1024px) the sidebar becomes a drawer — tap the
+        toggle to open it.
+      </DemoInset>
+    </SidebarProvider>
+  ),
+};
+
+export const WithDataAttributes: Story = {
+  render: () => (
+    <SidebarProvider>
+      <DemoSidebar variant="floating" side="right" />
+      <DemoInset />
+    </SidebarProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const sidebar = canvasElement.querySelector('[data-slot="sidebar"]');
+    await expect(sidebar).toBeInTheDocument();
+    await expect(sidebar).toHaveAttribute('data-variant', 'floating');
+    await expect(sidebar).toHaveAttribute('data-side', 'right');
+    await expect(sidebar).toHaveAttribute('data-state', 'expanded');
+
+    const trigger = canvasElement.querySelector(
+      '[data-slot="sidebar-trigger"]'
+    );
+    await expect(trigger).toBeInTheDocument();
+
+    const activeButton = canvasElement.querySelector(
+      '[data-slot="sidebar-menu-button"][data-active="true"]'
+    );
+    await expect(activeButton).toBeInTheDocument();
+  },
+};
+
+export const ClickInteraction: Story = {
+  render: () => (
+    <SidebarProvider>
+      <DemoSidebar />
+      <DemoInset />
+    </SidebarProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const sidebar = canvasElement.querySelector('[data-slot="sidebar"]');
+    const trigger = canvasElement.querySelector<HTMLButtonElement>(
+      '[data-slot="sidebar-trigger"]'
+    );
+    await expect(sidebar).toHaveAttribute('data-state', 'expanded');
+
+    await userEvent.click(trigger!);
+    await expect(sidebar).toHaveAttribute('data-state', 'collapsed');
+
+    await userEvent.click(trigger!);
+    await expect(sidebar).toHaveAttribute('data-state', 'expanded');
+  },
+};
+
+export const KeyboardInteraction: Story = {
+  render: () => (
+    <SidebarProvider>
+      <DemoSidebar />
+      <DemoInset />
+    </SidebarProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const sidebar = canvasElement.querySelector('[data-slot="sidebar"]');
+    await expect(sidebar).toHaveAttribute('data-state', 'expanded');
+
+    // Ctrl/Cmd+B toggles the sidebar from anywhere in the document.
+    await userEvent.keyboard('{Control>}b{/Control}');
+    await expect(sidebar).toHaveAttribute('data-state', 'collapsed');
+
+    await userEvent.keyboard('{Control>}b{/Control}');
+    await expect(sidebar).toHaveAttribute('data-state', 'expanded');
+  },
+};
+
+/**
+ * Visual grid reference for every `SidebarMenuButton` variant, size, and the
+ * `asChild` composition. Uses `collapsible="none"` and a bounded height so the
+ * panel sits inline (not viewport-fixed) — this is the export the base-variants
+ * generator reuses to render the sidebar across all 5 bases × 2 themes.
+ */
+export const AllVariants: Story = {
+  render: () => (
+    <div className="h-96 w-full overflow-hidden rounded-lg border border-[var(--nx-color-border-default)]">
+      <SidebarProvider style={{ minHeight: 'unset', height: '100%' }}>
+        <Sidebar collapsible="none">
+          <SidebarHeader>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton size="lg">
+                  <IconLayoutGrid />
+                  <span>Acme Inc</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarHeader>
+          <SidebarContent>
+            <SidebarGroup>
+              <SidebarGroupLabel>Variants</SidebarGroupLabel>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton isActive>
+                      <IconHome />
+                      <span>Active</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton variant="outline">
+                      <IconInbox />
+                      <span>Outline</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton size="sm">
+                      <IconCalendar />
+                      <span>Small</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton asChild>
+                      <a href="https://example.com">
+                        <IconSettings />
+                        <span>As link</span>
+                      </a>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          </SidebarContent>
+        </Sidebar>
+        <DemoInset />
+      </SidebarProvider>
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/Sidebar.stories.tsx
+++ b/packages/react/src/components/ui/Sidebar.stories.tsx
@@ -272,7 +272,11 @@ export const WithDataAttributes: Story = {
     </SidebarProvider>
   ),
   play: async ({ canvasElement }) => {
-    const sidebar = canvasElement.querySelector('[data-slot="sidebar"]');
+    // data-state / data-variant / data-side live on the desktop docked panel,
+    // which renders because the test viewport is above the `lg` floor.
+    const sidebar = canvasElement.querySelector(
+      '[data-slot="sidebar"][data-state]'
+    );
     await expect(sidebar).toBeInTheDocument();
     await expect(sidebar).toHaveAttribute('data-variant', 'floating');
     await expect(sidebar).toHaveAttribute('data-side', 'right');
@@ -298,7 +302,10 @@ export const ClickInteraction: Story = {
     </SidebarProvider>
   ),
   play: async ({ canvasElement }) => {
-    const sidebar = canvasElement.querySelector('[data-slot="sidebar"]');
+    // data-state lives on the desktop docked panel (test viewport ≥ `lg`).
+    const sidebar = canvasElement.querySelector(
+      '[data-slot="sidebar"][data-state]'
+    );
     const trigger = canvasElement.querySelector<HTMLButtonElement>(
       '[data-slot="sidebar-trigger"]'
     );
@@ -320,7 +327,10 @@ export const KeyboardInteraction: Story = {
     </SidebarProvider>
   ),
   play: async ({ canvasElement }) => {
-    const sidebar = canvasElement.querySelector('[data-slot="sidebar"]');
+    // data-state lives on the desktop docked panel (test viewport ≥ `lg`).
+    const sidebar = canvasElement.querySelector(
+      '[data-slot="sidebar"][data-state]'
+    );
     await expect(sidebar).toHaveAttribute('data-state', 'expanded');
 
     // Ctrl/Cmd+B toggles the sidebar from anywhere in the document.

--- a/packages/react/src/components/ui/Sidebar.stories.tsx
+++ b/packages/react/src/components/ui/Sidebar.stories.tsx
@@ -123,11 +123,11 @@ function DemoSidebar(props: React.ComponentProps<typeof Sidebar>) {
 function DemoInset({ children }: { children?: React.ReactNode }) {
   return (
     <SidebarInset>
-      <header className="flex h-16 items-center gap-2 border-b border-[var(--nx-color-border-default)] px-4">
+      <header className="nx:flex nx:h-16 nx:items-center nx:gap-2 nx:border-b nx:border-border-default nx:px-4">
         <SidebarTrigger />
-        <span className="text-sm font-medium">Dashboard</span>
+        <span className="nx:text-sm nx:font-medium">Dashboard</span>
       </header>
-      <div className="min-h-[20rem] p-4 text-sm text-[var(--nx-color-muted-foreground)]">
+      <div className="nx:min-h-[20rem] nx:p-4 nx:text-sm nx:text-muted-foreground">
         {children ?? 'Main content area.'}
       </div>
     </SidebarInset>
@@ -350,7 +350,7 @@ export const KeyboardInteraction: Story = {
  */
 export const AllVariants: Story = {
   render: () => (
-    <div className="h-96 w-full overflow-hidden rounded-lg border border-[var(--nx-color-border-default)]">
+    <div className="nx:h-96 nx:w-full nx:overflow-hidden nx:rounded-lg nx:border nx:border-border-default">
       <SidebarProvider style={{ minHeight: 'unset', height: '100%' }}>
         <Sidebar collapsible="none">
           <SidebarHeader>

--- a/packages/react/src/components/ui/sidebar.tsx
+++ b/packages/react/src/components/ui/sidebar.tsx
@@ -289,8 +289,9 @@ function Sidebar({
           data-slot="sidebar"
           data-mobile="true"
           side={side}
+          showCloseButton={false}
           className={cn(
-            'nx:w-(--sidebar-width) nx:bg-nav-background nx:p-0 nx:text-nav-foreground nx:[&>button]:hidden',
+            'nx:w-(--sidebar-width) nx:bg-nav-background nx:p-0 nx:text-nav-foreground',
             className
           )}
           style={
@@ -850,6 +851,7 @@ function SidebarMenuButton({
   const button = (
     <Comp
       data-slot="sidebar-menu-button"
+      data-variant={variant}
       data-size={size}
       data-active={isActive}
       className={cn(sidebarMenuButtonVariants({ variant, size }), className)}

--- a/packages/react/src/components/ui/sidebar.tsx
+++ b/packages/react/src/components/ui/sidebar.tsx
@@ -1,0 +1,1144 @@
+import * as React from 'react';
+
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { IconLayoutSidebar } from '@/lib/icons';
+import { cn } from '@/lib/utils';
+
+const SIDEBAR_COOKIE_NAME = 'sidebar_state';
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+const SIDEBAR_WIDTH = '16rem';
+const SIDEBAR_WIDTH_MOBILE = '18rem';
+const SIDEBAR_WIDTH_ICON = '3rem';
+const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
+
+/**
+ * SidebarContextProps
+ *
+ * Shape of the context shared by `SidebarProvider` with every sidebar part.
+ */
+interface SidebarContextProps {
+  state: 'expanded' | 'collapsed';
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  openMobile: boolean;
+  setOpenMobile: (open: boolean) => void;
+  isMobile: boolean;
+  toggleSidebar: () => void;
+}
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null);
+
+/**
+ * useSidebar
+ *
+ * Reads the sidebar context (open state, mobile state, and the toggle helper).
+ * Must be called within a `SidebarProvider`; throws otherwise.
+ *
+ * @example
+ * ```tsx
+ * const { state, toggleSidebar } = useSidebar();
+ * ```
+ */
+function useSidebar() {
+  const context = React.useContext(SidebarContext);
+  if (!context) {
+    throw new Error('useSidebar must be used within a SidebarProvider.');
+  }
+
+  return context;
+}
+
+/**
+ * SidebarProviderProps
+ *
+ * Props for the SidebarProvider component.
+ */
+interface SidebarProviderProps extends React.ComponentProps<'div'> {
+  /**
+   * Whether the sidebar starts open when uncontrolled.
+   * @default true
+   */
+  defaultOpen?: boolean;
+  /**
+   * Controlled open state. Pair with `onOpenChange` to control externally.
+   */
+  open?: boolean;
+  /**
+   * Called when the open state changes (in controlled mode).
+   */
+  onOpenChange?: (open: boolean) => void;
+}
+
+/**
+ * SidebarProvider
+ *
+ * Owns the sidebar's open state, the `Ctrl/Cmd+B` keyboard shortcut, and cookie
+ * persistence. Wrap your app shell in it; every sidebar part reads its context.
+ * Renders a `TooltipProvider` so collapsed-icon tooltips work out of the box.
+ *
+ * @example
+ * ```tsx
+ * <SidebarProvider>
+ *   <Sidebar>…</Sidebar>
+ *   <SidebarInset>…</SidebarInset>
+ * </SidebarProvider>
+ * ```
+ */
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  className,
+  style,
+  children,
+  ...props
+}: SidebarProviderProps) {
+  const isMobile = useIsMobile();
+  const [openMobile, setOpenMobile] = React.useState(false);
+
+  // Internal open state; openProp/setOpenProp take over when controlled.
+  const [_open, _setOpen] = React.useState(defaultOpen);
+  const open = openProp ?? _open;
+  const setOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === 'function' ? value(open) : value;
+      if (setOpenProp) {
+        setOpenProp(openState);
+      } else {
+        _setOpen(openState);
+      }
+
+      // Persist the open state across reloads.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+    },
+    [setOpenProp, open]
+  );
+
+  const toggleSidebar = React.useCallback(() => {
+    return isMobile
+      ? setOpenMobile((value) => !value)
+      : setOpen((value) => !value);
+  }, [isMobile, setOpen, setOpenMobile]);
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault();
+        toggleSidebar();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [toggleSidebar]);
+
+  // Drives data-state="expanded" | "collapsed" for the styling hooks below.
+  const state = open ? 'expanded' : 'collapsed';
+
+  const contextValue = React.useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+    }),
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+  );
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <TooltipProvider delayDuration={0}>
+        <div
+          data-slot="sidebar-wrapper"
+          style={
+            {
+              '--sidebar-width': SIDEBAR_WIDTH,
+              '--sidebar-width-icon': SIDEBAR_WIDTH_ICON,
+              ...style,
+            } as React.CSSProperties
+          }
+          className={cn(
+            'nx:group/sidebar-wrapper nx:flex nx:min-h-svh nx:w-full nx:has-data-[variant=inset]:bg-nav-background',
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </div>
+      </TooltipProvider>
+    </SidebarContext.Provider>
+  );
+}
+
+/**
+ * SidebarProps
+ *
+ * Props for the Sidebar component.
+ */
+interface SidebarProps extends React.ComponentProps<'div'> {
+  /**
+   * Which edge the sidebar docks to.
+   * @default 'left'
+   */
+  side?: 'left' | 'right';
+  /**
+   * Visual treatment: flush `sidebar`, detached `floating`, or `inset` (pairs
+   * with `SidebarInset` for a card-like main region).
+   * @default 'sidebar'
+   */
+  variant?: 'sidebar' | 'floating' | 'inset';
+  /**
+   * Collapse behaviour: slide `offcanvas`, shrink to an `icon` rail, or `none`.
+   * @default 'offcanvas'
+   */
+  collapsible?: 'offcanvas' | 'icon' | 'none';
+}
+
+/**
+ * Sidebar
+ *
+ * The sidebar panel. On viewports below the Standard floor (`lg`) it renders as
+ * a Sheet drawer; at or above `lg` it docks to the chosen `side` and collapses
+ * per the `collapsible` mode.
+ *
+ * @example
+ * ```tsx
+ * <Sidebar collapsible="icon">
+ *   <SidebarContent>…</SidebarContent>
+ * </Sidebar>
+ * ```
+ */
+function Sidebar({
+  side = 'left',
+  variant = 'sidebar',
+  collapsible = 'offcanvas',
+  className,
+  children,
+  ...props
+}: SidebarProps) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+
+  if (collapsible === 'none') {
+    return (
+      <div
+        data-slot="sidebar"
+        className={cn(
+          'nx:flex nx:h-full nx:w-(--sidebar-width) nx:flex-col nx:bg-nav-background nx:text-nav-foreground',
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          data-slot="sidebar"
+          data-mobile="true"
+          className="nx:w-(--sidebar-width) nx:bg-nav-background nx:p-0 nx:text-nav-foreground nx:[&>button]:hidden"
+          style={
+            {
+              '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="nx:sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="nx:flex nx:h-full nx:w-full nx:flex-col">
+            {children}
+          </div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <div
+      className="nx:group nx:peer nx:hidden nx:text-nav-foreground nx:lg:block"
+      data-state={state}
+      data-collapsible={state === 'collapsed' ? collapsible : ''}
+      data-variant={variant}
+      data-side={side}
+      data-slot="sidebar"
+    >
+      {/* Handles the sidebar gap on desktop. */}
+      <div
+        data-slot="sidebar-gap"
+        className={cn(
+          'nx:relative nx:w-(--sidebar-width) nx:bg-transparent nx:transition-[width] nx:duration-200 nx:ease-linear',
+          'nx:group-data-[collapsible=offcanvas]:w-0',
+          'nx:group-data-[side=right]:rotate-180',
+          variant === 'floating' || variant === 'inset'
+            ? 'nx:group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+1rem)]'
+            : 'nx:group-data-[collapsible=icon]:w-(--sidebar-width-icon)'
+        )}
+      />
+      <div
+        data-slot="sidebar-container"
+        className={cn(
+          'nx:fixed nx:inset-y-0 nx:z-sticky nx:hidden nx:h-svh nx:w-(--sidebar-width) nx:transition-[left,right,width] nx:duration-200 nx:ease-linear nx:lg:flex',
+          side === 'left'
+            ? 'nx:left-0 nx:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
+            : 'nx:right-0 nx:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
+          // Floating and inset variants gain padding around the panel; the
+          // +1rem in the icon-collapse width below matches this inset.
+          // nexus-allow-numeric: floating/inset panel inset
+          (variant === 'floating' || variant === 'inset') && 'nx:p-2',
+          variant === 'floating' || variant === 'inset'
+            ? 'nx:group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+1rem+2px)]'
+            : 'nx:group-data-[collapsible=icon]:w-(--sidebar-width-icon) nx:group-data-[side=left]:border-r nx:group-data-[side=right]:border-l nx:border-nav-border',
+          className
+        )}
+        {...props}
+      >
+        <div
+          data-slot="sidebar-inner"
+          className="nx:flex nx:h-full nx:w-full nx:flex-col nx:bg-nav-background nx:group-data-[variant=floating]:rounded-lg nx:group-data-[variant=floating]:border nx:group-data-[variant=floating]:border-nav-border nx:group-data-[variant=floating]:shadow-sm"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * SidebarTriggerProps
+ *
+ * Props for the SidebarTrigger component.
+ */
+interface SidebarTriggerProps extends React.ComponentProps<typeof Button> {}
+
+/**
+ * SidebarTrigger
+ *
+ * Icon button that toggles the sidebar. Place it in your top bar or sidebar
+ * header. Also reachable via `Ctrl/Cmd+B`.
+ */
+function SidebarTrigger({ className, onClick, ...props }: SidebarTriggerProps) {
+  const { toggleSidebar } = useSidebar();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    onClick?.(event);
+    toggleSidebar();
+  };
+
+  return (
+    <Button
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon"
+      className={cn('nx:size-7', className)}
+      onClick={handleClick}
+      {...props}
+    >
+      <IconLayoutSidebar />
+      <span className="nx:sr-only">Toggle Sidebar</span>
+    </Button>
+  );
+}
+
+/**
+ * SidebarRailProps
+ *
+ * Props for the SidebarRail component.
+ */
+interface SidebarRailProps extends React.ComponentProps<'button'> {}
+
+/**
+ * SidebarRail
+ *
+ * Thin hit-target along the sidebar's inner edge that toggles it on click —
+ * a quick affordance for collapsing/expanding without leaving the panel.
+ */
+function SidebarRail({ className, ...props }: SidebarRailProps) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <button
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        'nx:absolute nx:inset-y-0 nx:z-sticky nx:hidden nx:w-4 nx:-translate-x-1/2 nx:transition-all nx:ease-linear nx:group-data-[side=left]:-right-4 nx:group-data-[side=right]:left-0 nx:after:absolute nx:after:inset-y-0 nx:after:left-1/2 nx:after:w-[2px] nx:hover:after:bg-nav-border nx:lg:flex',
+        'nx:in-data-[side=left]:cursor-w-resize nx:in-data-[side=right]:cursor-e-resize',
+        'nx:[[data-side=left][data-state=collapsed]_&]:cursor-e-resize nx:[[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
+        'nx:group-data-[collapsible=offcanvas]:translate-x-0 nx:group-data-[collapsible=offcanvas]:after:left-full nx:hover:group-data-[collapsible=offcanvas]:bg-nav-background',
+        'nx:[[data-side=left][data-collapsible=offcanvas]_&]:-right-2',
+        'nx:[[data-side=right][data-collapsible=offcanvas]_&]:-left-2',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarInsetProps
+ *
+ * Props for the SidebarInset component.
+ */
+interface SidebarInsetProps extends React.ComponentProps<'main'> {}
+
+/**
+ * SidebarInset
+ *
+ * The main content region beside the sidebar. With `variant="inset"` it floats
+ * as a rounded card; otherwise it fills the remaining width.
+ */
+function SidebarInset({ className, ...props }: SidebarInsetProps) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        'nx:relative nx:flex nx:w-full nx:flex-1 nx:flex-col nx:bg-background',
+        'nx:lg:peer-data-[variant=inset]:m-2 nx:lg:peer-data-[variant=inset]:ml-0 nx:lg:peer-data-[variant=inset]:rounded-xl nx:lg:peer-data-[variant=inset]:shadow-sm nx:lg:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarInputProps
+ *
+ * Props for the SidebarInput component.
+ */
+interface SidebarInputProps extends React.ComponentProps<typeof Input> {}
+
+/**
+ * SidebarInput
+ *
+ * An `Input` pre-styled to sit inside the sidebar (e.g. a filter field).
+ */
+function SidebarInput({ className, ...props }: SidebarInputProps) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      className={cn('nx:h-8 nx:w-full nx:bg-background', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarHeaderProps
+ *
+ * Props for the SidebarHeader component.
+ */
+interface SidebarHeaderProps extends React.ComponentProps<'div'> {}
+
+/**
+ * SidebarHeader
+ *
+ * Top region of the sidebar — typically the brand mark or a workspace switcher.
+ */
+function SidebarHeader({ className, ...props }: SidebarHeaderProps) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      // nexus-allow-numeric: sidebar nav-chrome rhythm
+      className={cn('nx:flex nx:flex-col nx:gap-2 nx:p-2', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarFooterProps
+ *
+ * Props for the SidebarFooter component.
+ */
+interface SidebarFooterProps extends React.ComponentProps<'div'> {}
+
+/**
+ * SidebarFooter
+ *
+ * Bottom region of the sidebar — typically a user menu or sign-out control.
+ */
+function SidebarFooter({ className, ...props }: SidebarFooterProps) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      // nexus-allow-numeric: sidebar nav-chrome rhythm
+      className={cn('nx:flex nx:flex-col nx:gap-2 nx:p-2', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarSeparatorProps
+ *
+ * Props for the SidebarSeparator component.
+ */
+interface SidebarSeparatorProps extends React.ComponentProps<
+  typeof Separator
+> {}
+
+/**
+ * SidebarSeparator
+ *
+ * A `Separator` inset to align with the sidebar's content padding.
+ */
+function SidebarSeparator({ className, ...props }: SidebarSeparatorProps) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      className={cn('nx:mx-2 nx:w-auto nx:bg-nav-border', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarContentProps
+ *
+ * Props for the SidebarContent component.
+ */
+interface SidebarContentProps extends React.ComponentProps<'div'> {}
+
+/**
+ * SidebarContent
+ *
+ * Scrollable middle region holding the sidebar's groups and menus. Hides
+ * overflow when collapsed to the icon rail.
+ */
+function SidebarContent({ className, ...props }: SidebarContentProps) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      className={cn(
+        // nexus-allow-numeric: sidebar nav-chrome rhythm
+        'nx:flex nx:min-h-0 nx:flex-1 nx:flex-col nx:gap-2 nx:overflow-auto nx:group-data-[collapsible=icon]:overflow-hidden',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarGroupProps
+ *
+ * Props for the SidebarGroup component.
+ */
+interface SidebarGroupProps extends React.ComponentProps<'div'> {}
+
+/**
+ * SidebarGroup
+ *
+ * A labelled section of the sidebar, grouping related menu items.
+ */
+function SidebarGroup({ className, ...props }: SidebarGroupProps) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      className={cn(
+        // nexus-allow-numeric: sidebar nav-chrome rhythm
+        'nx:relative nx:flex nx:w-full nx:min-w-0 nx:flex-col nx:p-2',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarGroupLabelProps
+ *
+ * Props for the SidebarGroupLabel component.
+ */
+interface SidebarGroupLabelProps extends React.ComponentProps<'div'> {
+  /**
+   * Render as the child element via Radix `Slot` (e.g. an accessible heading).
+   * @default false
+   */
+  asChild?: boolean;
+}
+
+/**
+ * SidebarGroupLabel
+ *
+ * The heading above a `SidebarGroup`. Fades out when the sidebar collapses to
+ * the icon rail.
+ */
+function SidebarGroupLabel({
+  className,
+  asChild = false,
+  ...props
+}: SidebarGroupLabelProps) {
+  const Comp = asChild ? Slot : 'div';
+
+  return (
+    <Comp
+      data-slot="sidebar-group-label"
+      className={cn(
+        // nexus-allow-numeric: sidebar nav-chrome rhythm
+        'nx:flex nx:h-8 nx:shrink-0 nx:items-center nx:rounded-md nx:px-2 nx:text-xs nx:font-medium nx:text-nav-muted-foreground nx:transition-[margin,opacity] nx:duration-200 nx:ease-linear nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&>svg]:size-4 nx:[&>svg]:shrink-0',
+        'nx:group-data-[collapsible=icon]:-mt-8 nx:group-data-[collapsible=icon]:opacity-0',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarGroupActionProps
+ *
+ * Props for the SidebarGroupAction component.
+ */
+interface SidebarGroupActionProps extends React.ComponentProps<'button'> {
+  /**
+   * Render as the child element via Radix `Slot`.
+   * @default false
+   */
+  asChild?: boolean;
+}
+
+/**
+ * SidebarGroupAction
+ *
+ * A small action button pinned to a group's top-right (e.g. "add" next to a
+ * group label). Hidden when collapsed to the icon rail.
+ */
+function SidebarGroupAction({
+  className,
+  asChild = false,
+  ...props
+}: SidebarGroupActionProps) {
+  const Comp = asChild ? Slot : 'button';
+
+  return (
+    <Comp
+      data-slot="sidebar-group-action"
+      className={cn(
+        'nx:absolute nx:top-3.5 nx:right-3 nx:flex nx:aspect-square nx:w-5 nx:items-center nx:justify-center nx:rounded-md nx:p-0 nx:text-nav-foreground nx:transition-transform nx:hover:bg-nav-item-hover nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&>svg]:size-4 nx:[&>svg]:shrink-0',
+        // Enlarges the hit area on touch viewports.
+        'nx:after:absolute nx:after:-inset-2 nx:lg:after:hidden',
+        'nx:group-data-[collapsible=icon]:hidden',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarGroupContentProps
+ *
+ * Props for the SidebarGroupContent component.
+ */
+interface SidebarGroupContentProps extends React.ComponentProps<'div'> {}
+
+/**
+ * SidebarGroupContent
+ *
+ * Wrapper for the body of a `SidebarGroup` (usually a `SidebarMenu`).
+ */
+function SidebarGroupContent({
+  className,
+  ...props
+}: SidebarGroupContentProps) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      className={cn('nx:w-full nx:text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarMenuProps
+ *
+ * Props for the SidebarMenu component.
+ */
+interface SidebarMenuProps extends React.ComponentProps<'ul'> {}
+
+/**
+ * SidebarMenu
+ *
+ * The `<ul>` holding a group's navigation items.
+ */
+function SidebarMenu({ className, ...props }: SidebarMenuProps) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      className={cn(
+        // nexus-allow-numeric: sidebar nav-chrome rhythm
+        'nx:flex nx:w-full nx:min-w-0 nx:flex-col nx:gap-1',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarMenuItemProps
+ *
+ * Props for the SidebarMenuItem component.
+ */
+interface SidebarMenuItemProps extends React.ComponentProps<'li'> {}
+
+/**
+ * SidebarMenuItem
+ *
+ * A single `<li>` in a `SidebarMenu`; wraps a `SidebarMenuButton` plus optional
+ * action/badge/sub-menu.
+ */
+function SidebarMenuItem({ className, ...props }: SidebarMenuItemProps) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      className={cn('nx:group/menu-item nx:relative', className)}
+      {...props}
+    />
+  );
+}
+
+const sidebarMenuButtonVariants = cva(
+  cn(
+    // nexus-allow-numeric: sidebar nav-chrome rhythm
+    'nx:peer/menu-button nx:flex nx:w-full nx:items-center nx:gap-2 nx:overflow-hidden nx:rounded-md nx:p-2 nx:text-left nx:text-sm nx:transition-[width,height,padding]',
+    'nx:group-has-data-[slot=sidebar-menu-action]/menu-item:pr-8 nx:group-data-[collapsible=icon]:size-8! nx:group-data-[collapsible=icon]:p-2!',
+    'nx:hover:bg-nav-item-hover nx:active:bg-nav-item-active',
+    'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
+    'nx:disabled:pointer-events-none nx:disabled:opacity-50 nx:aria-disabled:pointer-events-none nx:aria-disabled:opacity-50',
+    'nx:data-[active=true]:bg-nav-item-active nx:data-[active=true]:font-medium',
+    'nx:data-[state=open]:hover:bg-nav-item-hover',
+    'nx:[&>span:last-child]:truncate nx:[&>svg]:size-4 nx:[&>svg]:shrink-0'
+  ),
+  {
+    variants: {
+      variant: {
+        default: 'nx:hover:bg-nav-item-hover',
+        outline:
+          'nx:border nx:border-nav-border nx:bg-background nx:hover:bg-nav-item-hover',
+      },
+      size: {
+        default: 'nx:h-8 nx:text-sm',
+        sm: 'nx:h-7 nx:text-xs',
+        lg: 'nx:h-12 nx:text-sm nx:group-data-[collapsible=icon]:p-0!',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+/**
+ * SidebarMenuButtonProps
+ *
+ * Props for the SidebarMenuButton component.
+ */
+interface SidebarMenuButtonProps
+  extends
+    React.ComponentProps<'button'>,
+    VariantProps<typeof sidebarMenuButtonVariants> {
+  /**
+   * Render as the child element via Radix `Slot` (e.g. an `<a>` or router link).
+   * @default false
+   */
+  asChild?: boolean;
+  /**
+   * Marks the item as the current page; styles it as selected.
+   * @default false
+   */
+  isActive?: boolean;
+  /**
+   * Tooltip shown only when the sidebar is collapsed to the icon rail. Pass a
+   * string for label-only, or `TooltipContent` props for full control.
+   */
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>;
+}
+
+/**
+ * SidebarMenuButton
+ *
+ * The primary clickable nav item. When the sidebar collapses to icons, an
+ * optional `tooltip` surfaces the label on hover.
+ *
+ * @example
+ * ```tsx
+ * <SidebarMenuButton isActive tooltip="Inbox">
+ *   <IconInbox /> <span>Inbox</span>
+ * </SidebarMenuButton>
+ * ```
+ */
+function SidebarMenuButton({
+  asChild = false,
+  isActive = false,
+  variant = 'default',
+  size = 'default',
+  tooltip,
+  className,
+  ...props
+}: SidebarMenuButtonProps) {
+  const Comp = asChild ? Slot : 'button';
+  const { isMobile, state } = useSidebar();
+
+  const button = (
+    <Comp
+      data-slot="sidebar-menu-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+
+  if (!tooltip) {
+    return button;
+  }
+
+  const tooltipProps =
+    typeof tooltip === 'string' ? { children: tooltip } : tooltip;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent
+        side="right"
+        align="center"
+        hidden={state !== 'collapsed' || isMobile}
+        {...tooltipProps}
+      />
+    </Tooltip>
+  );
+}
+
+/**
+ * SidebarMenuActionProps
+ *
+ * Props for the SidebarMenuAction component.
+ */
+interface SidebarMenuActionProps extends React.ComponentProps<'button'> {
+  /**
+   * Render as the child element via Radix `Slot`.
+   * @default false
+   */
+  asChild?: boolean;
+  /**
+   * Reveal the action only on hover/focus of the menu item (vs. always shown).
+   * @default false
+   */
+  showOnHover?: boolean;
+}
+
+/**
+ * SidebarMenuAction
+ *
+ * A secondary action pinned to a menu item's right edge (e.g. a "more" button).
+ */
+function SidebarMenuAction({
+  className,
+  asChild = false,
+  showOnHover = false,
+  ...props
+}: SidebarMenuActionProps) {
+  const Comp = asChild ? Slot : 'button';
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-action"
+      className={cn(
+        'nx:absolute nx:top-1.5 nx:right-1 nx:flex nx:aspect-square nx:w-5 nx:items-center nx:justify-center nx:rounded-md nx:p-0 nx:text-nav-foreground nx:transition-transform nx:hover:bg-nav-item-hover nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&>svg]:size-4 nx:[&>svg]:shrink-0',
+        // Enlarges the hit area on touch viewports.
+        'nx:after:absolute nx:after:-inset-2 nx:lg:after:hidden',
+        'nx:peer-data-[size=sm]/menu-button:top-1',
+        'nx:peer-data-[size=default]/menu-button:top-1.5',
+        'nx:peer-data-[size=lg]/menu-button:top-2.5',
+        'nx:group-data-[collapsible=icon]:hidden',
+        showOnHover &&
+          'nx:group-focus-within/menu-item:opacity-100 nx:group-hover/menu-item:opacity-100 nx:data-[state=open]:opacity-100 nx:lg:opacity-0',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarMenuBadgeProps
+ *
+ * Props for the SidebarMenuBadge component.
+ */
+interface SidebarMenuBadgeProps extends React.ComponentProps<'div'> {}
+
+/**
+ * SidebarMenuBadge
+ *
+ * A count or status pill aligned to a menu item's right edge.
+ */
+function SidebarMenuBadge({ className, ...props }: SidebarMenuBadgeProps) {
+  return (
+    <div
+      data-slot="sidebar-menu-badge"
+      className={cn(
+        // nexus-allow-numeric: sidebar nav-chrome rhythm
+        'nx:pointer-events-none nx:absolute nx:right-1 nx:flex nx:h-5 nx:min-w-5 nx:items-center nx:justify-center nx:rounded-md nx:px-1 nx:text-xs nx:font-medium nx:text-nav-foreground nx:tabular-nums nx:select-none',
+        'nx:peer-data-[size=sm]/menu-button:top-1',
+        'nx:peer-data-[size=default]/menu-button:top-1.5',
+        'nx:peer-data-[size=lg]/menu-button:top-2.5',
+        'nx:group-data-[collapsible=icon]:hidden',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarMenuSkeletonProps
+ *
+ * Props for the SidebarMenuSkeleton component.
+ */
+interface SidebarMenuSkeletonProps extends React.ComponentProps<'div'> {
+  /**
+   * Render a leading icon-sized skeleton block alongside the text bar.
+   * @default false
+   */
+  showIcon?: boolean;
+}
+
+/**
+ * SidebarMenuSkeleton
+ *
+ * Loading placeholder for a menu row. Render a cluster while nav data loads.
+ */
+function SidebarMenuSkeleton({
+  className,
+  showIcon = false,
+  ...props
+}: SidebarMenuSkeletonProps) {
+  // Vary the text-bar width (50–90%) so a stack of skeletons looks organic.
+  const width = React.useMemo(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`;
+  }, []);
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      className={cn(
+        // nexus-allow-numeric: sidebar nav-chrome rhythm
+        'nx:flex nx:h-8 nx:items-center nx:gap-2 nx:rounded-md nx:px-2',
+        className
+      )}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          data-slot="sidebar-menu-skeleton-icon"
+          className="nx:size-4 nx:rounded-md"
+        />
+      )}
+      <Skeleton
+        data-slot="sidebar-menu-skeleton-text"
+        className="nx:h-4 nx:max-w-(--skeleton-width) nx:flex-1"
+        style={
+          {
+            '--skeleton-width': width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  );
+}
+
+/**
+ * SidebarMenuSubProps
+ *
+ * Props for the SidebarMenuSub component.
+ */
+interface SidebarMenuSubProps extends React.ComponentProps<'ul'> {}
+
+/**
+ * SidebarMenuSub
+ *
+ * The `<ul>` for a nested submenu, drawn with a left guide rule. Hidden when
+ * collapsed to the icon rail.
+ */
+function SidebarMenuSub({ className, ...props }: SidebarMenuSubProps) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      className={cn(
+        // nexus-allow-numeric: sidebar nav-chrome rhythm
+        'nx:mx-3.5 nx:flex nx:min-w-0 nx:translate-x-px nx:flex-col nx:gap-1 nx:border-l nx:border-nav-border nx:px-2.5 nx:py-0.5',
+        'nx:group-data-[collapsible=icon]:hidden',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarMenuSubItemProps
+ *
+ * Props for the SidebarMenuSubItem component.
+ */
+interface SidebarMenuSubItemProps extends React.ComponentProps<'li'> {}
+
+/**
+ * SidebarMenuSubItem
+ *
+ * A single `<li>` within a `SidebarMenuSub`.
+ */
+function SidebarMenuSubItem({ className, ...props }: SidebarMenuSubItemProps) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      className={cn('nx:group/menu-sub-item nx:relative', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * SidebarMenuSubButtonProps
+ *
+ * Props for the SidebarMenuSubButton component.
+ */
+interface SidebarMenuSubButtonProps extends React.ComponentProps<'a'> {
+  /**
+   * Render as the child element via Radix `Slot` (e.g. a router link).
+   * @default false
+   */
+  asChild?: boolean;
+  /**
+   * Text size of the sub-item.
+   * @default 'md'
+   */
+  size?: 'sm' | 'md';
+  /**
+   * Marks the sub-item as the current page; styles it as selected.
+   * @default false
+   */
+  isActive?: boolean;
+}
+
+/**
+ * SidebarMenuSubButton
+ *
+ * A clickable item inside a submenu, rendered as an `<a>` by default.
+ */
+function SidebarMenuSubButton({
+  asChild = false,
+  size = 'md',
+  isActive = false,
+  className,
+  ...props
+}: SidebarMenuSubButtonProps) {
+  const Comp = asChild ? Slot : 'a';
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-sub-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(
+        // nexus-allow-numeric: sidebar nav-chrome rhythm
+        'nx:flex nx:h-7 nx:min-w-0 nx:-translate-x-px nx:items-center nx:gap-2 nx:overflow-hidden nx:rounded-md nx:px-2 nx:text-nav-foreground nx:outline-hidden nx:hover:bg-nav-item-hover nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:active:bg-nav-item-active nx:disabled:pointer-events-none nx:disabled:opacity-50 nx:aria-disabled:pointer-events-none nx:aria-disabled:opacity-50 nx:[&>span:last-child]:truncate nx:[&>svg]:size-4 nx:[&>svg]:shrink-0 nx:[&>svg]:text-nav-foreground',
+        'nx:data-[active=true]:bg-nav-item-active',
+        size === 'sm' && 'nx:text-xs',
+        size === 'md' && 'nx:text-sm',
+        'nx:group-data-[collapsible=icon]:hidden',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  type SidebarContentProps,
+  SidebarFooter,
+  type SidebarFooterProps,
+  SidebarGroup,
+  SidebarGroupAction,
+  type SidebarGroupActionProps,
+  SidebarGroupContent,
+  type SidebarGroupContentProps,
+  SidebarGroupLabel,
+  type SidebarGroupLabelProps,
+  type SidebarGroupProps,
+  SidebarHeader,
+  type SidebarHeaderProps,
+  SidebarInput,
+  type SidebarInputProps,
+  SidebarInset,
+  type SidebarInsetProps,
+  SidebarMenu,
+  SidebarMenuAction,
+  type SidebarMenuActionProps,
+  SidebarMenuBadge,
+  type SidebarMenuBadgeProps,
+  SidebarMenuButton,
+  type SidebarMenuButtonProps,
+  sidebarMenuButtonVariants,
+  SidebarMenuItem,
+  type SidebarMenuItemProps,
+  type SidebarMenuProps,
+  SidebarMenuSkeleton,
+  type SidebarMenuSkeletonProps,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  type SidebarMenuSubButtonProps,
+  SidebarMenuSubItem,
+  type SidebarMenuSubItemProps,
+  type SidebarMenuSubProps,
+  type SidebarProps,
+  SidebarProvider,
+  type SidebarProviderProps,
+  SidebarRail,
+  type SidebarRailProps,
+  SidebarSeparator,
+  type SidebarSeparatorProps,
+  SidebarTrigger,
+  type SidebarTriggerProps,
+  useSidebar,
+};

--- a/packages/react/src/components/ui/sidebar.tsx
+++ b/packages/react/src/components/ui/sidebar.tsx
@@ -31,6 +31,16 @@ const SIDEBAR_WIDTH_MOBILE = '18rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
 
+/** Whether the event target is a text-entry element (input, textarea, or contenteditable). */
+function isEditableTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) return false;
+  return (
+    target.isContentEditable ||
+    target.tagName === 'INPUT' ||
+    target.tagName === 'TEXTAREA'
+  );
+}
+
 /**
  * SidebarContextProps
  *
@@ -39,7 +49,7 @@ const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
 interface SidebarContextProps {
   state: 'expanded' | 'collapsed';
   open: boolean;
-  setOpen: (open: boolean) => void;
+  setOpen: (value: boolean | ((value: boolean) => boolean)) => void;
   openMobile: boolean;
   setOpenMobile: (open: boolean) => void;
   isMobile: boolean;
@@ -76,7 +86,18 @@ function useSidebar() {
 interface SidebarProviderProps extends React.ComponentProps<'div'> {
   /**
    * Whether the sidebar starts open when uncontrolled.
+   *
+   * When uncontrolled, the provider persists the open state to a `sidebar_state`
+   * cookie. It does not read the cookie back — restore across reloads by reading
+   * it server-side and passing the result here.
    * @default true
+   * @example
+   * ```tsx
+   * // Server Component (e.g. Next.js app/layout.tsx)
+   * const store = await cookies();
+   * const defaultOpen = store.get('sidebar_state')?.value !== 'false';
+   * return <SidebarProvider defaultOpen={defaultOpen}>{children}</SidebarProvider>;
+   * ```
    */
   defaultOpen?: boolean;
   /**
@@ -124,11 +145,11 @@ function SidebarProvider({
       const openState = typeof value === 'function' ? value(open) : value;
       if (setOpenProp) {
         setOpenProp(openState);
-      } else {
-        _setOpen(openState);
+        return;
       }
 
-      // Persist the open state across reloads.
+      _setOpen(openState);
+      // Persist uncontrolled open state to a cookie for server-side restore.
       document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
     },
     [setOpenProp, open]
@@ -142,13 +163,13 @@ function SidebarProvider({
 
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (
-        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey)
-      ) {
-        event.preventDefault();
-        toggleSidebar();
-      }
+      if (event.key !== SIDEBAR_KEYBOARD_SHORTCUT) return;
+      if (!event.metaKey && !event.ctrlKey) return;
+      // Don't hijack Cmd/Ctrl+B (native bold) while typing in an editor.
+      if (isEditableTarget(event.target)) return;
+
+      event.preventDefault();
+      toggleSidebar();
     };
 
     window.addEventListener('keydown', handleKeyDown);
@@ -239,6 +260,7 @@ function Sidebar({
   variant = 'sidebar',
   collapsible = 'offcanvas',
   className,
+  style,
   children,
   ...props
 }: SidebarProps) {
@@ -252,6 +274,7 @@ function Sidebar({
           'nx:flex nx:h-full nx:w-(--sidebar-width) nx:flex-col nx:bg-nav-background nx:text-nav-foreground',
           className
         )}
+        style={style}
         {...props}
       >
         {children}
@@ -261,17 +284,22 @@ function Sidebar({
 
   if (isMobile) {
     return (
-      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+      <Sheet open={openMobile} onOpenChange={setOpenMobile}>
         <SheetContent
           data-slot="sidebar"
           data-mobile="true"
-          className="nx:w-(--sidebar-width) nx:bg-nav-background nx:p-0 nx:text-nav-foreground nx:[&>button]:hidden"
+          side={side}
+          className={cn(
+            'nx:w-(--sidebar-width) nx:bg-nav-background nx:p-0 nx:text-nav-foreground nx:[&>button]:hidden',
+            className
+          )}
           style={
             {
               '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
+              ...style,
             } as React.CSSProperties
           }
-          side={side}
+          {...props}
         >
           <SheetHeader className="nx:sr-only">
             <SheetTitle>Sidebar</SheetTitle>
@@ -322,6 +350,7 @@ function Sidebar({
             : 'nx:group-data-[collapsible=icon]:w-(--sidebar-width-icon) nx:group-data-[side=left]:border-r nx:group-data-[side=right]:border-l nx:border-nav-border',
           className
         )}
+        style={style}
         {...props}
       >
         <div
@@ -953,9 +982,11 @@ function SidebarMenuSkeleton({
   ...props
 }: SidebarMenuSkeletonProps) {
   // Vary the text-bar width (50–90%) so a stack of skeletons looks organic.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
+  // Seed from the SSR-stable useId() — Math.random() here would differ between
+  // server and client and trip a hydration mismatch.
+  const id = React.useId();
+  const seed = [...id].reduce((sum, char) => sum + char.charCodeAt(0), 0);
+  const width = `${50 + (seed % 41)}%`;
 
   return (
     <div

--- a/packages/react/src/hooks/use-mobile.ts
+++ b/packages/react/src/hooks/use-mobile.ts
@@ -1,16 +1,18 @@
 import * as React from 'react';
 
 /**
- * Width (px) below which page-shell chrome should switch to its mobile layout.
- * Matches the Nexus Standard layout floor (`lg` = 1024px) — below it the Sidebar
- * collapses into a Sheet drawer rather than a docked panel.
+ * Media query matching viewports below the Nexus Standard layout floor
+ * (`lg` = 64rem / 1024px at a 16px root). The query is rem-based so it tracks
+ * the user's base font size exactly as the `nx:lg:` utilities do — a px query
+ * would diverge under an enlarged font and leave a band where neither the
+ * docked panel nor the mobile drawer renders.
  */
-const MOBILE_BREAKPOINT = 1024;
+const MOBILE_QUERY = '(max-width: 63.99rem)';
 
 /**
  * useIsMobile
  *
- * Tracks whether the viewport is below the Standard layout floor (1024px).
+ * Tracks whether the viewport is below the Standard layout floor (`lg`).
  * Subscribes to a `matchMedia` query so it stays in sync as the viewport
  * resizes. Page-shell components (e.g. Sidebar) read this to decide between a
  * docked panel and a mobile drawer.
@@ -27,12 +29,10 @@ export function useIsMobile() {
   );
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    };
+    const mql = window.matchMedia(MOBILE_QUERY);
+    const onChange = () => setIsMobile(mql.matches);
     mql.addEventListener('change', onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    setIsMobile(mql.matches);
     return () => mql.removeEventListener('change', onChange);
   }, []);
 

--- a/packages/react/src/hooks/use-mobile.ts
+++ b/packages/react/src/hooks/use-mobile.ts
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+/**
+ * Width (px) below which page-shell chrome should switch to its mobile layout.
+ * Matches the Nexus Standard layout floor (`lg` = 1024px) — below it the Sidebar
+ * collapses into a Sheet drawer rather than a docked panel.
+ */
+const MOBILE_BREAKPOINT = 1024;
+
+/**
+ * useIsMobile
+ *
+ * Tracks whether the viewport is below the Standard layout floor (1024px).
+ * Subscribes to a `matchMedia` query so it stays in sync as the viewport
+ * resizes. Page-shell components (e.g. Sidebar) read this to decide between a
+ * docked panel and a mobile drawer.
+ *
+ * @example
+ * ```tsx
+ * const isMobile = useIsMobile();
+ * return isMobile ? <Drawer /> : <DockedPanel />;
+ * ```
+ */
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
+    undefined
+  );
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    };
+    mql.addEventListener('change', onChange);
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+
+  return !!isMobile;
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -41,6 +41,3 @@ export * from '@/components/ui/tooltip';
 // Primitives
 export * from '@/components/primitives/hide';
 export * from '@/components/primitives/show';
-
-// Hooks
-export * from '@/hooks/use-mobile';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -30,6 +30,7 @@ export * from '@/components/ui/scroll-area';
 export * from '@/components/ui/select';
 export * from '@/components/ui/separator';
 export * from '@/components/ui/sheet';
+export * from '@/components/ui/sidebar';
 export * from '@/components/ui/skeleton';
 export * from '@/components/ui/switch';
 export * from '@/components/ui/table';
@@ -40,3 +41,6 @@ export * from '@/components/ui/tooltip';
 // Primitives
 export * from '@/components/primitives/hide';
 export * from '@/components/primitives/show';
+
+// Hooks
+export * from '@/hooks/use-mobile';

--- a/packages/react/src/lib/icons.ts
+++ b/packages/react/src/lib/icons.ts
@@ -20,6 +20,7 @@ export {
   IconChevronDown,
   IconChevronRight,
   IconChevronUp,
+  IconLayoutSidebar,
 } from '@tabler/icons-react';
 
 // Actions


### PR DESCRIPTION
## Summary

- Adapts shadcn/ui `sidebar` into a first-class Nexus component (~23 exports): `SidebarProvider`, `Sidebar`, `SidebarTrigger`, `SidebarRail`, `SidebarInset`, the group/menu parts, and `useSidebar`.
- Collapsible app-shell sidebar — icon-rail collapse, mobile Sheet drawer below `lg` (1024px), `Ctrl/Cmd+B` toggle, and cookie persistence.
- Maps the `sidebar-*` tokens to the **`nav-*`** namespace; canonical focus ring; outline-button shadow → real `border-nav-border` (no-shadow-on-focusable); `--spacing(4)` → literal `1rem` (Nexus's `--spacing-*: initial` reset); `Slot.Root` → `Slot`; dropped the redundant `data-sidebar` attr (kept `data-slot`, rewrote the one `group-has-data-[…]` selector to `data-[slot=…]`).
- New `useIsMobile` hook (matchMedia) and `IconLayoutSidebar` (Tabler). **No new npm dependency** — composes Button / Input / Separator / Skeleton / Sheet / Tooltip.
- Sidebar alone is **66.12 kB** ESM. After #272 (form) merged into `main`, the bundle CI builds (form + sidebar) is **68.57 kB**, so this PR bumps the ESM `size-limit` **68 → 70 kB** — a dep-free component add, matching the #268 precedent that last moved this ceiling.

## GitHub Issue

Closes #177

## Test Plan

- [x] `yarn workspace @nexus/react typecheck`
- [x] `yarn lint` (full, `--max-warnings 0`)
- [x] Story tests **10/10** in real Chromium — a11y (axe) + play-fns (click toggle, ⌘B toggle, data-attributes)
- [x] `yarn workspace @nexus/react audit:storybook-coverage --component sidebar` → 0 missing, 0 drift
- [x] base-variants smoke test + `yarn workspace @nexus/react build` + nav utilities verified in `dist/react.css`
- [x] `yarn size-limit` — sidebar-only ESM **66.12 / 70 kB**; merged form+sidebar (what CI builds) **68.57 / 70 kB**; CSS **8.87 / 30 kB**

> **Sibling-PR note:** #272 (form) merged into `main` first. This branch merges cleanly — the `index.ts` export hunks don't overlap and #272 didn't touch `base-variants.config.json` — so no rebase is needed; re-measuring the merged bundle is what drove the `size-limit` bump above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
