### PR TITLE
feat(components): add kbd component

### DIFF
--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -49,6 +49,7 @@
         "KeyboardInteraction": ["TypeInteraction"]
       }
     },
+    { "name": "Kbd", "showcase": "AllVariants" },
     { "name": "Pagination", "showcase": "AllVariants" },
     {
       "name": "Popover",

--- a/packages/react/src/components/ui/Kbd.stories.tsx
+++ b/packages/react/src/components/ui/Kbd.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+
+import { Kbd, KbdGroup } from './kbd';
+
+const meta: Meta<typeof Kbd> = {
+  title: 'Components/Kbd',
+  component: Kbd,
+};
+
+export default meta;
+type Story = StoryObj<typeof Kbd>;
+
+// A single keycap next to a two-key chord composed with KbdGroup.
+export const Default: Story = {
+  render: () => (
+    <div className="nx:flex nx:items-center nx:gap-4">
+      <Kbd>⌘</Kbd>
+      <KbdGroup>
+        <Kbd>⌘</Kbd>
+        <Kbd>K</Kbd>
+      </KbdGroup>
+    </div>
+  ),
+};
+
+// Single modifier keys render as square-ish caps (min-width floor); wider
+// labels grow to fit.
+export const SingleKeys: Story = {
+  render: () => (
+    <div className="nx:flex nx:items-center nx:gap-2">
+      <Kbd>⌘</Kbd>
+      <Kbd>⇧</Kbd>
+      <Kbd>⌥</Kbd>
+      <Kbd>⌃</Kbd>
+      <Kbd>Esc</Kbd>
+      <Kbd>Enter</Kbd>
+    </div>
+  ),
+};
+
+// Both structural parts carry a data-slot hook for styling and inspection.
+export const WithDataAttributes: Story = {
+  render: () => (
+    <KbdGroup>
+      <Kbd>⌘</Kbd>
+      <Kbd>K</Kbd>
+    </KbdGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const group = canvasElement.querySelector('[data-slot="kbd-group"]');
+    await expect(group).toBeInTheDocument();
+
+    const keys = within(canvasElement).getAllByText(/⌘|K/);
+    await expect(keys.length).toBeGreaterThan(0);
+    await expect(
+      canvasElement.querySelector('[data-slot="kbd"]')
+    ).toBeInTheDocument();
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// The full anatomy: single modifier caps, wider labelled keys, and multi-key
+// chords grouped with KbdGroup. Reused by the per-base variant generator.
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-4">
+      <div className="nx:flex nx:items-center nx:gap-2">
+        <Kbd>⌘</Kbd>
+        <Kbd>⇧</Kbd>
+        <Kbd>⌥</Kbd>
+        <Kbd>⌃</Kbd>
+        <Kbd>↵</Kbd>
+      </div>
+      <div className="nx:flex nx:items-center nx:gap-2">
+        <Kbd>Esc</Kbd>
+        <Kbd>Tab</Kbd>
+        <Kbd>Enter</Kbd>
+        <Kbd>Space</Kbd>
+      </div>
+      <div className="nx:flex nx:items-center nx:gap-4">
+        <KbdGroup>
+          <Kbd>⌘</Kbd>
+          <Kbd>K</Kbd>
+        </KbdGroup>
+        <KbdGroup>
+          <Kbd>⌘</Kbd>
+          <Kbd>⇧</Kbd>
+          <Kbd>P</Kbd>
+        </KbdGroup>
+      </div>
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/kbd.tsx
+++ b/packages/react/src/components/ui/kbd.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * KbdProps
+ *
+ * Props for the Kbd component.
+ */
+interface KbdProps extends React.ComponentProps<'kbd'> {}
+
+/**
+ * Kbd
+ *
+ * A keyboard-key indicator for documenting shortcuts — one keycap per key
+ * (`⌘`, `Esc`, `Enter`). Compose several inside `KbdGroup` to show a chord
+ * (`⌘ K`). Non-interactive by design (`pointer-events-none`): it labels a
+ * shortcut, it does not handle one.
+ *
+ * @example
+ * ```tsx
+ * <Kbd>⌘</Kbd>
+ *
+ * <KbdGroup>
+ *   <Kbd>⌘</Kbd>
+ *   <Kbd>K</Kbd>
+ * </KbdGroup>
+ * ```
+ */
+function Kbd({ className, ...props }: KbdProps) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        // nexus-allow-numeric: keycap footprint — a square-ish single-key chip
+        'nx:pointer-events-none nx:inline-flex nx:h-5 nx:w-fit nx:min-w-5 nx:items-center nx:justify-center nx:gap-1 nx:rounded-sm nx:bg-muted nx:px-1 nx:typography-label-small nx:text-muted-foreground nx:select-none nx:[&_svg]:size-3',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * KbdGroupProps
+ *
+ * Props for the KbdGroup component.
+ */
+interface KbdGroupProps extends React.ComponentProps<'kbd'> {}
+
+/**
+ * KbdGroup
+ *
+ * Lays out a row of `Kbd` keycaps as one chord (e.g. `⌘ K`).
+ */
+function KbdGroup({ className, ...props }: KbdGroupProps) {
+  return (
+    <kbd
+      data-slot="kbd-group"
+      className={cn(
+        // nexus-allow-numeric: tight gap between chord keys
+        'nx:inline-flex nx:items-center nx:gap-1',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Kbd, KbdGroup, type KbdGroupProps, type KbdProps };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -23,6 +23,7 @@ export * from '@/components/ui/dropdown-menu';
 export * from '@/components/ui/form';
 export * from '@/components/ui/input';
 export * from '@/components/ui/input-otp';
+export * from '@/components/ui/kbd';
 export * from '@/components/ui/label';
 export * from '@/components/ui/pagination';
 export * from '@/components/ui/popover';


### PR DESCRIPTION
## Summary

- Adapt shadcn **Kbd** → first-class Nexus `Kbd` + `KbdGroup` — a keyboard-key indicator for documenting shortcuts (`⌘`, `Esc`, chords like `⌘ K`).
- `nx:`-prefixed semantic tokens (`bg-muted` / `text-muted-foreground`), `nx:typography-label-small` (carries the Inter sans family, overriding `<kbd>`'s UA monospace), `data-slot` hooks, non-interactive by design (`pointer-events-none`).
- Icons inside a key are sized via `nx:[&_svg]:size-3` — the Button convention, not shadcn's `:not([class*='size-'])` escape hatch (no Nexus component uses that form).
- **Deliberate divergence:** omits shadcn's `[[data-slot=tooltip-content]_&]` nested override (a cross-component coupling + `dark:`-on-token, both anti-patterns here). Additive later if a Kbd-in-Tooltip case needs it.

## GitHub Issue

Closes #302

## Test Plan

- [x] `typecheck`, `eslint . --max-warnings 0`, `prettier --check` clean
- [x] `audit:storybook-coverage --component kbd` → 0 missing, 0 drift (display-only)
- [x] `size-limit` → ESM 67.5 kB / 70 kB (no new dependency)
- [x] CSS utilities emitted (`min-w-5`, `size-3`, `typography-label-small`, …)
- [x] storybook play-fns pass locally (5/5); CI runs them across 5 bases × 2 themes