### PR TITLE
feat(console): CRM kanban board view (Phase 2d)

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -10,6 +10,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.4.0",
     "@nexus/react": "*",
     "@phosphor-icons/react": "^2.1.10",

--- a/apps/console/src/app/router.tsx
+++ b/apps/console/src/app/router.tsx
@@ -84,6 +84,11 @@ const appearanceRoute = createRoute({
 const crmContactsRoute = createRoute({
   getParentRoute: () => appRoute,
   path: '/m/crm',
+  // `.default` (not `.catch`) keeps the param optional for navigation, so the
+  // existing `<Link to="/m/crm">` call sites don't need to pass `search`.
+  validateSearch: z.object({
+    view: z.enum(['table', 'board']).default('table'),
+  }),
   component: ContactsRoute,
 });
 

--- a/apps/console/src/app/router.tsx
+++ b/apps/console/src/app/router.tsx
@@ -84,10 +84,11 @@ const appearanceRoute = createRoute({
 const crmContactsRoute = createRoute({
   getParentRoute: () => appRoute,
   path: '/m/crm',
-  // `.default` (not `.catch`) keeps the param optional for navigation, so the
-  // existing `<Link to="/m/crm">` call sites don't need to pass `search`.
+  // `.default` keeps the param optional for navigation (existing `<Link
+  // to="/m/crm">` calls don't pass `search`); `.catch` also recovers an invalid
+  // value (e.g. a stale `?view=foo`) to 'table' instead of throwing a search error.
   validateSearch: z.object({
-    view: z.enum(['table', 'board']).default('table'),
+    view: z.enum(['table', 'board']).default('table').catch('table'),
   }),
   component: ContactsRoute,
 });

--- a/apps/console/src/lib/crm-api.ts
+++ b/apps/console/src/lib/crm-api.ts
@@ -21,6 +21,17 @@ export type Contact = {
   lastContacted: string;
 };
 
+/**
+ * TanStack Query keys for the CRM module — declared once so the table, board,
+ * detail, and mutations can't drift apart (a mismatched key silently breaks the
+ * optimistic cache writes).
+ */
+export const crmKeys = {
+  all: ['crm'] as const,
+  contacts: ['crm', 'contacts'] as const,
+  contact: (id: string) => ['crm', 'contact', id] as const,
+};
+
 // Returns the server envelope (mirrors the wire shape, like the auth-api
 // wrappers) so a future server-side `{ contacts, totalCount }` for paging is an
 // additive change here, not a new return type.

--- a/apps/console/src/modules/crm/contact-detail-route.tsx
+++ b/apps/console/src/modules/crm/contact-detail-route.tsx
@@ -29,6 +29,7 @@ import { Link, useParams } from '@tanstack/react-router';
 import {
   type ActivityKind,
   type ContactDetail,
+  crmKeys,
   fetchContact,
 } from '../../lib/crm-api';
 import { formatCurrency, formatDate } from '../../lib/format';
@@ -39,7 +40,7 @@ import { ContactStatusBadge, initials } from './contact-ui';
 export function ContactDetailRoute() {
   const { id } = useParams({ from: '/app/m/crm/$id' });
   const { data, isPending, isError } = useQuery({
-    queryKey: ['crm', 'contact', id],
+    queryKey: crmKeys.contact(id),
     queryFn: () => fetchContact(id),
   });
 

--- a/apps/console/src/modules/crm/contact-form-sheet.tsx
+++ b/apps/console/src/modules/crm/contact-form-sheet.tsx
@@ -34,6 +34,7 @@ import {
   type Contact,
   type ContactStatus,
   createContact,
+  crmKeys,
   updateContact,
 } from '../../lib/crm-api';
 
@@ -98,7 +99,7 @@ export function ContactFormSheet({
     mutationFn: (values: ContactFormValues) =>
       contact ? updateContact(contact.id, values) : createContact(values),
     onSuccess: ({ contact: saved }) => {
-      queryClient.invalidateQueries({ queryKey: ['crm'] });
+      queryClient.invalidateQueries({ queryKey: crmKeys.all });
       toast.success(isEdit ? 'Contact updated' : 'Contact created', {
         description: saved.name,
       });

--- a/apps/console/src/modules/crm/contacts-board.tsx
+++ b/apps/console/src/modules/crm/contacts-board.tsx
@@ -15,6 +15,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   type Contact,
   type ContactStatus,
+  crmKeys,
   updateContact,
 } from '../../lib/crm-api';
 import { formatCurrency } from '../../lib/format';
@@ -28,7 +29,6 @@ const COLUMNS: { status: ContactStatus; label: string }[] = [
 ];
 
 type ContactsCache = { contacts: Contact[] };
-const CONTACTS_KEY = ['crm', 'contacts'];
 
 /**
  * Kanban view of the contacts: three status columns, draggable cards. Dropping a
@@ -59,9 +59,11 @@ export function ContactsBoard({ contacts }: { contacts: Contact[] }) {
         value: contact.value,
       }),
     onMutate: async ({ contact, status }) => {
-      await queryClient.cancelQueries({ queryKey: CONTACTS_KEY });
-      const previous = queryClient.getQueryData<ContactsCache>(CONTACTS_KEY);
-      queryClient.setQueryData<ContactsCache>(CONTACTS_KEY, (old) =>
+      await queryClient.cancelQueries({ queryKey: crmKeys.contacts });
+      const previous = queryClient.getQueryData<ContactsCache>(
+        crmKeys.contacts
+      );
+      queryClient.setQueryData<ContactsCache>(crmKeys.contacts, (old) =>
         old
           ? {
               contacts: old.contacts.map((c) =>
@@ -74,10 +76,10 @@ export function ContactsBoard({ contacts }: { contacts: Contact[] }) {
     },
     onError: (_error, _vars, context) => {
       if (context?.previous) {
-        queryClient.setQueryData(CONTACTS_KEY, context.previous);
+        queryClient.setQueryData(crmKeys.contacts, context.previous);
       }
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ['crm'] }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: crmKeys.all }),
   });
 
   const handleDragEnd = (event: DragEndEvent) => {

--- a/apps/console/src/modules/crm/contacts-board.tsx
+++ b/apps/console/src/modules/crm/contacts-board.tsx
@@ -1,0 +1,178 @@
+import {
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { CSS } from '@dnd-kit/utilities';
+import { Avatar, AvatarFallback } from '@nexus/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import {
+  type Contact,
+  type ContactStatus,
+  updateContact,
+} from '../../lib/crm-api';
+import { formatCurrency } from '../../lib/format';
+
+import { initials } from './contact-ui';
+
+const COLUMNS: { status: ContactStatus; label: string }[] = [
+  { status: 'lead', label: 'Lead' },
+  { status: 'active', label: 'Active' },
+  { status: 'churned', label: 'Churned' },
+];
+
+type ContactsCache = { contacts: Contact[] };
+const CONTACTS_KEY = ['crm', 'contacts'];
+
+/**
+ * Kanban view of the contacts: three status columns, draggable cards. Dropping a
+ * card in another column changes that contact's status (optimistically, so the
+ * card moves immediately; the PATCH + refetch reconcile in the background).
+ */
+export function ContactsBoard({ contacts }: { contacts: Contact[] }) {
+  const queryClient = useQueryClient();
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor)
+  );
+
+  const mutation = useMutation({
+    mutationFn: ({
+      contact,
+      status,
+    }: {
+      contact: Contact;
+      status: ContactStatus;
+    }) =>
+      updateContact(contact.id, {
+        name: contact.name,
+        email: contact.email,
+        company: contact.company,
+        status,
+        owner: contact.owner,
+        value: contact.value,
+      }),
+    onMutate: async ({ contact, status }) => {
+      await queryClient.cancelQueries({ queryKey: CONTACTS_KEY });
+      const previous = queryClient.getQueryData<ContactsCache>(CONTACTS_KEY);
+      queryClient.setQueryData<ContactsCache>(CONTACTS_KEY, (old) =>
+        old
+          ? {
+              contacts: old.contacts.map((c) =>
+                c.id === contact.id ? { ...c, status } : c
+              ),
+            }
+          : old
+      );
+      return { previous };
+    },
+    onError: (_error, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(CONTACTS_KEY, context.previous);
+      }
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['crm'] }),
+  });
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) return;
+    const target = COLUMNS.find((col) => col.status === over.id);
+    const contact = contacts.find((c) => c.id === active.id);
+    if (!target || !contact || contact.status === target.status) return;
+    mutation.mutate({ contact, status: target.status });
+  };
+
+  return (
+    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+      <div className="nx:grid nx:gap-4 nx:sm:grid-cols-3">
+        {COLUMNS.map((col) => (
+          <BoardColumn
+            key={col.status}
+            status={col.status}
+            label={col.label}
+            contacts={contacts.filter((c) => c.status === col.status)}
+          />
+        ))}
+      </div>
+    </DndContext>
+  );
+}
+
+function BoardColumn({
+  status,
+  label,
+  contacts,
+}: {
+  status: ContactStatus;
+  label: string;
+  contacts: Contact[];
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: status });
+  return (
+    <div
+      ref={setNodeRef}
+      data-status={status}
+      className={`nx:flex nx:min-h-40 nx:flex-col nx:gap-3 nx:rounded-lg nx:p-3 nx:transition-colors ${
+        isOver ? 'nx:bg-background-hover' : 'nx:bg-muted'
+      }`}
+    >
+      <div className="nx:flex nx:items-center nx:justify-between nx:px-1">
+        <span className="nx:typography-label-default nx:text-foreground">
+          {label}
+        </span>
+        <span className="nx:text-muted-foreground nx:text-xs">
+          {contacts.length}
+        </span>
+      </div>
+      {contacts.map((contact) => (
+        <BoardCard key={contact.id} contact={contact} />
+      ))}
+    </div>
+  );
+}
+
+function BoardCard({ contact }: { contact: Contact }) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({ id: contact.id });
+  const style = transform
+    ? { transform: CSS.Translate.toString(transform) }
+    : undefined;
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...listeners}
+      {...attributes}
+      className={`nx:bg-container nx:border-border-default nx:cursor-grab nx:space-y-2 nx:rounded-md nx:border nx:p-3 nx:active:cursor-grabbing ${
+        isDragging ? 'nx:opacity-50' : ''
+      }`}
+    >
+      <div className="nx:text-foreground nx:font-medium">{contact.name}</div>
+      <div className="nx:text-muted-foreground nx:text-sm">
+        {contact.company}
+      </div>
+      <div className="nx:flex nx:items-center nx:justify-between">
+        <div className="nx:flex nx:items-center nx:gap-2">
+          <Avatar className="nx:size-6">
+            <AvatarFallback className="nx:text-xs">
+              {initials(contact.owner)}
+            </AvatarFallback>
+          </Avatar>
+          <span className="nx:text-muted-foreground nx:text-xs">
+            {contact.owner}
+          </span>
+        </div>
+        <span className="nx:text-xs nx:tabular-nums">
+          {formatCurrency(contact.value)}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/modules/crm/contacts-route.tsx
+++ b/apps/console/src/modules/crm/contacts-route.tsx
@@ -1,14 +1,23 @@
 import { useState } from 'react';
 
 import { Button, Skeleton } from '@nexus/react';
-import { IconPlus, IconUsers } from '@tabler/icons-react';
+import {
+  IconLayoutKanban,
+  IconPlus,
+  IconTable,
+  IconUsers,
+} from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
+import { getRouteApi } from '@tanstack/react-router';
 
 import { DataTable } from '../../components/data-table';
 import { fetchContacts } from '../../lib/crm-api';
 
 import { ContactFormSheet } from './contact-form-sheet';
+import { ContactsBoard } from './contacts-board';
 import { contactColumns } from './contacts-columns';
+
+const crmRoute = getRouteApi('/app/m/crm');
 
 export function ContactsRoute() {
   const { data, isPending, isError } = useQuery({
@@ -16,6 +25,8 @@ export function ContactsRoute() {
     queryFn: fetchContacts,
   });
   const contacts = data?.contacts;
+  const { view } = crmRoute.useSearch();
+  const navigate = crmRoute.useNavigate();
   const [createOpen, setCreateOpen] = useState(false);
 
   return (
@@ -35,6 +46,25 @@ export function ContactsRoute() {
         </Button>
       </header>
 
+      <div className="nx:inline-flex nx:gap-1">
+        <Button
+          variant={view === 'table' ? 'default' : 'ghost'}
+          size="sm"
+          onClick={() => navigate({ search: { view: 'table' } })}
+        >
+          <IconTable />
+          Table
+        </Button>
+        <Button
+          variant={view === 'board' ? 'default' : 'ghost'}
+          size="sm"
+          onClick={() => navigate({ search: { view: 'board' } })}
+        >
+          <IconLayoutKanban />
+          Board
+        </Button>
+      </div>
+
       {isPending && <ContactsSkeleton />}
       {isError && (
         <p className="nx:text-error-foreground nx:text-sm">
@@ -44,6 +74,8 @@ export function ContactsRoute() {
       {contacts &&
         (contacts.length === 0 ? (
           <ContactsEmpty />
+        ) : view === 'board' ? (
+          <ContactsBoard contacts={contacts} />
         ) : (
           <DataTable
             columns={contactColumns}

--- a/apps/console/src/modules/crm/contacts-route.tsx
+++ b/apps/console/src/modules/crm/contacts-route.tsx
@@ -11,7 +11,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getRouteApi } from '@tanstack/react-router';
 
 import { DataTable } from '../../components/data-table';
-import { fetchContacts } from '../../lib/crm-api';
+import { crmKeys, fetchContacts } from '../../lib/crm-api';
 
 import { ContactFormSheet } from './contact-form-sheet';
 import { ContactsBoard } from './contacts-board';
@@ -21,7 +21,7 @@ const crmRoute = getRouteApi('/app/m/crm');
 
 export function ContactsRoute() {
   const { data, isPending, isError } = useQuery({
-    queryKey: ['crm', 'contacts'],
+    queryKey: crmKeys.contacts,
     queryFn: fetchContacts,
   });
   const contacts = data?.contacts;

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,6 +245,29 @@
   resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz#333fedabc3fd1a8e5d0100013731cf19e6a8c5d3"
   integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
 
+"@dnd-kit/accessibility@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz#3b4202bd6bb370a0730f6734867785919beac6af"
+  integrity sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.3.1.tgz#4c36406a62c7baac499726f899935f93f0e6d003"
+  integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.1.1"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz#5a32b6af356dc5f74d61b37d6f7129a4040ced7b"
+  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@emnapi/core@^1.10.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"


### PR DESCRIPTION
## Summary

Phase 2d of the CRM flagship — a **kanban board** view of contacts, toggled from the table via a `?view=table|board` search param. Follows 2a–2c. Next: 2e saved views/filters.

- **`ContactsBoard`** — `@dnd-kit` `DndContext` (Pointer + Keyboard sensors) with three droppable status columns (Lead / Active / Churned) and draggable contact cards. Dropping a card in another column changes that contact's **status optimistically** (`onMutate` updates the cache so the card moves immediately; the PATCH + `invalidate` reconcile in the background, with rollback `onError`).
- **View switcher** — a Table | Board toggle in the header drives the `view` search param (`validateSearch` zod enum, default `table`); the body swaps `DataTable` ↔ board. Linkable (`/m/crm?view=board`).
- Adds `@dnd-kit/core` + `@dnd-kit/utilities` (app deps — the `@nexus/react` bundle-size gate is unaffected).

## Test Plan

Walked in-browser:

- [x] Board renders three columns with correct card distribution (Lead 8 / Active 12 / Churned 4 = 24)
- [x] Switcher toggles Board ↔ Table via the URL (`?view=board` / `?view=table`); the body swaps
- [x] Status-change PATCH path verified (the data path `onDragEnd` uses)
- [x] 0 console errors/warnings; `typecheck` + ESLint clean

**Note on drag verification:** the drag *gesture* can't be driven by the test harness's synthetic pointer events (same limitation as Radix triggers in this environment) — a real pointer or the keyboard sensor performs the drag. The board rendering, the `onDragEnd → updateContact` wiring, and the PATCH-status endpoint are all verified; the optimistic cache update is the standard react-query pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)