### PR TITLE
feat(console): CRM saved views + status filter (Phase 2e)

### DIFF
--- a/apps/console/src/app/router.tsx
+++ b/apps/console/src/app/router.tsx
@@ -13,6 +13,7 @@ import { VerifyRoute } from '../modules/auth/verify-route';
 import { ComingSoon } from '../modules/coming-soon';
 import { ContactDetailRoute } from '../modules/crm/contact-detail-route';
 import { ContactsRoute } from '../modules/crm/contacts-route';
+import { contactsSearchSchema } from '../modules/crm/contacts-search';
 import { AppearanceRoute } from '../modules/design-system/appearance-route';
 import { ReferenceRoute } from '../modules/design-system/reference-route';
 import { ScenesRoute } from '../modules/design-system/scenes-route';
@@ -84,16 +85,7 @@ const appearanceRoute = createRoute({
 const crmContactsRoute = createRoute({
   getParentRoute: () => appRoute,
   path: '/m/crm',
-  // `.default` keeps the param optional for navigation (existing `<Link
-  // to="/m/crm">` calls don't pass `search`); `.catch` also recovers an invalid
-  // value (e.g. a stale `?view=foo`) to 'table' instead of throwing a search error.
-  validateSearch: z.object({
-    view: z.enum(['table', 'board']).default('table').catch('table'),
-    status: z
-      .array(z.enum(['active', 'lead', 'churned']))
-      .default([])
-      .catch([]),
-  }),
+  validateSearch: contactsSearchSchema,
   component: ContactsRoute,
 });
 

--- a/apps/console/src/app/router.tsx
+++ b/apps/console/src/app/router.tsx
@@ -89,6 +89,10 @@ const crmContactsRoute = createRoute({
   // value (e.g. a stale `?view=foo`) to 'table' instead of throwing a search error.
   validateSearch: z.object({
     view: z.enum(['table', 'board']).default('table').catch('table'),
+    status: z
+      .array(z.enum(['active', 'lead', 'churned']))
+      .default([])
+      .catch([]),
   }),
   component: ContactsRoute,
 });

--- a/apps/console/src/lib/crm-api.ts
+++ b/apps/console/src/lib/crm-api.ts
@@ -4,8 +4,15 @@
  * fetches through these via TanStack Query.
  */
 
+/**
+ * The lifecycle statuses a contact can hold — the single source for the
+ * {@link ContactStatus} union, the route's status facet, and the create/edit
+ * form's status enum (all derive from this `as const` tuple).
+ */
+export const CONTACT_STATUSES = ['active', 'lead', 'churned'] as const;
+
 /** Lifecycle status of a contact — rendered as a status badge. */
-export type ContactStatus = 'active' | 'lead' | 'churned';
+export type ContactStatus = (typeof CONTACT_STATUSES)[number];
 
 export type Contact = {
   id: string;

--- a/apps/console/src/modules/crm/contact-form-sheet.tsx
+++ b/apps/console/src/modules/crm/contact-form-sheet.tsx
@@ -32,6 +32,7 @@ import { z } from 'zod';
 
 import {
   type Contact,
+  CONTACT_STATUSES,
   type ContactStatus,
   createContact,
   crmKeys,
@@ -55,7 +56,7 @@ const contactSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   email: z.email('Enter a valid email address'),
   company: z.string().min(1, 'Company is required'),
-  status: z.enum(['active', 'lead', 'churned']),
+  status: z.enum(CONTACT_STATUSES),
   owner: z.string().min(1, 'Owner is required'),
   value: z.number().min(0, 'Open value must be 0 or more'),
 });

--- a/apps/console/src/modules/crm/contacts-route.tsx
+++ b/apps/console/src/modules/crm/contacts-route.tsx
@@ -11,8 +11,8 @@ import { crmKeys, fetchContacts } from '../../lib/crm-api';
 import { ContactFormSheet } from './contact-form-sheet';
 import { ContactsBoard } from './contacts-board';
 import { contactColumns } from './contacts-columns';
+import type { ContactsView } from './contacts-search';
 import { ContactsToolbar } from './contacts-toolbar';
-import type { ContactsView } from './saved-views';
 
 const crmRoute = getRouteApi('/app/m/crm');
 
@@ -27,7 +27,15 @@ export function ContactsRoute() {
   const [createOpen, setCreateOpen] = useState(false);
 
   const setSearch = (patch: Partial<ContactsView>) =>
-    navigate({ search: (prev) => ({ ...prev, ...patch }) });
+    navigate({
+      search: (prev) => {
+        const next = { ...prev, ...patch };
+        // The status facet is table-only — the board is organised by status, so
+        // never carry a hidden status filter into board view (incl. when applying
+        // a saved board view).
+        return next.view === 'board' ? { ...next, status: [] } : next;
+      },
+    });
 
   return (
     <div className="nx:space-y-6 nx:p-6">

--- a/apps/console/src/modules/crm/contacts-route.tsx
+++ b/apps/console/src/modules/crm/contacts-route.tsx
@@ -1,12 +1,7 @@
 import { useState } from 'react';
 
 import { Button, Skeleton } from '@nexus/react';
-import {
-  IconLayoutKanban,
-  IconPlus,
-  IconTable,
-  IconUsers,
-} from '@tabler/icons-react';
+import { IconPlus, IconUsers } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import { getRouteApi } from '@tanstack/react-router';
 
@@ -16,6 +11,8 @@ import { crmKeys, fetchContacts } from '../../lib/crm-api';
 import { ContactFormSheet } from './contact-form-sheet';
 import { ContactsBoard } from './contacts-board';
 import { contactColumns } from './contacts-columns';
+import { ContactsToolbar } from './contacts-toolbar';
+import type { ContactsView } from './saved-views';
 
 const crmRoute = getRouteApi('/app/m/crm');
 
@@ -25,9 +22,12 @@ export function ContactsRoute() {
     queryFn: fetchContacts,
   });
   const contacts = data?.contacts;
-  const { view } = crmRoute.useSearch();
+  const { view, status } = crmRoute.useSearch();
   const navigate = crmRoute.useNavigate();
   const [createOpen, setCreateOpen] = useState(false);
+
+  const setSearch = (patch: Partial<ContactsView>) =>
+    navigate({ search: (prev) => ({ ...prev, ...patch }) });
 
   return (
     <div className="nx:space-y-6 nx:p-6">
@@ -46,24 +46,7 @@ export function ContactsRoute() {
         </Button>
       </header>
 
-      <div className="nx:inline-flex nx:gap-1">
-        <Button
-          variant={view === 'table' ? 'default' : 'ghost'}
-          size="sm"
-          onClick={() => navigate({ search: { view: 'table' } })}
-        >
-          <IconTable />
-          Table
-        </Button>
-        <Button
-          variant={view === 'board' ? 'default' : 'ghost'}
-          size="sm"
-          onClick={() => navigate({ search: { view: 'board' } })}
-        >
-          <IconLayoutKanban />
-          Board
-        </Button>
-      </div>
+      <ContactsToolbar view={view} status={status} setSearch={setSearch} />
 
       {isPending && <ContactsSkeleton />}
       {isError && (
@@ -79,7 +62,11 @@ export function ContactsRoute() {
         ) : (
           <DataTable
             columns={contactColumns}
-            data={contacts}
+            data={
+              status.length > 0
+                ? contacts.filter((c) => status.includes(c.status))
+                : contacts
+            }
             filterColumn="name"
             filterPlaceholder="Filter by name…"
           />

--- a/apps/console/src/modules/crm/contacts-search.ts
+++ b/apps/console/src/modules/crm/contacts-search.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+import { CONTACT_STATUSES } from '../../lib/crm-api';
+
+/**
+ * The Contacts list view contract: the zod schema that validates the `/m/crm`
+ * search params, and the single source for {@link ContactsView}. The route, the
+ * toolbar, and the saved-views store all derive from this — so the URL shape and
+ * the persisted shape can't drift.
+ *
+ * `.default` keeps each param optional for `<Link to="/m/crm">` (callers needn't
+ * pass `search`); `.catch` recovers a stale/invalid value (e.g. `?view=foo`)
+ * instead of throwing a search error.
+ */
+export const contactsSearchSchema = z.object({
+  view: z.enum(['table', 'board']).default('table').catch('table'),
+  status: z.array(z.enum(CONTACT_STATUSES)).default([]).catch([]),
+});
+
+/** The shareable Contacts view state — inferred from {@link contactsSearchSchema}. */
+export type ContactsView = z.infer<typeof contactsSearchSchema>;

--- a/apps/console/src/modules/crm/contacts-toolbar.tsx
+++ b/apps/console/src/modules/crm/contacts-toolbar.tsx
@@ -14,10 +14,13 @@ import {
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Separator,
   toast,
 } from '@nexus/react';
 import {
@@ -31,7 +34,8 @@ import {
 
 import type { ContactStatus } from '../../lib/crm-api';
 
-import { type ContactsView, useSavedViews } from './saved-views';
+import type { ContactsView } from './contacts-search';
+import { useSavedViews } from './saved-views';
 
 const STATUS_FILTERS: { value: ContactStatus; label: string }[] = [
   { value: 'active', label: 'Active' },
@@ -142,6 +146,7 @@ function SavedViewsMenu({
   const views = useSavedViews((s) => s.views);
   const save = useSavedViews((s) => s.save);
   const remove = useSavedViews((s) => s.remove);
+  const [open, setOpen] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [name, setName] = useState('');
 
@@ -154,55 +159,74 @@ function SavedViewsMenu({
     setDialogOpen(false);
   };
 
+  const applyView = (view: ContactsView) => {
+    setSearch(view);
+    setOpen(false);
+  };
+
+  // A Popover (not a DropdownMenu) so each row carries two sibling buttons —
+  // apply + delete — both keyboard-reachable. A menu's roving focus only lands on
+  // `role="menuitem"` rows, which would strand a nested delete control (and trip
+  // axe's `nested-interactive`).
   return (
     <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
           <Button variant="outline" size="sm">
             <IconBookmark />
             Views
           </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="nx:w-56">
-          <DropdownMenuLabel>Saved views</DropdownMenuLabel>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="nx:w-64 nx:p-0">
+          <p className="nx:typography-label-small nx:text-muted-foreground nx:px-3 nx:pt-3 nx:pb-2">
+            Saved views
+          </p>
           {views.length === 0 ? (
-            <DropdownMenuItem disabled>No saved views yet</DropdownMenuItem>
+            <p className="nx:text-muted-foreground nx:px-3 nx:pb-3 nx:text-sm">
+              No saved views yet.
+            </p>
           ) : (
-            views.map((saved) => (
-              <DropdownMenuItem
-                key={saved.id}
-                onSelect={() => setSearch(saved.view)}
-                className="nx:flex nx:items-center nx:justify-between nx:gap-2"
-              >
-                <span className="nx:truncate">{saved.name}</span>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  aria-label={`Delete view ${saved.name}`}
-                  className="nx:text-muted-foreground nx:hover:text-error-foreground nx:shrink-0"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    remove(saved.id);
-                  }}
-                  onPointerDown={(e) => e.stopPropagation()}
-                >
-                  <IconTrash className="nx:size-4" />
-                </Button>
-              </DropdownMenuItem>
-            ))
+            <ul className="nx:px-1 nx:pb-1">
+              {views.map((saved) => (
+                <li key={saved.id} className="nx:flex nx:items-center nx:gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => applyView(saved.view)}
+                    className="nx:min-w-0 nx:flex-1 nx:justify-start"
+                  >
+                    <span className="nx:truncate">{saved.name}</span>
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-label={`Delete view ${saved.name}`}
+                    onClick={() => remove(saved.id)}
+                    className="nx:text-muted-foreground nx:hover:text-error-foreground nx:shrink-0"
+                  >
+                    <IconTrash className="nx:size-4" />
+                  </Button>
+                </li>
+              ))}
+            </ul>
           )}
-          <DropdownMenuSeparator />
-          <DropdownMenuItem
-            onSelect={(e) => {
-              e.preventDefault();
-              setDialogOpen(true);
-            }}
-          >
-            <IconPlus />
-            Save current view…
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+          <Separator />
+          <div className="nx:p-1">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setOpen(false);
+                setDialogOpen(true);
+              }}
+              className="nx:w-full nx:justify-start"
+            >
+              <IconPlus />
+              Save current view…
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
 
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent>

--- a/apps/console/src/modules/crm/contacts-toolbar.tsx
+++ b/apps/console/src/modules/crm/contacts-toolbar.tsx
@@ -1,0 +1,236 @@
+import { useState } from 'react';
+
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Input,
+  toast,
+} from '@nexus/react';
+import {
+  IconBookmark,
+  IconFilter,
+  IconLayoutKanban,
+  IconPlus,
+  IconTable,
+  IconTrash,
+} from '@tabler/icons-react';
+
+import type { ContactStatus } from '../../lib/crm-api';
+
+import { type ContactsView, useSavedViews } from './saved-views';
+
+const STATUS_FILTERS: { value: ContactStatus; label: string }[] = [
+  { value: 'active', label: 'Active' },
+  { value: 'lead', label: 'Lead' },
+  { value: 'churned', label: 'Churned' },
+];
+
+interface ContactsToolbarProps {
+  view: ContactsView['view'];
+  status: ContactStatus[];
+  setSearch: (patch: Partial<ContactsView>) => void;
+}
+
+export function ContactsToolbar({
+  view,
+  status,
+  setSearch,
+}: ContactsToolbarProps) {
+  return (
+    <div className="nx:flex nx:flex-wrap nx:items-center nx:gap-3">
+      <ViewSwitcher view={view} setSearch={setSearch} />
+      {view === 'table' && (
+        <StatusFilter status={status} setSearch={setSearch} />
+      )}
+      <div className="nx:ml-auto">
+        <SavedViewsMenu current={{ view, status }} setSearch={setSearch} />
+      </div>
+    </div>
+  );
+}
+
+function ViewSwitcher({
+  view,
+  setSearch,
+}: Pick<ContactsToolbarProps, 'view' | 'setSearch'>) {
+  return (
+    <div className="nx:inline-flex nx:gap-1">
+      <Button
+        variant={view === 'table' ? 'default' : 'ghost'}
+        size="sm"
+        onClick={() => setSearch({ view: 'table' })}
+      >
+        <IconTable />
+        Table
+      </Button>
+      <Button
+        variant={view === 'board' ? 'default' : 'ghost'}
+        size="sm"
+        onClick={() => setSearch({ view: 'board' })}
+      >
+        <IconLayoutKanban />
+        Board
+      </Button>
+    </div>
+  );
+}
+
+function StatusFilter({
+  status,
+  setSearch,
+}: Pick<ContactsToolbarProps, 'status' | 'setSearch'>) {
+  const toggle = (value: ContactStatus, on: boolean) =>
+    setSearch({
+      status: on ? [...status, value] : status.filter((s) => s !== value),
+    });
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm">
+          <IconFilter />
+          Status
+          {status.length > 0 && (
+            <Badge variant="secondary">{status.length}</Badge>
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {STATUS_FILTERS.map((option) => (
+          <DropdownMenuCheckboxItem
+            key={option.value}
+            checked={status.includes(option.value)}
+            onCheckedChange={(checked) => toggle(option.value, !!checked)}
+          >
+            {option.label}
+          </DropdownMenuCheckboxItem>
+        ))}
+        {status.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={() => setSearch({ status: [] })}>
+              Clear filters
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function SavedViewsMenu({
+  current,
+  setSearch,
+}: {
+  current: ContactsView;
+  setSearch: (patch: Partial<ContactsView>) => void;
+}) {
+  const views = useSavedViews((s) => s.views);
+  const save = useSavedViews((s) => s.save);
+  const remove = useSavedViews((s) => s.remove);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [name, setName] = useState('');
+
+  const handleSave = () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    save(trimmed, current);
+    toast.success(`View "${trimmed}" saved`);
+    setName('');
+    setDialogOpen(false);
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm">
+            <IconBookmark />
+            Views
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="nx:w-56">
+          <DropdownMenuLabel>Saved views</DropdownMenuLabel>
+          {views.length === 0 ? (
+            <DropdownMenuItem disabled>No saved views yet</DropdownMenuItem>
+          ) : (
+            views.map((saved) => (
+              <DropdownMenuItem
+                key={saved.id}
+                onSelect={() => setSearch(saved.view)}
+                className="nx:flex nx:items-center nx:justify-between nx:gap-2"
+              >
+                <span className="nx:truncate">{saved.name}</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  aria-label={`Delete view ${saved.name}`}
+                  className="nx:text-muted-foreground nx:hover:text-error-foreground nx:shrink-0"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    remove(saved.id);
+                  }}
+                  onPointerDown={(e) => e.stopPropagation()}
+                >
+                  <IconTrash className="nx:size-4" />
+                </Button>
+              </DropdownMenuItem>
+            ))
+          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault();
+              setDialogOpen(true);
+            }}
+          >
+            <IconPlus />
+            Save current view…
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Save view</DialogTitle>
+            <DialogDescription>
+              Name this view and filter combination to reuse it later.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="e.g. Active deals"
+            aria-label="View name"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleSave();
+            }}
+          />
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">Cancel</Button>
+            </DialogClose>
+            <Button onClick={handleSave} disabled={!name.trim()}>
+              Save view
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/console/src/modules/crm/saved-views.ts
+++ b/apps/console/src/modules/crm/saved-views.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+import type { ContactStatus } from '../../lib/crm-api';
+
+/** The shareable Contacts view state — mirrors the route's search params. */
+export type ContactsView = {
+  view: 'table' | 'board';
+  status: ContactStatus[];
+};
+
+export type SavedView = {
+  id: string;
+  name: string;
+  view: ContactsView;
+};
+
+type SavedViewsState = {
+  views: SavedView[];
+  save: (name: string, view: ContactsView) => void;
+  remove: (id: string) => void;
+};
+
+/**
+ * User-saved Contacts views (a named view + status-filter combo), persisted to
+ * localStorage. Applying one navigates the table to its search params; this
+ * store only owns the saved list, not the live view (which lives in the URL).
+ */
+export const useSavedViews = create<SavedViewsState>()(
+  persist(
+    (set) => ({
+      views: [],
+      save: (name, view) =>
+        set((state) => ({
+          views: [...state.views, { id: crypto.randomUUID(), name, view }],
+        })),
+      remove: (id) =>
+        set((state) => ({ views: state.views.filter((v) => v.id !== id) })),
+    }),
+    { name: 'nexus-console-crm-views' }
+  )
+);

--- a/apps/console/src/modules/crm/saved-views.ts
+++ b/apps/console/src/modules/crm/saved-views.ts
@@ -1,13 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-import type { ContactStatus } from '../../lib/crm-api';
-
-/** The shareable Contacts view state — mirrors the route's search params. */
-export type ContactsView = {
-  view: 'table' | 'board';
-  status: ContactStatus[];
-};
+import type { ContactsView } from './contacts-search';
 
 export type SavedView = {
   id: string;


### PR DESCRIPTION
## Summary

Phase 2e — the **Phase-2 capstone**: faceted **filtering** + **saved views** on the Contacts list. Completes the CRM flagship (table → detail → create/edit → kanban → views/filters).

- **Status facet filter** (table view) — a multi-select **Status** dropdown drives a `status` search param. The view/search contract now lives in `contacts-search.ts`: a single zod schema (`contactsSearchSchema`) that the router validates against and that `ContactsView` derives from via `z.infer`, with `CONTACT_STATUSES` as the one source for the status values. Table rows are pre-filtered; the facet is table-only since the board is already organised by status (switching to board clears the filter so it never persists invisibly).
- **Saved views** — a **Views** popover lists user-saved view+filter combos (Zustand, persisted to localStorage), applies one by navigating to its search params, and deletes per row. "Save current view…" names the live view in a dialog. The view/status state lives entirely in the URL, so views are shareable.
- Extracted **`ContactsToolbar`** (view switcher + status filter + views popover).

## Review fixes (b2ec2c8)

Addresses both bot reviews:

- **a11y blocker (SDE2)** — the per-row delete was a `<button>` nested in a `DropdownMenuItem`, unreachable by Radix roving focus and tripping axe `nested-interactive`. Rebuilt `SavedViewsMenu` as a **Popover** whose rows carry sibling apply/delete buttons, both Tab-reachable.
- **source of truth (Architect)** — `ContactsView` hand-duplicated the route's zod shape; now derived via `z.infer` from the shared `contactsSearchSchema`, with `CONTACT_STATUSES` single-sourcing the values (route facet + form enum both reference it).
- **stale board filter (SDE2)** — `setSearch` clears `status` when `view==='board'`.
- _Declined with rationale:_ persist `version`/`migrate` (`project-stage.md` forbids migration theater; `.catch([])` degrades a stale value gracefully) and pushing the filter to the query layer (would add latency + fork the shared `crmKeys.contacts` cache the board's optimistic writes depend on; an inline `select` re-runs each render too; 24-row scale).

## Test Plan (browser-verified)

- [x] `?status=["active"]` → table filtered to the 12 active contacts (Page 1 of 2); the **Status** button shows a count badge
- [x] `?status=foo` (invalid) → recovers to no filter, no crash
- [x] **Save** a view → persisted to localStorage as `{view, status}`; dialog closes
- [x] **Apply** a saved view → navigates to its search params (verified via keyboard)
- [x] **Delete** a saved view is keyboard-reachable — Tab lands on the delete control, Enter removes it (the a11y fix)
- [x] Switching to **Board** clears the status filter (`status=[]`)
- [x] `typecheck`, `eslint --max-warnings 0`, `prettier --check` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
