### PR TITLE
feat(components): add pagination component

### DIFF
--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -49,6 +49,7 @@
         "KeyboardInteraction": ["TypeInteraction"]
       }
     },
+    { "name": "Pagination", "showcase": "AllVariants" },
     {
       "name": "Popover",
       "showcase": "AllVariants",

--- a/packages/react/src/components/ui/Pagination.stories.tsx
+++ b/packages/react/src/components/ui/Pagination.stories.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
@@ -88,22 +90,31 @@ export const FewPages: Story = {
 // paging state.
 export const ClickInteraction: Story = {
   args: { onClick: fn() },
-  render: (args) => (
-    <Pagination>
-      <PaginationContent>
-        <PaginationItem>
-          <PaginationLink href="#" onClick={args.onClick}>
-            1
-          </PaginationLink>
-        </PaginationItem>
-        <PaginationItem>
-          <PaginationLink href="#" isActive onClick={args.onClick}>
-            2
-          </PaginationLink>
-        </PaginationItem>
-      </PaginationContent>
-    </Pagination>
-  ),
+  render: (args) => {
+    // Pagination links are anchors; with no router in a story, activating one
+    // performs the default navigation and tears down the test page. Cancel it,
+    // then let the spy observe the click.
+    const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      args.onClick?.(event);
+    };
+    return (
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="#" onClick={handleClick}>
+              1
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#" isActive onClick={handleClick}>
+              2
+            </PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+  },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
     const page1 = canvas.getByRole('link', { name: '1' });
@@ -117,20 +128,28 @@ export const ClickInteraction: Story = {
 // pointer users.
 export const KeyboardInteraction: Story = {
   args: { onClick: fn() },
-  render: (args) => (
-    <Pagination>
-      <PaginationContent>
-        <PaginationItem>
-          <PaginationLink href="#" onClick={args.onClick}>
-            1
-          </PaginationLink>
-        </PaginationItem>
-        <PaginationItem>
-          <PaginationLink href="#">2</PaginationLink>
-        </PaginationItem>
-      </PaginationContent>
-    </Pagination>
-  ),
+  render: (args) => {
+    // Enter on a focused anchor dispatches a click that would navigate; cancel
+    // the default so the test page survives and the spy still records the call.
+    const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      args.onClick?.(event);
+    };
+    return (
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationLink href="#" onClick={handleClick}>
+              1
+            </PaginationLink>
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationLink href="#">2</PaginationLink>
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    );
+  },
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
     const page1 = canvas.getByRole('link', { name: '1' });

--- a/packages/react/src/components/ui/Pagination.stories.tsx
+++ b/packages/react/src/components/ui/Pagination.stories.tsx
@@ -1,0 +1,224 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from './pagination';
+
+const meta: Meta<typeof Pagination> = {
+  title: 'Components/Pagination',
+  component: Pagination,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Pagination>;
+
+// The canonical row: previous/next edge controls, a run of page numbers with
+// the current page active, and an ellipsis standing in for the pages skipped
+// before the last one.
+export const Default: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            2
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">3</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">10</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+};
+
+// A short pager with no overflow — every page fits, so no ellipsis is needed.
+export const FewPages: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            1
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">2</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">3</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+};
+
+// Clicking a page link fires its handler — the consumer wires this to its
+// paging state.
+export const ClickInteraction: Story = {
+  args: { onClick: fn() },
+  render: (args) => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationLink href="#" onClick={args.onClick}>
+            1
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive onClick={args.onClick}>
+            2
+          </PaginationLink>
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const page1 = canvas.getByRole('link', { name: '1' });
+
+    await userEvent.click(page1);
+    await expect(args.onClick).toHaveBeenCalledTimes(1);
+  },
+};
+
+// Page links are reachable by Tab and activate on Enter — keyboard parity with
+// pointer users.
+export const KeyboardInteraction: Story = {
+  args: { onClick: fn() },
+  render: (args) => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationLink href="#" onClick={args.onClick}>
+            1
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">2</PaginationLink>
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const page1 = canvas.getByRole('link', { name: '1' });
+
+    await userEvent.tab();
+    await expect(page1).toHaveFocus();
+
+    await userEvent.keyboard('{Enter}');
+    await expect(args.onClick).toHaveBeenCalledTimes(1);
+  },
+};
+
+// Every structural part carries a data-slot hook; the active page advertises
+// itself to assistive tech via aria-current and exposes a data-active hook.
+export const WithDataAttributes: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            1
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+  play: async ({ canvasElement }) => {
+    for (const slot of [
+      'pagination',
+      'pagination-content',
+      'pagination-item',
+      'pagination-link',
+      'pagination-ellipsis',
+    ]) {
+      await expect(
+        canvasElement.querySelector(`[data-slot="${slot}"]`)
+      ).toBeInTheDocument();
+    }
+
+    const active = canvasElement.querySelector('[data-active="true"]');
+    await expect(active).toHaveAttribute('aria-current', 'page');
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// The full anatomy in one row: edge controls, ghost page links, the active
+// page in its outline treatment, and the overflow ellipsis. Reused by the
+// per-base variant generator.
+export const AllVariants: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            2
+          </PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">3</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">10</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+};

--- a/packages/react/src/components/ui/pagination.tsx
+++ b/packages/react/src/components/ui/pagination.tsx
@@ -1,0 +1,245 @@
+import * as React from 'react';
+
+import { type ButtonProps, buttonVariants } from '@/components/ui/button';
+import { IconChevronLeft, IconChevronRight, IconDots } from '@/lib/icons';
+import { cn } from '@/lib/utils';
+
+/**
+ * PaginationProps
+ *
+ * Props for the Pagination component.
+ */
+interface PaginationProps extends React.ComponentProps<'nav'> {}
+
+/**
+ * Pagination
+ *
+ * Page navigation for list and table views, wrapped in the `navigation`
+ * landmark. Compose with the sub-components: `PaginationContent` lays out a row
+ * of `PaginationItem`s, each holding a `PaginationLink` (page number),
+ * `PaginationPrevious` / `PaginationNext` (edge controls), or
+ * `PaginationEllipsis` (overflow indicator).
+ *
+ * This is the structural primitive only — page-number generation and any
+ * page-size control are the consumer's concern (compose them with `Select` and
+ * your own paging state).
+ *
+ * @example
+ * ```tsx
+ * <Pagination>
+ *   <PaginationContent>
+ *     <PaginationItem>
+ *       <PaginationPrevious href="#" />
+ *     </PaginationItem>
+ *     <PaginationItem>
+ *       <PaginationLink href="#">1</PaginationLink>
+ *     </PaginationItem>
+ *     <PaginationItem>
+ *       <PaginationLink href="#" isActive>
+ *         2
+ *       </PaginationLink>
+ *     </PaginationItem>
+ *     <PaginationItem>
+ *       <PaginationEllipsis />
+ *     </PaginationItem>
+ *     <PaginationItem>
+ *       <PaginationNext href="#" />
+ *     </PaginationItem>
+ *   </PaginationContent>
+ * </Pagination>
+ * ```
+ */
+function Pagination({ className, ...props }: PaginationProps) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn(
+        'nx:mx-auto nx:flex nx:w-full nx:justify-center',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * PaginationContentProps
+ *
+ * Props for the PaginationContent component.
+ */
+interface PaginationContentProps extends React.ComponentProps<'ul'> {}
+
+/**
+ * PaginationContent
+ *
+ * The `<ul>` that lays the pagination items out in a horizontal row.
+ */
+function PaginationContent({ className, ...props }: PaginationContentProps) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn(
+        // nexus-allow-numeric: tight gap between pager items
+        'nx:flex nx:flex-row nx:items-center nx:gap-1',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * PaginationItemProps
+ *
+ * Props for the PaginationItem component.
+ */
+interface PaginationItemProps extends React.ComponentProps<'li'> {}
+
+/**
+ * PaginationItem
+ *
+ * A single `<li>` slot in the pagination row.
+ */
+function PaginationItem(props: PaginationItemProps) {
+  return <li data-slot="pagination-item" {...props} />;
+}
+
+/**
+ * PaginationLinkProps
+ *
+ * Props for the PaginationLink component.
+ */
+interface PaginationLinkProps
+  extends React.ComponentProps<'a'>, Pick<ButtonProps, 'size'> {
+  /**
+   * Marks this link as the current page — applies the `outline` button
+   * treatment and sets `aria-current="page"`.
+   * @default false
+   */
+  isActive?: boolean;
+}
+
+/**
+ * PaginationLink
+ *
+ * A page link styled with the button system. The active page uses the
+ * `outline` variant; the rest use `ghost`. Defaults to the square `icon` size,
+ * suited to single page numbers.
+ */
+function PaginationLink({
+  className,
+  isActive,
+  size = 'icon',
+  children,
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? 'page' : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({ variant: isActive ? 'outline' : 'ghost', size }),
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </a>
+  );
+}
+
+/**
+ * PaginationPreviousProps
+ *
+ * Props for the PaginationPrevious component.
+ */
+interface PaginationPreviousProps extends React.ComponentProps<
+  typeof PaginationLink
+> {}
+
+/**
+ * PaginationPrevious
+ *
+ * The "previous page" edge control — a left chevron and label.
+ */
+function PaginationPrevious(props: PaginationPreviousProps) {
+  return (
+    <PaginationLink aria-label="Go to previous page" size="default" {...props}>
+      <IconChevronLeft />
+      <span>Previous</span>
+    </PaginationLink>
+  );
+}
+
+/**
+ * PaginationNextProps
+ *
+ * Props for the PaginationNext component.
+ */
+interface PaginationNextProps extends React.ComponentProps<
+  typeof PaginationLink
+> {}
+
+/**
+ * PaginationNext
+ *
+ * The "next page" edge control — a label and right chevron.
+ */
+function PaginationNext(props: PaginationNextProps) {
+  return (
+    <PaginationLink aria-label="Go to next page" size="default" {...props}>
+      <span>Next</span>
+      <IconChevronRight />
+    </PaginationLink>
+  );
+}
+
+/**
+ * PaginationEllipsisProps
+ *
+ * Props for the PaginationEllipsis component.
+ */
+interface PaginationEllipsisProps extends React.ComponentProps<'span'> {}
+
+/**
+ * PaginationEllipsis
+ *
+ * A non-interactive overflow indicator standing in for skipped page numbers.
+ */
+function PaginationEllipsis({ className, ...props }: PaginationEllipsisProps) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn(
+        // nexus-allow-numeric: match the size="icon" link footprint
+        'nx:flex nx:items-center nx:justify-center nx:p-2.5',
+        className
+      )}
+      {...props}
+    >
+      <IconDots className="nx:size-4" />
+      <span className="nx:sr-only">More pages</span>
+    </span>
+  );
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  type PaginationContentProps,
+  PaginationEllipsis,
+  type PaginationEllipsisProps,
+  PaginationItem,
+  type PaginationItemProps,
+  PaginationLink,
+  type PaginationLinkProps,
+  PaginationNext,
+  type PaginationNextProps,
+  PaginationPrevious,
+  type PaginationPreviousProps,
+  type PaginationProps,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -24,6 +24,7 @@ export * from '@/components/ui/form';
 export * from '@/components/ui/input';
 export * from '@/components/ui/input-otp';
 export * from '@/components/ui/label';
+export * from '@/components/ui/pagination';
 export * from '@/components/ui/popover';
 export * from '@/components/ui/progress';
 export * from '@/components/ui/radio-group';

--- a/packages/react/src/lib/icons.ts
+++ b/packages/react/src/lib/icons.ts
@@ -18,8 +18,10 @@ export { IconLoader2 } from '@tabler/icons-react';
 // Navigation
 export {
   IconChevronDown,
+  IconChevronLeft,
   IconChevronRight,
   IconChevronUp,
+  IconDots,
   IconLayoutSidebar,
 } from '@tabler/icons-react';
 


### PR DESCRIPTION
## Summary

Adapts shadcn's Pagination into a first-class `@nexus/react` component — the structural primitive surfaced by the Atlas Contacts DataTable dogfooding (#281).

**Components:** `Pagination`, `PaginationContent`, `PaginationItem`, `PaginationLink`, `PaginationPrevious`, `PaginationNext`, `PaginationEllipsis`.

- `nx:`-prefixed semantic tokens via `buttonVariants` (active page = `outline`, the rest = `ghost`); `data-slot` on every part; canonical focus ring inherited from the button system
- **No new dependency** — pure markup reusing `buttonVariants` + the icon barrel (`+IconChevronLeft`, `+IconDots`); ESM bundle 67.41 kB (< 70 kB limit)
- Opted into the per-base variant generator (`AllVariants` showcase)

### Scope — structural primitive only
The issue's Gap mentions *page-size select* and *disabled edges*. This PR ships the structural primitive the issue names as the reference; the rest stays app-side by design:

- **Page-size select** composes with the existing `Select` + the consumer's paging state — not baked into the DS component (`composition-over-render-props`).
- **Disabled edges** are a consumer concern — an `<a>` can't be `disabled`; the app conditionally renders/styles its edge controls.
- Dropped shadcn's `hidden sm:*` label-hiding — `responsive.md` bars viewport prefixes in component internals (Pagination is not a full-viewport overlay), so Previous/Next labels always show.
- No `asChild` on `PaginationLink` — Previous/Next render two children and Radix `Slot` requires a single child.

If a *smart pager* (page-number generation + size select in one component) was intended instead, flag it and I'll extend.

## GitHub Issue

Closes #281

## Test Plan

- [x] `yarn workspace @nexus/react typecheck`
- [x] `yarn lint` — `eslint . --max-warnings 0`
- [x] `yarn workspace @nexus/react audit:storybook-coverage --component pagination` — 0 missing, 0 drift
- [x] `yarn size-limit` — 67.41 kB ESM / 8.89 kB CSS
- [ ] `yarn test:storybook` — Click/Keyboard/WithDataAttributes play-fns + a11y run in **CI** (the worktree browser runner crashes non-deterministically; the chromium base-variants smoke test passes locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)