### PR TITLE
feat(components): add spinner component

### DIFF
--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -80,6 +80,7 @@
     },
     { "name": "Show", "showcase": "AllAxes", "sourceDir": "primitives" },
     { "name": "Hide", "showcase": "AllAxes", "sourceDir": "primitives" },
+    { "name": "Spinner", "showcase": "AllVariants" },
     { "name": "Switch", "showcase": "AllVariants" },
     { "name": "Table", "showcase": "AllVariants" },
     {

--- a/packages/react/src/components/ui/Spinner.stories.tsx
+++ b/packages/react/src/components/ui/Spinner.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+
+import { Spinner } from './spinner';
+
+const meta: Meta<typeof Spinner> = {
+  title: 'Components/Spinner',
+  component: Spinner,
+};
+
+export default meta;
+type Story = StoryObj<typeof Spinner>;
+
+// The default spinner — a 16px glyph rotating in the current text color.
+export const Default: Story = {
+  render: () => <Spinner />,
+};
+
+// Sized with nx:size-* utilities; the glyph inherits currentColor, so it tints
+// with nx:text-*.
+export const Sizes: Story = {
+  render: () => (
+    <div className="nx:flex nx:items-center nx:gap-4 nx:text-foreground">
+      <Spinner className="nx:size-4" />
+      <Spinner className="nx:size-6" />
+      <Spinner className="nx:size-8 nx:text-primary-subtle-foreground" />
+    </div>
+  ),
+};
+
+// The spinner is a status live-region: role="status" carrying an accessible
+// name, plus a data-slot hook.
+export const WithDataAttributes: Story = {
+  render: () => <Spinner />,
+  play: async ({ canvasElement }) => {
+    const spinner = within(canvasElement).getByRole('status');
+    await expect(spinner).toHaveAccessibleName('Loading');
+    await expect(spinner).toHaveAttribute('data-slot', 'spinner');
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// A range of sizes, a tinted variant, and an inline "loading more" caption.
+// Reused by the per-base variant generator.
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-4 nx:text-foreground">
+      <div className="nx:flex nx:items-center nx:gap-4">
+        <Spinner className="nx:size-4" />
+        <Spinner className="nx:size-6" />
+        <Spinner className="nx:size-8" />
+      </div>
+      <div className="nx:flex nx:items-center nx:gap-2 nx:text-sm nx:text-muted-foreground">
+        <Spinner className="nx:size-4" />
+        <span>Loading more…</span>
+      </div>
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/spinner.tsx
+++ b/packages/react/src/components/ui/spinner.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+
+import { IconLoader2 } from '@/lib/icons';
+import { cn } from '@/lib/utils';
+
+/**
+ * SpinnerProps
+ *
+ * Props for the Spinner component.
+ */
+interface SpinnerProps extends React.ComponentProps<'svg'> {}
+
+/**
+ * Spinner
+ *
+ * A loading indicator — a continuously rotating glyph for full-page loads,
+ * "loading more…" rows, overlays on cards and tables, and Suspense fallbacks.
+ * Announces itself to assistive tech via `role="status"` and an `aria-label`,
+ * and honours `prefers-reduced-motion` (it freezes rather than spins when the
+ * user has reduced motion on). Size it with a `nx:size-*` class; it draws in
+ * `currentColor`, so recolour with `nx:text-*`.
+ *
+ * @example
+ * ```tsx
+ * <Spinner />
+ * <Spinner className="nx:size-6 nx:text-primary-subtle-foreground" />
+ * <Spinner aria-label="Saving changes" />
+ * ```
+ */
+function Spinner({ className, ...props }: SpinnerProps) {
+  return (
+    <IconLoader2
+      role="status"
+      aria-label="Loading"
+      data-slot="spinner"
+      className={cn(
+        // nexus-allow-numeric: default icon footprint
+        'nx:size-4 nx:animate-spin nx:motion-reduce:animate-none',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Spinner, type SpinnerProps };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -36,6 +36,7 @@ export * from '@/components/ui/sheet';
 export * from '@/components/ui/sidebar';
 export * from '@/components/ui/skeleton';
 export * from '@/components/ui/sonner';
+export * from '@/components/ui/spinner';
 export * from '@/components/ui/switch';
 export * from '@/components/ui/table';
 export * from '@/components/ui/tabs';


### PR DESCRIPTION
## Summary

- Adapt shadcn **Spinner** → first-class Nexus `Spinner` — a loading indicator for full-page loads, "loading more…" rows, overlays, and Suspense fallbacks.
- Wraps the shared **`IconLoader2`** (`@/lib/icons`) — the exact glyph Button's loading state already uses, so the system has one spinner.
- Announces itself via `role="status"` + `aria-label="Loading"`; sizes with `nx:size-*` and tints via `currentColor` (`nx:text-*`).
- **Beyond shadcn:** honours `prefers-reduced-motion` via `nx:motion-reduce:animate-none` (freezes rather than spinning), as the issue requires.

## GitHub Issue

Closes #304

Follow-up (not this PR): Button #204 to consume this shared Spinner instead of its own inline copy.

## Test Plan

- [x] `typecheck`, `eslint . --max-warnings 0`, `prettier --check` clean
- [x] `audit:storybook-coverage --component spinner` → 0 missing, 0 drift (display-only)
- [x] `size-limit` → ESM 67.55 kB / 70 kB (no new dependency; reuses bundled IconLoader2)
- [x] CSS emission verified incl. the `prefers-reduced-motion` media query
- [x] storybook play-fns pass locally (5/5); CI runs them across 5 bases × 2 themes