### PR TITLE
feat(components): add breadcrumb component

### DIFF
--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -23,6 +23,7 @@
     },
     { "name": "Avatar", "showcase": "AllSizes" },
     { "name": "Badge", "showcase": "AllVariants" },
+    { "name": "Breadcrumb", "showcase": "AllVariants" },
     { "name": "Button", "showcase": "AllVariants" },
     { "name": "Card", "showcase": "AllVariants" },
     { "name": "Checkbox", "showcase": "AllVariants" },

--- a/packages/react/src/components/ui/Breadcrumb.stories.tsx
+++ b/packages/react/src/components/ui/Breadcrumb.stories.tsx
@@ -1,0 +1,155 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+
+import {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from './breadcrumb';
+
+const meta: Meta<typeof Breadcrumb> = {
+  title: 'Components/Breadcrumb',
+  component: Breadcrumb,
+};
+
+export default meta;
+type Story = StoryObj<typeof Breadcrumb>;
+
+// A three-level trail ending on the current page.
+export const Default: Story = {
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Components</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};
+
+// A long trail collapsed with an ellipsis standing in for the middle.
+export const WithEllipsis: Story = {
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbEllipsis />
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Settings</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};
+
+// BreadcrumbLink composes with a custom element via asChild (e.g. a router
+// link), keeping the link styling and the data-slot hook.
+export const AsChild: Story = {
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink asChild>
+            <a href="/contacts" data-testid="router-link">
+              Home
+            </a>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Contacts</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+  play: async ({ canvasElement }) => {
+    // Slot merges BreadcrumbLink's props onto the child anchor.
+    const link = within(canvasElement).getByTestId('router-link');
+    await expect(link.tagName).toBe('A');
+    await expect(link).toHaveAttribute('data-slot', 'breadcrumb-link');
+  },
+};
+
+// Every structural part carries a data-slot hook; the current page advertises
+// aria-current.
+export const WithDataAttributes: Story = {
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Contacts</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+  play: async ({ canvasElement }) => {
+    for (const slot of [
+      'breadcrumb',
+      'breadcrumb-list',
+      'breadcrumb-item',
+      'breadcrumb-link',
+      'breadcrumb-separator',
+      'breadcrumb-page',
+    ]) {
+      await expect(
+        canvasElement.querySelector(`[data-slot="${slot}"]`)
+      ).toBeInTheDocument();
+    }
+
+    const page = canvasElement.querySelector('[data-slot="breadcrumb-page"]');
+    await expect(page).toHaveAttribute('aria-current', 'page');
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// The full anatomy: links, chevron separators, a collapsed ellipsis, and the
+// current page. Reused by the per-base variant generator.
+export const AllVariants: Story = {
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbEllipsis />
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Components</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Breadcrumb</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+};

--- a/packages/react/src/components/ui/breadcrumb.tsx
+++ b/packages/react/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,233 @@
+import * as React from 'react';
+
+import { Slot } from '@radix-ui/react-slot';
+
+import { IconChevronRight, IconDots } from '@/lib/icons';
+import { cn } from '@/lib/utils';
+
+/**
+ * BreadcrumbProps
+ *
+ * Props for the Breadcrumb component.
+ */
+interface BreadcrumbProps extends React.ComponentProps<'nav'> {}
+
+/**
+ * Breadcrumb
+ *
+ * A hierarchical navigation trail wrapped in the `navigation` landmark. Compose
+ * with the sub-components: `BreadcrumbList` lays out a row of `BreadcrumbItem`s,
+ * each holding a `BreadcrumbLink` (an ancestor) or `BreadcrumbPage` (the current
+ * page); `BreadcrumbSeparator` divides them and `BreadcrumbEllipsis` stands in
+ * for a collapsed middle.
+ *
+ * @example
+ * ```tsx
+ * <Breadcrumb>
+ *   <BreadcrumbList>
+ *     <BreadcrumbItem>
+ *       <BreadcrumbLink href="/">Home</BreadcrumbLink>
+ *     </BreadcrumbItem>
+ *     <BreadcrumbSeparator />
+ *     <BreadcrumbItem>
+ *       <BreadcrumbPage>Contacts</BreadcrumbPage>
+ *     </BreadcrumbItem>
+ *   </BreadcrumbList>
+ * </Breadcrumb>
+ * ```
+ */
+function Breadcrumb(props: BreadcrumbProps) {
+  return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />;
+}
+
+/**
+ * BreadcrumbListProps
+ *
+ * Props for the BreadcrumbList component.
+ */
+interface BreadcrumbListProps extends React.ComponentProps<'ol'> {}
+
+/**
+ * BreadcrumbList
+ *
+ * The `<ol>` that lays the trail out in a horizontal, wrapping row.
+ */
+function BreadcrumbList({ className, ...props }: BreadcrumbListProps) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        // nexus-allow-numeric: tight trail rhythm
+        'nx:flex nx:flex-wrap nx:items-center nx:gap-1.5 nx:break-words nx:typography-body-small nx:text-muted-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * BreadcrumbItemProps
+ *
+ * Props for the BreadcrumbItem component.
+ */
+interface BreadcrumbItemProps extends React.ComponentProps<'li'> {}
+
+/**
+ * BreadcrumbItem
+ *
+ * A single `<li>` slot in the trail.
+ */
+function BreadcrumbItem({ className, ...props }: BreadcrumbItemProps) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn(
+        // nexus-allow-numeric: link/separator gap
+        'nx:inline-flex nx:items-center nx:gap-1.5',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * BreadcrumbLinkProps
+ *
+ * Props for the BreadcrumbLink component.
+ */
+interface BreadcrumbLinkProps extends React.ComponentProps<'a'> {
+  /**
+   * Render as the child element via Radix Slot — e.g. a router `<Link>` — while
+   * keeping the breadcrumb link styling.
+   * @default false
+   */
+  asChild?: boolean;
+}
+
+/**
+ * BreadcrumbLink
+ *
+ * A link to an ancestor page. Muted by default, darkening on hover; carries the
+ * canonical focus ring since it is reachable by keyboard.
+ */
+function BreadcrumbLink({ asChild, className, ...props }: BreadcrumbLinkProps) {
+  const Comp = asChild ? Slot : 'a';
+
+  return (
+    <Comp
+      data-slot="breadcrumb-link"
+      className={cn(
+        'nx:rounded-sm nx:transition-colors nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * BreadcrumbPageProps
+ *
+ * Props for the BreadcrumbPage component.
+ */
+interface BreadcrumbPageProps extends React.ComponentProps<'span'> {}
+
+/**
+ * BreadcrumbPage
+ *
+ * The current page — non-interactive, announced via `aria-current="page"`.
+ */
+function BreadcrumbPage({ className, ...props }: BreadcrumbPageProps) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn('nx:font-normal nx:text-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * BreadcrumbSeparatorProps
+ *
+ * Props for the BreadcrumbSeparator component.
+ */
+interface BreadcrumbSeparatorProps extends React.ComponentProps<'li'> {}
+
+/**
+ * BreadcrumbSeparator
+ *
+ * The divider between items — a right chevron by default; pass `children` to
+ * use a different glyph.
+ */
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: BreadcrumbSeparatorProps) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn('nx:[&>svg]:size-3.5', className)}
+      {...props}
+    >
+      {children ?? <IconChevronRight />}
+    </li>
+  );
+}
+
+/**
+ * BreadcrumbEllipsisProps
+ *
+ * Props for the BreadcrumbEllipsis component.
+ */
+interface BreadcrumbEllipsisProps extends React.ComponentProps<'span'> {}
+
+/**
+ * BreadcrumbEllipsis
+ *
+ * Stands in for a collapsed run of middle items; pair with a menu to reveal
+ * them.
+ */
+function BreadcrumbEllipsis({ className, ...props }: BreadcrumbEllipsisProps) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn(
+        // nexus-allow-numeric: ellipsis hit-slot footprint
+        'nx:flex nx:size-9 nx:items-center nx:justify-center',
+        className
+      )}
+      {...props}
+    >
+      <IconDots className="nx:size-4" />
+      <span className="nx:sr-only">More</span>
+    </span>
+  );
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbEllipsis,
+  type BreadcrumbEllipsisProps,
+  BreadcrumbItem,
+  type BreadcrumbItemProps,
+  BreadcrumbLink,
+  type BreadcrumbLinkProps,
+  BreadcrumbList,
+  type BreadcrumbListProps,
+  BreadcrumbPage,
+  type BreadcrumbPageProps,
+  type BreadcrumbProps,
+  BreadcrumbSeparator,
+  type BreadcrumbSeparatorProps,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -14,6 +14,7 @@ export * from '@/components/ui/alert';
 export * from '@/components/ui/alert-dialog';
 export * from '@/components/ui/avatar';
 export * from '@/components/ui/badge';
+export * from '@/components/ui/breadcrumb';
 export * from '@/components/ui/button';
 export * from '@/components/ui/card';
 export * from '@/components/ui/checkbox';


### PR DESCRIPTION
## Summary

- Adapt shadcn **breadcrumb** → first-class Nexus `Breadcrumb` + `BreadcrumbList`, `BreadcrumbItem`, `BreadcrumbLink` (`asChild`), `BreadcrumbPage`, `BreadcrumbSeparator`, `BreadcrumbEllipsis` — a hierarchical navigation trail with separators, overflow ellipsis, and current-page semantics.
- Composed pure-markup, **no new dependency**: `Slot` from the already-present `@radix-ui/react-slot`; chevron + ellipsis reuse `IconChevronRight` / `IconDots`.

## Decisions / divergences

- **radix-ui import rewrite:** shadcn new-york-v4 sources `import { Slot } from "radix-ui"` and uses `Slot.Root`; rewritten to the per-primitive `import { Slot } from '@radix-ui/react-slot'` + `Slot` — Nexus's convention (Button/Badge), so no new dep.
- **Focus ring added:** `BreadcrumbLink` is a Tab-reachable link, so it gets the canonical focus ring (`outline-focus-default`) — shadcn leaves it without a visible indicator.
- **Dropped `sm:gap-2.5`** — a viewport prefix inside a component is a Nexus anti-pattern (`responsive.md`); ships a single `nx:gap-1.5`.
- Anchor play-fns are navigation-free (the `asChild` story asserts the slotted element + merged `data-slot` without clicking), per the lesson from Pagination.

## GitHub Issue

Closes #285

## Test Plan

- [x] `typecheck`, `eslint . --max-warnings 0`, `prettier --check` clean
- [x] `audit:storybook-coverage --component breadcrumb` → 0 missing, 0 drift (display-only; `aria-disabled` did not false-gate)
- [x] `size-limit` → ESM 67.9 kB / 70 kB (no new dependency)
- [x] CSS emission verified incl. the focus-ring outline and `gap-1.5` / `size-3.5`
- [x] storybook play-fns pass locally (6/6); CI runs them across 5 bases × 2 themes