### PR TITLE
fix(components): use error-subtle-foreground for Form error text

### DIFF
--- a/packages/core/scripts/audit-contrast.js
+++ b/packages/core/scripts/audit-contrast.js
@@ -41,6 +41,21 @@ const BASE_PAIRS = [
     minLc: 60,
     tier: 'ui',
   },
+  // Form error label + message render error-coloured text on the neutral form
+  // surface (page background or a Card container), not on error.subtle — guard
+  // both so the error-text token stays legible there in every base + theme.
+  {
+    fg: 'error.subtle-foreground',
+    bg: 'background',
+    minLc: 60,
+    tier: 'ui',
+  },
+  {
+    fg: 'error.subtle-foreground',
+    bg: 'container',
+    minLc: 60,
+    tier: 'ui',
+  },
   {
     fg: 'success.foreground',
     bg: 'success.background',

--- a/packages/react/src/components/ui/form.tsx
+++ b/packages/react/src/components/ui/form.tsx
@@ -168,7 +168,10 @@ function FormLabel({ className, ...props }: FormLabelProps) {
     <Label
       data-slot="form-label"
       data-error={!!error}
-      className={cn('nx:data-[error=true]:text-error-foreground', className)}
+      className={cn(
+        'nx:data-[error=true]:text-error-subtle-foreground',
+        className
+      )}
       htmlFor={formItemId}
       {...props}
     />
@@ -256,7 +259,7 @@ function FormMessage({ className, children, ...props }: FormMessageProps) {
     <p
       data-slot="form-message"
       id={formMessageId}
-      className={cn('nx:text-sm nx:text-error-foreground', className)}
+      className={cn('nx:text-sm nx:text-error-subtle-foreground', className)}
       {...props}
     >
       {body}


### PR DESCRIPTION
## Summary

- `FormLabel` (error state) and `FormMessage` used `text-error-foreground` — the **white-on-red-fill** token — on the neutral form surface. Result: error text rendered white-on-white (**invisible**) on a Card or page background in light mode, and merely white (not error-coloured) in dark.
- Swap both to `text-error-subtle-foreground`, the readable-red "error text on neutral surface" token already used by `Alert`, `Badge`, and the destructive `DropdownMenu` item.
- **Regression guard:** add `error.subtle-foreground ↔ background` and `↔ container` pairs to `audit:contrast`. No existing test caught this — axe's contrast rules are disabled (APCA model) and the Form stories assert behaviour, not colour.

## Context

Surfaced by the #178 playground capstone (the Profile form's invalid-email state). Undetected since the Form component shipped (#176); no pre-existing tracked issue.

## Test Plan

- [ ] `yarn workspace @nexus/core audit:contrast` — 460/460 pass; the new pairs clear APCA Lc 60 across all 5 bases × 2 themes (Lc ~71 light, ~82 dark)
- [ ] Built `dist/react.css` emits `text-error-subtle-foreground` **and** the `data-[error=true]` variant, each resolving to `var(--nx-color-error-subtle-foreground)`
- [ ] `yarn workspace @nexus/react typecheck` + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)