### PR TITLE
feat(components): add native-select component

### DIFF
--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -56,6 +56,7 @@
     { "name": "InputGroup", "showcase": "AllVariants" },
     { "name": "Item", "showcase": "AllVariants" },
     { "name": "Kbd", "showcase": "AllVariants" },
+    { "name": "NativeSelect", "showcase": "AllVariants" },
     { "name": "Pagination", "showcase": "AllVariants" },
     {
       "name": "Popover",

--- a/packages/react/src/components/ui/NativeSelect.stories.tsx
+++ b/packages/react/src/components/ui/NativeSelect.stories.tsx
@@ -1,0 +1,172 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import {
+  NativeSelect,
+  NativeSelectOptGroup,
+  NativeSelectOption,
+} from './native-select';
+
+const meta: Meta<typeof NativeSelect> = {
+  title: 'Components/NativeSelect',
+  component: NativeSelect,
+};
+
+export default meta;
+type Story = StoryObj<typeof NativeSelect>;
+
+// A basic select with a styled closed trigger; the open list is OS-rendered.
+export const Default: Story = {
+  render: () => (
+    <NativeSelect aria-label="Plan" defaultValue="pro">
+      <NativeSelectOption value="free">Free</NativeSelectOption>
+      <NativeSelectOption value="pro">Pro</NativeSelectOption>
+      <NativeSelectOption value="team">Team</NativeSelectOption>
+    </NativeSelect>
+  ),
+};
+
+// Both sizes: the default control height and the dense `sm`.
+export const Sizes: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-3">
+      <NativeSelect size="default" aria-label="Default size" defaultValue="pro">
+        <NativeSelectOption value="free">Free</NativeSelectOption>
+        <NativeSelectOption value="pro">Pro</NativeSelectOption>
+      </NativeSelect>
+      <NativeSelect size="sm" aria-label="Small size" defaultValue="pro">
+        <NativeSelectOption value="free">Free</NativeSelectOption>
+        <NativeSelectOption value="pro">Pro</NativeSelectOption>
+      </NativeSelect>
+    </div>
+  ),
+};
+
+// Grouped options via optgroup.
+export const WithOptGroups: Story = {
+  render: () => (
+    <NativeSelect aria-label="Timezone" defaultValue="pst">
+      <NativeSelectOptGroup label="Americas">
+        <NativeSelectOption value="pst">Pacific</NativeSelectOption>
+        <NativeSelectOption value="est">Eastern</NativeSelectOption>
+      </NativeSelectOptGroup>
+      <NativeSelectOptGroup label="Europe">
+        <NativeSelectOption value="gmt">London</NativeSelectOption>
+        <NativeSelectOption value="cet">Berlin</NativeSelectOption>
+      </NativeSelectOptGroup>
+    </NativeSelect>
+  ),
+};
+
+// Invalid state — error border + error focus ring.
+export const Invalid: Story = {
+  render: () => (
+    <NativeSelect aria-label="Plan" aria-invalid defaultValue="free">
+      <NativeSelectOption value="free">Free</NativeSelectOption>
+      <NativeSelectOption value="pro">Pro</NativeSelectOption>
+    </NativeSelect>
+  ),
+};
+
+// Disabled — the select and its chevron dim together (wrapper has-[select:disabled]).
+export const Disabled: Story = {
+  render: () => (
+    <NativeSelect aria-label="Plan" defaultValue="free" disabled>
+      <NativeSelectOption value="free">Free</NativeSelectOption>
+      <NativeSelectOption value="pro">Pro</NativeSelectOption>
+    </NativeSelect>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('combobox', { name: 'Plan' })).toBeDisabled();
+  },
+};
+
+// Selecting an option updates the value and fires onChange.
+export const ClickInteraction: Story = {
+  args: { onChange: fn() },
+  render: (args) => (
+    <NativeSelect
+      aria-label="Plan"
+      defaultValue="free"
+      onChange={args.onChange}
+    >
+      <NativeSelectOption value="free">Free</NativeSelectOption>
+      <NativeSelectOption value="pro">Pro</NativeSelectOption>
+      <NativeSelectOption value="team">Team</NativeSelectOption>
+    </NativeSelect>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const select = canvas.getByRole('combobox', { name: 'Plan' });
+    await userEvent.selectOptions(select, 'pro');
+    await expect(select).toHaveValue('pro');
+    await expect(args.onChange).toHaveBeenCalled();
+  },
+};
+
+// The select is keyboard-reachable via Tab.
+export const KeyboardInteraction: Story = {
+  render: () => (
+    <NativeSelect aria-label="Plan" defaultValue="free">
+      <NativeSelectOption value="free">Free</NativeSelectOption>
+      <NativeSelectOption value="pro">Pro</NativeSelectOption>
+    </NativeSelect>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const select = canvas.getByRole('combobox', { name: 'Plan' });
+    await userEvent.tab();
+    await expect(select).toHaveFocus();
+  },
+};
+
+// The wrapper, control, and icon carry data-slot hooks; the control carries data-size.
+export const WithDataAttributes: Story = {
+  render: () => (
+    <NativeSelect aria-label="Plan" defaultValue="free">
+      <NativeSelectOption value="free">Free</NativeSelectOption>
+      <NativeSelectOption value="pro">Pro</NativeSelectOption>
+    </NativeSelect>
+  ),
+  play: async ({ canvasElement }) => {
+    const select = canvasElement.querySelector('[data-slot="native-select"]');
+    await expect(select).toBeInTheDocument();
+    await expect(select).toHaveAttribute('data-size', 'default');
+    await expect(
+      canvasElement.querySelector('[data-slot="native-select-wrapper"]')
+    ).toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-slot="native-select-icon"]')
+    ).toBeInTheDocument();
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// Default, small, invalid, and disabled side by side. Reused by the per-base
+// variant generator.
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-3">
+      <NativeSelect size="default" aria-label="Default" defaultValue="pro">
+        <NativeSelectOption value="free">Free</NativeSelectOption>
+        <NativeSelectOption value="pro">Pro</NativeSelectOption>
+      </NativeSelect>
+      <NativeSelect size="sm" aria-label="Small" defaultValue="pro">
+        <NativeSelectOption value="free">Free</NativeSelectOption>
+        <NativeSelectOption value="pro">Pro</NativeSelectOption>
+      </NativeSelect>
+      <NativeSelect aria-label="Invalid" aria-invalid defaultValue="free">
+        <NativeSelectOption value="free">Free</NativeSelectOption>
+        <NativeSelectOption value="pro">Pro</NativeSelectOption>
+      </NativeSelect>
+      <NativeSelect aria-label="Disabled" defaultValue="free" disabled>
+        <NativeSelectOption value="free">Free</NativeSelectOption>
+        <NativeSelectOption value="pro">Pro</NativeSelectOption>
+      </NativeSelect>
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/native-select.tsx
+++ b/packages/react/src/components/ui/native-select.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { IconChevronDown } from '@/lib/icons';
+import { cn } from '@/lib/utils';
+
+const nativeSelectVariants = cva(
+  [
+    'nx:w-full nx:min-w-0 nx:appearance-none nx:rounded-md nx:border nx:border-border-default',
+    'nx:bg-background nx:text-foreground nx:shadow-xs nx:transition-colors nx:outline-none',
+    'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
+    'nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error',
+    'nx:disabled:cursor-not-allowed',
+  ],
+  {
+    variants: {
+      size: {
+        // nexus-allow-numeric: select padding + chevron room (match Input)
+        default: 'nx:px-3 nx:py-control-md nx:pr-9 nx:text-sm',
+        // nexus-allow-numeric: select padding + chevron room (match Input)
+        sm: 'nx:px-2.5 nx:py-control-sm nx:pr-9 nx:text-xs',
+      },
+    },
+    defaultVariants: {
+      size: 'default',
+    },
+  }
+);
+
+/**
+ * NativeSelectProps
+ *
+ * Props for the NativeSelect component.
+ */
+interface NativeSelectProps
+  extends
+    Omit<React.ComponentProps<'select'>, 'size'>,
+    VariantProps<typeof nativeSelectVariants> {}
+
+/**
+ * NativeSelect
+ *
+ * A styled wrapper over the native `<select>` — on mobile it opens the OS
+ * picker (iOS wheel / Android sheet), the preferred dense-form UX there. The
+ * closed trigger is styled to match `Input`; the open list is OS-rendered.
+ * For rich options (icons, descriptions, grouping) on desktop, use `Select`.
+ *
+ * @example
+ * ```tsx
+ * <NativeSelect aria-label="Country" defaultValue="us">
+ *   <NativeSelectOption value="us">United States</NativeSelectOption>
+ *   <NativeSelectOption value="ca">Canada</NativeSelectOption>
+ * </NativeSelect>
+ * ```
+ */
+function NativeSelect({
+  className,
+  size = 'default',
+  ...props
+}: NativeSelectProps) {
+  return (
+    <div
+      data-slot="native-select-wrapper"
+      className="nx:group/native-select nx:relative nx:w-fit nx:has-[select:disabled]:opacity-50"
+    >
+      <select
+        data-slot="native-select"
+        data-size={size}
+        className={cn(nativeSelectVariants({ size }), className)}
+        {...props}
+      />
+      <IconChevronDown
+        aria-hidden="true"
+        data-slot="native-select-icon"
+        className="nx:pointer-events-none nx:absolute nx:top-1/2 nx:right-3.5 nx:size-4 nx:-translate-y-1/2 nx:text-muted-foreground nx:opacity-50 nx:select-none"
+      />
+    </div>
+  );
+}
+
+/**
+ * NativeSelectOption
+ *
+ * An `<option>` for `NativeSelect`. Uses the `Canvas` / `CanvasText` system
+ * colors so the OS-rendered list stays legible in both light and dark themes.
+ */
+function NativeSelectOption({
+  className,
+  ...props
+}: React.ComponentProps<'option'>) {
+  return (
+    <option
+      data-slot="native-select-option"
+      className={cn('nx:bg-[Canvas] nx:text-[CanvasText]', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * NativeSelectOptGroup
+ *
+ * An `<optgroup>` for grouping `NativeSelect` options.
+ */
+function NativeSelectOptGroup({
+  className,
+  ...props
+}: React.ComponentProps<'optgroup'>) {
+  return (
+    <optgroup
+      data-slot="native-select-optgroup"
+      className={cn('nx:bg-[Canvas] nx:text-[CanvasText]', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  NativeSelect,
+  NativeSelectOptGroup,
+  NativeSelectOption,
+  type NativeSelectProps,
+  nativeSelectVariants,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -31,6 +31,7 @@ export * from '@/components/ui/input-otp';
 export * from '@/components/ui/item';
 export * from '@/components/ui/kbd';
 export * from '@/components/ui/label';
+export * from '@/components/ui/native-select';
 export * from '@/components/ui/pagination';
 export * from '@/components/ui/popover';
 export * from '@/components/ui/progress';


### PR DESCRIPTION
## Summary

Adapts shadcn/ui **native-select** into `@nexus/react` — a styled wrapper over the native `<select>`. On mobile it opens the OS picker (iOS wheel / Android sheet), the preferred dense-form UX; it's the mobile-first counterpart to the Radix **Select (#209)**, which stays for rich desktop options.

- **Components:** `NativeSelect` (`size` cva: default / sm), `NativeSelectOption`, `NativeSelectOptGroup`.
- **Styling:** the closed trigger matches `Input` — padding-based sizing (no fixed height), the canonical outline focus ring, and the `aria-invalid` error border + error focus ring. `appearance-none` + an `IconChevronDown` (already in `lib/icons`); the wrapper dims the select **and** its chevron together via `has-[select:disabled]`.
- **OS-list legibility:** options/optgroups use the `Canvas` / `CanvasText` system colors so the OS-rendered list stays readable in both light and dark themes.
- **Divergences from shadcn:** dropped the vestigial `selection:` / `placeholder:` utilities (no-ops on a `<select>`) and the `dark:bg-input/*` modifiers; sizing is padding-based, not `h-9`/`h-8`.
- **No new dependency.**

## GitHub Issue

Closes #303

## Test Plan

- [x] `typecheck` clean (regenerates base-variants; `NativeSelect` showcase generates)
- [x] `eslint . --max-warnings 0` clean
- [x] `prettier --check` clean
- [x] `audit:storybook-coverage --component native-select` → 0 missing / 0 drift (`size` covered by Sizes/AllVariants; interaction stories are bonus — the source has no display-gate signal)
- [x] `build` clean; emitted CSS verified to carry `appearance-none`, the `Canvas` option colors, `data-size=sm`, and the `has-[select:disabled]` dim
- [x] `size-limit` — ESM 65.82 kB / 70 kB
- [ ] Storybook play-fns (Click via `selectOptions` / Keyboard focus / Disabled + WithDataAttributes) — run in CI