### PR TITLE
feat(console): CRM contact detail page (Phase 2b)

### DIFF
--- a/apps/console/src/app/router.tsx
+++ b/apps/console/src/app/router.tsx
@@ -11,6 +11,7 @@ import { LoginRoute } from '../modules/auth/login-route';
 import { SignupRoute } from '../modules/auth/signup-route';
 import { VerifyRoute } from '../modules/auth/verify-route';
 import { ComingSoon } from '../modules/coming-soon';
+import { ContactDetailRoute } from '../modules/crm/contact-detail-route';
 import { ContactsRoute } from '../modules/crm/contacts-route';
 import { AppearanceRoute } from '../modules/design-system/appearance-route';
 import { ReferenceRoute } from '../modules/design-system/reference-route';
@@ -86,6 +87,12 @@ const crmContactsRoute = createRoute({
   component: ContactsRoute,
 });
 
+const crmContactDetailRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: '/m/crm/$id',
+  component: ContactDetailRoute,
+});
+
 // One shared placeholder backs every not-yet-built module.
 const moduleRoute = createRoute({
   getParentRoute: () => appRoute,
@@ -135,6 +142,7 @@ const routeTree = rootRoute.addChildren([
     scenesRoute,
     appearanceRoute,
     crmContactsRoute,
+    crmContactDetailRoute,
     moduleRoute,
   ]),
   authRoute.addChildren([loginRoute, signupRoute, verifyRoute, forgotRoute]),

--- a/apps/console/src/lib/crm-api.ts
+++ b/apps/console/src/lib/crm-api.ts
@@ -31,3 +31,26 @@ export async function fetchContacts(): Promise<{ contacts: Contact[] }> {
   }
   return (await res.json()) as { contacts: Contact[] };
 }
+
+export type ActivityKind = 'created' | 'email' | 'status' | 'note';
+
+export type ActivityItem = {
+  id: string;
+  kind: ActivityKind;
+  /** ISO date (YYYY-MM-DD). */
+  date: string;
+  summary: string;
+};
+
+/** A contact plus its activity timeline — the record-detail payload. */
+export type ContactDetail = Contact & { activity: ActivityItem[] };
+
+export async function fetchContact(
+  id: string
+): Promise<{ contact: ContactDetail }> {
+  const res = await fetch(`/api/crm/contacts/${id}`);
+  if (!res.ok) {
+    throw new Error('Failed to load contact.');
+  }
+  return (await res.json()) as { contact: ContactDetail };
+}

--- a/apps/console/src/lib/format.ts
+++ b/apps/console/src/lib/format.ts
@@ -1,0 +1,25 @@
+/**
+ * App-wide value formatters. CRM, Billing, and Analytics all render currency and
+ * dates, so these live in `lib/` (per the plan's folder shape) rather than any
+ * one module.
+ *
+ * Dates are formatted in **UTC**: an ISO date like `2026-05-28` parses as UTC
+ * midnight, so rendering in the viewer's local zone would show the previous day
+ * for anyone west of UTC. Pinning the formatter to UTC renders the authored
+ * calendar day everywhere.
+ */
+const currencyFmt = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0,
+});
+
+const dateFmt = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+
+export const formatCurrency = (value: number) => currencyFmt.format(value);
+export const formatDate = (iso: string) => dateFmt.format(new Date(iso));

--- a/apps/console/src/lib/query-client.ts
+++ b/apps/console/src/lib/query-client.ts
@@ -9,6 +9,11 @@ export const queryClient = new QueryClient({
     queries: {
       staleTime: 60_000,
       refetchOnWindowFocus: false,
+      // The mock API is deterministic — a request either succeeds or 404s, and a
+      // retry never changes that. Skipping retries makes error states (e.g. an
+      // unknown contact id) render instantly instead of after react-query's
+      // backoff. Revisit when a real, transient-failure-prone backend lands.
+      retry: false,
     },
   },
 });

--- a/apps/console/src/mocks/handlers.ts
+++ b/apps/console/src/mocks/handlers.ts
@@ -1,6 +1,7 @@
 import { delay, http, HttpResponse, type RequestHandler } from 'msw';
 
 import type { User } from '../lib/auth-api';
+import type { ActivityItem, Contact } from '../lib/crm-api';
 
 import { CONTACTS } from './crm-fixtures';
 
@@ -21,6 +22,47 @@ function userFromEmail(email: string): User {
 type LoginBody = { email?: string; password?: string };
 type SignupBody = { name?: string; email?: string; password?: string };
 type VerifyBody = { email?: string; code?: string };
+
+/** Shift an ISO date (YYYY-MM-DD) back by `days`, returning the same format. */
+function isoMinusDays(iso: string, days: number): string {
+  const d = new Date(iso);
+  d.setDate(d.getDate() - days);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * A deterministic activity timeline synthesised from the contact's own fields
+ * (no stored events) — newest first, dated by offsets from the last touchpoint.
+ */
+function buildActivity(contact: Contact): ActivityItem[] {
+  const { id, name, owner, status, lastContacted } = contact;
+  return [
+    {
+      id: `${id}-a1`,
+      kind: 'email',
+      date: lastContacted,
+      summary: `Logged an email with ${name}`,
+    },
+    {
+      id: `${id}-a2`,
+      kind: 'note',
+      date: isoMinusDays(lastContacted, 9),
+      summary: `${owner} added a note`,
+    },
+    {
+      id: `${id}-a3`,
+      kind: 'status',
+      date: isoMinusDays(lastContacted, 34),
+      summary: `Status set to ${status}`,
+    },
+    {
+      id: `${id}-a4`,
+      kind: 'created',
+      date: isoMinusDays(lastContacted, 96),
+      summary: `Created and assigned to ${owner}`,
+    },
+  ];
+}
 
 /**
  * MSW request handlers — there is no real backend. Auth is a two-step flow: a
@@ -73,5 +115,20 @@ export const handlers: RequestHandler[] = [
   http.get('/api/crm/contacts', async () => {
     await delay(500);
     return HttpResponse.json({ contacts: CONTACTS });
+  }),
+
+  // A single contact + its synthesised activity timeline (404 when unknown).
+  http.get('/api/crm/contacts/:id', async ({ params }) => {
+    await delay(300);
+    const contact = CONTACTS.find((c) => c.id === params.id);
+    if (!contact) {
+      return HttpResponse.json(
+        { message: 'Contact not found.' },
+        { status: 404 }
+      );
+    }
+    return HttpResponse.json({
+      contact: { ...contact, activity: buildActivity(contact) },
+    });
   }),
 ];

--- a/apps/console/src/modules/crm/contact-detail-route.tsx
+++ b/apps/console/src/modules/crm/contact-detail-route.tsx
@@ -1,0 +1,193 @@
+import {
+  Avatar,
+  AvatarFallback,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Separator,
+  Skeleton,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from '@nexus/react';
+import {
+  IconArrowLeft,
+  IconFlag,
+  IconMail,
+  IconNote,
+  IconUserPlus,
+} from '@tabler/icons-react';
+import { useQuery } from '@tanstack/react-query';
+import { Link, useParams } from '@tanstack/react-router';
+
+import {
+  type ActivityKind,
+  type ContactDetail,
+  fetchContact,
+} from '../../lib/crm-api';
+
+import {
+  ContactStatusBadge,
+  formatCurrency,
+  formatDate,
+  initials,
+} from './contact-ui';
+
+export function ContactDetailRoute() {
+  const { id } = useParams({ from: '/app/m/crm/$id' });
+  const { data, isPending, isError } = useQuery({
+    queryKey: ['crm', 'contact', id],
+    queryFn: () => fetchContact(id),
+  });
+
+  return (
+    <div className="nx:space-y-6 nx:p-6">
+      <Link
+        to="/m/crm"
+        className="nx:text-muted-foreground nx:hover:text-foreground nx:inline-flex nx:items-center nx:gap-1 nx:text-sm"
+      >
+        <IconArrowLeft className="nx:size-4" />
+        Contacts
+      </Link>
+
+      {isPending && <DetailSkeleton />}
+      {isError && <NotFound />}
+      {data && <DetailContent contact={data.contact} />}
+    </div>
+  );
+}
+
+function DetailContent({ contact }: { contact: ContactDetail }) {
+  return (
+    <>
+      <header className="nx:flex nx:items-center nx:gap-4">
+        <Avatar className="nx:size-12">
+          <AvatarFallback>{initials(contact.name)}</AvatarFallback>
+        </Avatar>
+        <div className="nx:space-y-1">
+          <div className="nx:flex nx:items-center nx:gap-3">
+            <h1 className="nx:typography-heading-large nx:text-foreground">
+              {contact.name}
+            </h1>
+            <ContactStatusBadge status={contact.status} />
+          </div>
+          <p className="nx:text-muted-foreground">{contact.company}</p>
+        </div>
+      </header>
+
+      <Tabs defaultValue="overview">
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="activity">Activity</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview">
+          <Card>
+            <CardHeader>
+              <CardTitle>Details</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Field label="Email" value={contact.email} />
+              <Separator />
+              <Field label="Owner" value={contact.owner} />
+              <Separator />
+              <Field label="Open value" value={formatCurrency(contact.value)} />
+              <Separator />
+              <Field
+                label="Last contacted"
+                value={formatDate(contact.lastContacted)}
+              />
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="activity">
+          <Card>
+            <CardHeader>
+              <CardTitle>Activity</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ol className="nx:space-y-4">
+                {contact.activity.map((item) => (
+                  <li key={item.id} className="nx:flex nx:gap-3">
+                    <div className="nx:bg-muted nx:text-muted-foreground nx:flex nx:size-8 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-full">
+                      <ActivityIcon kind={item.kind} />
+                    </div>
+                    <div className="nx:space-y-0.5">
+                      <p className="nx:text-foreground nx:text-sm">
+                        {item.summary}
+                      </p>
+                      <p className="nx:text-muted-foreground nx:text-xs">
+                        {formatDate(item.date)}
+                      </p>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="nx:flex nx:items-center nx:justify-between nx:py-3">
+      <span className="nx:text-muted-foreground nx:text-sm">{label}</span>
+      <span className="nx:text-foreground nx:text-sm nx:font-medium">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+const ACTIVITY_ICON: Record<ActivityKind, typeof IconMail> = {
+  email: IconMail,
+  note: IconNote,
+  status: IconFlag,
+  created: IconUserPlus,
+};
+
+function ActivityIcon({ kind }: { kind: ActivityKind }) {
+  const Icon = ACTIVITY_ICON[kind];
+  return <Icon className="nx:size-4" />;
+}
+
+function DetailSkeleton() {
+  return (
+    <div className="nx:space-y-6">
+      <div className="nx:flex nx:items-center nx:gap-4">
+        <Skeleton className="nx:size-12 nx:rounded-full" />
+        <div className="nx:space-y-2">
+          <Skeleton className="nx:h-6 nx:w-48" />
+          <Skeleton className="nx:h-4 nx:w-32" />
+        </div>
+      </div>
+      <Skeleton className="nx:h-64 nx:w-full" />
+    </div>
+  );
+}
+
+// App-local not-found — the polished @nexus/react EmptyState is tracked in #282.
+function NotFound() {
+  return (
+    <div className="nx:border-border-default nx:flex nx:flex-col nx:items-center nx:justify-center nx:gap-3 nx:rounded-md nx:border nx:border-dashed nx:p-12 nx:text-center">
+      <h2 className="nx:typography-heading-medium nx:text-foreground">
+        Contact not found
+      </h2>
+      <p className="nx:text-muted-foreground nx:max-w-sm">
+        This contact doesn&apos;t exist, or may have been removed.
+      </p>
+      <Link
+        to="/m/crm"
+        className="nx:text-primary-subtle-foreground nx:hover:underline"
+      >
+        Back to Contacts
+      </Link>
+    </div>
+  );
+}

--- a/apps/console/src/modules/crm/contact-detail-route.tsx
+++ b/apps/console/src/modules/crm/contact-detail-route.tsx
@@ -27,13 +27,9 @@ import {
   type ContactDetail,
   fetchContact,
 } from '../../lib/crm-api';
+import { formatCurrency, formatDate } from '../../lib/format';
 
-import {
-  ContactStatusBadge,
-  formatCurrency,
-  formatDate,
-  initials,
-} from './contact-ui';
+import { ContactStatusBadge, initials } from './contact-ui';
 
 export function ContactDetailRoute() {
   const { id } = useParams({ from: '/app/m/crm/$id' });

--- a/apps/console/src/modules/crm/contact-ui.tsx
+++ b/apps/console/src/modules/crm/contact-ui.tsx
@@ -24,17 +24,3 @@ export function initials(name: string): string {
   const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : '';
   return (first + last).toUpperCase();
 }
-
-const currencyFmt = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-  maximumFractionDigits: 0,
-});
-const dateFmt = new Intl.DateTimeFormat('en-US', {
-  month: 'short',
-  day: 'numeric',
-  year: 'numeric',
-});
-
-export const formatCurrency = (value: number) => currencyFmt.format(value);
-export const formatDate = (iso: string) => dateFmt.format(new Date(iso));

--- a/apps/console/src/modules/crm/contact-ui.tsx
+++ b/apps/console/src/modules/crm/contact-ui.tsx
@@ -1,0 +1,40 @@
+import { Badge, type BadgeProps } from '@nexus/react';
+
+import type { ContactStatus } from '../../lib/crm-api';
+
+const STATUS_META: Record<
+  ContactStatus,
+  { label: string; variant: BadgeProps['variant'] }
+> = {
+  active: { label: 'Active', variant: 'success' },
+  lead: { label: 'Lead', variant: 'information' },
+  churned: { label: 'Churned', variant: 'secondary' },
+};
+
+/** The status badge, shared by the Contacts table and the detail page. */
+export function ContactStatusBadge({ status }: { status: ContactStatus }) {
+  const { label, variant } = STATUS_META[status];
+  return <Badge variant={variant}>{label}</Badge>;
+}
+
+/** First + last initial, e.g. "Ada Lovelace" → "AL". */
+export function initials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  const first = parts[0]?.[0] ?? '';
+  const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : '';
+  return (first + last).toUpperCase();
+}
+
+const currencyFmt = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0,
+});
+const dateFmt = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+});
+
+export const formatCurrency = (value: number) => currencyFmt.format(value);
+export const formatDate = (iso: string) => dateFmt.format(new Date(iso));

--- a/apps/console/src/modules/crm/contacts-columns.tsx
+++ b/apps/console/src/modules/crm/contacts-columns.tsx
@@ -21,13 +21,9 @@ import { Link } from '@tanstack/react-router';
 import type { Column, ColumnDef } from '@tanstack/react-table';
 
 import type { Contact } from '../../lib/crm-api';
+import { formatCurrency, formatDate } from '../../lib/format';
 
-import {
-  ContactStatusBadge,
-  formatCurrency,
-  formatDate,
-  initials,
-} from './contact-ui';
+import { ContactStatusBadge, initials } from './contact-ui';
 
 /** A clickable column header that cycles the column's sort and shows its state. */
 function SortHeader({

--- a/apps/console/src/modules/crm/contacts-columns.tsx
+++ b/apps/console/src/modules/crm/contacts-columns.tsx
@@ -3,8 +3,6 @@ import type { ReactNode } from 'react';
 import {
   Avatar,
   AvatarFallback,
-  Badge,
-  type BadgeProps,
   Button,
   Checkbox,
   DropdownMenu,
@@ -19,36 +17,17 @@ import {
   IconDots,
   IconSelector,
 } from '@tabler/icons-react';
+import { Link } from '@tanstack/react-router';
 import type { Column, ColumnDef } from '@tanstack/react-table';
 
-import type { Contact, ContactStatus } from '../../lib/crm-api';
+import type { Contact } from '../../lib/crm-api';
 
-const currencyUSD = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-  maximumFractionDigits: 0,
-});
-const dateFmt = new Intl.DateTimeFormat('en-US', {
-  month: 'short',
-  day: 'numeric',
-  year: 'numeric',
-});
-
-function initials(name: string): string {
-  const parts = name.trim().split(/\s+/);
-  const first = parts[0]?.[0] ?? '';
-  const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : '';
-  return (first + last).toUpperCase();
-}
-
-const STATUS_META: Record<
-  ContactStatus,
-  { label: string; variant: BadgeProps['variant'] }
-> = {
-  active: { label: 'Active', variant: 'success' },
-  lead: { label: 'Lead', variant: 'information' },
-  churned: { label: 'Churned', variant: 'secondary' },
-};
+import {
+  ContactStatusBadge,
+  formatCurrency,
+  formatDate,
+  initials,
+} from './contact-ui';
 
 /** A clickable column header that cycles the column's sort and shows its state. */
 function SortHeader({
@@ -107,9 +86,13 @@ export const contactColumns: ColumnDef<Contact>[] = [
     accessorKey: 'name',
     header: ({ column }) => <SortHeader column={column}>Name</SortHeader>,
     cell: ({ row }) => (
-      <span className="nx:text-foreground nx:font-medium">
+      <Link
+        to="/m/crm/$id"
+        params={{ id: row.original.id }}
+        className="nx:text-foreground nx:font-medium nx:hover:underline"
+      >
         {row.original.name}
-      </span>
+      </Link>
     ),
   },
   {
@@ -119,10 +102,7 @@ export const contactColumns: ColumnDef<Contact>[] = [
   {
     accessorKey: 'status',
     header: ({ column }) => <SortHeader column={column}>Status</SortHeader>,
-    cell: ({ row }) => {
-      const { label, variant } = STATUS_META[row.original.status];
-      return <Badge variant={variant}>{label}</Badge>;
-    },
+    cell: ({ row }) => <ContactStatusBadge status={row.original.status} />,
   },
   {
     accessorKey: 'owner',
@@ -143,7 +123,7 @@ export const contactColumns: ColumnDef<Contact>[] = [
     header: ({ column }) => <SortHeader column={column}>Open value</SortHeader>,
     cell: ({ row }) => (
       <span className="nx:tabular-nums">
-        {currencyUSD.format(row.original.value)}
+        {formatCurrency(row.original.value)}
       </span>
     ),
   },
@@ -154,7 +134,7 @@ export const contactColumns: ColumnDef<Contact>[] = [
     ),
     cell: ({ row }) => (
       <span className="nx:text-muted-foreground">
-        {dateFmt.format(new Date(row.original.lastContacted))}
+        {formatDate(row.original.lastContacted)}
       </span>
     ),
   },
@@ -189,6 +169,11 @@ function RowActions({ contact }: { contact: Contact }) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        <DropdownMenuItem asChild>
+          <Link to="/m/crm/$id" params={{ id: contact.id }}>
+            View details
+          </Link>
+        </DropdownMenuItem>
         <DropdownMenuItem onSelect={() => copy('Email', contact.email)}>
           Copy email
         </DropdownMenuItem>


### PR DESCRIPTION
## Summary

Phase 2b of the CRM flagship — the **record detail page** at `/m/crm/$id`, the read-only slice after the Contacts table (#283). Next: 2c create/edit · 2d kanban · 2e saved views.

- **Detail page** (`modules/crm/contact-detail-route.tsx`) — an action header (back link · contact name · status badge · avatar) over **Overview** (a Details card) and **Activity** (a timeline) tabs, with loading **Skeleton** and **not-found** states.
- **Data** — `ContactDetail` (`Contact` + `activity[]`) + `fetchContact(id)`; MSW `GET /api/crm/contacts/:id` finds the contact and **synthesises a deterministic activity feed** (offsets from `lastContacted`), 404 when the id is unknown.
- **Shared presentation** (`modules/crm/contact-ui.tsx`) — `ContactStatusBadge`, `initials`, and the currency/date formatters extracted from the 2a columns and reused by the detail (de-dupes the columns file).
- **Table wiring** — the name cell and a "View details" action link to `/m/crm/$id` (a static detail route; the sidebar already highlights `/m/crm/` by pathname).
- **query-client `retry: false`** — the mock API is deterministic, so error states (unknown id) render instantly instead of after react-query's backoff.

## Test Plan

Walked end-to-end in-browser:

- [x] Table name (or "View details") → `/m/crm/$id`; detail renders (header, status badge, avatar = contact initials)
- [x] **Overview** tab: Email / Owner / Open value / Last contacted
- [x] **Activity** tab: 4-item synthesised timeline, newest first, formatted dates
- [x] Unknown id (`/m/crm/does-not-exist`) → instant "Contact not found" (single 404, no retry storm)
- [x] Sidebar stays highlighted on CRM at the detail route
- [x] 0 console errors/warnings on happy paths; `typecheck` + ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)