### PR TITLE
feat(components): add item component

### DIFF
--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -53,6 +53,7 @@
         "KeyboardInteraction": ["TypeInteraction"]
       }
     },
+    { "name": "Item", "showcase": "AllVariants" },
     { "name": "Kbd", "showcase": "AllVariants" },
     { "name": "Pagination", "showcase": "AllVariants" },
     {

--- a/packages/react/src/components/ui/Item.stories.tsx
+++ b/packages/react/src/components/ui/Item.stories.tsx
@@ -1,0 +1,236 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { IconFile } from '@tabler/icons-react';
+import { expect, within } from 'storybook/test';
+
+import { Button } from './button';
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemMedia,
+  ItemSeparator,
+  ItemTitle,
+} from './item';
+
+const meta: Meta<typeof Item> = {
+  title: 'Components/Item',
+  component: Item,
+};
+
+export default meta;
+type Story = StoryObj<typeof Item>;
+
+// A gray thumbnail rendered without a network request.
+const THUMB =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Crect width='40' height='40' fill='%23999'/%3E%3C/svg%3E";
+
+// A standard row: icon media, title + description, and a trailing action.
+export const Default: Story = {
+  render: () => (
+    <Item variant="outline" className="nx:w-96">
+      <ItemMedia variant="icon">
+        <IconFile />
+      </ItemMedia>
+      <ItemContent>
+        <ItemTitle>Report.pdf</ItemTitle>
+        <ItemDescription>2.4 MB · edited 3 days ago</ItemDescription>
+      </ItemContent>
+      <ItemActions>
+        <Button variant="outline" size="sm">
+          Open
+        </Button>
+      </ItemActions>
+    </Item>
+  ),
+};
+
+// The three surface variants.
+export const Variants: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-96 nx:flex-col nx:gap-3">
+      <Item variant="default">
+        <ItemContent>
+          <ItemTitle>Default</ItemTitle>
+          <ItemDescription>Transparent, borderless.</ItemDescription>
+        </ItemContent>
+      </Item>
+      <Item variant="outline">
+        <ItemContent>
+          <ItemTitle>Outline</ItemTitle>
+          <ItemDescription>Bordered surface.</ItemDescription>
+        </ItemContent>
+      </Item>
+      <Item variant="muted">
+        <ItemContent>
+          <ItemTitle>Muted</ItemTitle>
+          <ItemDescription>Filled surface.</ItemDescription>
+        </ItemContent>
+      </Item>
+    </div>
+  ),
+};
+
+// Default vs the denser sm size.
+export const Sizes: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-96 nx:flex-col nx:gap-3">
+      <Item variant="outline" size="default">
+        <ItemContent>
+          <ItemTitle>Default size</ItemTitle>
+        </ItemContent>
+      </Item>
+      <Item variant="outline" size="sm">
+        <ItemContent>
+          <ItemTitle>Small size</ItemTitle>
+        </ItemContent>
+      </Item>
+    </div>
+  ),
+};
+
+// The icon medallion and image thumbnail media variants.
+export const Media: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-96 nx:flex-col nx:gap-3">
+      <Item variant="outline">
+        <ItemMedia variant="icon">
+          <IconFile />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>Icon media</ItemTitle>
+        </ItemContent>
+      </Item>
+      <Item variant="outline">
+        <ItemMedia variant="image">
+          <img src={THUMB} alt="" />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>Image media</ItemTitle>
+        </ItemContent>
+      </Item>
+    </div>
+  ),
+};
+
+// A grouped list divided by separators.
+export const Grouped: Story = {
+  render: () => (
+    <ItemGroup className="nx:w-96">
+      <Item>
+        <ItemContent>
+          <ItemTitle>First</ItemTitle>
+        </ItemContent>
+      </Item>
+      <ItemSeparator />
+      <Item>
+        <ItemContent>
+          <ItemTitle>Second</ItemTitle>
+        </ItemContent>
+      </Item>
+    </ItemGroup>
+  ),
+};
+
+// Item composes with a custom element via asChild — here a whole-row link.
+export const AsChild: Story = {
+  render: () => (
+    <Item asChild variant="outline" className="nx:w-96">
+      <a href="/files/report" data-testid="item-link">
+        <ItemMedia variant="icon">
+          <IconFile />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>Open report</ItemTitle>
+          <ItemDescription>Navigates to the file.</ItemDescription>
+        </ItemContent>
+      </a>
+    </Item>
+  ),
+  play: async ({ canvasElement }) => {
+    const link = within(canvasElement).getByTestId('item-link');
+    await expect(link.tagName).toBe('A');
+    await expect(link).toHaveAttribute('data-slot', 'item');
+  },
+};
+
+// Each structural part carries a data-slot; Item advertises its variant + size.
+export const WithDataAttributes: Story = {
+  render: () => (
+    <Item variant="muted" size="sm" className="nx:w-96">
+      <ItemMedia variant="icon">
+        <IconFile />
+      </ItemMedia>
+      <ItemContent>
+        <ItemTitle>Inspect me</ItemTitle>
+        <ItemDescription>Hooks for styling and tests.</ItemDescription>
+      </ItemContent>
+    </Item>
+  ),
+  play: async ({ canvasElement }) => {
+    const item = canvasElement.querySelector('[data-slot="item"]');
+    await expect(item).toBeInTheDocument();
+    await expect(item).toHaveAttribute('data-variant', 'muted');
+    await expect(item).toHaveAttribute('data-size', 'sm');
+    for (const slot of [
+      'item-media',
+      'item-content',
+      'item-title',
+      'item-description',
+    ]) {
+      await expect(
+        canvasElement.querySelector(`[data-slot="${slot}"]`)
+      ).toBeInTheDocument();
+    }
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// A grouped list exercising the variants, sizes, and media types in one frame.
+// Reused by the per-base variant generator.
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-96 nx:flex-col nx:gap-3">
+      <Item variant="outline">
+        <ItemMedia variant="icon">
+          <IconFile />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>Report.pdf</ItemTitle>
+          <ItemDescription>Outline · icon media · action</ItemDescription>
+        </ItemContent>
+        <ItemActions>
+          <Button variant="outline" size="sm">
+            Open
+          </Button>
+        </ItemActions>
+      </Item>
+      <Item variant="muted" size="sm">
+        <ItemMedia variant="image">
+          <img src={THUMB} alt="" />
+        </ItemMedia>
+        <ItemContent>
+          <ItemTitle>Cover.png</ItemTitle>
+          <ItemDescription>Muted · sm · image media</ItemDescription>
+        </ItemContent>
+      </Item>
+      <ItemGroup>
+        <Item>
+          <ItemContent>
+            <ItemTitle>Grouped row one</ItemTitle>
+          </ItemContent>
+        </Item>
+        <ItemSeparator />
+        <Item>
+          <ItemContent>
+            <ItemTitle>Grouped row two</ItemTitle>
+          </ItemContent>
+        </Item>
+      </ItemGroup>
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/item.tsx
+++ b/packages/react/src/components/ui/item.tsx
@@ -9,12 +9,13 @@ import { cn } from '@/lib/utils';
 /**
  * ItemGroup
  *
- * A vertical list of `Item`s, exposed to assistive tech as a `list`.
+ * A vertical stack of related `Item`s, divided by `ItemSeparator`. No ARIA
+ * `list` role is imposed — `Item` is also used standalone, so list/listitem
+ * semantics are the consumer's to add when the grouping is truly a list.
  */
 function ItemGroup({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      role="list"
       data-slot="item-group"
       className={cn('nx:group/item-group nx:flex nx:flex-col', className)}
       {...props}

--- a/packages/react/src/components/ui/item.tsx
+++ b/packages/react/src/components/ui/item.tsx
@@ -1,0 +1,305 @@
+import * as React from 'react';
+
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
+
+/**
+ * ItemGroup
+ *
+ * A vertical list of `Item`s, exposed to assistive tech as a `list`.
+ */
+function ItemGroup({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      role="list"
+      data-slot="item-group"
+      className={cn('nx:group/item-group nx:flex nx:flex-col', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * ItemSeparator
+ *
+ * A flush horizontal rule between items in an `ItemGroup`.
+ */
+function ItemSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="item-separator"
+      orientation="horizontal"
+      className={cn('nx:my-0', className)}
+      {...props}
+    />
+  );
+}
+
+const itemVariants = cva(
+  'nx:group/item nx:flex nx:flex-wrap nx:items-center nx:rounded-md nx:border nx:border-transparent nx:typography-body-small nx:transition-colors nx:duration-100 nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[a]:hover:bg-background-hover',
+  {
+    variants: {
+      variant: {
+        default: 'nx:bg-transparent',
+        outline: 'nx:border-border-default',
+        muted: 'nx:bg-muted',
+      },
+      size: {
+        // nexus-allow-numeric: row density
+        default: 'nx:gap-4 nx:p-4',
+        // nexus-allow-numeric: dense row density
+        sm: 'nx:gap-2.5 nx:px-4 nx:py-3',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+/**
+ * ItemProps
+ *
+ * Props for the Item component.
+ */
+interface ItemProps
+  extends React.ComponentProps<'div'>, VariantProps<typeof itemVariants> {
+  /**
+   * Render as the child element via Radix Slot — e.g. an `<a>` or router link —
+   * keeping the item styling.
+   * @default false
+   */
+  asChild?: boolean;
+}
+
+/**
+ * Item
+ *
+ * A flexible list row — media (icon / image) + title + description + actions.
+ * Compose with `ItemMedia`, `ItemContent`, `ItemTitle`, `ItemDescription`, and
+ * `ItemActions`; group rows with `ItemGroup` divided by `ItemSeparator`. The
+ * `outline` and `muted` variants give the row a visible surface; size `sm` is a
+ * denser row. When rendered `asChild` as a link it gains hover + focus affordances.
+ *
+ * @example
+ * ```tsx
+ * <Item variant="outline">
+ *   <ItemMedia variant="icon">
+ *     <IconFile />
+ *   </ItemMedia>
+ *   <ItemContent>
+ *     <ItemTitle>Report.pdf</ItemTitle>
+ *     <ItemDescription>2.4 MB · edited 3d ago</ItemDescription>
+ *   </ItemContent>
+ *   <ItemActions>
+ *     <Button size="sm" variant="outline">Open</Button>
+ *   </ItemActions>
+ * </Item>
+ * ```
+ */
+function Item({
+  className,
+  variant = 'default',
+  size = 'default',
+  asChild = false,
+  ...props
+}: ItemProps) {
+  const Comp = asChild ? Slot : 'div';
+
+  return (
+    <Comp
+      data-slot="item"
+      data-variant={variant}
+      data-size={size}
+      className={cn(itemVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+}
+
+const itemMediaVariants = cva(
+  // nexus-allow-numeric: media rhythm + description-aligned nudge
+  'nx:flex nx:shrink-0 nx:items-center nx:justify-center nx:gap-2 nx:group-has-[[data-slot=item-description]]/item:translate-y-0.5 nx:group-has-[[data-slot=item-description]]/item:self-start nx:[&_svg]:pointer-events-none',
+  {
+    variants: {
+      variant: {
+        default: 'nx:bg-transparent',
+        // nexus-allow-numeric: icon medallion footprint
+        icon: 'nx:size-8 nx:rounded-sm nx:border nx:border-border-default nx:bg-muted nx:[&_svg]:size-4',
+        // nexus-allow-numeric: thumbnail footprint
+        image:
+          'nx:size-10 nx:overflow-hidden nx:rounded-sm nx:[&_img]:size-full nx:[&_img]:object-cover',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+/**
+ * ItemMediaProps
+ *
+ * Props for the ItemMedia component.
+ */
+interface ItemMediaProps
+  extends React.ComponentProps<'div'>, VariantProps<typeof itemMediaVariants> {}
+
+/**
+ * ItemMedia
+ *
+ * The leading visual of an item. `icon` renders a muted rounded medallion;
+ * `image` a square thumbnail that cover-fits its `<img>`; `default` is an
+ * unstyled wrapper.
+ */
+function ItemMedia({
+  className,
+  variant = 'default',
+  ...props
+}: ItemMediaProps) {
+  return (
+    <div
+      data-slot="item-media"
+      data-variant={variant}
+      className={cn(itemMediaVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * ItemContent
+ *
+ * The middle column — title and description — that grows to fill the row.
+ */
+function ItemContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="item-content"
+      className={cn(
+        // nexus-allow-numeric: title/description stack rhythm
+        'nx:flex nx:flex-1 nx:flex-col nx:gap-1 nx:[&+[data-slot=item-content]]:flex-none',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * ItemTitle
+ *
+ * The item's primary label.
+ */
+function ItemTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="item-title"
+      className={cn(
+        // nexus-allow-numeric: inline gap to adjacent marks
+        'nx:flex nx:w-fit nx:items-center nx:gap-2 nx:typography-label-default',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * ItemDescription
+ *
+ * Supporting copy beneath the title; clamps to two lines, anchors underlined.
+ */
+function ItemDescription({ className, ...props }: React.ComponentProps<'p'>) {
+  return (
+    <p
+      data-slot="item-description"
+      className={cn(
+        'nx:line-clamp-2 nx:typography-body-small nx:text-balance nx:text-muted-foreground nx:[&>a]:underline nx:[&>a]:underline-offset-4 nx:[&>a:hover]:text-primary-subtle-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * ItemActions
+ *
+ * The trailing controls of a row — typically one or two buttons.
+ */
+function ItemActions({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="item-actions"
+      className={cn(
+        // nexus-allow-numeric: action gap
+        'nx:flex nx:items-center nx:gap-2',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * ItemHeader
+ *
+ * A full-width row above the media/content — e.g. a label and a meta value.
+ */
+function ItemHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="item-header"
+      className={cn(
+        // nexus-allow-numeric: header row gap
+        'nx:flex nx:basis-full nx:items-center nx:justify-between nx:gap-2',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * ItemFooter
+ *
+ * A full-width row below the media/content.
+ */
+function ItemFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="item-footer"
+      className={cn(
+        // nexus-allow-numeric: footer row gap
+        'nx:flex nx:basis-full nx:items-center nx:justify-between nx:gap-2',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemFooter,
+  ItemGroup,
+  ItemHeader,
+  ItemMedia,
+  type ItemMediaProps,
+  itemMediaVariants,
+  type ItemProps,
+  ItemSeparator,
+  ItemTitle,
+  itemVariants,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -27,6 +27,7 @@ export * from '@/components/ui/empty-state';
 export * from '@/components/ui/form';
 export * from '@/components/ui/input';
 export * from '@/components/ui/input-otp';
+export * from '@/components/ui/item';
 export * from '@/components/ui/kbd';
 export * from '@/components/ui/label';
 export * from '@/components/ui/pagination';


### PR DESCRIPTION
## Summary

- Adapt shadcn **item** → first-class Nexus `Item` + `ItemGroup`, `ItemMedia`, `ItemContent`, `ItemTitle`, `ItemDescription`, `ItemActions`, `ItemHeader`, `ItemFooter`, `ItemSeparator` — a flexible list-row primitive (media + title + description + actions).
- Composed over shipped primitives, **no new dependency** (`Slot`, `Separator`).

## Decisions / divergences

- **radix-ui import rewrite:** `import { Slot } from "radix-ui"` (`Slot.Root`) → `@radix-ui/react-slot` (`Slot`).
- **Focus ring:** replaced shadcn's box-shadow ring (`focus-visible:border-ring` + `ring-[3px]` + `ring-ring/50`) with Nexus's **canonical outline ring** — `Item` is focusable when rendered `asChild` as a link/button.
- `accent` hover → `background-hover`; the `[&_svg:not([class*='size-'])]` icon-sizing → the simpler Nexus `[&_svg]` convention (so no `[class*=]` quoting).
- `itemVariants` (variant `default`/`outline`/`muted` × size `default`/`sm`) and `itemMediaVariants` (`default`/`icon`/`image`). `typography-body-small` / `typography-label-default`.

## GitHub Issue

Closes #301

## Test Plan

- [x] `typecheck`, `eslint . --max-warnings 0`, `prettier --check` clean
- [x] `audit:storybook-coverage --component item` → 0 missing, 0 drift (incl. `AsChild` story + per-variant/size coverage)
- [ ] CI: Build, Bundle Size (no new dep), Test (React) play-fns across 5 bases × 2 themes