### PR TITLE
feat(components): add empty-state component

### DIFF
--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -41,6 +41,7 @@
         "Disabled": ["WithDisabledItems"]
       }
     },
+    { "name": "EmptyState", "showcase": "AllVariants" },
     {
       "name": "Input",
       "showcase": "AllVariants",

--- a/packages/react/src/components/ui/EmptyState.stories.tsx
+++ b/packages/react/src/components/ui/EmptyState.stories.tsx
@@ -1,0 +1,140 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { IconUsers } from '@tabler/icons-react';
+import { expect } from 'storybook/test';
+
+import { Button } from './button';
+import {
+  EmptyState,
+  EmptyStateContent,
+  EmptyStateDescription,
+  EmptyStateHeader,
+  EmptyStateMedia,
+  EmptyStateTitle,
+} from './empty-state';
+
+const meta: Meta<typeof EmptyState> = {
+  title: 'Components/EmptyState',
+  component: EmptyState,
+};
+
+export default meta;
+type Story = StoryObj<typeof EmptyState>;
+
+// The canonical empty state: an icon medallion, a title, a description, and a
+// primary action.
+export const Default: Story = {
+  render: () => (
+    <EmptyState>
+      <EmptyStateHeader>
+        <EmptyStateMedia variant="icon">
+          <IconUsers aria-hidden />
+        </EmptyStateMedia>
+        <EmptyStateTitle>No contacts yet</EmptyStateTitle>
+        <EmptyStateDescription>
+          Add your first contact to start building your CRM.
+        </EmptyStateDescription>
+      </EmptyStateHeader>
+      <EmptyStateContent>
+        <Button>Add contact</Button>
+      </EmptyStateContent>
+    </EmptyState>
+  ),
+};
+
+// Header only — an empty state with no call to action.
+export const WithoutAction: Story = {
+  render: () => (
+    <EmptyState>
+      <EmptyStateHeader>
+        <EmptyStateMedia variant="icon">
+          <IconUsers aria-hidden />
+        </EmptyStateMedia>
+        <EmptyStateTitle>No results</EmptyStateTitle>
+        <EmptyStateDescription>
+          Try adjusting your filters or search terms.
+        </EmptyStateDescription>
+      </EmptyStateHeader>
+    </EmptyState>
+  ),
+};
+
+// Every structural part carries a data-slot hook; the media advertises its
+// variant.
+export const WithDataAttributes: Story = {
+  render: () => (
+    <EmptyState>
+      <EmptyStateHeader>
+        <EmptyStateMedia variant="icon">
+          <IconUsers aria-hidden />
+        </EmptyStateMedia>
+        <EmptyStateTitle>No contacts yet</EmptyStateTitle>
+        <EmptyStateDescription>Add your first contact.</EmptyStateDescription>
+      </EmptyStateHeader>
+      <EmptyStateContent>
+        <Button>Add contact</Button>
+      </EmptyStateContent>
+    </EmptyState>
+  ),
+  play: async ({ canvasElement }) => {
+    for (const slot of [
+      'empty-state',
+      'empty-state-header',
+      'empty-state-media',
+      'empty-state-title',
+      'empty-state-description',
+      'empty-state-content',
+    ]) {
+      await expect(
+        canvasElement.querySelector(`[data-slot="${slot}"]`)
+      ).toBeInTheDocument();
+    }
+
+    const media = canvasElement.querySelector(
+      '[data-slot="empty-state-media"]'
+    );
+    await expect(media).toHaveAttribute('data-variant', 'icon');
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// Both media variants — the muted icon medallion inside a dashed-bordered box
+// with an action, and the borderless default wrapper holding a larger glyph.
+// Reused by the per-base variant generator.
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-6">
+      <EmptyState className="nx:border nx:border-border-default">
+        <EmptyStateHeader>
+          <EmptyStateMedia variant="icon">
+            <IconUsers aria-hidden />
+          </EmptyStateMedia>
+          <EmptyStateTitle>No contacts yet</EmptyStateTitle>
+          <EmptyStateDescription>
+            Add your first contact to get started.
+          </EmptyStateDescription>
+        </EmptyStateHeader>
+        <EmptyStateContent>
+          <Button>Add contact</Button>
+        </EmptyStateContent>
+      </EmptyState>
+
+      <EmptyState>
+        <EmptyStateHeader>
+          <EmptyStateMedia variant="default">
+            <IconUsers
+              aria-hidden
+              className="nx:size-12 nx:text-muted-foreground"
+            />
+          </EmptyStateMedia>
+          <EmptyStateTitle>No results</EmptyStateTitle>
+          <EmptyStateDescription>
+            Try adjusting your filters.
+          </EmptyStateDescription>
+        </EmptyStateHeader>
+      </EmptyState>
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/empty-state.tsx
+++ b/packages/react/src/components/ui/empty-state.tsx
@@ -1,0 +1,221 @@
+import * as React from 'react';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * EmptyStateProps
+ *
+ * Props for the EmptyState component.
+ */
+interface EmptyStateProps extends React.ComponentProps<'div'> {}
+
+/**
+ * EmptyState
+ *
+ * A centered empty-state region for list, table, and record views with no
+ * content yet — an icon, a title, a short description, and an optional action.
+ * Compose with the sub-components: `EmptyStateHeader` groups the
+ * `EmptyStateMedia` (icon), `EmptyStateTitle`, and `EmptyStateDescription`;
+ * `EmptyStateContent` holds the call to action. Carries a dashed border style
+ * that only shows when a consumer adds a border width.
+ *
+ * @example
+ * ```tsx
+ * <EmptyState>
+ *   <EmptyStateHeader>
+ *     <EmptyStateMedia variant="icon">
+ *       <IconInbox />
+ *     </EmptyStateMedia>
+ *     <EmptyStateTitle>No contacts yet</EmptyStateTitle>
+ *     <EmptyStateDescription>
+ *       Add your first contact to get started.
+ *     </EmptyStateDescription>
+ *   </EmptyStateHeader>
+ *   <EmptyStateContent>
+ *     <Button>Add contact</Button>
+ *   </EmptyStateContent>
+ * </EmptyState>
+ * ```
+ */
+function EmptyState({ className, ...props }: EmptyStateProps) {
+  return (
+    <div
+      data-slot="empty-state"
+      className={cn(
+        // nexus-allow-numeric: empty-state layout rhythm
+        'nx:flex nx:min-w-0 nx:flex-1 nx:flex-col nx:items-center nx:justify-center nx:gap-6 nx:rounded-lg nx:border-dashed nx:p-6 nx:text-center nx:text-balance',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * EmptyStateHeaderProps
+ *
+ * Props for the EmptyStateHeader component.
+ */
+interface EmptyStateHeaderProps extends React.ComponentProps<'div'> {}
+
+/**
+ * EmptyStateHeader
+ *
+ * Groups the media, title, and description in a narrow centered column.
+ */
+function EmptyStateHeader({ className, ...props }: EmptyStateHeaderProps) {
+  return (
+    <div
+      data-slot="empty-state-header"
+      className={cn(
+        // nexus-allow-numeric: header sub-element rhythm
+        'nx:flex nx:max-w-sm nx:flex-col nx:items-center nx:gap-2 nx:text-center',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+const emptyStateMediaVariants = cva(
+  // nexus-allow-numeric: media wrapper rhythm
+  'nx:mb-2 nx:flex nx:shrink-0 nx:items-center nx:justify-center nx:[&_svg]:pointer-events-none nx:[&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: 'nx:bg-transparent',
+        // nexus-allow-numeric: icon medallion footprint
+        icon: 'nx:size-10 nx:rounded-lg nx:bg-muted nx:text-foreground nx:[&_svg]:size-6',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+/**
+ * EmptyStateMediaProps
+ *
+ * Props for the EmptyStateMedia component.
+ */
+interface EmptyStateMediaProps
+  extends
+    React.ComponentProps<'div'>,
+    VariantProps<typeof emptyStateMediaVariants> {}
+
+/**
+ * EmptyStateMedia
+ *
+ * Holds the empty-state's icon or illustration. The `icon` variant renders a
+ * muted rounded medallion sized for a single glyph; `default` is an unstyled
+ * wrapper for a larger illustration.
+ */
+function EmptyStateMedia({
+  className,
+  variant = 'default',
+  ...props
+}: EmptyStateMediaProps) {
+  return (
+    <div
+      data-slot="empty-state-media"
+      data-variant={variant}
+      className={cn(emptyStateMediaVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * EmptyStateTitleProps
+ *
+ * Props for the EmptyStateTitle component.
+ */
+interface EmptyStateTitleProps extends React.ComponentProps<'div'> {}
+
+/**
+ * EmptyStateTitle
+ *
+ * The headline of the empty state — what is missing.
+ */
+function EmptyStateTitle({ className, ...props }: EmptyStateTitleProps) {
+  return (
+    <div
+      data-slot="empty-state-title"
+      className={cn('nx:typography-heading-xsmall', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * EmptyStateDescriptionProps
+ *
+ * Props for the EmptyStateDescription component.
+ */
+interface EmptyStateDescriptionProps extends React.ComponentProps<'p'> {}
+
+/**
+ * EmptyStateDescription
+ *
+ * Supporting copy beneath the title; anchors inside are underlined.
+ */
+function EmptyStateDescription({
+  className,
+  ...props
+}: EmptyStateDescriptionProps) {
+  return (
+    <p
+      data-slot="empty-state-description"
+      className={cn(
+        'nx:typography-body-small nx:text-muted-foreground nx:[&>a]:underline nx:[&>a]:underline-offset-4 nx:[&>a:hover]:text-primary-subtle-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * EmptyStateContentProps
+ *
+ * Props for the EmptyStateContent component.
+ */
+interface EmptyStateContentProps extends React.ComponentProps<'div'> {}
+
+/**
+ * EmptyStateContent
+ *
+ * The action area below the header — typically one or two buttons.
+ */
+function EmptyStateContent({ className, ...props }: EmptyStateContentProps) {
+  return (
+    <div
+      data-slot="empty-state-content"
+      className={cn(
+        // nexus-allow-numeric: content stack rhythm
+        'nx:flex nx:w-full nx:max-w-sm nx:min-w-0 nx:flex-col nx:items-center nx:gap-4 nx:text-balance',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  EmptyState,
+  EmptyStateContent,
+  type EmptyStateContentProps,
+  EmptyStateDescription,
+  type EmptyStateDescriptionProps,
+  EmptyStateHeader,
+  type EmptyStateHeaderProps,
+  EmptyStateMedia,
+  type EmptyStateMediaProps,
+  emptyStateMediaVariants,
+  type EmptyStateProps,
+  EmptyStateTitle,
+  type EmptyStateTitleProps,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -20,6 +20,7 @@ export * from '@/components/ui/checkbox';
 export * from '@/components/ui/command';
 export * from '@/components/ui/dialog';
 export * from '@/components/ui/dropdown-menu';
+export * from '@/components/ui/empty-state';
 export * from '@/components/ui/form';
 export * from '@/components/ui/input';
 export * from '@/components/ui/input-otp';


### PR DESCRIPTION
## Summary

- Adapt shadcn's `empty` family → first-class Nexus **EmptyState**: `EmptyState` + `EmptyStateHeader`, `EmptyStateMedia` (`default` / `icon` variants), `EmptyStateTitle`, `EmptyStateDescription`, `EmptyStateContent`.
- Composed pure-markup (no dependency) for the list / table / record empty states surfaced by the Atlas CRM — icon, title, description, and an optional action.
- Semantic tokens throughout (`bg-muted`, `text-muted-foreground`, link → `primary-subtle-foreground`); title → `nx:typography-heading-xsmall`, description → `nx:typography-body-small`.

## Decisions / divergences

- **Naming:** `EmptyState*` (the issue's + Atlas's term), not shadcn's `Empty*`.
- **Dropped shadcn's `md:p-12`** — a viewport prefix inside a component is a Nexus anti-pattern (`responsive.md`). Ships a single `nx:p-6`; a future `@container` polish can restore a roomier desktop pad without making EmptyState the first `@container` component.
- Kept shadcn's `border-dashed` (style only) — the dashed box appears when a consumer adds a border width; shown in `AllVariants`.

## GitHub Issue

Closes #282

## Test Plan

- [x] `typecheck`, `eslint . --max-warnings 0`, `prettier --check` clean
- [x] `audit:storybook-coverage --component empty-state` → 0 missing, 0 drift (display-only)
- [x] `size-limit` → ESM 67.7 kB / 70 kB (no new dependency)
- [x] CSS emission verified (`typography-heading-xsmall`, `border-dashed`, `text-balance`, …)
- [x] storybook play-fns pass locally (5/5); CI runs them across 5 bases × 2 themes