### PR TITLE
feat(console): Projects module — issues table + detail + create/edit (Phase 3a)

### DIFF
--- a/apps/console/src/app/router.tsx
+++ b/apps/console/src/app/router.tsx
@@ -17,6 +17,8 @@ import { contactsSearchSchema } from '../modules/crm/contacts-search';
 import { AppearanceRoute } from '../modules/design-system/appearance-route';
 import { ReferenceRoute } from '../modules/design-system/reference-route';
 import { ScenesRoute } from '../modules/design-system/scenes-route';
+import { IssueDetailRoute } from '../modules/projects/issue-detail-route';
+import { IssuesRoute } from '../modules/projects/issues-route';
 
 import { AuthLayout } from './auth-layout';
 import { NotFound } from './not-found';
@@ -95,6 +97,19 @@ const crmContactDetailRoute = createRoute({
   component: ContactDetailRoute,
 });
 
+// Projects / Issues (Phase 3a). Static `/m/projects` outranks `/m/$module`.
+const projectsIssuesRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: '/m/projects',
+  component: IssuesRoute,
+});
+
+const projectsIssueDetailRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: '/m/projects/$id',
+  component: IssueDetailRoute,
+});
+
 // One shared placeholder backs every not-yet-built module.
 const moduleRoute = createRoute({
   getParentRoute: () => appRoute,
@@ -145,6 +160,8 @@ const routeTree = rootRoute.addChildren([
     appearanceRoute,
     crmContactsRoute,
     crmContactDetailRoute,
+    projectsIssuesRoute,
+    projectsIssueDetailRoute,
     moduleRoute,
   ]),
   authRoute.addChildren([loginRoute, signupRoute, verifyRoute, forgotRoute]),

--- a/apps/console/src/lib/format.ts
+++ b/apps/console/src/lib/format.ts
@@ -23,3 +23,11 @@ const dateFmt = new Intl.DateTimeFormat('en-US', {
 
 export const formatCurrency = (value: number) => currencyFmt.format(value);
 export const formatDate = (iso: string) => dateFmt.format(new Date(iso));
+
+/** First + last initial, e.g. "Ada Lovelace" → "AL". Used for avatar fallbacks. */
+export function initials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  const first = parts[0]?.[0] ?? '';
+  const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : '';
+  return (first + last).toUpperCase();
+}

--- a/apps/console/src/lib/projects-api.ts
+++ b/apps/console/src/lib/projects-api.ts
@@ -1,0 +1,111 @@
+/**
+ * Projects API client. Thin typed wrappers over the mock endpoints served by MSW
+ * (`src/mocks/handlers.ts`) — there is no real backend. Mirrors the CRM module's
+ * shape: a single query-key object, fetch/mutate fns, and `as const` enums that
+ * single-source both the union type and the form's `z.enum`.
+ */
+
+/**
+ * Issue lifecycle statuses — the single source for the {@link IssueStatus} union
+ * and the create/edit form's status enum (both derive from this `as const`).
+ */
+export const ISSUE_STATUSES = [
+  'backlog',
+  'todo',
+  'in_progress',
+  'done',
+  'canceled',
+] as const;
+
+/** Where an issue sits in its lifecycle — rendered as a status badge. */
+export type IssueStatus = (typeof ISSUE_STATUSES)[number];
+
+/** Priority levels — single source for {@link IssuePriority} + the form enum. */
+export const ISSUE_PRIORITIES = [
+  'urgent',
+  'high',
+  'medium',
+  'low',
+  'none',
+] as const;
+
+/** How urgent an issue is — rendered as a priority badge. */
+export type IssuePriority = (typeof ISSUE_PRIORITIES)[number];
+
+export type Issue = {
+  id: string;
+  /** Human-readable identifier shown in the UI, e.g. `ATL-204`. */
+  key: string;
+  title: string;
+  status: IssueStatus;
+  priority: IssuePriority;
+  /** Team member the issue is assigned to — rendered as an avatar + name. */
+  assignee: string;
+  /** ISO date (YYYY-MM-DD) the issue was created. */
+  createdAt: string;
+  /** ISO date (YYYY-MM-DD) of the last update. */
+  updatedAt: string;
+};
+
+/**
+ * TanStack Query keys for the Projects module — declared once so the table,
+ * detail, and mutations can't drift apart (a mismatched key silently breaks
+ * cache invalidation).
+ */
+export const projectKeys = {
+  all: ['projects'] as const,
+  issues: ['projects', 'issues'] as const,
+  issue: (id: string) => ['projects', 'issue', id] as const,
+};
+
+// Returns the server envelope (mirrors the wire shape) so a future server-side
+// `{ issues, totalCount }` for paging is an additive change here.
+export async function fetchIssues(): Promise<{ issues: Issue[] }> {
+  const res = await fetch('/api/projects/issues');
+  if (!res.ok) {
+    throw new Error('Failed to load issues. Please try again.');
+  }
+  return (await res.json()) as { issues: Issue[] };
+}
+
+/** An issue plus its long-form description — the record-detail payload. */
+export type IssueDetail = Issue & { description: string };
+
+export async function fetchIssue(id: string): Promise<{ issue: IssueDetail }> {
+  const res = await fetch(`/api/projects/issues/${id}`);
+  if (!res.ok) {
+    throw new Error('Failed to load issue.');
+  }
+  return (await res.json()) as { issue: IssueDetail };
+}
+
+/** The editable fields of an issue — `id`, `key`, and dates are server-set. */
+export type IssueInput = {
+  title: string;
+  description: string;
+  status: IssueStatus;
+  priority: IssuePriority;
+  assignee: string;
+};
+
+async function save(
+  url: string,
+  method: 'POST' | 'PATCH',
+  input: IssueInput
+): Promise<{ issue: Issue }> {
+  const res = await fetch(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to save issue. Please try again.');
+  }
+  return (await res.json()) as { issue: Issue };
+}
+
+export const createIssue = (input: IssueInput) =>
+  save('/api/projects/issues', 'POST', input);
+
+export const updateIssue = (id: string, input: IssueInput) =>
+  save(`/api/projects/issues/${id}`, 'PATCH', input);

--- a/apps/console/src/mocks/handlers.ts
+++ b/apps/console/src/mocks/handlers.ts
@@ -76,7 +76,7 @@ const store: Contact[] = CONTACTS.map((c) => ({ ...c }));
 // a fresh `ATL-` key from a running sequence seeded just past the fixtures.
 type StoredIssue = Issue & { description: string };
 const issuesStore: StoredIssue[] = ISSUES.map((i) => ({ ...i }));
-let nextIssueSeq = 125;
+let nextIssueSeq = 125; // one past the last fixture key (ATL-124)
 
 /**
  * MSW request handlers — there is no real backend. Auth is a two-step flow: a
@@ -174,10 +174,32 @@ export const handlers: RequestHandler[] = [
   }),
 
   // --- Projects ---
-  // The full issue list; the DataTable sorts/filters/paginates client-side.
+  // The issue list returns the `Issue` shape only — `description` is detail-only,
+  // so it's projected away here. The DataTable sorts/filters/paginates client-side.
   http.get('/api/projects/issues', async () => {
     await delay(500);
-    return HttpResponse.json({ issues: issuesStore });
+    const issues: Issue[] = issuesStore.map(
+      ({
+        id,
+        key,
+        title,
+        status,
+        priority,
+        assignee,
+        createdAt,
+        updatedAt,
+      }) => ({
+        id,
+        key,
+        title,
+        status,
+        priority,
+        assignee,
+        createdAt,
+        updatedAt,
+      })
+    );
+    return HttpResponse.json({ issues });
   }),
 
   // A single issue incl. its long-form description (404 when unknown).

--- a/apps/console/src/mocks/handlers.ts
+++ b/apps/console/src/mocks/handlers.ts
@@ -2,8 +2,10 @@ import { delay, http, HttpResponse, type RequestHandler } from 'msw';
 
 import type { User } from '../lib/auth-api';
 import type { ActivityItem, Contact, ContactInput } from '../lib/crm-api';
+import type { Issue, IssueInput } from '../lib/projects-api';
 
 import { CONTACTS } from './crm-fixtures';
+import { ISSUES } from './projects-fixtures';
 
 /** The fixed demo OTP — shown as a hint on the verify screen. */
 const OTP_CODE = '123456';
@@ -68,6 +70,13 @@ function buildActivity(contact: Contact): ActivityItem[] {
 // and edited contacts persist across requests within a session (it resets on a
 // full page reload — there is no real backend).
 const store: Contact[] = CONTACTS.map((c) => ({ ...c }));
+
+// In-memory Projects store (same session lifecycle as the CRM store). Records
+// carry the long-form `description` the detail endpoint returns. New issues draw
+// a fresh `ATL-` key from a running sequence seeded just past the fixtures.
+type StoredIssue = Issue & { description: string };
+const issuesStore: StoredIssue[] = ISSUES.map((i) => ({ ...i }));
+let nextIssueSeq = 125;
 
 /**
  * MSW request handlers — there is no real backend. Auth is a two-step flow: a
@@ -162,5 +171,57 @@ export const handlers: RequestHandler[] = [
     }
     Object.assign(contact, (await request.json()) as ContactInput);
     return HttpResponse.json({ contact });
+  }),
+
+  // --- Projects ---
+  // The full issue list; the DataTable sorts/filters/paginates client-side.
+  http.get('/api/projects/issues', async () => {
+    await delay(500);
+    return HttpResponse.json({ issues: issuesStore });
+  }),
+
+  // A single issue incl. its long-form description (404 when unknown).
+  http.get('/api/projects/issues/:id', async ({ params }) => {
+    await delay(300);
+    const issue = issuesStore.find((i) => i.id === params.id);
+    if (!issue) {
+      return HttpResponse.json(
+        { message: 'Issue not found.' },
+        { status: 404 }
+      );
+    }
+    return HttpResponse.json({ issue });
+  }),
+
+  // Create: the server assigns the id, the ATL- key, and the timestamps.
+  http.post('/api/projects/issues', async ({ request }) => {
+    await delay(300);
+    const input = (await request.json()) as IssueInput;
+    const today = new Date().toISOString().slice(0, 10);
+    const issue: StoredIssue = {
+      ...input,
+      id: crypto.randomUUID(),
+      key: `ATL-${nextIssueSeq++}`,
+      createdAt: today,
+      updatedAt: today,
+    };
+    issuesStore.unshift(issue);
+    return HttpResponse.json({ issue }, { status: 201 });
+  }),
+
+  // Edit: patch the mutable fields in place + bump updatedAt; id/key/createdAt
+  // are preserved.
+  http.patch('/api/projects/issues/:id', async ({ params, request }) => {
+    await delay(300);
+    const issue = issuesStore.find((i) => i.id === params.id);
+    if (!issue) {
+      return HttpResponse.json(
+        { message: 'Issue not found.' },
+        { status: 404 }
+      );
+    }
+    Object.assign(issue, (await request.json()) as IssueInput);
+    issue.updatedAt = new Date().toISOString().slice(0, 10);
+    return HttpResponse.json({ issue });
   }),
 ];

--- a/apps/console/src/mocks/projects-fixtures.ts
+++ b/apps/console/src/mocks/projects-fixtures.ts
@@ -1,0 +1,299 @@
+import type { Issue } from '../lib/projects-api';
+
+/**
+ * Deterministic seed issues for the Projects module. Stored shape is
+ * {@link Issue} plus the long-form `description` the detail page renders; the
+ * list endpoint returns the same records (the extra field is harmless). 24 rows
+ * span every status and priority so the table, badges, and pager all have
+ * variety. Assignees reuse the CRM owner names for a consistent demo workspace.
+ */
+export const ISSUES: (Issue & { description: string })[] = [
+  {
+    id: 'i-01',
+    key: 'ATL-101',
+    title: 'Persisted theme drops stale mode values on load',
+    status: 'in_progress',
+    priority: 'high',
+    assignee: 'Ada Lovelace',
+    createdAt: '2026-05-02',
+    updatedAt: '2026-06-01',
+    description:
+      'A workspace that saved a now-removed typography mode 404s on the theme CSS fetch. Sanitize persisted theme against the live axis values before loading.',
+  },
+  {
+    id: 'i-02',
+    key: 'ATL-102',
+    title: 'Saved-view delete is unreachable by keyboard',
+    status: 'done',
+    priority: 'urgent',
+    assignee: 'Grace Hopper',
+    createdAt: '2026-04-18',
+    updatedAt: '2026-05-30',
+    description:
+      'The per-row delete control sat inside a menu item and never received keyboard focus. Rebuilt the list as a popover with sibling buttons.',
+  },
+  {
+    id: 'i-03',
+    key: 'ATL-103',
+    title: 'Contact dates render a day early west of UTC',
+    status: 'done',
+    priority: 'high',
+    assignee: 'Alan Turing',
+    createdAt: '2026-04-10',
+    updatedAt: '2026-05-21',
+    description:
+      'ISO dates parsed as UTC midnight shifted back a day in US time zones. Pin the date formatter to UTC so the authored calendar day renders everywhere.',
+  },
+  {
+    id: 'i-04',
+    key: 'ATL-104',
+    title: 'Kanban board: add swimlanes by assignee',
+    status: 'backlog',
+    priority: 'medium',
+    assignee: 'Katherine Johnson',
+    createdAt: '2026-05-12',
+    updatedAt: '2026-05-12',
+    description:
+      'Group the pipeline board into horizontal lanes per owner, collapsible, with a per-lane count.',
+  },
+  {
+    id: 'i-05',
+    key: 'ATL-105',
+    title: 'Command palette: fuzzy search across modules',
+    status: 'todo',
+    priority: 'high',
+    assignee: 'Ada Lovelace',
+    createdAt: '2026-05-20',
+    updatedAt: '2026-05-28',
+    description:
+      'Wire the ⌘K palette to search contacts, issues, and settings with a ranked, debounced fuzzy match.',
+  },
+  {
+    id: 'i-06',
+    key: 'ATL-106',
+    title: 'Invoices table exceeds viewport on mobile',
+    status: 'backlog',
+    priority: 'low',
+    assignee: 'Grace Hopper',
+    createdAt: '2026-05-08',
+    updatedAt: '2026-05-15',
+    description:
+      'Below the md breakpoint the billing table overflows horizontally. Collapse low-priority columns into an expandable row.',
+  },
+  {
+    id: 'i-07',
+    key: 'ATL-107',
+    title: 'Analytics: date-range picker resets on tab switch',
+    status: 'todo',
+    priority: 'medium',
+    assignee: 'Alan Turing',
+    createdAt: '2026-05-22',
+    updatedAt: '2026-05-29',
+    description:
+      'Switching report tabs discards the selected range. Lift the range into the URL search params so it survives navigation.',
+  },
+  {
+    id: 'i-08',
+    key: 'ATL-108',
+    title: 'People directory: bulk role assignment',
+    status: 'backlog',
+    priority: 'low',
+    assignee: 'Katherine Johnson',
+    createdAt: '2026-05-03',
+    updatedAt: '2026-05-09',
+    description:
+      'Select multiple members and assign a role in one action, with an undo toast.',
+  },
+  {
+    id: 'i-09',
+    key: 'ATL-109',
+    title: 'Sidebar collapse state not persisted',
+    status: 'done',
+    priority: 'low',
+    assignee: 'Ada Lovelace',
+    createdAt: '2026-03-28',
+    updatedAt: '2026-04-30',
+    description:
+      'Collapsing the sidebar resets on reload. Persist the open/closed flag to localStorage via the shell store.',
+  },
+  {
+    id: 'i-10',
+    key: 'ATL-110',
+    title: 'Focus ring invisible on primary buttons in dark mode',
+    status: 'in_progress',
+    priority: 'urgent',
+    assignee: 'Grace Hopper',
+    createdAt: '2026-05-25',
+    updatedAt: '2026-06-01',
+    description:
+      'The focus outline blends into the primary fill on a near-blue dark canvas. Use the dedicated theme-split focus token at a 2px offset.',
+  },
+  {
+    id: 'i-11',
+    key: 'ATL-111',
+    title: 'Inbox: collapse quoted reply history',
+    status: 'todo',
+    priority: 'medium',
+    assignee: 'Alan Turing',
+    createdAt: '2026-05-19',
+    updatedAt: '2026-05-26',
+    description:
+      'Long threads repeat quoted history. Collapse prior quotes behind a "show trimmed content" toggle.',
+  },
+  {
+    id: 'i-12',
+    key: 'ATL-112',
+    title: 'Table column visibility config menu',
+    status: 'backlog',
+    priority: 'medium',
+    assignee: 'Katherine Johnson',
+    createdAt: '2026-05-06',
+    updatedAt: '2026-05-14',
+    description:
+      'Let users hide and reorder columns from a dropdown, persisted per table per workspace.',
+  },
+  {
+    id: 'i-13',
+    key: 'ATL-113',
+    title: 'Drag-drop pipeline flickers on slow networks',
+    status: 'canceled',
+    priority: 'low',
+    assignee: 'Ada Lovelace',
+    createdAt: '2026-04-02',
+    updatedAt: '2026-04-22',
+    description:
+      'Optimistic move then server roll-back caused a flash. Superseded by the cache-write approach in the kanban rework.',
+  },
+  {
+    id: 'i-14',
+    key: 'ATL-114',
+    title: 'Notifications center: mark-all-as-read',
+    status: 'todo',
+    priority: 'low',
+    assignee: 'Grace Hopper',
+    createdAt: '2026-05-21',
+    updatedAt: '2026-05-27',
+    description:
+      'Add a single action to clear all unread badges, with an optimistic update and a confirm for >50 items.',
+  },
+  {
+    id: 'i-15',
+    key: 'ATL-115',
+    title: 'Onboarding checklist persists across sessions',
+    status: 'backlog',
+    priority: 'medium',
+    assignee: 'Alan Turing',
+    createdAt: '2026-05-10',
+    updatedAt: '2026-05-18',
+    description:
+      'Track first-run steps (create workspace, invite team, choose plan) and resume where the user left off.',
+  },
+  {
+    id: 'i-16',
+    key: 'ATL-116',
+    title: 'Empty states need a shared illustration slot',
+    status: 'in_progress',
+    priority: 'medium',
+    assignee: 'Katherine Johnson',
+    createdAt: '2026-05-24',
+    updatedAt: '2026-05-31',
+    description:
+      'Each module hand-rolls its empty state. Extract a Nexus EmptyState with icon, title, body, and action slots.',
+  },
+  {
+    id: 'i-17',
+    key: 'ATL-117',
+    title: 'Search input debounce drops fast keystrokes',
+    status: 'done',
+    priority: 'high',
+    assignee: 'Ada Lovelace',
+    createdAt: '2026-04-14',
+    updatedAt: '2026-05-11',
+    description:
+      'The 300ms debounce dropped the trailing character on fast typists. Switch to a trailing-edge debounce that always flushes the latest value.',
+  },
+  {
+    id: 'i-18',
+    key: 'ATL-118',
+    title: 'Billing: proration preview before plan change',
+    status: 'backlog',
+    priority: 'high',
+    assignee: 'Grace Hopper',
+    createdAt: '2026-05-05',
+    updatedAt: '2026-05-13',
+    description:
+      'Show the prorated amount and next-invoice date in a confirm dialog before applying an upgrade or downgrade.',
+  },
+  {
+    id: 'i-19',
+    key: 'ATL-119',
+    title: 'Tooltip clips inside scrollable table cells',
+    status: 'todo',
+    priority: 'low',
+    assignee: 'Alan Turing',
+    createdAt: '2026-05-17',
+    updatedAt: '2026-05-23',
+    description:
+      'Tooltips on truncated cells get cut by the cell overflow. Portal the tooltip content to the body so it escapes the clip.',
+  },
+  {
+    id: 'i-20',
+    key: 'ATL-120',
+    title: 'Audit log export to CSV',
+    status: 'backlog',
+    priority: 'low',
+    assignee: 'Katherine Johnson',
+    createdAt: '2026-05-01',
+    updatedAt: '2026-05-07',
+    description:
+      'Stream the filtered audit log to a downloadable CSV with the active date range and actor filters applied.',
+  },
+  {
+    id: 'i-21',
+    key: 'ATL-121',
+    title: 'Avatar group overflow count for >5 members',
+    status: 'done',
+    priority: 'medium',
+    assignee: 'Ada Lovelace',
+    createdAt: '2026-04-20',
+    updatedAt: '2026-05-19',
+    description:
+      'Stacked avatars beyond five should collapse into a "+N" chip with a tooltip listing the remaining names.',
+  },
+  {
+    id: 'i-22',
+    key: 'ATL-122',
+    title: 'Unsaved-changes guard on slide-over forms',
+    status: 'in_progress',
+    priority: 'high',
+    assignee: 'Grace Hopper',
+    createdAt: '2026-05-23',
+    updatedAt: '2026-05-31',
+    description:
+      'Closing a dirty create/edit sheet should prompt before discarding. Wire a confirm dialog to the dirty form state.',
+  },
+  {
+    id: 'i-23',
+    key: 'ATL-123',
+    title: 'Keyboard shortcuts cheat-sheet overlay',
+    status: 'backlog',
+    priority: 'none',
+    assignee: 'Alan Turing',
+    createdAt: '2026-05-04',
+    updatedAt: '2026-05-04',
+    description:
+      'A "?" shortcut opens a modal listing the app shortcuts grouped by area, rendered with the Kbd component.',
+  },
+  {
+    id: 'i-24',
+    key: 'ATL-124',
+    title: 'Dashboard KPI cards: sparkline trend lines',
+    status: 'todo',
+    priority: 'medium',
+    assignee: 'Katherine Johnson',
+    createdAt: '2026-05-16',
+    updatedAt: '2026-05-22',
+    description:
+      'Each KPI card should show a 14-day sparkline and a percent-change pill versus the prior period.',
+  },
+];

--- a/apps/console/src/modules/crm/contact-detail-route.tsx
+++ b/apps/console/src/modules/crm/contact-detail-route.tsx
@@ -32,10 +32,10 @@ import {
   crmKeys,
   fetchContact,
 } from '../../lib/crm-api';
-import { formatCurrency, formatDate } from '../../lib/format';
+import { formatCurrency, formatDate, initials } from '../../lib/format';
 
 import { ContactFormSheet } from './contact-form-sheet';
-import { ContactStatusBadge, initials } from './contact-ui';
+import { ContactStatusBadge } from './contact-ui';
 
 export function ContactDetailRoute() {
   const { id } = useParams({ from: '/app/m/crm/$id' });

--- a/apps/console/src/modules/crm/contact-ui.tsx
+++ b/apps/console/src/modules/crm/contact-ui.tsx
@@ -16,11 +16,3 @@ export function ContactStatusBadge({ status }: { status: ContactStatus }) {
   const { label, variant } = STATUS_META[status];
   return <Badge variant={variant}>{label}</Badge>;
 }
-
-/** First + last initial, e.g. "Ada Lovelace" → "AL". */
-export function initials(name: string): string {
-  const parts = name.trim().split(/\s+/);
-  const first = parts[0]?.[0] ?? '';
-  const last = parts.length > 1 ? (parts[parts.length - 1]?.[0] ?? '') : '';
-  return (first + last).toUpperCase();
-}

--- a/apps/console/src/modules/crm/contacts-board.tsx
+++ b/apps/console/src/modules/crm/contacts-board.tsx
@@ -18,9 +18,7 @@ import {
   crmKeys,
   updateContact,
 } from '../../lib/crm-api';
-import { formatCurrency } from '../../lib/format';
-
-import { initials } from './contact-ui';
+import { formatCurrency, initials } from '../../lib/format';
 
 const COLUMNS: { status: ContactStatus; label: string }[] = [
   { status: 'lead', label: 'Lead' },

--- a/apps/console/src/modules/projects/issue-detail-route.tsx
+++ b/apps/console/src/modules/projects/issue-detail-route.tsx
@@ -1,0 +1,185 @@
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+
+import {
+  Avatar,
+  AvatarFallback,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Separator,
+  Skeleton,
+} from '@nexus/react';
+import { IconArrowLeft, IconPencil } from '@tabler/icons-react';
+import { useQuery } from '@tanstack/react-query';
+import { Link, useParams } from '@tanstack/react-router';
+
+import { formatDate, initials } from '../../lib/format';
+import {
+  fetchIssue,
+  type IssueDetail,
+  projectKeys,
+} from '../../lib/projects-api';
+
+import { IssueFormSheet } from './issue-form-sheet';
+import { IssuePriorityBadge, IssueStatusBadge } from './issue-ui';
+
+export function IssueDetailRoute() {
+  const { id } = useParams({ from: '/app/m/projects/$id' });
+  const { data, isPending, isError } = useQuery({
+    queryKey: projectKeys.issue(id),
+    queryFn: () => fetchIssue(id),
+  });
+
+  return (
+    <div className="nx:space-y-6 nx:p-6">
+      <Link
+        to="/m/projects"
+        className="nx:text-muted-foreground nx:hover:text-foreground nx:inline-flex nx:items-center nx:gap-1 nx:text-sm"
+      >
+        <IconArrowLeft className="nx:size-4" />
+        Issues
+      </Link>
+
+      {isPending && <DetailSkeleton />}
+      {isError && <NotFound />}
+      {data && <DetailContent issue={data.issue} />}
+    </div>
+  );
+}
+
+function DetailContent({ issue }: { issue: IssueDetail }) {
+  const [editOpen, setEditOpen] = useState(false);
+
+  return (
+    <>
+      <header className="nx:space-y-3">
+        <div className="nx:flex nx:items-start nx:justify-between nx:gap-4">
+          <div className="nx:space-y-1">
+            <p className="nx:text-muted-foreground nx:text-sm nx:tabular-nums">
+              {issue.key}
+            </p>
+            <h1 className="nx:typography-heading-large nx:text-foreground">
+              {issue.title}
+            </h1>
+          </div>
+          <Button
+            variant="outline"
+            className="nx:shrink-0"
+            onClick={() => setEditOpen(true)}
+          >
+            <IconPencil />
+            Edit
+          </Button>
+        </div>
+        <div className="nx:flex nx:flex-wrap nx:items-center nx:gap-2">
+          <IssueStatusBadge status={issue.status} />
+          <IssuePriorityBadge priority={issue.priority} />
+        </div>
+      </header>
+
+      <div className="nx:grid nx:gap-6 nx:lg:grid-cols-3">
+        <Card className="nx:lg:col-span-2">
+          <CardHeader>
+            <CardTitle>Description</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {issue.description ? (
+              <p className="nx:text-foreground nx:text-sm nx:leading-relaxed nx:whitespace-pre-wrap">
+                {issue.description}
+              </p>
+            ) : (
+              <p className="nx:text-muted-foreground nx:text-sm">
+                No description.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Details</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Row label="Assignee">
+              <div className="nx:flex nx:items-center nx:gap-2">
+                <Avatar className="nx:size-6">
+                  <AvatarFallback className="nx:text-xs">
+                    {initials(issue.assignee)}
+                  </AvatarFallback>
+                </Avatar>
+                <span>{issue.assignee}</span>
+              </div>
+            </Row>
+            <Separator />
+            <Row label="Status">
+              <IssueStatusBadge status={issue.status} />
+            </Row>
+            <Separator />
+            <Row label="Priority">
+              <IssuePriorityBadge priority={issue.priority} />
+            </Row>
+            <Separator />
+            <Row label="Created">{formatDate(issue.createdAt)}</Row>
+            <Separator />
+            <Row label="Updated">{formatDate(issue.updatedAt)}</Row>
+          </CardContent>
+        </Card>
+      </div>
+
+      <IssueFormSheet
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        issue={issue}
+      />
+    </>
+  );
+}
+
+function Row({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="nx:flex nx:items-center nx:justify-between nx:gap-4 nx:py-3">
+      <span className="nx:text-muted-foreground nx:text-sm">{label}</span>
+      <div className="nx:text-foreground nx:text-sm nx:font-medium">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function DetailSkeleton() {
+  return (
+    <div className="nx:space-y-6">
+      <div className="nx:space-y-2">
+        <Skeleton className="nx:h-4 nx:w-20" />
+        <Skeleton className="nx:h-7 nx:w-96 nx:max-w-full" />
+      </div>
+      <div className="nx:grid nx:gap-6 nx:lg:grid-cols-3">
+        <Skeleton className="nx:h-48 nx:lg:col-span-2" />
+        <Skeleton className="nx:h-48" />
+      </div>
+    </div>
+  );
+}
+
+// App-local not-found — the polished @nexus/react EmptyState is tracked in #282.
+function NotFound() {
+  return (
+    <div className="nx:border-border-default nx:flex nx:flex-col nx:items-center nx:justify-center nx:gap-3 nx:rounded-md nx:border nx:border-dashed nx:p-12 nx:text-center">
+      <h2 className="nx:typography-heading-medium nx:text-foreground">
+        Issue not found
+      </h2>
+      <p className="nx:text-muted-foreground nx:max-w-sm">
+        This issue doesn&apos;t exist, or may have been removed.
+      </p>
+      <Link
+        to="/m/projects"
+        className="nx:text-primary-subtle-foreground nx:hover:underline"
+      >
+        Back to Issues
+      </Link>
+    </div>
+  );
+}

--- a/apps/console/src/modules/projects/issue-form-sheet.tsx
+++ b/apps/console/src/modules/projects/issue-form-sheet.tsx
@@ -1,0 +1,272 @@
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  Textarea,
+  toast,
+} from '@nexus/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { z } from 'zod';
+
+import {
+  createIssue,
+  ISSUE_PRIORITIES,
+  ISSUE_STATUSES,
+  type IssueDetail,
+  projectKeys,
+  updateIssue,
+} from '../../lib/projects-api';
+
+import { PRIORITY_OPTIONS, STATUS_OPTIONS } from './issue-ui';
+
+const ASSIGNEES = [
+  'Ada Lovelace',
+  'Grace Hopper',
+  'Alan Turing',
+  'Katherine Johnson',
+] as const;
+
+const issueSchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  description: z.string(),
+  status: z.enum(ISSUE_STATUSES),
+  priority: z.enum(ISSUE_PRIORITIES),
+  assignee: z.string().min(1, 'Assignee is required'),
+});
+
+type IssueFormValues = z.infer<typeof issueSchema>;
+
+const EMPTY_VALUES: IssueFormValues = {
+  title: '',
+  description: '',
+  status: 'todo',
+  priority: 'medium',
+  assignee: ASSIGNEES[0],
+};
+
+function toFormValues(issue: IssueDetail): IssueFormValues {
+  const { title, description, status, priority, assignee } = issue;
+  return { title, description, status, priority, assignee };
+}
+
+interface IssueFormSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Present → edit that issue; absent → create a new one. */
+  issue?: IssueDetail;
+}
+
+export function IssueFormSheet({
+  open,
+  onOpenChange,
+  issue,
+}: IssueFormSheetProps) {
+  const queryClient = useQueryClient();
+  const isEdit = !!issue;
+  const form = useForm<IssueFormValues>({
+    resolver: zodResolver(issueSchema),
+    defaultValues: issue ? toFormValues(issue) : EMPTY_VALUES,
+  });
+
+  const mutation = useMutation({
+    mutationFn: (values: IssueFormValues) =>
+      issue ? updateIssue(issue.id, values) : createIssue(values),
+    onSuccess: ({ issue: saved }) => {
+      queryClient.invalidateQueries({ queryKey: projectKeys.all });
+      toast.success(isEdit ? 'Issue updated' : 'Issue created', {
+        description: saved.title,
+      });
+      onOpenChange(false);
+    },
+    onError: (error: Error) =>
+      form.setError('root', { message: error.message }),
+  });
+
+  // Re-sync the form each time the sheet opens — the instance is persistent, so
+  // without this a cancelled create or unsaved edit would survive into the next
+  // open (and a stale root error would linger). `reset` also clears errors.
+  useEffect(() => {
+    if (open) form.reset(issue ? toFormValues(issue) : EMPTY_VALUES);
+  }, [open, issue, form]);
+
+  const onSubmit = (values: IssueFormValues) => mutation.mutate(values);
+  const rootError = form.formState.errors.root?.message;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="nx:flex nx:w-full nx:flex-col nx:sm:max-w-md"
+      >
+        <Form {...form}>
+          <form
+            noValidate
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="nx:flex nx:min-h-0 nx:flex-1 nx:flex-col"
+          >
+            <SheetHeader>
+              <SheetTitle>{isEdit ? 'Edit issue' : 'New issue'}</SheetTitle>
+              <SheetDescription>
+                {isEdit
+                  ? `Update ${issue.key}.`
+                  : 'Add an issue to your project.'}
+              </SheetDescription>
+            </SheetHeader>
+
+            <div className="nx:min-h-0 nx:flex-1 nx:space-y-5 nx:overflow-y-auto nx:px-4">
+              {rootError && (
+                <Alert variant="destructive">
+                  <AlertDescription>{rootError}</AlertDescription>
+                </Alert>
+              )}
+
+              <FormField
+                control={form.control}
+                name="title"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Title</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Short, action-oriented summary"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        rows={4}
+                        placeholder="Context, acceptance criteria, links…"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="status"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Status</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {STATUS_OPTIONS.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="priority"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Priority</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {PRIORITY_OPTIONS.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="assignee"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Assignee</FormLabel>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {ASSIGNEES.map((assignee) => (
+                          <SelectItem key={assignee} value={assignee}>
+                            {assignee}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <SheetFooter>
+              <Button type="submit" loading={mutation.isPending}>
+                {isEdit ? 'Save changes' : 'Create issue'}
+              </Button>
+              <SheetClose asChild>
+                <Button type="button" variant="outline">
+                  Cancel
+                </Button>
+              </SheetClose>
+            </SheetFooter>
+          </form>
+        </Form>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/console/src/modules/projects/issue-form-sheet.tsx
+++ b/apps/console/src/modules/projects/issue-form-sheet.tsx
@@ -95,7 +95,13 @@ export function IssueFormSheet({
     mutationFn: (values: IssueFormValues) =>
       issue ? updateIssue(issue.id, values) : createIssue(values),
     onSuccess: ({ issue: saved }) => {
-      queryClient.invalidateQueries({ queryKey: projectKeys.all });
+      // A create dirties the list; an edit dirties the list + that one detail.
+      queryClient.invalidateQueries({ queryKey: projectKeys.issues });
+      if (issue) {
+        queryClient.invalidateQueries({
+          queryKey: projectKeys.issue(issue.id),
+        });
+      }
       toast.success(isEdit ? 'Issue updated' : 'Issue created', {
         description: saved.title,
       });

--- a/apps/console/src/modules/projects/issue-ui.tsx
+++ b/apps/console/src/modules/projects/issue-ui.tsx
@@ -1,0 +1,47 @@
+import { Badge, type BadgeProps } from '@nexus/react';
+
+import type { IssuePriority, IssueStatus } from '../../lib/projects-api';
+
+const STATUS_META: Record<
+  IssueStatus,
+  { label: string; variant: BadgeProps['variant'] }
+> = {
+  backlog: { label: 'Backlog', variant: 'outline' },
+  todo: { label: 'Todo', variant: 'secondary' },
+  in_progress: { label: 'In progress', variant: 'information' },
+  done: { label: 'Done', variant: 'success' },
+  canceled: { label: 'Canceled', variant: 'secondary' },
+};
+
+const PRIORITY_META: Record<
+  IssuePriority,
+  { label: string; variant: BadgeProps['variant'] }
+> = {
+  urgent: { label: 'Urgent', variant: 'error' },
+  high: { label: 'High', variant: 'warning' },
+  medium: { label: 'Medium', variant: 'information' },
+  low: { label: 'Low', variant: 'secondary' },
+  none: { label: 'No priority', variant: 'outline' },
+};
+
+/** The status badge, shared by the issues table and the detail page. */
+export function IssueStatusBadge({ status }: { status: IssueStatus }) {
+  const { label, variant } = STATUS_META[status];
+  return <Badge variant={variant}>{label}</Badge>;
+}
+
+/** The priority badge, shared by the issues table and the detail page. */
+export function IssuePriorityBadge({ priority }: { priority: IssuePriority }) {
+  const { label, variant } = PRIORITY_META[priority];
+  return <Badge variant={variant}>{label}</Badge>;
+}
+
+/** The ordered status options for the create/edit form's Select. */
+export const STATUS_OPTIONS = (
+  Object.entries(STATUS_META) as [IssueStatus, { label: string }][]
+).map(([value, { label }]) => ({ value, label }));
+
+/** The ordered priority options for the create/edit form's Select. */
+export const PRIORITY_OPTIONS = (
+  Object.entries(PRIORITY_META) as [IssuePriority, { label: string }][]
+).map(([value, { label }]) => ({ value, label }));

--- a/apps/console/src/modules/projects/issue-ui.tsx
+++ b/apps/console/src/modules/projects/issue-ui.tsx
@@ -1,6 +1,11 @@
 import { Badge, type BadgeProps } from '@nexus/react';
 
-import type { IssuePriority, IssueStatus } from '../../lib/projects-api';
+import {
+  ISSUE_PRIORITIES,
+  ISSUE_STATUSES,
+  type IssuePriority,
+  type IssueStatus,
+} from '../../lib/projects-api';
 
 const STATUS_META: Record<
   IssueStatus,
@@ -37,11 +42,13 @@ export function IssuePriorityBadge({ priority }: { priority: IssuePriority }) {
 }
 
 /** The ordered status options for the create/edit form's Select. */
-export const STATUS_OPTIONS = (
-  Object.entries(STATUS_META) as [IssueStatus, { label: string }][]
-).map(([value, { label }]) => ({ value, label }));
+export const STATUS_OPTIONS = ISSUE_STATUSES.map((value) => ({
+  value,
+  label: STATUS_META[value].label,
+}));
 
 /** The ordered priority options for the create/edit form's Select. */
-export const PRIORITY_OPTIONS = (
-  Object.entries(PRIORITY_META) as [IssuePriority, { label: string }][]
-).map(([value, { label }]) => ({ value, label }));
+export const PRIORITY_OPTIONS = ISSUE_PRIORITIES.map((value) => ({
+  value,
+  label: PRIORITY_META[value].label,
+}));

--- a/apps/console/src/modules/projects/issues-columns.tsx
+++ b/apps/console/src/modules/projects/issues-columns.tsx
@@ -20,17 +20,17 @@ import {
 import { Link } from '@tanstack/react-router';
 import type { Column, ColumnDef } from '@tanstack/react-table';
 
-import type { Contact } from '../../lib/crm-api';
-import { formatCurrency, formatDate, initials } from '../../lib/format';
+import { formatDate, initials } from '../../lib/format';
+import type { Issue } from '../../lib/projects-api';
 
-import { ContactStatusBadge } from './contact-ui';
+import { IssuePriorityBadge, IssueStatusBadge } from './issue-ui';
 
 /** A clickable column header that cycles the column's sort and shows its state. */
 function SortHeader({
   column,
   children,
 }: {
-  column: Column<Contact, unknown>;
+  column: Column<Issue, unknown>;
   children: ReactNode;
 }) {
   const sorted = column.getIsSorted();
@@ -53,7 +53,7 @@ function SortHeader({
   );
 }
 
-export const contactColumns: ColumnDef<Contact>[] = [
+export const issueColumns: ColumnDef<Issue>[] = [
   {
     id: 'select',
     header: ({ table }) => (
@@ -73,84 +73,83 @@ export const contactColumns: ColumnDef<Contact>[] = [
       <Checkbox
         checked={row.getIsSelected()}
         onCheckedChange={(value) => row.toggleSelected(!!value)}
-        aria-label={`Select ${row.original.name}`}
+        aria-label={`Select ${row.original.key}`}
       />
     ),
     enableSorting: false,
   },
   {
-    accessorKey: 'name',
-    header: ({ column }) => <SortHeader column={column}>Name</SortHeader>,
+    accessorKey: 'key',
+    header: ({ column }) => <SortHeader column={column}>ID</SortHeader>,
     cell: ({ row }) => (
-      <Link
-        to="/m/crm/$id"
-        params={{ id: row.original.id }}
-        className="nx:text-foreground nx:font-medium nx:hover:underline"
-      >
-        {row.original.name}
-      </Link>
-    ),
-  },
-  {
-    accessorKey: 'company',
-    header: ({ column }) => <SortHeader column={column}>Company</SortHeader>,
-  },
-  {
-    accessorKey: 'status',
-    header: ({ column }) => <SortHeader column={column}>Status</SortHeader>,
-    cell: ({ row }) => <ContactStatusBadge status={row.original.status} />,
-  },
-  {
-    accessorKey: 'owner',
-    header: 'Owner',
-    cell: ({ row }) => (
-      <div className="nx:flex nx:items-center nx:gap-2">
-        <Avatar className="nx:size-6">
-          <AvatarFallback className="nx:text-xs">
-            {initials(row.original.owner)}
-          </AvatarFallback>
-        </Avatar>
-        <span>{row.original.owner}</span>
-      </div>
-    ),
-  },
-  {
-    accessorKey: 'value',
-    header: ({ column }) => <SortHeader column={column}>Open value</SortHeader>,
-    cell: ({ row }) => (
-      <span className="nx:tabular-nums">
-        {formatCurrency(row.original.value)}
+      <span className="nx:text-muted-foreground nx:text-sm nx:tabular-nums">
+        {row.original.key}
       </span>
     ),
   },
   {
-    accessorKey: 'lastContacted',
-    header: ({ column }) => (
-      <SortHeader column={column}>Last contacted</SortHeader>
+    accessorKey: 'title',
+    header: ({ column }) => <SortHeader column={column}>Title</SortHeader>,
+    cell: ({ row }) => (
+      <Link
+        to="/m/projects/$id"
+        params={{ id: row.original.id }}
+        className="nx:text-foreground nx:font-medium nx:hover:underline"
+      >
+        {row.original.title}
+      </Link>
     ),
+  },
+  {
+    accessorKey: 'status',
+    header: ({ column }) => <SortHeader column={column}>Status</SortHeader>,
+    cell: ({ row }) => <IssueStatusBadge status={row.original.status} />,
+  },
+  {
+    accessorKey: 'priority',
+    header: ({ column }) => <SortHeader column={column}>Priority</SortHeader>,
+    cell: ({ row }) => <IssuePriorityBadge priority={row.original.priority} />,
+  },
+  {
+    accessorKey: 'assignee',
+    header: 'Assignee',
+    cell: ({ row }) => (
+      <div className="nx:flex nx:items-center nx:gap-2">
+        <Avatar className="nx:size-6">
+          <AvatarFallback className="nx:text-xs">
+            {initials(row.original.assignee)}
+          </AvatarFallback>
+        </Avatar>
+        <span>{row.original.assignee}</span>
+      </div>
+    ),
+  },
+  {
+    accessorKey: 'updatedAt',
+    header: ({ column }) => <SortHeader column={column}>Updated</SortHeader>,
     cell: ({ row }) => (
       <span className="nx:text-muted-foreground">
-        {formatDate(row.original.lastContacted)}
+        {formatDate(row.original.updatedAt)}
       </span>
     ),
   },
   {
     id: 'actions',
-    cell: ({ row }) => <RowActions contact={row.original} />,
+    cell: ({ row }) => <RowActions issue={row.original} />,
     enableSorting: false,
   },
 ];
 
-function RowActions({ contact }: { contact: Contact }) {
-  const copy = (label: string, value: string) => {
+function RowActions({ issue }: { issue: Issue }) {
+  const copyId = () => {
     if (!navigator.clipboard) {
       toast.error('Clipboard is unavailable in this context.');
       return;
     }
     navigator.clipboard
-      .writeText(value)
-      .then(() => toast.success(`${label} copied`))
-      .catch(() => toast.error(`Couldn't copy ${label.toLowerCase()}`));
+      .writeText(issue.key)
+      .then(() => toast.success('Issue ID copied'))
+      .catch(() => toast.error("Couldn't copy issue ID"));
   };
 
   return (
@@ -159,23 +158,18 @@ function RowActions({ contact }: { contact: Contact }) {
         <Button
           variant="ghost"
           size="sm"
-          aria-label={`Actions for ${contact.name}`}
+          aria-label={`Actions for ${issue.key}`}
         >
           <IconDots />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <DropdownMenuItem asChild>
-          <Link to="/m/crm/$id" params={{ id: contact.id }}>
+          <Link to="/m/projects/$id" params={{ id: issue.id }}>
             View details
           </Link>
         </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => copy('Email', contact.email)}>
-          Copy email
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => copy('Contact ID', contact.id)}>
-          Copy contact ID
-        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={copyId}>Copy issue ID</DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/console/src/modules/projects/issues-route.tsx
+++ b/apps/console/src/modules/projects/issues-route.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+
+import { Button, Skeleton } from '@nexus/react';
+import { IconBriefcase, IconPlus } from '@tabler/icons-react';
+import { useQuery } from '@tanstack/react-query';
+
+import { DataTable } from '../../components/data-table';
+import { fetchIssues, projectKeys } from '../../lib/projects-api';
+
+import { IssueFormSheet } from './issue-form-sheet';
+import { issueColumns } from './issues-columns';
+
+export function IssuesRoute() {
+  const { data, isPending, isError } = useQuery({
+    queryKey: projectKeys.issues,
+    queryFn: fetchIssues,
+  });
+  const issues = data?.issues;
+  const [createOpen, setCreateOpen] = useState(false);
+
+  return (
+    <div className="nx:space-y-6 nx:p-6">
+      <header className="nx:flex nx:items-start nx:justify-between nx:gap-4">
+        <div className="nx:space-y-1">
+          <h1 className="nx:typography-heading-large nx:text-foreground">
+            Issues
+          </h1>
+          <p className="nx:text-muted-foreground">
+            Track work across the team. Sort, filter, and open an issue for the
+            full details.
+          </p>
+        </div>
+        <Button onClick={() => setCreateOpen(true)}>
+          <IconPlus />
+          New issue
+        </Button>
+      </header>
+
+      {isPending && <IssuesSkeleton />}
+      {isError && (
+        <p className="nx:text-error-foreground nx:text-sm">
+          Couldn&apos;t load issues. Please try again.
+        </p>
+      )}
+      {issues &&
+        (issues.length === 0 ? (
+          <IssuesEmpty />
+        ) : (
+          <DataTable
+            columns={issueColumns}
+            data={issues}
+            filterColumn="title"
+            filterPlaceholder="Filter by title…"
+          />
+        ))}
+
+      <IssueFormSheet open={createOpen} onOpenChange={setCreateOpen} />
+    </div>
+  );
+}
+
+function IssuesSkeleton() {
+  return (
+    <div className="nx:space-y-4">
+      <Skeleton className="nx:h-9 nx:max-w-xs" />
+      <div className="nx:border-border-default nx:space-y-3 nx:rounded-md nx:border nx:p-4">
+        {Array.from({ length: 8 }, (_, i) => (
+          <Skeleton key={i} className="nx:h-8 nx:w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// App-local empty state — the polished @nexus/react EmptyState is tracked in #282.
+function IssuesEmpty() {
+  return (
+    <div className="nx:border-border-default nx:flex nx:flex-col nx:items-center nx:justify-center nx:gap-3 nx:rounded-md nx:border nx:border-dashed nx:p-12 nx:text-center">
+      <div className="nx:bg-muted nx:text-muted-foreground nx:flex nx:size-12 nx:items-center nx:justify-center nx:rounded-full">
+        <IconBriefcase />
+      </div>
+      <h2 className="nx:typography-heading-medium nx:text-foreground">
+        No issues yet
+      </h2>
+      <p className="nx:text-muted-foreground nx:max-w-sm">
+        Issues you create will show up here, ready to sort, filter, and work
+        through.
+      </p>
+    </div>
+  );
+}

--- a/apps/console/src/shell/modules.ts
+++ b/apps/console/src/shell/modules.ts
@@ -22,7 +22,12 @@ import {
 export const MODULE_ITEMS = [
   { label: 'Dashboard', module: 'dashboard', icon: IconLayoutDashboard },
   { label: 'CRM', module: 'crm', icon: IconUsers, route: '/m/crm' },
-  { label: 'Projects', module: 'projects', icon: IconBriefcase },
+  {
+    label: 'Projects',
+    module: 'projects',
+    icon: IconBriefcase,
+    route: '/m/projects',
+  },
   { label: 'Inbox', module: 'inbox', icon: IconInbox },
   { label: 'Billing', module: 'billing', icon: IconCreditCard },
   { label: 'Analytics', module: 'analytics', icon: IconChartBar },


### PR DESCRIPTION
## Summary

Phase 3a — the first **breadth** module: **Projects / Issues**, a Linear-style issue tracker that reuses the CRM record-loop recipe (table → detail → create/edit) across a second module, proving a new module spins up from the established pattern.

- **Issues table** on the shared app-level `DataTable` — sort, filter-by-title, row-select, paginate; columns for ID (`ATL-` key), title (link), status + priority **badges**, assignee **avatar**, updated date.
- **Issue detail** (`/m/projects/$id`) — description + a details card (assignee / status / priority / created / updated).
- **Create / edit** via a reset-on-open `Sheet` (rhf + zod), with a **`Textarea`** for the description.
- **MSW** mutable issues store + 24 deterministic fixtures; `POST` assigns the `ATL-` key + timestamps, `PATCH` bumps `updatedAt`.
- `lib/projects-api.ts` single-sources `ISSUE_STATUSES` / `ISSUE_PRIORITIES` (`as const` → `z.enum` + the union type), mirroring CRM's `CONTACT_STATUSES` (the #338 lesson, carried in from the start).
- Static `/m/projects` + `/m/projects/$id` routes wired ahead of the `/m/$module` placeholder; `route` added to the module registry → Projects is no longer "coming soon".
- Extracted the shared `initials()` helper into `lib/format.ts` (now used by CRM + Projects — Projects is its second consumer).

**Scope (advisor-validated): breadth, not depth.** The **kanban board, calendar, cycles, and a status facet are deferred** — board + facet are already dogfooded in CRM (re-porting adds no new component coverage), and calendar is a tracked Nexus gap. The board is a pure-reuse fast-follow if we want it.

## Test Plan (browser-verified)

- [x] Sidebar **Projects** links to `/m/projects` and renders the Issues table, not the "coming soon" placeholder
- [x] Table: 24 issues across 3 pages; key/title/status/priority/assignee columns; select footer ("0 of 24 selected")
- [x] Issue detail renders title, key, status + priority badges, description, and the details card
- [x] **Create** → new issue gets a server-assigned key (`ATL-125`), lands at the top, count 24 → 25, sheet closes
- [x] **Edit** → form prefills the issue's values (reset-on-open), `PATCH` updates, the detail reflects the change
- [x] Not-found (`/m/projects/<bogus>`) → "Issue not found"
- [x] `typecheck`, `eslint --max-warnings 0`, `prettier --check` clean; no unexpected console errors (only a `favicon.ico` 404 + the deliberate not-found 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
