### PR TITLE
feat(console): add core auth — login/signup/OTP/forgot + route guards

### DIFF
--- a/apps/console/src/app/auth-layout.tsx
+++ b/apps/console/src/app/auth-layout.tsx
@@ -1,0 +1,45 @@
+import { Outlet } from '@tanstack/react-router';
+
+/**
+ * The shell-less layout for the auth flow (login / signup / verify / forgot):
+ * a brand panel on the left (hidden below `lg`) and the active auth screen
+ * centered on the right.
+ *
+ * It sets `nx:bg-background nx:text-foreground` on its root because it renders
+ * OUTSIDE the app shell — a sibling pathless route, not a child — so it can't
+ * inherit the shell's base surface/text tokens. Omitting them reproduces the
+ * dark-mode regression that bit the foundation PR.
+ */
+export function AuthLayout() {
+  return (
+    <div className="nx:bg-background nx:text-foreground nx:flex nx:min-h-svh">
+      <aside className="nx:bg-primary-background nx:text-primary-foreground nx:hidden nx:w-1/2 nx:flex-col nx:justify-between nx:p-12 nx:lg:flex">
+        <div className="nx:flex nx:items-center nx:gap-2">
+          <div className="nx:bg-primary-foreground nx:flex nx:size-8 nx:items-center nx:justify-center nx:rounded-lg">
+            <span className="nx:text-primary-background nx:text-sm nx:font-bold">
+              A
+            </span>
+          </div>
+          <span className="nx:text-lg nx:font-semibold">Atlas</span>
+        </div>
+        <div className="nx:space-y-3">
+          <p className="nx:text-2xl nx:font-semibold nx:leading-snug">
+            The operating system for your whole company.
+          </p>
+          <p className="nx:text-primary-foreground/80 nx:text-sm">
+            CRM, projects, billing, and analytics — themed end to end by Nexus.
+          </p>
+        </div>
+        <p className="nx:text-primary-foreground/70 nx:text-xs">
+          Built on the Nexus design system.
+        </p>
+      </aside>
+
+      <main className="nx:flex nx:flex-1 nx:items-center nx:justify-center nx:p-6">
+        <div className="nx:w-full nx:max-w-sm">
+          <Outlet />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/console/src/app/not-found.tsx
+++ b/apps/console/src/app/not-found.tsx
@@ -1,0 +1,28 @@
+import { Link } from '@tanstack/react-router';
+
+/**
+ * Rendered under the thin root — outside both the `_app` shell and the `_auth`
+ * layout — when no route matches. It sets its own base surface/text tokens for
+ * the same reason `auth-layout.tsx` does: nothing above it does, so without them
+ * an unmatched URL renders bare (black-on-dark in dark mode). A richer 404 lands
+ * with Phase 4's state coverage.
+ */
+export function NotFound() {
+  return (
+    <div className="nx:bg-background nx:text-foreground nx:flex nx:min-h-svh nx:flex-col nx:items-center nx:justify-center nx:gap-3 nx:p-6 nx:text-center">
+      <p className="nx:typography-label-small nx:text-muted-foreground-subtle nx:uppercase nx:tracking-wide">
+        404
+      </p>
+      <h1 className="nx:typography-heading-large">Page not found</h1>
+      <p className="nx:text-muted-foreground nx:max-w-md">
+        That page doesn’t exist — it may have moved, or the link was mistyped.
+      </p>
+      <Link
+        to="/"
+        className="nx:text-primary-subtle-foreground nx:hover:underline"
+      >
+        Back to Atlas
+      </Link>
+    </div>
+  );
+}

--- a/apps/console/src/app/root-layout.tsx
+++ b/apps/console/src/app/root-layout.tsx
@@ -1,13 +1,14 @@
-import { SidebarInset, SidebarProvider, Toaster } from '@nexus/react';
+import { SidebarInset, SidebarProvider } from '@nexus/react';
 import { Outlet } from '@tanstack/react-router';
 
 import { AppSidebar } from '../shell/app-sidebar';
 import { Topbar } from '../shell/topbar';
 
 /**
- * The app shell rendered by the root route: collapsible sidebar + top bar with
- * the active module's content in the inset. Mounted once, so the sidebar and
- * top bar persist across navigations.
+ * The authenticated app shell, rendered by the `_app` pathless layout route
+ * (which guards it behind a session): collapsible sidebar + top bar with the
+ * active module's content in the inset. Mounted once, so the sidebar and top
+ * bar persist across navigations.
  */
 export function RootLayout() {
   return (
@@ -22,7 +23,6 @@ export function RootLayout() {
           <Outlet />
         </main>
       </SidebarInset>
-      <Toaster />
     </SidebarProvider>
   );
 }

--- a/apps/console/src/app/root.tsx
+++ b/apps/console/src/app/root.tsx
@@ -1,0 +1,17 @@
+import { Toaster } from '@nexus/react';
+import { Outlet } from '@tanstack/react-router';
+
+/**
+ * The thin root rendered by the root route. It holds only app-wide chrome that
+ * must sit above BOTH the authenticated shell and the auth screens — currently
+ * just the toast portal — plus an <Outlet> for whichever pathless layout (the
+ * authenticated `_app` shell or the shell-less `_auth` screens) matches.
+ */
+export function Root() {
+  return (
+    <>
+      <Outlet />
+      <Toaster />
+    </>
+  );
+}

--- a/apps/console/src/app/router.tsx
+++ b/apps/console/src/app/router.tsx
@@ -99,8 +99,8 @@ const signupRoute = createRoute({
 
 // `email` is carried from the login/signup step. Validated loose (optional) so a
 // stray hit doesn't throw a search error — beforeLoad redirects to /login when
-// it's absent. `VerifyRoute` reads it back via `verifyRoute.useSearch()`.
-export const verifyRoute = createRoute({
+// it's absent. `VerifyRoute` reads it back via `getRouteApi('/auth/verify')`.
+const verifyRoute = createRoute({
   getParentRoute: () => authRoute,
   path: '/verify',
   validateSearch: z.object({ email: z.string().optional() }),

--- a/apps/console/src/app/router.tsx
+++ b/apps/console/src/app/router.tsx
@@ -16,6 +16,7 @@ import { ReferenceRoute } from '../modules/design-system/reference-route';
 import { ScenesRoute } from '../modules/design-system/scenes-route';
 
 import { AuthLayout } from './auth-layout';
+import { NotFound } from './not-found';
 import { Root } from './root';
 import { RootLayout } from './root-layout';
 import { useSession } from './session';
@@ -129,7 +130,12 @@ const routeTree = rootRoute.addChildren([
   authRoute.addChildren([loginRoute, signupRoute, verifyRoute, forgotRoute]),
 ]);
 
-export const router = createRouter({ routeTree });
+// `NotFound` renders under the thin root (outside both layouts), so it carries
+// its own base tokens — see its file comment.
+export const router = createRouter({
+  routeTree,
+  defaultNotFoundComponent: NotFound,
+});
 
 declare module '@tanstack/react-router' {
   interface Register {

--- a/apps/console/src/app/router.tsx
+++ b/apps/console/src/app/router.tsx
@@ -4,18 +4,54 @@ import {
   createRouter,
   redirect,
 } from '@tanstack/react-router';
+import { z } from 'zod';
 
+import { ForgotRoute } from '../modules/auth/forgot-route';
+import { LoginRoute } from '../modules/auth/login-route';
+import { SignupRoute } from '../modules/auth/signup-route';
+import { VerifyRoute } from '../modules/auth/verify-route';
 import { ComingSoon } from '../modules/coming-soon';
 import { AppearanceRoute } from '../modules/design-system/appearance-route';
 import { ReferenceRoute } from '../modules/design-system/reference-route';
 import { ScenesRoute } from '../modules/design-system/scenes-route';
 
+import { AuthLayout } from './auth-layout';
+import { Root } from './root';
 import { RootLayout } from './root-layout';
+import { useSession } from './session';
 
-const rootRoute = createRootRoute({ component: RootLayout });
+const rootRoute = createRootRoute({ component: Root });
+
+// Pathless layout route: the authenticated app shell. Its guard bounces
+// unauthenticated visitors to /login before any child route loads.
+const appRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  id: 'app',
+  component: RootLayout,
+  beforeLoad: () => {
+    if (!useSession.getState().user) {
+      throw redirect({ to: '/login' });
+    }
+  },
+});
+
+// Pathless layout route: the shell-less auth screens. The mirror guard sends an
+// already-authenticated visitor to the app home instead of a login form.
+const authRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  id: 'auth',
+  component: AuthLayout,
+  beforeLoad: () => {
+    if (useSession.getState().user) {
+      throw redirect({ to: '/' });
+    }
+  },
+});
+
+// --- Authenticated app routes (children of appRoute) ---
 
 const indexRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appRoute,
   path: '/',
   beforeLoad: () => {
     throw redirect({ to: '/design/reference' });
@@ -23,36 +59,74 @@ const indexRoute = createRoute({
 });
 
 const referenceRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appRoute,
   path: '/design/reference',
   component: ReferenceRoute,
 });
 
 const scenesRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appRoute,
   path: '/design/scenes',
   component: ScenesRoute,
 });
 
 const appearanceRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appRoute,
   path: '/design/appearance',
   component: AppearanceRoute,
 });
 
 // One shared placeholder backs every not-yet-built module.
 const moduleRoute = createRoute({
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => appRoute,
   path: '/m/$module',
   component: ComingSoon,
 });
 
+// --- Auth routes (children of authRoute) ---
+
+const loginRoute = createRoute({
+  getParentRoute: () => authRoute,
+  path: '/login',
+  component: LoginRoute,
+});
+
+const signupRoute = createRoute({
+  getParentRoute: () => authRoute,
+  path: '/signup',
+  component: SignupRoute,
+});
+
+// `email` is carried from the login/signup step. Validated loose (optional) so a
+// stray hit doesn't throw a search error — beforeLoad redirects to /login when
+// it's absent. `VerifyRoute` reads it back via `verifyRoute.useSearch()`.
+export const verifyRoute = createRoute({
+  getParentRoute: () => authRoute,
+  path: '/verify',
+  validateSearch: z.object({ email: z.string().optional() }),
+  beforeLoad: ({ search }) => {
+    if (!search.email) {
+      throw redirect({ to: '/login' });
+    }
+  },
+  component: VerifyRoute,
+});
+
+const forgotRoute = createRoute({
+  getParentRoute: () => authRoute,
+  path: '/forgot',
+  component: ForgotRoute,
+});
+
 const routeTree = rootRoute.addChildren([
-  indexRoute,
-  referenceRoute,
-  scenesRoute,
-  appearanceRoute,
-  moduleRoute,
+  appRoute.addChildren([
+    indexRoute,
+    referenceRoute,
+    scenesRoute,
+    appearanceRoute,
+    moduleRoute,
+  ]),
+  authRoute.addChildren([loginRoute, signupRoute, verifyRoute, forgotRoute]),
 ]);
 
 export const router = createRouter({ routeTree });

--- a/apps/console/src/app/session.ts
+++ b/apps/console/src/app/session.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+import type { User } from '../lib/auth-api';
+
+type SessionState = {
+  user: User | null;
+  signIn: (user: User) => void;
+  signOut: () => void;
+};
+
+/**
+ * The single source of session truth. The auth screens write the verified user
+ * here on sign-in; the router's `beforeLoad` guards read it synchronously via
+ * `useSession.getState()`. `persist` uses localStorage (synchronous), so the
+ * store is hydrated before the first render — a guard never sees a stale `null`
+ * on reload.
+ */
+export const useSession = create<SessionState>()(
+  persist(
+    (set) => ({
+      user: null,
+      signIn: (user) => set({ user }),
+      signOut: () => set({ user: null }),
+    }),
+    { name: 'nexus-console-session' }
+  )
+);

--- a/apps/console/src/lib/auth-api.ts
+++ b/apps/console/src/lib/auth-api.ts
@@ -1,0 +1,45 @@
+/**
+ * Auth API client. Thin typed wrappers over the mock endpoints served by MSW
+ * (`src/mocks/handlers.ts`) — there is no real backend. Screens call these
+ * through TanStack Query mutations; the resolved user is written into the
+ * session store (`app/session.ts`), which is the single source of session truth.
+ */
+
+export type User = {
+  id: string;
+  name: string;
+  email: string;
+};
+
+type ApiError = { message?: string };
+
+async function post<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const data = (await res.json().catch(() => ({}))) as ApiError;
+    throw new Error(data.message ?? 'Something went wrong. Please try again.');
+  }
+  return res.json() as Promise<T>;
+}
+
+export type Credentials = { email: string; password: string };
+export type SignupInput = { name: string; email: string; password: string };
+export type VerifyInput = { email: string; code: string };
+
+/** Credentials check succeeds → the email proceeds to the OTP step. */
+export const login = (creds: Credentials) =>
+  post<{ email: string }>('/api/auth/login', creds);
+
+export const signup = (input: SignupInput) =>
+  post<{ email: string }>('/api/auth/signup', input);
+
+/** OTP check succeeds → the authenticated user is returned. */
+export const verifyOtp = (input: VerifyInput) =>
+  post<{ user: User }>('/api/auth/verify-otp', input);
+
+export const requestPasswordReset = (input: { email: string }) =>
+  post<{ ok: true }>('/api/auth/forgot', input);

--- a/apps/console/src/mocks/handlers.ts
+++ b/apps/console/src/mocks/handlers.ts
@@ -7,7 +7,7 @@ const OTP_CODE = '123456';
 
 /** Derive a stable demo user from an email — the mock has no real user table. */
 function userFromEmail(email: string): User {
-  const localPart = email.split('@')[0] ?? 'user';
+  const [localPart = ''] = email.split('@');
   const name = localPart
     .split(/[._-]+/)
     .filter(Boolean)
@@ -26,7 +26,8 @@ type VerifyBody = { email?: string; code?: string };
  * what actually authenticates and returns the user.
  */
 export const handlers: RequestHandler[] = [
-  // Credentials check: any email + an 8+ character password passes → proceed to OTP.
+  // Credentials check — no real validation (any email + an 8+ char password
+  // passes); the OTP step below is the only actual auth gate. Proceeds to OTP.
   http.post('/api/auth/login', async ({ request }) => {
     const { email, password } = (await request.json()) as LoginBody;
     if (!email || !password || password.length < 8) {

--- a/apps/console/src/mocks/handlers.ts
+++ b/apps/console/src/mocks/handlers.ts
@@ -1,7 +1,66 @@
-import type { RequestHandler } from 'msw';
+import { http, HttpResponse, type RequestHandler } from 'msw';
+
+import type { User } from '../lib/auth-api';
+
+/** The fixed demo OTP — shown as a hint on the verify screen. */
+const OTP_CODE = '123456';
+
+/** Derive a stable demo user from an email — the mock has no real user table. */
+function userFromEmail(email: string): User {
+  const localPart = email.split('@')[0] ?? 'user';
+  const name = localPart
+    .split(/[._-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+  return { id: email.toLowerCase(), name: name || 'Atlas User', email };
+}
+
+type LoginBody = { email?: string; password?: string };
+type SignupBody = { name?: string; email?: string; password?: string };
+type VerifyBody = { email?: string; code?: string };
 
 /**
- * MSW request handlers. Empty for the Phase 0 skeleton — each module appends
- * its own handlers here as it starts fetching mock data.
+ * MSW auth handlers — there is no real backend. The flow is two-step: a
+ * credentials check (login/signup) hands the email to the OTP step, which is
+ * what actually authenticates and returns the user.
  */
-export const handlers: RequestHandler[] = [];
+export const handlers: RequestHandler[] = [
+  // Credentials check: any email + an 8+ character password passes → proceed to OTP.
+  http.post('/api/auth/login', async ({ request }) => {
+    const { email, password } = (await request.json()) as LoginBody;
+    if (!email || !password || password.length < 8) {
+      return HttpResponse.json(
+        { message: 'Incorrect email or password.' },
+        { status: 401 }
+      );
+    }
+    return HttpResponse.json({ email });
+  }),
+
+  http.post('/api/auth/signup', async ({ request }) => {
+    const { name, email, password } = (await request.json()) as SignupBody;
+    if (!name || !email || !password || password.length < 8) {
+      return HttpResponse.json(
+        { message: 'Please complete every field (password 8+ characters).' },
+        { status: 400 }
+      );
+    }
+    return HttpResponse.json({ email });
+  }),
+
+  // OTP step: the fixed demo code authenticates and returns the user.
+  http.post('/api/auth/verify-otp', async ({ request }) => {
+    const { email, code } = (await request.json()) as VerifyBody;
+    if (!email || code !== OTP_CODE) {
+      return HttpResponse.json(
+        { message: 'That code is not valid. Try 123456.' },
+        { status: 401 }
+      );
+    }
+    return HttpResponse.json({ user: userFromEmail(email) });
+  }),
+
+  // Always acknowledge — never reveal whether an account exists for the email.
+  http.post('/api/auth/forgot', async () => HttpResponse.json({ ok: true })),
+];

--- a/apps/console/src/modules/auth/forgot-route.tsx
+++ b/apps/console/src/modules/auth/forgot-route.tsx
@@ -1,0 +1,111 @@
+import { useForm } from 'react-hook-form';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+} from '@nexus/react';
+import { useMutation } from '@tanstack/react-query';
+import { Link } from '@tanstack/react-router';
+import { z } from 'zod';
+
+import { requestPasswordReset } from '../../lib/auth-api';
+
+const forgotSchema = z.object({
+  email: z.email('Enter a valid email address'),
+});
+
+type ForgotValues = z.infer<typeof forgotSchema>;
+
+export function ForgotRoute() {
+  const form = useForm<ForgotValues>({
+    resolver: zodResolver(forgotSchema),
+    defaultValues: { email: '' },
+  });
+
+  const mutation = useMutation({ mutationFn: requestPasswordReset });
+  const onSubmit = (values: ForgotValues) => mutation.mutate(values);
+
+  if (mutation.isSuccess) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Check your email</CardTitle>
+          <CardDescription>
+            If an account exists for {form.getValues('email')}, we&apos;ve sent
+            a link to reset your password.
+          </CardDescription>
+        </CardHeader>
+        <CardFooter>
+          <Link
+            to="/login"
+            className="nx:text-primary-subtle-foreground nx:text-sm nx:hover:underline"
+          >
+            Back to sign in
+          </Link>
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <Form {...form}>
+        <form noValidate onSubmit={form.handleSubmit(onSubmit)}>
+          <CardHeader>
+            <CardTitle>Reset your password</CardTitle>
+            <CardDescription>
+              Enter your email and we&apos;ll send a link to reset it.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="you@example.com"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter className="nx:flex-col nx:gap-4">
+            <Button
+              type="submit"
+              className="nx:w-full"
+              loading={mutation.isPending}
+            >
+              Send reset link
+            </Button>
+            <Link
+              to="/login"
+              className="nx:text-muted-foreground nx:text-sm nx:hover:underline"
+            >
+              Back to sign in
+            </Link>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+}

--- a/apps/console/src/modules/auth/login-route.tsx
+++ b/apps/console/src/modules/auth/login-route.tsx
@@ -1,0 +1,130 @@
+import { useForm } from 'react-hook-form';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+} from '@nexus/react';
+import { useMutation } from '@tanstack/react-query';
+import { Link, useNavigate } from '@tanstack/react-router';
+import { z } from 'zod';
+
+import { login } from '../../lib/auth-api';
+
+const loginSchema = z.object({
+  email: z.email('Enter a valid email address'),
+  password: z.string().min(8, 'Password must be at least 8 characters'),
+});
+
+type LoginValues = z.infer<typeof loginSchema>;
+
+export function LoginRoute() {
+  const navigate = useNavigate();
+  const form = useForm<LoginValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: { email: 'demo@atlas.dev', password: 'demo1234' },
+  });
+
+  const mutation = useMutation({
+    mutationFn: login,
+    onSuccess: ({ email }) => navigate({ to: '/verify', search: { email } }),
+    onError: (error: Error) =>
+      form.setError('root', { message: error.message }),
+  });
+
+  const onSubmit = (values: LoginValues) => mutation.mutate(values);
+  const rootError = form.formState.errors.root?.message;
+
+  return (
+    <Card>
+      <Form {...form}>
+        <form noValidate onSubmit={form.handleSubmit(onSubmit)}>
+          <CardHeader>
+            <CardTitle>Sign in to Atlas</CardTitle>
+            <CardDescription>
+              Use the prefilled demo credentials, or any email with an 8+
+              character password.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="nx:space-y-5">
+            {rootError && (
+              <Alert variant="destructive">
+                <AlertDescription>{rootError}</AlertDescription>
+              </Alert>
+            )}
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="you@example.com"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <div className="nx:flex nx:items-center nx:justify-between">
+                    <FormLabel>Password</FormLabel>
+                    <Link
+                      to="/forgot"
+                      className="nx:text-primary-subtle-foreground nx:text-sm nx:hover:underline"
+                    >
+                      Forgot password?
+                    </Link>
+                  </div>
+                  <FormControl>
+                    <Input type="password" placeholder="••••••••" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter className="nx:flex-col nx:gap-4">
+            <Button
+              type="submit"
+              className="nx:w-full"
+              loading={mutation.isPending}
+            >
+              Continue
+            </Button>
+            <p className="nx:text-muted-foreground nx:text-sm">
+              No account?{' '}
+              <Link
+                to="/signup"
+                className="nx:text-primary-subtle-foreground nx:hover:underline"
+              >
+                Create one
+              </Link>
+            </p>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+}

--- a/apps/console/src/modules/auth/signup-route.tsx
+++ b/apps/console/src/modules/auth/signup-route.tsx
@@ -1,0 +1,136 @@
+import { useForm } from 'react-hook-form';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+} from '@nexus/react';
+import { useMutation } from '@tanstack/react-query';
+import { Link, useNavigate } from '@tanstack/react-router';
+import { z } from 'zod';
+
+import { signup } from '../../lib/auth-api';
+
+const signupSchema = z.object({
+  name: z.string().min(1, 'Enter your name'),
+  email: z.email('Enter a valid email address'),
+  password: z.string().min(8, 'Password must be at least 8 characters'),
+});
+
+type SignupValues = z.infer<typeof signupSchema>;
+
+export function SignupRoute() {
+  const navigate = useNavigate();
+  const form = useForm<SignupValues>({
+    resolver: zodResolver(signupSchema),
+    defaultValues: { name: '', email: '', password: '' },
+  });
+
+  const mutation = useMutation({
+    mutationFn: signup,
+    onSuccess: ({ email }) => navigate({ to: '/verify', search: { email } }),
+    onError: (error: Error) =>
+      form.setError('root', { message: error.message }),
+  });
+
+  const onSubmit = (values: SignupValues) => mutation.mutate(values);
+  const rootError = form.formState.errors.root?.message;
+
+  return (
+    <Card>
+      <Form {...form}>
+        <form noValidate onSubmit={form.handleSubmit(onSubmit)}>
+          <CardHeader>
+            <CardTitle>Create your account</CardTitle>
+            <CardDescription>
+              Start your Atlas workspace. We&apos;ll send a code to confirm your
+              email.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="nx:space-y-5">
+            {rootError && (
+              <Alert variant="destructive">
+                <AlertDescription>{rootError}</AlertDescription>
+              </Alert>
+            )}
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Ada Lovelace" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="you@example.com"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Password</FormLabel>
+                  <FormControl>
+                    <Input type="password" placeholder="••••••••" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter className="nx:flex-col nx:gap-4">
+            <Button
+              type="submit"
+              className="nx:w-full"
+              loading={mutation.isPending}
+            >
+              Create account
+            </Button>
+            <p className="nx:text-muted-foreground nx:text-sm">
+              Already have an account?{' '}
+              <Link
+                to="/login"
+                className="nx:text-primary-subtle-foreground nx:hover:underline"
+              >
+                Sign in
+              </Link>
+            </p>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+}

--- a/apps/console/src/modules/auth/verify-route.tsx
+++ b/apps/console/src/modules/auth/verify-route.tsx
@@ -15,18 +15,20 @@ import {
   InputOTPSlot,
 } from '@nexus/react';
 import { useMutation } from '@tanstack/react-query';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { getRouteApi, Link, useNavigate } from '@tanstack/react-router';
 
-// The route owns the `email` search schema; reading it through the route object
-// keeps the value typed. (The route's beforeLoad redirects when email is absent,
-// so the guard below is belt-and-braces.)
-import { verifyRoute } from '../../app/router';
 import { useSession } from '../../app/session';
 import { verifyOtp } from '../../lib/auth-api';
 
+// The route owns the `email` search schema; getRouteApi reads it back typed
+// without importing the route object (which would create a router ↔ screen
+// import cycle). The route's beforeLoad redirects when email is absent, so the
+// guard in the component body is belt-and-braces.
+const verifyApi = getRouteApi('/auth/verify');
+
 export function VerifyRoute() {
   const navigate = useNavigate();
-  const { email } = verifyRoute.useSearch();
+  const { email } = verifyApi.useSearch();
   const signIn = useSession((s) => s.signIn);
   const [code, setCode] = useState('');
   const [error, setError] = useState<string | null>(null);

--- a/apps/console/src/modules/auth/verify-route.tsx
+++ b/apps/console/src/modules/auth/verify-route.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from '@nexus/react';
+import { useMutation } from '@tanstack/react-query';
+import { Link, useNavigate } from '@tanstack/react-router';
+
+// The route owns the `email` search schema; reading it through the route object
+// keeps the value typed. (The route's beforeLoad redirects when email is absent,
+// so the guard below is belt-and-braces.)
+import { verifyRoute } from '../../app/router';
+import { useSession } from '../../app/session';
+import { verifyOtp } from '../../lib/auth-api';
+
+export function VerifyRoute() {
+  const navigate = useNavigate();
+  const { email } = verifyRoute.useSearch();
+  const signIn = useSession((s) => s.signIn);
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: verifyOtp,
+    onSuccess: ({ user }) => {
+      signIn(user);
+      navigate({ to: '/' });
+    },
+    onError: (err: Error) => setError(err.message),
+  });
+
+  if (!email) return null;
+
+  const submit = (value: string) => {
+    setError(null);
+    mutation.mutate({ email, code: value });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Check your email</CardTitle>
+        <CardDescription>
+          Enter the 6-digit code we sent to {email}. Demo code:{' '}
+          <span className="nx:text-foreground nx:font-medium">123456</span>.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="nx:flex nx:flex-col nx:items-center nx:gap-5">
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        <InputOTP
+          maxLength={6}
+          value={code}
+          onChange={setCode}
+          onComplete={submit}
+          disabled={mutation.isPending}
+          aria-label="One-time code"
+        >
+          <InputOTPGroup>
+            {Array.from({ length: 6 }, (_, i) => (
+              <InputOTPSlot key={i} index={i} />
+            ))}
+          </InputOTPGroup>
+        </InputOTP>
+      </CardContent>
+      <CardFooter className="nx:flex-col nx:gap-4">
+        <Button
+          className="nx:w-full"
+          loading={mutation.isPending}
+          disabled={code.length < 6}
+          onClick={() => submit(code)}
+        >
+          Verify
+        </Button>
+        <Link
+          to="/login"
+          className="nx:text-muted-foreground nx:text-sm nx:hover:underline"
+        >
+          Back to sign in
+        </Link>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/console/src/modules/coming-soon.tsx
+++ b/apps/console/src/modules/coming-soon.tsx
@@ -8,7 +8,9 @@ import { MODULE_ITEMS } from '../shell/modules';
  * theming, and mock-API layer are already in place beneath it.
  */
 export function ComingSoon() {
-  const { module } = useParams({ from: '/m/$module' });
+  // `from` is the route ID, which the pathless `_app` layout route prefixes
+  // with `/app` (the URL stays `/m/$module`).
+  const { module } = useParams({ from: '/app/m/$module' });
   const label = MODULE_ITEMS.find((m) => m.module === module)?.label ?? module;
   return (
     <div className="nx:flex nx:min-h-[60vh] nx:flex-col nx:items-center nx:justify-center nx:gap-3 nx:p-6 nx:text-center">

--- a/apps/console/src/shell/app-sidebar.tsx
+++ b/apps/console/src/shell/app-sidebar.tsx
@@ -1,4 +1,10 @@
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
   Sidebar,
   SidebarContent,
   SidebarFooter,
@@ -14,10 +20,13 @@ import {
 import {
   IconComponents,
   IconLayoutGrid,
+  IconLogout,
   IconPalette,
   IconUserCircle,
 } from '@tabler/icons-react';
-import { Link, useMatchRoute } from '@tanstack/react-router';
+import { Link, useMatchRoute, useNavigate } from '@tanstack/react-router';
+
+import { useSession } from '../app/session';
 
 import { MODULE_ITEMS } from './modules';
 
@@ -34,6 +43,14 @@ const DESIGN_ITEMS = [
  */
 export function AppSidebar() {
   const matchRoute = useMatchRoute();
+  const navigate = useNavigate();
+  const user = useSession((s) => s.user);
+  const signOut = useSession((s) => s.signOut);
+
+  const handleSignOut = () => {
+    signOut();
+    navigate({ to: '/login' });
+  };
 
   return (
     <Sidebar>
@@ -105,10 +122,31 @@ export function AppSidebar() {
       <SidebarFooter>
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton tooltip="Account">
-              <IconUserCircle />
-              <span>Account</span>
-            </SidebarMenuButton>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <SidebarMenuButton tooltip="Account">
+                  <IconUserCircle />
+                  <span>{user?.name ?? 'Account'}</span>
+                </SidebarMenuButton>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent side="right" align="end" className="nx:w-56">
+                {user && (
+                  <>
+                    <DropdownMenuLabel className="nx:flex nx:flex-col">
+                      <span>{user.name}</span>
+                      <span className="nx:text-muted-foreground nx:text-xs nx:font-normal">
+                        {user.email}
+                      </span>
+                    </DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                  </>
+                )}
+                <DropdownMenuItem onSelect={handleSignOut}>
+                  <IconLogout />
+                  Sign out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarFooter>

--- a/docs/plans/atlas-company-os.md
+++ b/docs/plans/atlas-company-os.md
@@ -84,13 +84,14 @@ apps/console/src/
 
 ## Phased roadmap (each phase = a PR)
 
-| Phase                         | Deliverable                                                                                                                                                            |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **0 · Foundation**            | Rename → `apps/console`; TanStack Router + app shell (sidebar/topbar) + `ThemeProvider` + TanStack Query + MSW skeleton; fold playground into the Design System module |
-| **1 · Auth + Onboarding**     | login/signup/SSO/forgot/OTP/invite + workspace creation + checklist                                                                                                    |
-| **2 · Flagship module (CRM)** | end-to-end: table + kanban + record page + create/edit + filters/saved views (proves the deep patterns once)                                                           |
-| **3 · Breadth**               | Projects, Inbox, Billing, Analytics, People — reusing Phase-2 patterns                                                                                                 |
-| **4 · Cross-cutting**         | ⌘K palette, global search, notifications center, all states (empty/error/404/403), responsive                                                                          |
-| **5 · Polish + theme proof**  | Appearance quick-control, "flip a theme axis → whole app re-themes" demo, a11y/contrast sweep                                                                          |
+| Phase                              | Deliverable                                                                                                                                                                                     |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **0 · Foundation**                 | Rename → `apps/console`; TanStack Router + app shell (sidebar/topbar) + `ThemeProvider` + TanStack Query + MSW skeleton; fold playground into the Design System module                          |
+| **1a · Core auth**                 | login · signup · 2FA OTP (`InputOtp`) · forgot-password — MSW-backed, Zustand session, route guards (pathless `_app` / `_auth` layouts), sidebar sign-out                                       |
+| **1b · Auth breadth + onboarding** | SSO/OAuth · magic-link · accept-invite · session-expired · reset-password completion **+** onboarding (create workspace · invite team · choose plan · setup checklist · first-run empty states) |
+| **2 · Flagship module (CRM)**      | end-to-end: table + kanban + record page + create/edit + filters/saved views (proves the deep patterns once)                                                                                    |
+| **3 · Breadth**                    | Projects, Inbox, Billing, Analytics, People — reusing Phase-2 patterns                                                                                                                          |
+| **4 · Cross-cutting**              | ⌘K palette, global search, notifications center, all states (empty/error/404/403), responsive                                                                                                   |
+| **5 · Polish + theme proof**       | Appearance quick-control, "flip a theme axis → whole app re-themes" demo, a11y/contrast sweep                                                                                                   |
 
 Missing components are extracted as their own Nexus component issues as they're hit — never hand-rolled in the app.


### PR DESCRIPTION
## Summary

Phase 1a of the Atlas build — **core auth**, MSW-backed (no real backend). Adds the authenticated/unauthenticated split and four auth screens.

- **Session** — Zustand `useSession` store, persisted to localStorage. The router's `beforeLoad` guards read it synchronously via `getState()` (persist uses sync storage, so it's hydrated before first paint).
- **Routing** — two pathless layout routes off the root: `_app` (the existing shell + an auth guard that bounces unauthenticated visitors to `/login`) and `_auth` (a shell-less split-panel layout + a mirror redirect-if-authed guard). The thin root route holds only the app-wide `<Toaster>`. URLs stay clean (`/login`, `/design/reference`); the pathless ids only surface in route-id `from`s (e.g. `/app/m/$module`).
- **Screens** — login (prefilled demo creds), signup, 2FA OTP verify (`InputOTP`, code `123456`), forgot-password (resolves to a "check your email" confirmation — the reset-completion screen is reached from the email link, so it's out of scope here). All reuse the rhf + zod + `useMutation` pattern.
- **Shell** — the sidebar Account footer is now a dropdown showing the signed-in user + a **Sign out** item (clears the session, navigates to `/login`).
- **MSW** — `/api/auth/{login,signup,verify-otp,forgot}`; login/signup accept any email + an 8+ char password and hand off to the OTP step; verify-otp authenticates on `123456`.

## Scope (tracked in `docs/plans/atlas-company-os.md`)

Phase 1 is split into **1a (this PR)** and **1b** — SSO/OAuth · magic-link · accept-invite · session-expired · reset-password completion **+** onboarding (workspace creation · invite team · choose plan · checklist · first-run empty states). The plan doc carries the split; this is not an untracked deferral.

The Design System showcase now sits behind the auth guard (a deliberate B2B-SaaS shape) — demo creds are prefilled and the session persists, so it's one-time friction.

## Test Plan

Walked end-to-end in-browser (light + dark):

- [x] Unauthed hit on `/design/reference` → bounced to `/login`
- [x] Login (demo creds) → `/verify?email=…` → OTP `123456` → `/design/reference`
- [x] Invalid OTP → inline error alert
- [x] Account dropdown → **Sign out** → session cleared → bounced to `/login`
- [x] Dark-mode auth screen renders correctly (base tokens apply outside the shell)
- [x] Forgot → confirmation state
- [x] Signup → `/verify` → OTP → app
- [x] `yarn workspace @nexus/console typecheck` + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)