### PR TITLE
feat(console): create + edit contact via Sheet form (Phase 2c)

### DIFF
--- a/apps/console/src/lib/crm-api.ts
+++ b/apps/console/src/lib/crm-api.ts
@@ -54,3 +54,28 @@ export async function fetchContact(
   }
   return (await res.json()) as { contact: ContactDetail };
 }
+
+/** The editable fields of a contact — `id` and `lastContacted` are server-set. */
+export type ContactInput = Omit<Contact, 'id' | 'lastContacted'>;
+
+async function save(
+  url: string,
+  method: 'POST' | 'PATCH',
+  input: ContactInput
+): Promise<{ contact: Contact }> {
+  const res = await fetch(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to save contact. Please try again.');
+  }
+  return (await res.json()) as { contact: Contact };
+}
+
+export const createContact = (input: ContactInput) =>
+  save('/api/crm/contacts', 'POST', input);
+
+export const updateContact = (id: string, input: ContactInput) =>
+  save(`/api/crm/contacts/${id}`, 'PATCH', input);

--- a/apps/console/src/mocks/handlers.ts
+++ b/apps/console/src/mocks/handlers.ts
@@ -1,7 +1,7 @@
 import { delay, http, HttpResponse, type RequestHandler } from 'msw';
 
 import type { User } from '../lib/auth-api';
-import type { ActivityItem, Contact } from '../lib/crm-api';
+import type { ActivityItem, Contact, ContactInput } from '../lib/crm-api';
 
 import { CONTACTS } from './crm-fixtures';
 
@@ -64,6 +64,11 @@ function buildActivity(contact: Contact): ActivityItem[] {
   ];
 }
 
+// In-memory CRM store, seeded from the fixtures. Create/edit mutate it so new
+// and edited contacts persist across requests within a session (it resets on a
+// full page reload — there is no real backend).
+const store: Contact[] = CONTACTS.map((c) => ({ ...c }));
+
 /**
  * MSW request handlers — there is no real backend. Auth is a two-step flow: a
  * credentials check (login/signup) hands the email to the OTP step, which is
@@ -114,13 +119,13 @@ export const handlers: RequestHandler[] = [
   // client-side. The short delay lets the loading Skeleton render in the demo.
   http.get('/api/crm/contacts', async () => {
     await delay(500);
-    return HttpResponse.json({ contacts: CONTACTS });
+    return HttpResponse.json({ contacts: store });
   }),
 
   // A single contact + its synthesised activity timeline (404 when unknown).
   http.get('/api/crm/contacts/:id', async ({ params }) => {
     await delay(300);
-    const contact = CONTACTS.find((c) => c.id === params.id);
+    const contact = store.find((c) => c.id === params.id);
     if (!contact) {
       return HttpResponse.json(
         { message: 'Contact not found.' },
@@ -130,5 +135,32 @@ export const handlers: RequestHandler[] = [
     return HttpResponse.json({
       contact: { ...contact, activity: buildActivity(contact) },
     });
+  }),
+
+  // Create: the server assigns the id and the last-contacted date (today).
+  http.post('/api/crm/contacts', async ({ request }) => {
+    await delay(300);
+    const input = (await request.json()) as ContactInput;
+    const contact: Contact = {
+      ...input,
+      id: crypto.randomUUID(),
+      lastContacted: new Date().toISOString().slice(0, 10),
+    };
+    store.unshift(contact);
+    return HttpResponse.json({ contact }, { status: 201 });
+  }),
+
+  // Edit: patch the mutable fields in place; id + lastContacted are preserved.
+  http.patch('/api/crm/contacts/:id', async ({ params, request }) => {
+    await delay(300);
+    const contact = store.find((c) => c.id === params.id);
+    if (!contact) {
+      return HttpResponse.json(
+        { message: 'Contact not found.' },
+        { status: 404 }
+      );
+    }
+    Object.assign(contact, (await request.json()) as ContactInput);
+    return HttpResponse.json({ contact });
   }),
 ];

--- a/apps/console/src/modules/crm/contact-detail-route.tsx
+++ b/apps/console/src/modules/crm/contact-detail-route.tsx
@@ -1,6 +1,9 @@
+import { useState } from 'react';
+
 import {
   Avatar,
   AvatarFallback,
+  Button,
   Card,
   CardContent,
   CardHeader,
@@ -17,6 +20,7 @@ import {
   IconFlag,
   IconMail,
   IconNote,
+  IconPencil,
   IconUserPlus,
 } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
@@ -29,6 +33,7 @@ import {
 } from '../../lib/crm-api';
 import { formatCurrency, formatDate } from '../../lib/format';
 
+import { ContactFormSheet } from './contact-form-sheet';
 import { ContactStatusBadge, initials } from './contact-ui';
 
 export function ContactDetailRoute() {
@@ -56,6 +61,8 @@ export function ContactDetailRoute() {
 }
 
 function DetailContent({ contact }: { contact: ContactDetail }) {
+  const [editOpen, setEditOpen] = useState(false);
+
   return (
     <>
       <header className="nx:flex nx:items-center nx:gap-4">
@@ -71,6 +78,14 @@ function DetailContent({ contact }: { contact: ContactDetail }) {
           </div>
           <p className="nx:text-muted-foreground">{contact.company}</p>
         </div>
+        <Button
+          variant="outline"
+          className="nx:ml-auto"
+          onClick={() => setEditOpen(true)}
+        >
+          <IconPencil />
+          Edit
+        </Button>
       </header>
 
       <Tabs defaultValue="overview">
@@ -126,6 +141,12 @@ function DetailContent({ contact }: { contact: ContactDetail }) {
           </Card>
         </TabsContent>
       </Tabs>
+
+      <ContactFormSheet
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        contact={contact}
+      />
     </>
   );
 }

--- a/apps/console/src/modules/crm/contact-form-sheet.tsx
+++ b/apps/console/src/modules/crm/contact-form-sheet.tsx
@@ -1,0 +1,278 @@
+import { useForm } from 'react-hook-form';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  toast,
+} from '@nexus/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import {
+  type Contact,
+  type ContactStatus,
+  createContact,
+  updateContact,
+} from '../../lib/crm-api';
+
+const OWNERS = [
+  'Ada Lovelace',
+  'Grace Hopper',
+  'Alan Turing',
+  'Katherine Johnson',
+] as const;
+
+const STATUS_OPTIONS: { value: ContactStatus; label: string }[] = [
+  { value: 'lead', label: 'Lead' },
+  { value: 'active', label: 'Active' },
+  { value: 'churned', label: 'Churned' },
+];
+
+const contactSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.email('Enter a valid email address'),
+  company: z.string().min(1, 'Company is required'),
+  status: z.enum(['active', 'lead', 'churned']),
+  owner: z.string().min(1, 'Owner is required'),
+  value: z.number().min(0, 'Open value must be 0 or more'),
+});
+
+type ContactFormValues = z.infer<typeof contactSchema>;
+
+const EMPTY_VALUES: ContactFormValues = {
+  name: '',
+  email: '',
+  company: '',
+  status: 'lead',
+  owner: OWNERS[0],
+  value: 0,
+};
+
+function toFormValues(contact: Contact): ContactFormValues {
+  const { name, email, company, status, owner, value } = contact;
+  return { name, email, company, status, owner, value };
+}
+
+interface ContactFormSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Present → edit that contact; absent → create a new one. */
+  contact?: Contact;
+}
+
+export function ContactFormSheet({
+  open,
+  onOpenChange,
+  contact,
+}: ContactFormSheetProps) {
+  const queryClient = useQueryClient();
+  const isEdit = !!contact;
+  const form = useForm<ContactFormValues>({
+    resolver: zodResolver(contactSchema),
+    defaultValues: contact ? toFormValues(contact) : EMPTY_VALUES,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (values: ContactFormValues) =>
+      contact ? updateContact(contact.id, values) : createContact(values),
+    onSuccess: ({ contact: saved }) => {
+      queryClient.invalidateQueries({ queryKey: ['crm'] });
+      toast.success(isEdit ? 'Contact updated' : 'Contact created', {
+        description: saved.name,
+      });
+      onOpenChange(false);
+      // Clear after a create so the next "New contact" opens fresh; an edit
+      // keeps the just-saved values (they match the contact).
+      if (!isEdit) form.reset(EMPTY_VALUES);
+    },
+    onError: (error: Error) =>
+      form.setError('root', { message: error.message }),
+  });
+
+  const onSubmit = (values: ContactFormValues) => mutation.mutate(values);
+  const rootError = form.formState.errors.root?.message;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="nx:flex nx:w-full nx:flex-col nx:sm:max-w-md"
+      >
+        <Form {...form}>
+          <form
+            noValidate
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="nx:flex nx:min-h-0 nx:flex-1 nx:flex-col"
+          >
+            <SheetHeader>
+              <SheetTitle>{isEdit ? 'Edit contact' : 'New contact'}</SheetTitle>
+              <SheetDescription>
+                {isEdit
+                  ? `Update ${contact.name}'s details.`
+                  : 'Add a contact to your pipeline.'}
+              </SheetDescription>
+            </SheetHeader>
+
+            <div className="nx:min-h-0 nx:flex-1 nx:space-y-5 nx:overflow-y-auto nx:px-4">
+              {rootError && (
+                <Alert variant="destructive">
+                  <AlertDescription>{rootError}</AlertDescription>
+                </Alert>
+              )}
+
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Ada Lovelace" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="email"
+                        placeholder="ada@example.com"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="company"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Company</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Northwind Traders" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="status"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Status</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {STATUS_OPTIONS.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="owner"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Owner</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {OWNERS.map((owner) => (
+                          <SelectItem key={owner} value={owner}>
+                            {owner}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="value"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Open value (USD)</FormLabel>
+                    <FormControl>
+                      {/* type=number gives a string; keep the field value a
+                          number so it matches the schema (empty → 0). */}
+                      <Input
+                        type="number"
+                        min={0}
+                        step={100}
+                        {...field}
+                        onChange={(e) => field.onChange(Number(e.target.value))}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <SheetFooter>
+              <Button type="submit" loading={mutation.isPending}>
+                {isEdit ? 'Save changes' : 'Create contact'}
+              </Button>
+              <SheetClose asChild>
+                <Button type="button" variant="outline">
+                  Cancel
+                </Button>
+              </SheetClose>
+            </SheetFooter>
+          </form>
+        </Form>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/console/src/modules/crm/contact-form-sheet.tsx
+++ b/apps/console/src/modules/crm/contact-form-sheet.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -102,13 +103,17 @@ export function ContactFormSheet({
         description: saved.name,
       });
       onOpenChange(false);
-      // Clear after a create so the next "New contact" opens fresh; an edit
-      // keeps the just-saved values (they match the contact).
-      if (!isEdit) form.reset(EMPTY_VALUES);
     },
     onError: (error: Error) =>
       form.setError('root', { message: error.message }),
   });
+
+  // Re-sync the form each time the sheet opens — the instance is persistent, so
+  // without this a cancelled create or unsaved edit would survive into the next
+  // open (and a stale root error would linger). `reset` also clears errors.
+  useEffect(() => {
+    if (open) form.reset(contact ? toFormValues(contact) : EMPTY_VALUES);
+  }, [open, contact, form]);
 
   const onSubmit = (values: ContactFormValues) => mutation.mutate(values);
   const rootError = form.formState.errors.root?.message;

--- a/apps/console/src/modules/crm/contacts-route.tsx
+++ b/apps/console/src/modules/crm/contacts-route.tsx
@@ -1,10 +1,13 @@
-import { Skeleton } from '@nexus/react';
-import { IconUsers } from '@tabler/icons-react';
+import { useState } from 'react';
+
+import { Button, Skeleton } from '@nexus/react';
+import { IconPlus, IconUsers } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 
 import { DataTable } from '../../components/data-table';
 import { fetchContacts } from '../../lib/crm-api';
 
+import { ContactFormSheet } from './contact-form-sheet';
 import { contactColumns } from './contacts-columns';
 
 export function ContactsRoute() {
@@ -13,16 +16,23 @@ export function ContactsRoute() {
     queryFn: fetchContacts,
   });
   const contacts = data?.contacts;
+  const [createOpen, setCreateOpen] = useState(false);
 
   return (
     <div className="nx:space-y-6 nx:p-6">
-      <header className="nx:space-y-1">
-        <h1 className="nx:typography-heading-large nx:text-foreground">
-          Contacts
-        </h1>
-        <p className="nx:text-muted-foreground">
-          Everyone in your pipeline. Sort, filter, and select to act in bulk.
-        </p>
+      <header className="nx:flex nx:items-start nx:justify-between nx:gap-4">
+        <div className="nx:space-y-1">
+          <h1 className="nx:typography-heading-large nx:text-foreground">
+            Contacts
+          </h1>
+          <p className="nx:text-muted-foreground">
+            Everyone in your pipeline. Sort, filter, and select to act in bulk.
+          </p>
+        </div>
+        <Button onClick={() => setCreateOpen(true)}>
+          <IconPlus />
+          New contact
+        </Button>
       </header>
 
       {isPending && <ContactsSkeleton />}
@@ -42,6 +52,8 @@ export function ContactsRoute() {
             filterPlaceholder="Filter by name…"
           />
         ))}
+
+      <ContactFormSheet open={createOpen} onOpenChange={setCreateOpen} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Phase 2c of the CRM flagship — **create and edit contacts** through a shared react-hook-form/zod form in a `Sheet`, backed by a mutable mock store so changes persist. Follows 2a (table, #283) and 2b (detail, #330). Next: 2d kanban · 2e saved views.

- **`ContactFormSheet`** — one Sheet form for both **create** (no `contact` prop) and **edit** (prefilled): name/email/company text fields + status/owner **Select**s + a number value field. On submit it POSTs/PATCHes, invalidates the `['crm']` queries, toasts, and closes.
- **Mutable mock store** — `handlers.ts` now holds an in-memory contacts store (seeded from the fixtures) so `POST`/`PATCH` persist across requests within a session; the list + detail handlers read it. `crm-api.ts` gains `ContactInput` + `createContact`/`updateContact`.
- **Wiring** — "New contact" in the table header opens the create sheet; "Edit" in the detail action header opens the edit sheet prefilled.

## Test Plan

Walked end-to-end in-browser:

- [x] **Create** — New contact → fill name/email/company (status/owner/value default) → Create → appears at the top of the table (24→25 rows), sheet closes, toast
- [x] **Edit** — detail → Edit → form prefilled → change company + value → Save → detail header + Open value update
- [x] **Validation** — empty submit shows "Name is required" / "Enter a valid email address" / "Company is required" and blocks
- [x] 0 console errors/warnings; `typecheck` + ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)