### PR TITLE
feat(components): add aspect-ratio component

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,6 +54,7 @@
     "@nexus/tailwind": "*",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
+    "@radix-ui/react-aspect-ratio": "^1.1.8",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -21,6 +21,7 @@
         "KeyboardInteraction": ["EscapeCancels"]
       }
     },
+    { "name": "AspectRatio", "showcase": "AllVariants" },
     { "name": "Avatar", "showcase": "AllSizes" },
     { "name": "Badge", "showcase": "AllVariants" },
     { "name": "Breadcrumb", "showcase": "AllVariants" },

--- a/packages/react/src/components/ui/AspectRatio.stories.tsx
+++ b/packages/react/src/components/ui/AspectRatio.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect } from 'storybook/test';
+
+import { AspectRatio } from './aspect-ratio';
+
+const meta: Meta<typeof AspectRatio> = {
+  title: 'Components/AspectRatio',
+  component: AspectRatio,
+};
+
+export default meta;
+type Story = StoryObj<typeof AspectRatio>;
+
+// A muted, labelled fill standing in for media across the stories.
+function Placeholder({ label }: { label: string }) {
+  return (
+    <div className="nx:flex nx:size-full nx:items-center nx:justify-center nx:rounded-md nx:bg-muted nx:text-muted-foreground nx:typography-label-small">
+      {label}
+    </div>
+  );
+}
+
+// A 16:9 box — the most common media ratio. AspectRatio fills its parent's
+// width, so wrap it in a sized container.
+export const Default: Story = {
+  render: () => (
+    <div className="nx:w-80">
+      <AspectRatio ratio={16 / 9}>
+        <Placeholder label="16 / 9" />
+      </AspectRatio>
+    </div>
+  ),
+};
+
+// Common ratios side by side.
+export const Ratios: Story = {
+  render: () => (
+    <div className="nx:flex nx:items-start nx:gap-4">
+      <div className="nx:w-40">
+        <AspectRatio ratio={1}>
+          <Placeholder label="1 / 1" />
+        </AspectRatio>
+      </div>
+      <div className="nx:w-40">
+        <AspectRatio ratio={4 / 3}>
+          <Placeholder label="4 / 3" />
+        </AspectRatio>
+      </div>
+      <div className="nx:w-56">
+        <AspectRatio ratio={16 / 9}>
+          <Placeholder label="16 / 9" />
+        </AspectRatio>
+      </div>
+    </div>
+  ),
+};
+
+// The wrapper carries a data-slot hook.
+export const WithDataAttributes: Story = {
+  render: () => (
+    <div className="nx:w-80">
+      <AspectRatio ratio={16 / 9}>
+        <Placeholder label="16 / 9" />
+      </AspectRatio>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    await expect(
+      canvasElement.querySelector('[data-slot="aspect-ratio"]')
+    ).toBeInTheDocument();
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// A range of ratios with muted fills. Reused by the per-base variant generator.
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:items-start nx:gap-4">
+      <div className="nx:w-40">
+        <AspectRatio ratio={1}>
+          <Placeholder label="1 / 1" />
+        </AspectRatio>
+      </div>
+      <div className="nx:w-56">
+        <AspectRatio ratio={16 / 9}>
+          <Placeholder label="16 / 9" />
+        </AspectRatio>
+      </div>
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/aspect-ratio.tsx
+++ b/packages/react/src/components/ui/aspect-ratio.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+
+import * as AspectRatioPrimitive from '@radix-ui/react-aspect-ratio';
+
+/**
+ * AspectRatioProps
+ *
+ * Props for the AspectRatio component.
+ */
+interface AspectRatioProps extends React.ComponentProps<
+  typeof AspectRatioPrimitive.Root
+> {}
+
+/**
+ * AspectRatio
+ *
+ * Constrains its content to a fixed width:height ratio — media, embeds,
+ * thumbnails, map tiles. Pass `ratio` (e.g. `16 / 9`); the single child fills
+ * the resulting box.
+ *
+ * @example
+ * ```tsx
+ * <AspectRatio ratio={16 / 9}>
+ *   <img src="…" alt="…" className="nx:size-full nx:object-cover" />
+ * </AspectRatio>
+ * ```
+ */
+function AspectRatio(props: AspectRatioProps) {
+  return <AspectRatioPrimitive.Root data-slot="aspect-ratio" {...props} />;
+}
+
+export { AspectRatio, type AspectRatioProps };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -12,6 +12,7 @@ export { cn } from '@/lib/utils';
 export * from '@/components/ui/accordion';
 export * from '@/components/ui/alert';
 export * from '@/components/ui/alert-dialog';
+export * from '@/components/ui/aspect-ratio';
 export * from '@/components/ui/avatar';
 export * from '@/components/ui/badge';
 export * from '@/components/ui/breadcrumb';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1063,6 +1063,13 @@
   dependencies:
     "@radix-ui/react-primitive" "2.1.3"
 
+"@radix-ui/react-aspect-ratio@^1.1.8":
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.8.tgz#97c8cc7df4470978e54d7de81da550d934a89d17"
+  integrity sha512-5nZrJTF7gH+e0nZS7/QxFz6tJV4VimhQb1avEgtsJxvvIp5JilL+c58HICsKzPxghdwaDt48hEfPM1au4zGy+w==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.4"
+
 "@radix-ui/react-avatar@^1.1.11":
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-avatar/-/react-avatar-1.1.11.tgz#3e24b70d636a12e2806abb2b4ce4b15df395f9c9"


### PR DESCRIPTION
## Summary

- Adapt shadcn **aspect-ratio** → first-class Nexus `AspectRatio` — a layout primitive (wrapping Radix `AspectRatio.Root`) that constrains content to a fixed width:height ratio for media, embeds, and thumbnails.
- **First bundled-Radix-dependency component of the batch** — proves the Radix path.

## Decisions / first-of-archetype gate

- **radix-ui import rewrite:** shadcn new-york-v4 sources `import { AspectRatio } from "radix-ui"`; rewritten to the per-primitive `import * as AspectRatioPrimitive from '@radix-ui/react-aspect-ratio'` (added `^1.1.8` to dependencies) — Nexus's convention (matches `dialog.tsx` etc.).
- Dropped shadcn's `"use client"` (Nexus is a component library, not a Next RSC app).
- Pure layout primitive — no tokens; carries `data-slot="aspect-ratio"`.
- **Bundle:** the dep bundles into the ESM (verified) and adds only **~0.1 kB** (it shares Radix internals already pulled in by other components) — ESM **68 kB / 70**.

## GitHub Issue

Closes #284

## Test Plan

- [x] `typecheck`, `eslint . --max-warnings 0`, `prettier --check` clean
- [x] `audit:storybook-coverage --component aspect-ratio` → 0 missing, 0 drift (display-only)
- [x] `size-limit` → ESM 68 kB / 70 (first Radix dep, +0.1 kB)
- [x] aspect-ratio code confirmed bundled into `dist/index.mjs` (not externalized)
- [x] storybook play-fns pass locally (5/5); CI runs them across 5 bases × 2 themes