### PR TITLE
feat(playground): composed Settings 'look & feel' scene (Phase 1 capstone)

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -10,14 +10,17 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.4.0",
     "@nexus/react": "*",
     "@phosphor-icons/react": "^2.1.10",
     "@tabler/icons-react": "^3.36.1",
     "lucide-react": "^0.562.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "react-hook-form": "^7.77.0",
     "sonner": "^2.0.7",
     "tw-animate-css": "^1.4.0",
+    "zod": "^4.4.3",
     "zustand": "^5.0.9"
   },
   "devDependencies": {

--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -10,11 +10,14 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@nexus/react": "*",
     "@phosphor-icons/react": "^2.1.10",
     "@tabler/icons-react": "^3.36.1",
     "lucide-react": "^0.562.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
+    "sonner": "^2.0.7",
+    "tw-animate-css": "^1.4.0",
     "zustand": "^5.0.9"
   },
   "devDependencies": {

--- a/apps/playground/src/App.css
+++ b/apps/playground/src/App.css
@@ -1,3 +1,13 @@
 /* Nexus Playground - Theme preview with nx: prefixed utilities */
 /* globals.css is copied from core/dist/modular by copy:themes script */
 @import './styles/globals.css';
+
+/* Component overlay animations (Dialog / Select / AlertDialog / Tooltip). */
+@import 'tw-animate-css';
+
+/* Emit the nx: utilities used inside @nexus/react by scanning its source.
+   Do NOT import @nexus/tailwind or @nexus/react/styles.css here — their frozen
+   token values would override the playground's live, switchable tokens and
+   break the theme switcher. Tailwind 4 skips node_modules, so we point at the
+   source directly. */
+@source '../../../packages/react/src';

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -1,29 +1,17 @@
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-  Button,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  toast,
-  Toaster,
-} from '@nexus/react';
+import { useState } from 'react';
+
+import { Button, Toaster } from '@nexus/react';
 
 import { ComponentShowcase } from './components/ComponentShowcase';
+import { SettingsScene } from './components/settings/SettingsScene';
 import { ThemeSwitcher } from './components/ThemeSwitcher';
 import { useTheme } from './hooks/useTheme';
 
+type View = 'reference' | 'scenes';
+
 export default function App() {
   const { theme, setTheme } = useTheme();
+  const [view, setView] = useState<View>('reference');
 
   return (
     <div className="nx:bg-background nx:text-foreground nx:min-h-screen">
@@ -33,68 +21,50 @@ export default function App() {
           {/* Header */}
           <header className="nx:sticky nx:top-0 nx:z-10 nx:bg-background/95 nx:backdrop-blur nx:border-b nx:border-border-default">
             <div className="nx:px-6 nx:py-4">
-              <div className="nx:flex nx:items-center nx:gap-3">
-                <div className="nx:w-8 nx:h-8 nx:rounded-lg nx:bg-primary-background nx:flex nx:items-center nx:justify-center">
-                  <span className="nx:text-primary-foreground nx:font-bold nx:text-sm">
-                    N
-                  </span>
+              <div className="nx:flex nx:items-center nx:justify-between nx:gap-3">
+                <div className="nx:flex nx:items-center nx:gap-3">
+                  <div className="nx:w-8 nx:h-8 nx:rounded-lg nx:bg-primary-background nx:flex nx:items-center nx:justify-center">
+                    <span className="nx:text-primary-foreground nx:font-bold nx:text-sm">
+                      N
+                    </span>
+                  </div>
+                  <div>
+                    <h1 className="nx:text-lg nx:font-semibold nx:text-foreground">
+                      Nexus Theme Playground
+                    </h1>
+                    <p className="nx:text-xs nx:text-muted-foreground">
+                      Preview and customize your design system
+                    </p>
+                  </div>
                 </div>
-                <div>
-                  <h1 className="nx:text-lg nx:font-semibold nx:text-foreground">
-                    Nexus Theme Playground
-                  </h1>
-                  <p className="nx:text-xs nx:text-muted-foreground">
-                    Preview and customize your design system
-                  </p>
+
+                {/* View switch — Reference (token showcase) ↔ Scenes (composed) */}
+                <div className="nx:inline-flex nx:gap-0.5 nx:rounded-lg nx:border nx:border-border-default nx:bg-muted nx:p-0.5">
+                  <Button
+                    variant={view === 'reference' ? 'secondary' : 'ghost'}
+                    size="sm"
+                    onClick={() => setView('reference')}
+                  >
+                    Reference
+                  </Button>
+                  <Button
+                    variant={view === 'scenes' ? 'secondary' : 'ghost'}
+                    size="sm"
+                    onClick={() => setView('scenes')}
+                  >
+                    Scenes
+                  </Button>
                 </div>
               </div>
             </div>
           </header>
 
-          {/* Phase-1 pipeline probe — exercises popover/overlay/container/error
-              tokens via real @nexus/react components. Replaced by the Settings
-              scene in Phase 2. */}
-          <section className="nx:flex nx:flex-wrap nx:items-center nx:gap-4 nx:p-6">
-            <Select defaultValue="pro">
-              <SelectTrigger className="nx:w-48">
-                <SelectValue placeholder="Select a plan" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="free">Free</SelectItem>
-                <SelectItem value="pro">Pro</SelectItem>
-                <SelectItem value="team">Team</SelectItem>
-              </SelectContent>
-            </Select>
-
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button variant="destructive">Delete account</Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This permanently deletes your account and all of its data.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction>Delete</AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-
-            <Button
-              onClick={() =>
-                toast.success('Saved', { description: 'Pipeline works.' })
-              }
-            >
-              Show toast
-            </Button>
-          </section>
-
           {/* Content */}
-          <ComponentShowcase />
+          {view === 'reference' ? (
+            <ComponentShowcase />
+          ) : (
+            <SettingsScene theme={theme} setTheme={setTheme} />
+          )}
         </main>
 
         {/* Sidebar */}

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -1,3 +1,23 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  Button,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  toast,
+  Toaster,
+} from '@nexus/react';
+
 import { ComponentShowcase } from './components/ComponentShowcase';
 import { ThemeSwitcher } from './components/ThemeSwitcher';
 import { useTheme } from './hooks/useTheme';
@@ -31,6 +51,48 @@ export default function App() {
             </div>
           </header>
 
+          {/* Phase-1 pipeline probe — exercises popover/overlay/container/error
+              tokens via real @nexus/react components. Replaced by the Settings
+              scene in Phase 2. */}
+          <section className="nx:flex nx:flex-wrap nx:items-center nx:gap-4 nx:p-6">
+            <Select defaultValue="pro">
+              <SelectTrigger className="nx:w-48">
+                <SelectValue placeholder="Select a plan" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="free">Free</SelectItem>
+                <SelectItem value="pro">Pro</SelectItem>
+                <SelectItem value="team">Team</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="destructive">Delete account</Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This permanently deletes your account and all of its data.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction>Delete</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+
+            <Button
+              onClick={() =>
+                toast.success('Saved', { description: 'Pipeline works.' })
+              }
+            >
+              Show toast
+            </Button>
+          </section>
+
           {/* Content */}
           <ComponentShowcase />
         </main>
@@ -42,6 +104,8 @@ export default function App() {
           </div>
         </aside>
       </div>
+
+      <Toaster />
     </div>
   );
 }

--- a/apps/playground/src/components/settings/AccountTab.tsx
+++ b/apps/playground/src/components/settings/AccountTab.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  toast,
+} from '@nexus/react';
+
+const PLANS = [
+  { value: 'free', label: 'Free' },
+  { value: 'pro', label: 'Pro' },
+  { value: 'team', label: 'Team' },
+  { value: 'enterprise', label: 'Enterprise' },
+];
+
+export function AccountTab() {
+  const [plan, setPlan] = useState('pro');
+  const [billingEmail, setBillingEmail] = useState('billing@example.com');
+
+  const handleDelete = () => {
+    toast.error('Account deleted', {
+      description: 'Your account and all of its data have been removed.',
+    });
+  };
+
+  return (
+    <div className="nx:space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Plan &amp; billing</CardTitle>
+          <CardDescription>
+            Manage your subscription and billing details.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="nx:space-y-4">
+          <div className="nx:flex nx:items-center nx:justify-between nx:gap-4">
+            <Label htmlFor="account-plan">Plan</Label>
+            <Select value={plan} onValueChange={setPlan}>
+              <SelectTrigger id="account-plan" className="nx:w-44">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PLANS.map((p) => (
+                  <SelectItem key={p.value} value={p.value}>
+                    {p.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="nx:space-y-2">
+            <Label htmlFor="billing-email">Billing email</Label>
+            <Input
+              id="billing-email"
+              type="email"
+              value={billingEmail}
+              onChange={(e) => setBillingEmail(e.target.value)}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="nx:border-border-error">
+        <CardHeader>
+          <CardTitle>Danger zone</CardTitle>
+          <CardDescription>
+            Permanently delete your account and all of its data.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="destructive">Delete account</Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This permanently deletes your account and removes all of your
+                  data. This action cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction variant="destructive" onClick={handleDelete}>
+                  Delete account
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/playground/src/components/settings/AppearanceSettings.tsx
+++ b/apps/playground/src/components/settings/AppearanceSettings.tsx
@@ -1,0 +1,178 @@
+import { useId } from 'react';
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Separator,
+  Switch,
+} from '@nexus/react';
+
+import {
+  BASES,
+  BRANDS,
+  RADIUS_MODES,
+  SPACING_MODES,
+  type ThemeConfig,
+  TOKEN_MODES,
+  TYPOGRAPHY_MODES,
+} from '../../hooks/useTheme';
+
+type AppearanceSettingsProps = {
+  theme: ThemeConfig;
+  setTheme: React.Dispatch<React.SetStateAction<ThemeConfig>>;
+};
+
+/** Turn a list of lowercase mode keys into title-cased Select options. */
+function modeOptions<T extends string>(
+  modes: readonly T[]
+): { value: T; label: string }[] {
+  return modes.map((m) => ({
+    value: m,
+    label: m.charAt(0).toUpperCase() + m.slice(1),
+  }));
+}
+
+/** One labelled axis dropdown, built from the shipped Nexus Select. */
+function AxisSelect<T extends string>({
+  label,
+  value,
+  options,
+  onValueChange,
+}: {
+  label: string;
+  value: T;
+  options: readonly { value: T; label: string }[];
+  onValueChange: (value: T) => void;
+}) {
+  const id = useId();
+
+  return (
+    <div className="nx:flex nx:items-center nx:justify-between nx:gap-4">
+      <Label htmlFor={id}>{label}</Label>
+      <Select value={value} onValueChange={(v) => onValueChange(v as T)}>
+        <SelectTrigger id={id} className="nx:w-44">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((o) => (
+            <SelectItem key={o.value} value={o.value}>
+              {o.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+/**
+ * The dogfood theme switcher: the same 8 axes the dev sidebar controls, rebuilt
+ * from shipped @nexus/react components and driving the shared `setTheme`. Every
+ * change applies live, so the whole scene (and the sidebar) re-theme instantly.
+ */
+export function AppearanceSettings({
+  theme,
+  setTheme,
+}: AppearanceSettingsProps) {
+  return (
+    <div className="nx:space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Theme</CardTitle>
+          <CardDescription>
+            Color identity — applies live across the whole app.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="nx:space-y-4">
+          <div className="nx:flex nx:items-center nx:justify-between nx:gap-4">
+            <div className="nx:space-y-0.5">
+              <Label htmlFor="appearance-dark">Dark mode</Label>
+              <p className="nx:typography-body-small nx:text-muted-foreground">
+                Switch between light and dark.
+              </p>
+            </div>
+            <Switch
+              id="appearance-dark"
+              checked={theme.dark}
+              onCheckedChange={(dark) => setTheme((t) => ({ ...t, dark }))}
+            />
+          </div>
+          <Separator />
+          <AxisSelect
+            label="Base"
+            value={theme.base}
+            options={BASES}
+            onValueChange={(base) => setTheme((t) => ({ ...t, base }))}
+          />
+          <AxisSelect
+            label="Brand"
+            value={theme.brand}
+            options={BRANDS}
+            onValueChange={(brand) => setTheme((t) => ({ ...t, brand }))}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Density &amp; type</CardTitle>
+          <CardDescription>Spacing rhythm and the type scale.</CardDescription>
+        </CardHeader>
+        <CardContent className="nx:space-y-4">
+          <AxisSelect
+            label="Spacing"
+            value={theme.spacing}
+            options={modeOptions(SPACING_MODES)}
+            onValueChange={(spacing) => setTheme((t) => ({ ...t, spacing }))}
+          />
+          <AxisSelect
+            label="Typography"
+            value={theme.typography}
+            options={modeOptions(TYPOGRAPHY_MODES)}
+            onValueChange={(typography) =>
+              setTheme((t) => ({ ...t, typography }))
+            }
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Surfaces</CardTitle>
+          <CardDescription>Elevation depth and edge treatment.</CardDescription>
+        </CardHeader>
+        <CardContent className="nx:space-y-4">
+          <AxisSelect
+            label="Shadow"
+            value={theme.shadow}
+            options={modeOptions(TOKEN_MODES)}
+            onValueChange={(shadow) => setTheme((t) => ({ ...t, shadow }))}
+          />
+          <AxisSelect
+            label="Radius"
+            value={theme.radius}
+            options={modeOptions(RADIUS_MODES)}
+            onValueChange={(radius) => setTheme((t) => ({ ...t, radius }))}
+          />
+          <AxisSelect
+            label="Border width"
+            value={theme.borderWidth}
+            options={modeOptions(TOKEN_MODES)}
+            onValueChange={(borderWidth) =>
+              setTheme((t) => ({ ...t, borderWidth }))
+            }
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/playground/src/components/settings/NotificationsTab.tsx
+++ b/apps/playground/src/components/settings/NotificationsTab.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Checkbox,
+  Label,
+  RadioGroup,
+  RadioGroupItem,
+  Switch,
+} from '@nexus/react';
+
+const ACTIVITY = [
+  { id: 'comments', label: 'Comments' },
+  { id: 'mentions', label: 'Mentions' },
+  { id: 'assignments', label: 'Assignments' },
+];
+
+const FREQUENCIES = [
+  { value: 'realtime', label: 'Real-time' },
+  { value: 'daily', label: 'Daily digest' },
+  { value: 'weekly', label: 'Weekly digest' },
+];
+
+export function NotificationsTab() {
+  const [productUpdates, setProductUpdates] = useState(true);
+  const [securityAlerts, setSecurityAlerts] = useState(true);
+  const [activity, setActivity] = useState<Record<string, boolean>>({
+    comments: true,
+    mentions: true,
+    assignments: false,
+  });
+  const [frequency, setFrequency] = useState('realtime');
+
+  return (
+    <div className="nx:space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Email notifications</CardTitle>
+          <CardDescription>Choose what we email you about.</CardDescription>
+        </CardHeader>
+        <CardContent className="nx:space-y-4">
+          <div className="nx:flex nx:items-center nx:justify-between nx:gap-4">
+            <div className="nx:space-y-0.5">
+              <Label htmlFor="notify-product">Product updates</Label>
+              <p className="nx:typography-body-small nx:text-muted-foreground">
+                News about features and improvements.
+              </p>
+            </div>
+            <Switch
+              id="notify-product"
+              checked={productUpdates}
+              onCheckedChange={setProductUpdates}
+            />
+          </div>
+          <div className="nx:flex nx:items-center nx:justify-between nx:gap-4">
+            <div className="nx:space-y-0.5">
+              <Label htmlFor="notify-security">Security alerts</Label>
+              <p className="nx:typography-body-small nx:text-muted-foreground">
+                Critical alerts about your account.
+              </p>
+            </div>
+            <Switch
+              id="notify-security"
+              checked={securityAlerts}
+              onCheckedChange={setSecurityAlerts}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Activity</CardTitle>
+          <CardDescription>
+            Get notified about activity that involves you.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="nx:space-y-3">
+          {ACTIVITY.map((item) => (
+            <div key={item.id} className="nx:flex nx:items-center nx:gap-3">
+              <Checkbox
+                id={`activity-${item.id}`}
+                checked={activity[item.id]}
+                onCheckedChange={(checked) =>
+                  setActivity((a) => ({ ...a, [item.id]: checked === true }))
+                }
+              />
+              <Label htmlFor={`activity-${item.id}`}>{item.label}</Label>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Digest frequency</CardTitle>
+          <CardDescription>
+            How often we bundle your notifications.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <RadioGroup
+            value={frequency}
+            onValueChange={setFrequency}
+            className="nx:space-y-3"
+          >
+            {FREQUENCIES.map((f) => (
+              <div key={f.value} className="nx:flex nx:items-center nx:gap-3">
+                <RadioGroupItem value={f.value} id={`freq-${f.value}`} />
+                <Label htmlFor={`freq-${f.value}`}>{f.label}</Label>
+              </div>
+            ))}
+          </RadioGroup>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/playground/src/components/settings/ProfileTab.tsx
+++ b/apps/playground/src/components/settings/ProfileTab.tsx
@@ -1,0 +1,164 @@
+import { useForm } from 'react-hook-form';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Textarea,
+  toast,
+} from '@nexus/react';
+import { z } from 'zod';
+
+const profileSchema = z.object({
+  firstName: z.string().min(1, 'First name is required'),
+  lastName: z.string().min(1, 'Last name is required'),
+  email: z.email('Enter a valid email address'),
+  username: z.string().min(2, 'Username must be at least 2 characters'),
+  bio: z.string().max(160, 'Bio must be 160 characters or less'),
+});
+
+type ProfileValues = z.infer<typeof profileSchema>;
+
+const DEFAULT_VALUES: ProfileValues = {
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  email: 'ada@example.com',
+  username: 'ada',
+  bio: 'Mathematician and writer, known for work on the Analytical Engine.',
+};
+
+export function ProfileTab() {
+  const form = useForm<ProfileValues>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: DEFAULT_VALUES,
+  });
+
+  const onSubmit = (values: ProfileValues) => {
+    toast.success('Profile saved', {
+      description: `Saved changes for @${values.username}.`,
+    });
+  };
+
+  return (
+    <Card>
+      <Form {...form}>
+        {/* noValidate: let zod + FormMessage own validation, not the native bubble */}
+        <form noValidate onSubmit={form.handleSubmit(onSubmit)}>
+          <CardHeader>
+            <CardTitle>Profile</CardTitle>
+            <CardDescription>
+              Update your personal information. Validated with zod.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="nx:space-y-5">
+            <div className="nx:grid nx:gap-5 nx:sm:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="firstName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>First name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Ada" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="lastName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Last name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Lovelace" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="you@example.com"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    We&apos;ll use this for account notifications.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="username"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Username</FormLabel>
+                  <FormControl>
+                    <Input placeholder="ada" {...field} />
+                  </FormControl>
+                  <FormDescription>Your public display name.</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="bio"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Bio</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Tell us a little about yourself"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>Maximum 160 characters.</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter className="nx:justify-end nx:gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => form.reset()}
+            >
+              Cancel
+            </Button>
+            <Button type="submit">Save profile</Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+}

--- a/apps/playground/src/components/settings/SettingsScene.tsx
+++ b/apps/playground/src/components/settings/SettingsScene.tsx
@@ -1,0 +1,92 @@
+import {
+  Button,
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Separator,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  toast,
+} from '@nexus/react';
+
+import type { ThemeConfig } from '../../hooks/useTheme';
+
+import { AppearanceSettings } from './AppearanceSettings';
+
+type SettingsSceneProps = {
+  theme: ThemeConfig;
+  setTheme: React.Dispatch<React.SetStateAction<ThemeConfig>>;
+};
+
+/** Placeholder for tabs whose content lands in a later phase of this PR. */
+function ComingUp({ title }: { title: string }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>This section is part of the scene.</CardDescription>
+      </CardHeader>
+    </Card>
+  );
+}
+
+/**
+ * The composed Settings scene — a realistic product screen assembled entirely
+ * from @nexus/react. Its Appearance tab drives the live theme; the others are
+ * realistic settings forms. Layers background → container (Card) → popover /
+ * overlay (Select / AlertDialog) to exercise the surface contract.
+ */
+export function SettingsScene({ theme, setTheme }: SettingsSceneProps) {
+  const handleSave = () => {
+    toast.success('Settings saved', {
+      description: 'Your preferences have been updated.',
+    });
+  };
+
+  return (
+    <div className="nx:mx-auto nx:max-w-3xl nx:space-y-6 nx:p-6">
+      <div className="nx:space-y-1">
+        <h2 className="nx:typography-heading-large nx:text-foreground">
+          Settings
+        </h2>
+        <p className="nx:typography-body-default nx:text-muted-foreground">
+          Manage your profile, account, notifications, and appearance.
+        </p>
+      </div>
+
+      <Tabs defaultValue="appearance" className="nx:gap-6">
+        <TabsList>
+          <TabsTrigger value="profile">Profile</TabsTrigger>
+          <TabsTrigger value="account">Account</TabsTrigger>
+          <TabsTrigger value="notifications">Notifications</TabsTrigger>
+          <TabsTrigger value="appearance">Appearance</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="profile">
+          <ComingUp title="Profile" />
+        </TabsContent>
+        <TabsContent value="account">
+          <ComingUp title="Account" />
+        </TabsContent>
+        <TabsContent value="notifications">
+          <ComingUp title="Notifications" />
+        </TabsContent>
+        <TabsContent value="appearance">
+          <AppearanceSettings theme={theme} setTheme={setTheme} />
+        </TabsContent>
+      </Tabs>
+
+      <Separator />
+
+      <div className="nx:flex nx:justify-end nx:gap-3">
+        <Button variant="outline" onClick={() => toast('Changes discarded')}>
+          Cancel
+        </Button>
+        <Button onClick={handleSave}>Save changes</Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/playground/src/components/settings/SettingsScene.tsx
+++ b/apps/playground/src/components/settings/SettingsScene.tsx
@@ -1,35 +1,16 @@
-import {
-  Card,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from '@nexus/react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@nexus/react';
 
 import type { ThemeConfig } from '../../hooks/useTheme';
 
+import { AccountTab } from './AccountTab';
 import { AppearanceSettings } from './AppearanceSettings';
+import { NotificationsTab } from './NotificationsTab';
 import { ProfileTab } from './ProfileTab';
 
 type SettingsSceneProps = {
   theme: ThemeConfig;
   setTheme: React.Dispatch<React.SetStateAction<ThemeConfig>>;
 };
-
-/** Placeholder for tabs whose content lands in a later phase of this PR. */
-function ComingUp({ title }: { title: string }) {
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{title}</CardTitle>
-        <CardDescription>This section is part of the scene.</CardDescription>
-      </CardHeader>
-    </Card>
-  );
-}
 
 /**
  * The composed Settings scene — a realistic product screen assembled entirely
@@ -61,10 +42,10 @@ export function SettingsScene({ theme, setTheme }: SettingsSceneProps) {
           <ProfileTab />
         </TabsContent>
         <TabsContent value="account">
-          <ComingUp title="Account" />
+          <AccountTab />
         </TabsContent>
         <TabsContent value="notifications">
-          <ComingUp title="Notifications" />
+          <NotificationsTab />
         </TabsContent>
         <TabsContent value="appearance">
           <AppearanceSettings theme={theme} setTheme={setTheme} />

--- a/apps/playground/src/components/settings/SettingsScene.tsx
+++ b/apps/playground/src/components/settings/SettingsScene.tsx
@@ -1,20 +1,18 @@
 import {
-  Button,
   Card,
   CardDescription,
   CardHeader,
   CardTitle,
-  Separator,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
-  toast,
 } from '@nexus/react';
 
 import type { ThemeConfig } from '../../hooks/useTheme';
 
 import { AppearanceSettings } from './AppearanceSettings';
+import { ProfileTab } from './ProfileTab';
 
 type SettingsSceneProps = {
   theme: ThemeConfig;
@@ -40,12 +38,6 @@ function ComingUp({ title }: { title: string }) {
  * overlay (Select / AlertDialog) to exercise the surface contract.
  */
 export function SettingsScene({ theme, setTheme }: SettingsSceneProps) {
-  const handleSave = () => {
-    toast.success('Settings saved', {
-      description: 'Your preferences have been updated.',
-    });
-  };
-
   return (
     <div className="nx:mx-auto nx:max-w-3xl nx:space-y-6 nx:p-6">
       <div className="nx:space-y-1">
@@ -66,7 +58,7 @@ export function SettingsScene({ theme, setTheme }: SettingsSceneProps) {
         </TabsList>
 
         <TabsContent value="profile">
-          <ComingUp title="Profile" />
+          <ProfileTab />
         </TabsContent>
         <TabsContent value="account">
           <ComingUp title="Account" />
@@ -78,15 +70,6 @@ export function SettingsScene({ theme, setTheme }: SettingsSceneProps) {
           <AppearanceSettings theme={theme} setTheme={setTheme} />
         </TabsContent>
       </Tabs>
-
-      <Separator />
-
-      <div className="nx:flex nx:justify-end nx:gap-3">
-        <Button variant="outline" onClick={() => toast('Changes discarded')}>
-          Cancel
-        </Button>
-        <Button onClick={handleSave}>Save changes</Button>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Wires `@nexus/react` into `apps/playground` and adds a composed, theme-switchable **Settings** scene — the Phase 1 capstone that validates the whole library composing into one realistic screen.

- **CSS wiring:** keep the playground's generated `globals.css` as the live token + 8-axis theme-switch engine; add `@source ../../../packages/react/src` (emit component `nx:` utilities) + `tw-animate-css` (overlay animations) in `App.css`. Deliberately **not** importing `@nexus/tailwind` / `@nexus/react/styles.css` — their frozen token values would override the switchable `--nx-*` vars and break base/brand flipping (same rationale `apps/docs` documents).
- **Header view switch** Reference ↔ Scenes; one-time `<Toaster/>` at the app root.
- **Settings scene** assembled entirely from shipped components: `Tabs` · `Card` · `Label`+`Input`+`Textarea` · `Select` · `Switch`+`Checkbox`+`RadioGroup` · `Separator` · `Button` · `AlertDialog` · `Toaster`.
- **Appearance tab** — a SaaS-style theme panel built from Nexus `Select`/`Switch` driving **all 8 axes** through the shared `useTheme` state, so the scene and the dev sidebar stay in sync.
- **Profile tab** — react-hook-form + zod, with `noValidate` so the styled `FormMessage`/error ring own validation (not the native bubble).

## GitHub Issue

Closes #178

## Depends on

**#275** (`fix(components): use error-subtle-foreground for Form error text`). The Profile form's error text is invisible against the **current** `@nexus/react` dist; it renders correctly once #275 merges and the package rebuilds. **Merge #275 first.**

## Test Plan

- [ ] `yarn playground` builds & runs; the scene renders across light/dark and all bases
- [ ] Flipping each theme axis (dark / base / brand / spacing / typography / shadow / radius / border-width) visibly re-themes the scene — verified for dark, base, radius, spacing
- [ ] Uses real `@nexus/react` components only (no hand-rolled dupes); `nx:` utilities only
- [ ] `yarn workspace @nexus/playground build` / `typecheck` / `lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)