### PR TITLE
feat(components): add input-group component

### DIFF
--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -53,6 +53,7 @@
         "KeyboardInteraction": ["TypeInteraction"]
       }
     },
+    { "name": "InputGroup", "showcase": "AllVariants" },
     { "name": "Item", "showcase": "AllVariants" },
     { "name": "Kbd", "showcase": "AllVariants" },
     { "name": "Pagination", "showcase": "AllVariants" },

--- a/packages/react/src/components/ui/InputGroup.stories.tsx
+++ b/packages/react/src/components/ui/InputGroup.stories.tsx
@@ -1,0 +1,246 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { IconEye, IconMail, IconSearch, IconX } from '@tabler/icons-react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+  InputGroupText,
+  InputGroupTextarea,
+} from './input-group';
+
+const meta: Meta<typeof InputGroup> = {
+  title: 'Components/InputGroup',
+  component: InputGroup,
+};
+
+export default meta;
+type Story = StoryObj<typeof InputGroup>;
+
+// A search field: a leading icon addon and the input.
+export const Default: Story = {
+  render: () => (
+    <InputGroup className="nx:w-80">
+      <InputGroupAddon>
+        <IconSearch aria-hidden />
+      </InputGroupAddon>
+      <InputGroupInput aria-label="Search" placeholder="Search…" />
+    </InputGroup>
+  ),
+};
+
+// A trailing button addon.
+export const WithButton: Story = {
+  render: () => (
+    <InputGroup className="nx:w-80">
+      <InputGroupInput aria-label="Email" placeholder="you@example.com" />
+      <InputGroupAddon align="inline-end">
+        <InputGroupButton>Subscribe</InputGroupButton>
+      </InputGroupAddon>
+    </InputGroup>
+  ),
+};
+
+// A text prefix addon.
+export const WithText: Story = {
+  render: () => (
+    <InputGroup className="nx:w-80">
+      <InputGroupAddon>
+        <InputGroupText>https://</InputGroupText>
+      </InputGroupAddon>
+      <InputGroupInput aria-label="Site URL" placeholder="nexus.dev" />
+    </InputGroup>
+  ),
+};
+
+// Addons at each alignment — inline start/end and stacked block start/end.
+export const Alignments: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-80 nx:flex-col nx:gap-3">
+      <InputGroup>
+        <InputGroupAddon align="inline-start">
+          <IconMail aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Inline start" placeholder="inline-start" />
+      </InputGroup>
+      <InputGroup>
+        <InputGroupInput aria-label="Inline end" placeholder="inline-end" />
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton size="icon-xs" aria-label="Clear">
+            <IconX aria-hidden />
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+      <InputGroup>
+        <InputGroupAddon align="block-start">
+          <InputGroupText>Bio</InputGroupText>
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Bio" placeholder="block-start" />
+      </InputGroup>
+      <InputGroup>
+        <InputGroupInput aria-label="With counter" placeholder="block-end" />
+        <InputGroupAddon align="block-end">
+          <InputGroupText>0 / 200</InputGroupText>
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  ),
+};
+
+// The compact in-field button sizes.
+export const ButtonSizes: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-80 nx:flex-col nx:gap-3">
+      <InputGroup>
+        <InputGroupInput aria-label="Text buttons" placeholder="xs / sm" />
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton size="xs">xs</InputGroupButton>
+          <InputGroupButton size="sm">sm</InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+      <InputGroup>
+        <InputGroupInput aria-label="Icon buttons" placeholder="icon sizes" />
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton size="icon-xs" aria-label="Show">
+            <IconEye aria-hidden />
+          </InputGroupButton>
+          <InputGroupButton size="icon-sm" aria-label="Clear">
+            <IconX aria-hidden />
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  ),
+};
+
+// A textarea with a stacked footer addon.
+export const WithTextarea: Story = {
+  render: () => (
+    <InputGroup className="nx:w-80">
+      <InputGroupTextarea aria-label="Message" placeholder="Your message…" />
+      <InputGroupAddon align="block-end">
+        <InputGroupText>Markdown supported</InputGroupText>
+      </InputGroupAddon>
+    </InputGroup>
+  ),
+};
+
+// The group is a role=group field; the control + addon carry data-slot hooks.
+export const WithDataAttributes: Story = {
+  render: () => (
+    <InputGroup className="nx:w-80">
+      <InputGroupAddon>
+        <IconSearch aria-hidden />
+      </InputGroupAddon>
+      <InputGroupInput aria-label="Search" placeholder="Search…" />
+    </InputGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const group = canvasElement.querySelector('[data-slot="input-group"]');
+    await expect(group).toBeInTheDocument();
+    await expect(group).toHaveAttribute('role', 'group');
+    await expect(
+      canvasElement.querySelector('[data-slot="input-group-addon"]')
+    ).toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-slot="input-group-control"]')
+    ).toBeInTheDocument();
+  },
+};
+
+// Clicking an in-field button fires its handler (event bubbles to the group).
+export const ClickInteraction: Story = {
+  args: { onClick: fn() },
+  render: (args) => (
+    <InputGroup className="nx:w-80" onClick={args.onClick}>
+      <InputGroupInput aria-label="Email" placeholder="you@example.com" />
+      <InputGroupAddon align="inline-end">
+        <InputGroupButton>Subscribe</InputGroupButton>
+      </InputGroupAddon>
+    </InputGroup>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Subscribe' }));
+    await expect(args.onClick).toHaveBeenCalledTimes(1);
+  },
+};
+
+// Typing into the control updates its value.
+export const KeyboardInteraction: Story = {
+  render: () => (
+    <InputGroup className="nx:w-80">
+      <InputGroupAddon>
+        <IconSearch aria-hidden />
+      </InputGroupAddon>
+      <InputGroupInput aria-label="Search" placeholder="Search…" />
+    </InputGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox', { name: 'Search' });
+    await userEvent.type(input, 'nexus');
+    await expect(input).toHaveValue('nexus');
+  },
+};
+
+// A disabled control + button; the group dims its addons via data-disabled.
+export const Disabled: Story = {
+  render: () => (
+    <InputGroup className="nx:w-80" data-disabled="true">
+      <InputGroupInput
+        aria-label="Email"
+        placeholder="you@example.com"
+        disabled
+      />
+      <InputGroupAddon align="inline-end">
+        <InputGroupButton disabled>Subscribe</InputGroupButton>
+      </InputGroupAddon>
+    </InputGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('textbox', { name: 'Email' })).toBeDisabled();
+    await expect(
+      canvas.getByRole('button', { name: 'Subscribe' })
+    ).toBeDisabled();
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// Icon-prefixed search, a text prefix with a trailing clear button, and a
+// textarea with a footer addon. Reused by the per-base variant generator.
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-80 nx:flex-col nx:gap-3">
+      <InputGroup>
+        <InputGroupAddon>
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Search" placeholder="Search…" />
+      </InputGroup>
+      <InputGroup>
+        <InputGroupAddon>
+          <InputGroupText>https://</InputGroupText>
+        </InputGroupAddon>
+        <InputGroupInput aria-label="URL" placeholder="nexus.dev" />
+        <InputGroupAddon align="inline-end">
+          <InputGroupButton size="icon-xs" aria-label="Clear">
+            <IconX aria-hidden />
+          </InputGroupButton>
+        </InputGroupAddon>
+      </InputGroup>
+      <InputGroup>
+        <InputGroupTextarea aria-label="Message" placeholder="Your message…" />
+        <InputGroupAddon align="block-end">
+          <InputGroupText>0 / 200</InputGroupText>
+        </InputGroupAddon>
+      </InputGroup>
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/input-group.tsx
+++ b/packages/react/src/components/ui/input-group.tsx
@@ -1,0 +1,236 @@
+import * as React from 'react';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+/**
+ * InputGroup
+ *
+ * Wraps an input (or textarea) with leading/trailing addons — icons, text,
+ * buttons, or kbd hints — inside one bordered field that shares a focus ring.
+ * Place an `InputGroupInput` / `InputGroupTextarea` as the control and one or
+ * more `InputGroupAddon`s (positioned with `align`) around it; the whole group
+ * lights up when the control is focused, and reflects the control's invalid
+ * state.
+ *
+ * @example
+ * ```tsx
+ * <InputGroup>
+ *   <InputGroupAddon>
+ *     <IconSearch />
+ *   </InputGroupAddon>
+ *   <InputGroupInput placeholder="Search…" />
+ * </InputGroup>
+ * ```
+ */
+function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        // nexus-allow-numeric: field-internal addon/control padding rhythm
+        'nx:group/input-group nx:relative nx:flex nx:w-full nx:min-w-0 nx:items-center nx:rounded-md nx:border nx:border-border-default nx:shadow-xs nx:transition-[color,box-shadow] nx:outline-none',
+        // Alignment: addons push the control's padding to make room.
+        'nx:has-[>[data-align=inline-start]]:[&>input]:pl-2',
+        'nx:has-[>[data-align=inline-end]]:[&>input]:pr-2',
+        'nx:has-[>[data-align=block-start]]:flex-col nx:has-[>[data-align=block-start]]:[&>input]:pb-3',
+        'nx:has-[>[data-align=block-end]]:flex-col nx:has-[>[data-align=block-end]]:[&>input]:pt-3',
+        // Focus: the group shows the ring when the inner control is focused
+        // (the control suppresses its own outline).
+        'nx:has-[[data-slot=input-group-control]:focus-visible]:outline-2 nx:has-[[data-slot=input-group-control]:focus-visible]:outline-focus-default nx:has-[[data-slot=input-group-control]:focus-visible]:outline-offset-(--focus-offset)',
+        // Error: an invalid inner control reddens the group border.
+        'nx:has-[[data-slot][aria-invalid=true]]:border-border-error',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+const inputGroupAddonVariants = cva(
+  // nexus-allow-numeric: addon inset rhythm
+  'nx:flex nx:h-auto nx:cursor-text nx:items-center nx:justify-start nx:gap-2 nx:py-1.5 nx:typography-label-default nx:text-muted-foreground nx:select-none nx:group-data-[disabled=true]/input-group:opacity-50 nx:[&>kbd]:rounded-sm nx:[&>svg]:size-4',
+  {
+    variants: {
+      align: {
+        'inline-start':
+          'nx:order-first nx:pl-3 nx:has-[>button]:ml-[-0.45rem] nx:has-[>kbd]:ml-[-0.35rem]',
+        'inline-end':
+          'nx:order-last nx:pr-3 nx:has-[>button]:mr-[-0.45rem] nx:has-[>kbd]:mr-[-0.35rem]',
+        // nexus-allow-numeric: stacked addon inset matches input padding
+        'block-start': 'nx:order-first nx:w-full nx:px-3 nx:pt-3',
+        // nexus-allow-numeric: stacked addon inset matches input padding
+        'block-end': 'nx:order-last nx:w-full nx:px-3 nx:pb-3',
+      },
+    },
+    defaultVariants: {
+      align: 'inline-start',
+    },
+  }
+);
+
+/**
+ * InputGroupAddonProps
+ *
+ * Props for the InputGroupAddon component.
+ */
+interface InputGroupAddonProps
+  extends
+    React.ComponentProps<'div'>,
+    VariantProps<typeof inputGroupAddonVariants> {}
+
+/**
+ * InputGroupAddon
+ *
+ * A leading / trailing / stacked slot for icons, text, buttons, or kbd hints.
+ * Position with `align` — inline (start / end) or stacked (block start / end).
+ */
+function InputGroupAddon({
+  className,
+  align = 'inline-start',
+  ...props
+}: InputGroupAddonProps) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      {...props}
+    />
+  );
+}
+
+const inputGroupButtonVariants = cva(
+  'nx:flex nx:items-center nx:text-sm nx:shadow-none',
+  {
+    variants: {
+      size: {
+        // nexus-allow-numeric: dense in-field button footprints
+        xs: 'nx:h-6 nx:gap-1 nx:rounded-sm nx:px-2 nx:has-[>svg]:px-2 nx:[&>svg]:size-3.5',
+        // nexus-allow-numeric: dense in-field button footprints
+        sm: 'nx:h-8 nx:gap-1.5 nx:rounded-md nx:px-2.5 nx:has-[>svg]:px-2.5',
+        'icon-xs': 'nx:size-6 nx:rounded-sm nx:p-0 nx:has-[>svg]:p-0',
+        'icon-sm': 'nx:size-8 nx:p-0 nx:has-[>svg]:p-0',
+      },
+    },
+    defaultVariants: {
+      size: 'xs',
+    },
+  }
+);
+
+/**
+ * InputGroupButtonProps
+ *
+ * Props for the InputGroupButton component.
+ */
+interface InputGroupButtonProps
+  extends
+    Omit<React.ComponentProps<typeof Button>, 'size'>,
+    VariantProps<typeof inputGroupButtonVariants> {}
+
+/**
+ * InputGroupButton
+ *
+ * A compact button sized to sit inside an `InputGroupAddon` — defaults to the
+ * `ghost` variant and the `xs` in-field size.
+ */
+function InputGroupButton({
+  className,
+  type = 'button',
+  variant = 'ghost',
+  size = 'xs',
+  ...props
+}: InputGroupButtonProps) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * InputGroupText
+ *
+ * Inline addon text — a unit, a label, a prefix.
+ */
+function InputGroupText({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      className={cn(
+        // nexus-allow-numeric: inline addon gap
+        'nx:flex nx:items-center nx:gap-2 nx:typography-body-small nx:text-muted-foreground nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * InputGroupInput
+ *
+ * The text input inside an `InputGroup` — borderless and transparent so the
+ * group provides the frame and focus ring.
+ */
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        'nx:flex-1 nx:rounded-none nx:border-0 nx:bg-transparent nx:shadow-none nx:focus-visible:outline-none',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * InputGroupTextarea
+ *
+ * The textarea inside an `InputGroup` — borderless and transparent so the group
+ * provides the frame and focus ring.
+ */
+function InputGroupTextarea({
+  className,
+  ...props
+}: React.ComponentProps<typeof Textarea>) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn(
+        // nexus-allow-numeric: textarea inset
+        'nx:flex-1 nx:resize-none nx:rounded-none nx:border-0 nx:bg-transparent nx:py-3 nx:shadow-none nx:focus-visible:outline-none',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  type InputGroupAddonProps,
+  inputGroupAddonVariants,
+  InputGroupButton,
+  type InputGroupButtonProps,
+  inputGroupButtonVariants,
+  InputGroupInput,
+  InputGroupText,
+  InputGroupTextarea,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -26,6 +26,7 @@ export * from '@/components/ui/dropdown-menu';
 export * from '@/components/ui/empty-state';
 export * from '@/components/ui/form';
 export * from '@/components/ui/input';
+export * from '@/components/ui/input-group';
 export * from '@/components/ui/input-otp';
 export * from '@/components/ui/item';
 export * from '@/components/ui/kbd';


### PR DESCRIPTION
## Summary

Adapts shadcn/ui **input-group** into `@nexus/react` — a bordered field that wraps an input/textarea with leading/trailing/stacked addons (icons, text, `kbd`, buttons) sharing one focus ring.

- **Components:** `InputGroup`, `InputGroupAddon` (`align` cva: inline-start/-end, block-start/-end), `InputGroupButton` (`size` cva: xs/sm/icon-xs/icon-sm, wraps a ghost `Button`), `InputGroupText`, `InputGroupInput`, `InputGroupTextarea`.
- **Group-level focus/error:** the ring renders on the group via `has-[[data-slot=input-group-control]:focus-visible]` and the error border via `has-[…aria-invalid]`; the inner control suppresses its own outline so there's one shared ring.
- **Padding-based** (no fixed field height) — the group auto-sizes to the Nexus `Input`; addons nudge the control's padding so leading/trailing content lines up.
- **No new dependency** — composes the already-shipped `Input` / `Textarea` / `Button`.
- **Dropped affordance (intentional):** shadcn's click-empty-addon-to-focus handler is omitted. Under `--max-warnings 0`, attaching a click handler to the non-interactive addon trips `jsx-a11y/no-noninteractive-element-interactions` (and the warn-level static/keyboard rules) with no lint-clean escape; the control itself is the focus target and the wide input area already focuses on click. `cursor-text` is kept for visual cohesion.

## GitHub Issue

Closes #300

## Test Plan

- [x] `typecheck` clean (regenerates base-variants; `InputGroup` showcase generates)
- [x] `eslint . --max-warnings 0` clean
- [x] `prettier --check` clean
- [x] `audit:storybook-coverage --component input-group` → 0 missing / 0 drift (`align` enum info-only; `size` covered by ButtonSizes/Alignments/AllVariants)
- [x] `build` clean; emitted CSS verified to carry the group focus ring, `data-align` padding adjustments, and the disabled-dim
- [x] `size-limit` — ESM 69.22 kB / 70 kB, CSS 9.86 kB / 30 kB
- [ ] Storybook play-fns (Click / Keyboard / Disabled + WithDataAttributes) — run in CI