### PR TITLE
feat(components): add sonner component

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     {
       "name": "@nexus/react (ESM)",
       "path": "packages/react/dist/index.mjs",
-      "limit": "70 kB"
+      "limit": "80 kB"
     },
     {
       "name": "@nexus/react (CSS)",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,11 @@
     {
       "name": "@nexus/react (ESM)",
       "path": "packages/react/dist/index.mjs",
-      "limit": "80 kB"
+      "ignore": [
+        "react-hook-form",
+        "sonner"
+      ],
+      "limit": "70 kB"
     },
     {
       "name": "@nexus/react (CSS)",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,6 +41,7 @@
     "@vitejs/plugin-react": "^5.1.2",
     "react-hook-form": "^7.77.0",
     "recharts": "^3.8.1",
+    "sonner": "^2.0.7",
     "storybook": "^10.1.10",
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "^1.4.0",
@@ -73,16 +74,19 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "input-otp": "^1.4.2",
-    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"
   },
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.77.0"
+    "react-hook-form": "^7.77.0",
+    "sonner": "^2.0.7"
   },
   "peerDependenciesMeta": {
     "react-hook-form": {
+      "optional": true
+    },
+    "sonner": {
       "optional": true
     }
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -73,6 +73,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "input-otp": "^1.4.2",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"
   },
   "peerDependencies": {

--- a/packages/react/src/components/ui/Sonner.stories.tsx
+++ b/packages/react/src/components/ui/Sonner.stories.tsx
@@ -1,0 +1,173 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { Button } from './button';
+import { toast, Toaster } from './sonner';
+
+const meta: Meta<typeof Toaster> = {
+  title: 'Components/Sonner',
+  component: Toaster,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Toaster>;
+
+export const Default: Story = {
+  render: () => (
+    <>
+      <Button variant="outline" onClick={() => toast('Event has been created')}>
+        Show toast
+      </Button>
+      <Toaster />
+    </>
+  ),
+};
+
+export const Success: Story = {
+  render: () => (
+    <>
+      <Button variant="outline" onClick={() => toast.success('Changes saved')}>
+        Show success
+      </Button>
+      <Toaster richColors />
+    </>
+  ),
+};
+
+export const Error: Story = {
+  render: () => (
+    <>
+      <Button
+        variant="outline"
+        onClick={() => toast.error('Something went wrong')}
+      >
+        Show error
+      </Button>
+      <Toaster richColors />
+    </>
+  ),
+};
+
+export const Warning: Story = {
+  render: () => (
+    <>
+      <Button
+        variant="outline"
+        onClick={() => toast.warning('Your session is about to expire')}
+      >
+        Show warning
+      </Button>
+      <Toaster richColors />
+    </>
+  ),
+};
+
+export const Info: Story = {
+  render: () => (
+    <>
+      <Button
+        variant="outline"
+        onClick={() => toast.info('A new version is available')}
+      >
+        Show info
+      </Button>
+      <Toaster richColors />
+    </>
+  ),
+};
+
+export const WithAction: Story = {
+  render: () => {
+    const showToast = () =>
+      toast('File deleted', {
+        action: { label: 'Undo', onClick: () => toast('File restored') },
+      });
+    return (
+      <>
+        <Button variant="outline" onClick={showToast}>
+          Show with action
+        </Button>
+        <Toaster />
+      </>
+    );
+  },
+};
+
+export const Promise: Story = {
+  render: () => {
+    const save = () =>
+      new globalThis.Promise<void>((resolve) => {
+        setTimeout(resolve, 1500);
+      });
+    const showToast = () =>
+      toast.promise(save, {
+        loading: 'Saving…',
+        success: 'Settings saved',
+        error: 'Could not save',
+      });
+    return (
+      <>
+        <Button variant="outline" onClick={showToast}>
+          Show promise
+        </Button>
+        <Toaster />
+      </>
+    );
+  },
+};
+
+export const ClickInteraction: Story = {
+  render: () => (
+    <>
+      <Button onClick={() => toast('Event has been created')}>
+        Show toast
+      </Button>
+      <Toaster />
+    </>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Show toast' }));
+
+    // Sonner renders the toast outside the canvas subtree — query the document.
+    const status = await within(document.body).findByText(
+      'Event has been created'
+    );
+    await expect(status).toBeInTheDocument();
+  },
+};
+
+export const WithDataAttributes: Story = {
+  render: () => <Toaster />,
+  play: async ({ canvasElement }) => {
+    const toaster = canvasElement.querySelector('[data-slot="toaster"]');
+    await expect(toaster).toBeInTheDocument();
+    await expect(toaster).toHaveAttribute('data-slot', 'toaster');
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-4">
+      <Button variant="outline" onClick={() => toast('Default toast')}>
+        Default
+      </Button>
+      <Button variant="outline" onClick={() => toast.success('Success toast')}>
+        Success
+      </Button>
+      <Button variant="outline" onClick={() => toast.error('Error toast')}>
+        Error
+      </Button>
+      <Button variant="outline" onClick={() => toast.warning('Warning toast')}>
+        Warning
+      </Button>
+      <Button variant="outline" onClick={() => toast.info('Info toast')}>
+        Info
+      </Button>
+      <Toaster richColors />
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/Sonner.stories.tsx
+++ b/packages/react/src/components/ui/Sonner.stories.tsx
@@ -96,10 +96,11 @@ export const WithAction: Story = {
   },
 };
 
-export const Promise: Story = {
+export const PromiseStory: Story = {
+  name: 'Promise',
   render: () => {
     const save = () =>
-      new globalThis.Promise<void>((resolve) => {
+      new Promise<void>((resolve) => {
         setTimeout(resolve, 1500);
       });
     const showToast = () =>

--- a/packages/react/src/components/ui/sonner.tsx
+++ b/packages/react/src/components/ui/sonner.tsx
@@ -12,11 +12,9 @@ import {
 import { cn } from '@/lib/utils';
 
 /**
- * Track the active theme by observing the `.dark` class on the document root —
- * Nexus toggles dark mode there, so this keeps sonner's own `theme` (and the
- * shadows / gray scales it doesn't expose as tokens) aligned with the design
- * system. `useSyncExternalStore` subscribes to the class via MutationObserver
- * without syncing React state through an effect.
+ * Track the active theme by observing the `.dark` class on the document root
+ * (where Nexus toggles dark mode) via MutationObserver, keeping sonner's own
+ * `theme` in sync with the design system.
  */
 function subscribeToTheme(notify: () => void) {
   const observer = new MutationObserver(notify);
@@ -50,11 +48,8 @@ const toasterIcons = {
 
 /**
  * Sonner reads these custom properties off the toaster container to colour each
- * toast; map every one to its Nexus semantic token. Set inline on the container
- * so they beat sonner's own lower-specificity `[data-sonner-toaster]` defaults
- * and inherit down to the toasts — and so they re-resolve under `.dark`
- * automatically. The `-bg`/`-text`/`-border` triples for success/error/warning/
- * info apply when `richColors` is enabled.
+ * toast; map every one to its Nexus semantic token. The `-bg`/`-text`/`-border`
+ * triples for success/error/warning/info apply when `richColors` is enabled.
  */
 const toasterThemeVars = {
   '--normal-bg': 'var(--nx-color-container)',

--- a/packages/react/src/components/ui/sonner.tsx
+++ b/packages/react/src/components/ui/sonner.tsx
@@ -1,0 +1,119 @@
+import * as React from 'react';
+
+import { toast, Toaster as Sonner, type ToasterProps, useSonner } from 'sonner';
+
+import {
+  IconAlertCircle,
+  IconAlertTriangle,
+  IconCircleCheck,
+  IconInfoCircle,
+  IconLoader2,
+} from '@/lib/icons';
+import { cn } from '@/lib/utils';
+
+/**
+ * Track the active theme by observing the `.dark` class on the document root —
+ * Nexus toggles dark mode there, so this keeps sonner's own `theme` (and the
+ * shadows / gray scales it doesn't expose as tokens) aligned with the design
+ * system. `useSyncExternalStore` subscribes to the class via MutationObserver
+ * without syncing React state through an effect.
+ */
+function subscribeToTheme(notify: () => void) {
+  const observer = new MutationObserver(notify);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['class'],
+  });
+  return () => observer.disconnect();
+}
+
+function getThemeSnapshot(): 'light' | 'dark' {
+  return document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+}
+
+function useToasterTheme(): 'light' | 'dark' {
+  return React.useSyncExternalStore(
+    subscribeToTheme,
+    getThemeSnapshot,
+    () => 'light'
+  );
+}
+
+/** Tabler icons in place of sonner's bundled set, matching Nexus iconography. */
+const toasterIcons = {
+  success: <IconCircleCheck className="nx:size-4" />,
+  info: <IconInfoCircle className="nx:size-4" />,
+  warning: <IconAlertTriangle className="nx:size-4" />,
+  error: <IconAlertCircle className="nx:size-4" />,
+  loading: <IconLoader2 className="nx:size-4 nx:animate-spin" />,
+};
+
+/**
+ * Sonner reads these custom properties off the toaster container to colour each
+ * toast; map every one to its Nexus semantic token. Set inline on the container
+ * so they beat sonner's own lower-specificity `[data-sonner-toaster]` defaults
+ * and inherit down to the toasts — and so they re-resolve under `.dark`
+ * automatically. The `-bg`/`-text`/`-border` triples for success/error/warning/
+ * info apply when `richColors` is enabled.
+ */
+const toasterThemeVars = {
+  '--normal-bg': 'var(--nx-color-container)',
+  '--normal-text': 'var(--nx-color-foreground)',
+  '--normal-border': 'var(--nx-color-border-default)',
+  '--border-radius': 'var(--nx-radius-md)',
+  '--success-bg': 'var(--nx-color-success-background)',
+  '--success-text': 'var(--nx-color-success-foreground)',
+  '--success-border': 'var(--nx-color-border-success)',
+  '--info-bg': 'var(--nx-color-information-background)',
+  '--info-text': 'var(--nx-color-information-foreground)',
+  '--info-border': 'var(--nx-color-border-information)',
+  '--warning-bg': 'var(--nx-color-warning-background)',
+  '--warning-text': 'var(--nx-color-warning-foreground)',
+  '--warning-border': 'var(--nx-color-border-warning)',
+  '--error-bg': 'var(--nx-color-error-background)',
+  '--error-text': 'var(--nx-color-error-foreground)',
+  '--error-border': 'var(--nx-color-border-error)',
+} as React.CSSProperties;
+
+/**
+ * Toaster
+ *
+ * Renders toast notifications, themed to Nexus tokens and riding the toast
+ * layer (`nx:z-toast`). Mount once near the root of your app, then call
+ * `toast(...)` (re-exported here) from anywhere. The active theme follows the
+ * `.dark` class automatically.
+ *
+ * @example
+ * ```tsx
+ * import { Toaster, toast } from '@nexus/react';
+ *
+ * function App() {
+ *   return (
+ *     <>
+ *       <button onClick={() => toast('Saved')}>Save</button>
+ *       <Toaster />
+ *     </>
+ *   );
+ * }
+ * ```
+ */
+function Toaster({ className, style, ...props }: ToasterProps) {
+  const theme = useToasterTheme();
+  // Force the toast layer with `!`: sonner injects a runtime <style> that
+  // hardcodes the container to z-index 999999999, which a non-important utility
+  // can't override.
+  return (
+    <div data-slot="toaster">
+      <Sonner
+        theme={theme}
+        icons={toasterIcons}
+        className={cn('nx:z-toast!', className)}
+        style={{ ...toasterThemeVars, ...style }}
+        {...props}
+      />
+    </div>
+  );
+}
+
+export { toast, Toaster, useSonner };
+export type { ToasterProps };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -33,6 +33,7 @@ export * from '@/components/ui/separator';
 export * from '@/components/ui/sheet';
 export * from '@/components/ui/sidebar';
 export * from '@/components/ui/skeleton';
+export * from '@/components/ui/sonner';
 export * from '@/components/ui/switch';
 export * from '@/components/ui/table';
 export * from '@/components/ui/tabs';

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -28,13 +28,20 @@ export default defineConfig({
       fileName: (format) => `index.${format === 'es' ? 'mjs' : 'js'}`,
     },
     rollupOptions: {
-      external: ['react', 'react-dom', 'react/jsx-runtime', 'react-hook-form'],
+      external: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        'react-hook-form',
+        'sonner',
+      ],
       output: {
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
           'react/jsx-runtime': 'jsxRuntime',
           'react-hook-form': 'ReactHookForm',
+          sonner: 'Sonner',
         },
       },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6440,6 +6440,11 @@ slice-ansi@^7.1.0:
     ansi-styles "^6.2.1"
     is-fullwidth-code-point "^5.0.0"
 
+sonner@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/sonner/-/sonner-2.0.7.tgz#810c1487a67ec3370126e0f400dfb9edddc3e4f6"
+  integrity sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==
+
 source-map-js@^1.0.1, source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"


### PR DESCRIPTION
## Summary

- Adapt `sonner@2.0.7` as the Nexus `Toaster` (the toast slot, re-scoped to Sonner per #97).
- Themed to Nexus semantic tokens via sonner's CSS custom properties — normal **and** rich colors (`success`/`error`/`warning`/`info` → status `-background`/`-foreground`/`-border`), `--border-radius` → `nx-radius-md`.
- Rides the toast layer (`nx:z-toast`); theme synced to the `.dark` class via `useSyncExternalStore` + `MutationObserver` (replaces shadcn's `next-themes`).
- Tabler icons for the success/info/warning/error/loading slots; re-exports `toast` + `useSonner`.
- `data-slot="toaster"`; exports `Toaster` + `ToasterProps`.
- 10 stories: Default, Success, Error, Warning, Info, WithAction, Promise, ClickInteraction (trigger play), WithDataAttributes, AllVariants.

## GitHub Issue

Closes #97

## Notable decisions

- **`nx:z-toast!` (important).** Sonner injects its CSS at runtime as a `<style>` hardcoding `[data-sonner-toaster]{z-index:999999999}` (no `!important`). Its order vs the consumer's `react.css` is unknowable, so a plain `nx:z-toast` ties on specificity and can't reliably win — the important modifier is the deterministic override. Inline `zIndex: 'var(...)'` is rejected by csstype.
- **`<div data-slot="toaster">` wrapper.** `ToasterProps` is a closed interface (no `HTMLAttributes`), so sonner drops arbitrary `data-*` — the wrapper carries the `data-slot` convention. The fixed `<ol>` escapes the static div (no layout impact).
- **Inline CSS-var theming.** Sonner defines its var defaults on the `<ol data-sonner-toaster>` (0,2,0); setting them inline on that same element wins and inherits down to each toast, rich colors included. Vars map to `var(--nx-color-*)` so they re-resolve under `.dark`.
- **Optional peer + rollup-external (per review #274).** Sonner's store is a module-global singleton (`new Observer()`), so a second sonner copy anywhere in the consumer tree would split the store and silently drop toasts. Sonner is therefore an optional `peerDependency` + rollup `external`, mirroring react-hook-form (#272): this dedupes to the consumer's single copy and preserves sonner's `'use client'` directive (rollup concatenation strips it when bundled). Both optional peers (`sonner`, `react-hook-form`) are `ignore`d in `size-limit` — the consumer installs them, so they do not count toward `@nexus/react`'s shipped bundle — and the ESM ceiling stays at 70 kB.
- **Focus ring intentionally not applied to sonner's action/close/cancel buttons.** They carry a high-specificity box-shadow `:focus-visible` (`[data-sonner-toast][data-styled='true'] [data-button]:focus-visible`, 0,4,0); converting to the Nexus outline ring would require `!important` overrides fighting sonner internals. This PR keeps a clean colors-only theming boundary; sonner's own (functional) focus styling stands.
- **No base-variants opt-in.** Toasts portal/escape the `[data-nexus-base]` scoping, so a per-base grid would show only empty containers.

## Test Plan

- [x] `yarn workspace @nexus/react audit:storybook-coverage --component sonner` — 0 missing, 0 drift
- [x] `yarn workspace @nexus/react typecheck`
- [x] `yarn lint` (`eslint . --max-warnings 0`)
- [x] `yarn size-limit` — ESM 67.08 kB ≤ 70 (sonner + react-hook-form `ignore`d as optional peers), CSS 8.87 kB ≤ 30
- [x] Sonner storybook tests (chromium) — 10/10 incl. play-fns + a11y
- [x] Confirmed `nx:z-toast!` emits `z-index:var(--nx-z-index-toast,100)!important`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
