### PR TITLE
feat(components): add button-group component

### DIFF
--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -26,6 +26,7 @@
     { "name": "Badge", "showcase": "AllVariants" },
     { "name": "Breadcrumb", "showcase": "AllVariants" },
     { "name": "Button", "showcase": "AllVariants" },
+    { "name": "ButtonGroup", "showcase": "AllVariants" },
     { "name": "Card", "showcase": "AllVariants" },
     { "name": "Checkbox", "showcase": "AllVariants" },
     {

--- a/packages/react/src/components/ui/ButtonGroup.stories.tsx
+++ b/packages/react/src/components/ui/ButtonGroup.stories.tsx
@@ -1,0 +1,124 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+
+import { Button } from './button';
+import {
+  ButtonGroup,
+  ButtonGroupSeparator,
+  ButtonGroupText,
+} from './button-group';
+
+const meta: Meta<typeof ButtonGroup> = {
+  title: 'Components/ButtonGroup',
+  component: ButtonGroup,
+};
+
+export default meta;
+type Story = StoryObj<typeof ButtonGroup>;
+
+// Three outline buttons joined into one horizontal cluster.
+export const Default: Story = {
+  render: () => (
+    <ButtonGroup>
+      <Button variant="outline">Day</Button>
+      <Button variant="outline">Week</Button>
+      <Button variant="outline">Month</Button>
+    </ButtonGroup>
+  ),
+};
+
+// Vertical orientation stacks the cluster.
+export const Vertical: Story = {
+  render: () => (
+    <ButtonGroup orientation="vertical">
+      <Button variant="outline">Top</Button>
+      <Button variant="outline">Middle</Button>
+      <Button variant="outline">Bottom</Button>
+    </ButtonGroup>
+  ),
+};
+
+// A text addon as a leading prefix.
+export const WithText: Story = {
+  render: () => (
+    <ButtonGroup>
+      <ButtonGroupText>https://</ButtonGroupText>
+      <Button variant="outline">nexus.dev</Button>
+    </ButtonGroup>
+  ),
+};
+
+// A separator divides two sub-clusters.
+export const WithSeparator: Story = {
+  render: () => (
+    <ButtonGroup>
+      <Button variant="outline">Undo</Button>
+      <Button variant="outline">Redo</Button>
+      <ButtonGroupSeparator />
+      <Button variant="outline">Save</Button>
+    </ButtonGroup>
+  ),
+};
+
+// The group is a role=group region that advertises its orientation.
+export const WithDataAttributes: Story = {
+  render: () => (
+    <ButtonGroup orientation="horizontal">
+      <Button variant="outline">One</Button>
+      <Button variant="outline">Two</Button>
+    </ButtonGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const group = canvasElement.querySelector('[data-slot="button-group"]');
+    await expect(group).toBeInTheDocument();
+    await expect(group).toHaveAttribute('role', 'group');
+    await expect(group).toHaveAttribute('data-orientation', 'horizontal');
+  },
+};
+
+// ButtonGroupText composes with a custom element via asChild — here a link
+// addon — keeping the addon styling and data-slot hook.
+export const AsChild: Story = {
+  render: () => (
+    <ButtonGroup>
+      <ButtonGroupText asChild>
+        <a href="https://example.com">Docs</a>
+      </ButtonGroupText>
+      <Button variant="outline">Open</Button>
+    </ButtonGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const link = within(canvasElement).getByRole('link', { name: 'Docs' });
+    await expect(link.tagName).toBe('A');
+    await expect(link).toHaveAttribute('data-slot', 'button-group-text');
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// Both orientations plus a text addon and a separator. Reused by the per-base
+// variant generator.
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:items-start nx:gap-4">
+      <ButtonGroup>
+        <Button variant="outline">Day</Button>
+        <Button variant="outline">Week</Button>
+        <Button variant="outline">Month</Button>
+      </ButtonGroup>
+      <ButtonGroup>
+        <ButtonGroupText>https://</ButtonGroupText>
+        <Button variant="outline">nexus.dev</Button>
+        <ButtonGroupSeparator />
+        <Button variant="outline">Go</Button>
+      </ButtonGroup>
+      <ButtonGroup orientation="vertical">
+        <Button variant="outline">Top</Button>
+        <Button variant="outline">Middle</Button>
+        <Button variant="outline">Bottom</Button>
+      </ButtonGroup>
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/button-group.tsx
+++ b/packages/react/src/components/ui/button-group.tsx
@@ -1,0 +1,146 @@
+import * as React from 'react';
+
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
+
+const buttonGroupVariants = cva(
+  // nexus-allow-numeric: joined-cluster layout rhythm
+  "nx:flex nx:w-fit nx:items-stretch nx:has-[>[data-slot=button-group]]:gap-2 nx:[&>*]:focus-visible:relative nx:[&>*]:focus-visible:z-10 nx:has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md nx:[&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit nx:[&>input]:flex-1",
+  {
+    variants: {
+      orientation: {
+        horizontal:
+          'nx:[&>*:not(:first-child)]:rounded-l-none nx:[&>*:not(:first-child)]:border-l-0 nx:[&>*:not(:last-child)]:rounded-r-none',
+        vertical:
+          'nx:flex-col nx:[&>*:not(:first-child)]:rounded-t-none nx:[&>*:not(:first-child)]:border-t-0 nx:[&>*:not(:last-child)]:rounded-b-none',
+      },
+    },
+    defaultVariants: {
+      orientation: 'horizontal',
+    },
+  }
+);
+
+/**
+ * ButtonGroupProps
+ *
+ * Props for the ButtonGroup component.
+ */
+interface ButtonGroupProps
+  extends
+    React.ComponentProps<'div'>,
+    VariantProps<typeof buttonGroupVariants> {}
+
+/**
+ * ButtonGroup
+ *
+ * A visually-joined cluster of buttons (or inputs / selects) sharing borders
+ * and outer rounding — adjacent children lose their touching corners and the
+ * seam between them. Lay out horizontally (default) or vertically with
+ * `orientation`.
+ *
+ * @example
+ * ```tsx
+ * <ButtonGroup>
+ *   <Button variant="outline">Day</Button>
+ *   <Button variant="outline">Week</Button>
+ *   <Button variant="outline">Month</Button>
+ * </ButtonGroup>
+ * ```
+ */
+function ButtonGroup({ className, orientation, ...props }: ButtonGroupProps) {
+  return (
+    <div
+      role="group"
+      data-slot="button-group"
+      data-orientation={orientation}
+      className={cn(buttonGroupVariants({ orientation }), className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * ButtonGroupTextProps
+ *
+ * Props for the ButtonGroupText component.
+ */
+interface ButtonGroupTextProps extends React.ComponentProps<'div'> {
+  /**
+   * Render as the child element via Radix Slot, keeping the addon styling.
+   * @default false
+   */
+  asChild?: boolean;
+}
+
+/**
+ * ButtonGroupText
+ *
+ * A non-interactive label or addon inside a group — a leading prefix, a unit, a
+ * count. Matches the buttons' height, border, and elevation.
+ */
+function ButtonGroupText({
+  className,
+  asChild = false,
+  ...props
+}: ButtonGroupTextProps) {
+  const Comp = asChild ? Slot : 'div';
+
+  return (
+    <Comp
+      data-slot="button-group-text"
+      className={cn(
+        // nexus-allow-numeric: addon rhythm matching adjacent controls
+        'nx:flex nx:items-center nx:gap-2 nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:px-4 nx:typography-label-default nx:shadow-xs nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * ButtonGroupSeparatorProps
+ *
+ * Props for the ButtonGroupSeparator component.
+ */
+interface ButtonGroupSeparatorProps extends React.ComponentProps<
+  typeof Separator
+> {}
+
+/**
+ * ButtonGroupSeparator
+ *
+ * A divider between sub-clusters in a group; stretches to the group's full
+ * cross-axis. Defaults to a vertical rule for the common horizontal group.
+ */
+function ButtonGroupSeparator({
+  className,
+  orientation = 'vertical',
+  ...props
+}: ButtonGroupSeparatorProps) {
+  return (
+    <Separator
+      data-slot="button-group-separator"
+      orientation={orientation}
+      className={cn(
+        'nx:relative nx:m-0! nx:self-stretch nx:data-[orientation=vertical]:h-auto',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  ButtonGroup,
+  type ButtonGroupProps,
+  ButtonGroupSeparator,
+  type ButtonGroupSeparatorProps,
+  ButtonGroupText,
+  type ButtonGroupTextProps,
+  buttonGroupVariants,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -17,6 +17,7 @@ export * from '@/components/ui/avatar';
 export * from '@/components/ui/badge';
 export * from '@/components/ui/breadcrumb';
 export * from '@/components/ui/button';
+export * from '@/components/ui/button-group';
 export * from '@/components/ui/card';
 export * from '@/components/ui/checkbox';
 export * from '@/components/ui/command';


### PR DESCRIPTION
## Summary

- Adapt shadcn **button-group** → first-class Nexus `ButtonGroup` + `ButtonGroupText` + `ButtonGroupSeparator` — a visually-joined cluster of buttons / inputs / selects sharing borders and outer rounding.
- Composed over shipped primitives, **no new dependency** (`Slot` from `@radix-ui/react-slot`, `Separator` from `@/components/ui/separator`).

## Decisions / divergences

- **radix-ui import rewrite:** `import { Slot } from "radix-ui"` (`Slot.Root`) → per-primitive `@radix-ui/react-slot` (`Slot`).
- `orientation` cva (horizontal / vertical) strips the touching corners + border seam between adjacent children. The Select/Input integration selectors are kept and verified — Nexus Select's trigger is `data-slot="select-trigger"`, matching shadcn's `[&>[data-slot=select-trigger]…]` hooks.
- `ButtonGroupText` addon → `typography-label-default` / `border-border-default` / `bg-muted` / `shadow-xs`.
- `ButtonGroupSeparator` reuses Separator's own `bg-border-default` default (dropped shadcn's redundant `bg-input` override).

## GitHub Issue

Closes #298

## Test Plan

- [x] `typecheck`, `eslint . --max-warnings 0`, `prettier --check` clean
- [x] `audit:storybook-coverage --component button-group` → 0 missing, 0 drift (incl. the `AsChild` story for `ButtonGroupText`'s `asChild`)
- [ ] CI: Build, Bundle Size (no new dep), and Test (React) play-fns across 5 bases × 2 themes