### PR TITLE
feat(components): add field component

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "react-hook-form",
         "sonner"
       ],
-      "limit": "70 kB"
+      "limit": "75 kB"
     },
     {
       "name": "@nexus/react (CSS)",

--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -45,6 +45,7 @@
       }
     },
     { "name": "EmptyState", "showcase": "AllVariants" },
+    { "name": "Field", "showcase": "AllVariants" },
     {
       "name": "Input",
       "showcase": "AllVariants",

--- a/packages/react/src/components/ui/Field.stories.tsx
+++ b/packages/react/src/components/ui/Field.stories.tsx
@@ -1,0 +1,246 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { Checkbox } from './checkbox';
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldTitle,
+} from './field';
+import { Input } from './input';
+
+const meta: Meta<typeof Field> = {
+  title: 'Components/Field',
+  component: Field,
+};
+
+export default meta;
+type Story = StoryObj<typeof Field>;
+
+// A label + control + helper text — the canonical vertical field.
+export const Default: Story = {
+  render: () => (
+    <div className="nx:w-80">
+      <Field>
+        <FieldLabel htmlFor="field-email">Email</FieldLabel>
+        <Input id="field-email" type="email" placeholder="you@example.com" />
+        <FieldDescription>We never share it.</FieldDescription>
+      </Field>
+    </div>
+  ),
+};
+
+// The three orientations: vertical, horizontal, and container-responsive.
+export const Orientations: Story = {
+  render: () => (
+    <FieldGroup className="nx:w-80">
+      <Field orientation="vertical">
+        <FieldLabel htmlFor="field-o-name">Name</FieldLabel>
+        <Input id="field-o-name" placeholder="Ada Lovelace" />
+      </Field>
+      <Field orientation="horizontal">
+        <FieldLabel htmlFor="field-o-newsletter">Newsletter</FieldLabel>
+        <Checkbox id="field-o-newsletter" />
+      </Field>
+      <Field orientation="responsive">
+        <FieldContent>
+          <FieldLabel htmlFor="field-o-bio">Bio</FieldLabel>
+          <FieldDescription>Shown on your public profile.</FieldDescription>
+        </FieldContent>
+        <Input id="field-o-bio" placeholder="A short bio" />
+      </Field>
+    </FieldGroup>
+  ),
+};
+
+// Both legend emphases: the larger fieldset `legend` and the label-sized one.
+export const LegendVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-80 nx:flex-col nx:gap-6">
+      <FieldSet>
+        <FieldLegend variant="legend">Notifications</FieldLegend>
+        <FieldDescription>How should we reach you?</FieldDescription>
+        <Field orientation="horizontal">
+          <FieldLabel htmlFor="field-l-email">Email</FieldLabel>
+          <Checkbox id="field-l-email" defaultChecked />
+        </Field>
+      </FieldSet>
+      <FieldSet>
+        <FieldLegend variant="label">Smaller caption</FieldLegend>
+        <Field orientation="horizontal">
+          <FieldLabel htmlFor="field-l-sms">SMS</FieldLabel>
+          <Checkbox id="field-l-sms" />
+        </Field>
+      </FieldSet>
+    </div>
+  ),
+};
+
+// An invalid field with an error message wired via the errors prop.
+export const WithError: Story = {
+  render: () => (
+    <div className="nx:w-80">
+      <Field data-invalid="true">
+        <FieldLabel htmlFor="field-err">Password</FieldLabel>
+        <Input id="field-err" type="password" aria-invalid />
+        <FieldError errors={[{ message: 'Must be at least 8 characters.' }]} />
+      </Field>
+    </div>
+  ),
+};
+
+// A divider between groups of fields, with centered content.
+export const WithSeparator: Story = {
+  render: () => (
+    <FieldGroup className="nx:w-80">
+      <Field>
+        <FieldLabel htmlFor="field-sep-email">Email</FieldLabel>
+        <Input id="field-sep-email" type="email" />
+      </Field>
+      <FieldSeparator>OR</FieldSeparator>
+      <Field>
+        <FieldLabel htmlFor="field-sep-phone">Phone</FieldLabel>
+        <Input id="field-sep-phone" type="tel" />
+      </Field>
+    </FieldGroup>
+  ),
+};
+
+// The checkbox-card pattern: a FieldLabel wrapping a Field becomes a selectable card.
+export const CheckboxCard: Story = {
+  render: () => (
+    <div className="nx:w-80">
+      <FieldLabel htmlFor="field-card">
+        <Field orientation="horizontal">
+          <Checkbox
+            id="field-card"
+            defaultChecked
+            aria-labelledby="field-card-title"
+          />
+          <FieldContent>
+            <FieldTitle id="field-card-title">
+              Enable two-factor auth
+            </FieldTitle>
+            <FieldDescription>
+              Add an extra layer of security to your account.
+            </FieldDescription>
+          </FieldContent>
+        </Field>
+      </FieldLabel>
+    </div>
+  ),
+};
+
+// The group is role=group; parts carry data-slot hooks; orientation is reflected.
+export const WithDataAttributes: Story = {
+  render: () => (
+    <div className="nx:w-80">
+      <Field>
+        <FieldLabel htmlFor="field-da">Username</FieldLabel>
+        <Input id="field-da" />
+        <FieldDescription>Your public handle.</FieldDescription>
+      </Field>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const field = canvas.getByRole('group');
+    await expect(field).toHaveAttribute('data-slot', 'field');
+    await expect(field).toHaveAttribute('data-orientation', 'vertical');
+    await expect(
+      canvasElement.querySelector('[data-slot="field-label"]')
+    ).toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-slot="field-description"]')
+    ).toBeInTheDocument();
+  },
+};
+
+// Clicking a FieldLabel toggles its associated control (label htmlFor wiring).
+export const ClickInteraction: Story = {
+  render: () => (
+    <div className="nx:w-80">
+      <Field orientation="horizontal">
+        <Checkbox id="field-click" />
+        <FieldLabel htmlFor="field-click">Accept the terms</FieldLabel>
+      </Field>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The control's accessible name resolves through the label's htmlFor, so
+    // this query both proves the wiring and gives a stable click target.
+    const checkbox = canvas.getByRole('checkbox', { name: 'Accept the terms' });
+    await expect(checkbox).not.toBeChecked();
+    await userEvent.click(checkbox);
+    await expect(checkbox).toBeChecked();
+  },
+};
+
+// The control inside a field is keyboard-reachable via Tab.
+export const KeyboardInteraction: Story = {
+  render: () => (
+    <div className="nx:w-80">
+      <Field>
+        <FieldLabel htmlFor="field-kbd">Email</FieldLabel>
+        <Input id="field-kbd" type="email" />
+      </Field>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox');
+    await userEvent.tab();
+    await expect(input).toHaveFocus();
+  },
+};
+
+// A disabled field: data-disabled dims the label and the control is disabled.
+export const Disabled: Story = {
+  render: () => (
+    <div className="nx:w-80">
+      <Field data-disabled="true">
+        <FieldLabel htmlFor="field-disabled">Email</FieldLabel>
+        <Input id="field-disabled" type="email" disabled />
+        <FieldDescription>This field is locked.</FieldDescription>
+      </Field>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('textbox')).toBeDisabled();
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// A fieldset with a legend, two fields, a description, and an error. Reused by
+// the per-base variant generator — aria-label (not htmlFor/id) avoids id
+// collisions across the generated cells.
+export const AllVariants: Story = {
+  render: () => (
+    <FieldSet className="nx:w-80">
+      <FieldLegend variant="legend">Account</FieldLegend>
+      <Field>
+        <FieldLabel>Email</FieldLabel>
+        <Input type="email" aria-label="Email" placeholder="you@example.com" />
+        <FieldDescription>We never share it.</FieldDescription>
+      </Field>
+      <FieldSeparator>OR</FieldSeparator>
+      <Field data-invalid="true">
+        <FieldLabel>Username</FieldLabel>
+        <Input aria-label="Username" aria-invalid />
+        <FieldError errors={[{ message: 'That username is taken.' }]} />
+      </Field>
+    </FieldSet>
+  ),
+};

--- a/packages/react/src/components/ui/field.tsx
+++ b/packages/react/src/components/ui/field.tsx
@@ -1,0 +1,350 @@
+import * as React from 'react';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { Label } from '@/components/ui/label';
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
+
+/**
+ * FieldSet
+ *
+ * A `<fieldset>` grouping related fields — pair with `FieldLegend` for the
+ * group's caption.
+ */
+function FieldSet({ className, ...props }: React.ComponentProps<'fieldset'>) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        // nexus-allow-numeric: field-group rhythm
+        'nx:flex nx:flex-col nx:gap-6 nx:has-[>[data-slot=checkbox-group]]:gap-3 nx:has-[>[data-slot=radio-group]]:gap-3',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * FieldLegendProps
+ *
+ * Props for the FieldLegend component.
+ */
+interface FieldLegendProps extends React.ComponentProps<'legend'> {
+  /**
+   * Caption emphasis. `legend` is the larger fieldset caption; `label` matches
+   * a field label's size.
+   *
+   * @default 'legend'
+   */
+  variant?: 'legend' | 'label';
+}
+
+/**
+ * FieldLegend
+ *
+ * The caption for a `FieldSet`.
+ */
+function FieldLegend({
+  className,
+  variant = 'legend',
+  ...props
+}: FieldLegendProps) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        // nexus-allow-numeric: legend caption spacing
+        'nx:mb-3 nx:font-medium nx:data-[variant=legend]:text-base nx:data-[variant=label]:text-sm',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * FieldGroup
+ *
+ * A vertical stack of `Field`s. Declares the `field-group` container so a
+ * `Field`'s `responsive` orientation can adapt to the group's width.
+ */
+function FieldGroup({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        // nexus-allow-numeric: field-group stack rhythm
+        'nx:group/field-group nx:@container/field-group nx:flex nx:w-full nx:flex-col nx:gap-7 nx:data-[slot=checkbox-group]:gap-3 nx:[&>[data-slot=field-group]]:gap-4',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+const fieldVariants = cva(
+  // nexus-allow-numeric: label/control/description gap
+  'nx:group/field nx:flex nx:w-full nx:gap-3 nx:data-[invalid=true]:text-error-subtle-foreground',
+  {
+    variants: {
+      orientation: {
+        vertical: 'nx:flex-col nx:[&>*]:w-full nx:[&>.sr-only]:w-auto',
+        horizontal:
+          'nx:flex-row nx:items-center nx:[&>[data-slot=field-label]]:flex-auto nx:has-[>[data-slot=field-content]]:items-start nx:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px',
+        responsive:
+          'nx:flex-col nx:@md/field-group:flex-row nx:@md/field-group:items-center nx:[&>*]:w-full nx:@md/field-group:[&>*]:w-auto nx:[&>.sr-only]:w-auto nx:@md/field-group:[&>[data-slot=field-label]]:flex-auto nx:@md/field-group:has-[>[data-slot=field-content]]:items-start nx:@md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px',
+      },
+    },
+    defaultVariants: {
+      orientation: 'vertical',
+    },
+  }
+);
+
+/**
+ * FieldProps
+ *
+ * Props for the Field component.
+ */
+interface FieldProps
+  extends React.ComponentProps<'div'>, VariantProps<typeof fieldVariants> {}
+
+/**
+ * Field
+ *
+ * The labeled-field layout primitive — composes a label, control, description,
+ * and error with their a11y wiring, decoupled from any form library. For the
+ * react-hook-form binding layer, use `Form`, which builds on this structure.
+ *
+ * @example
+ * ```tsx
+ * <Field>
+ *   <FieldLabel htmlFor="email">Email</FieldLabel>
+ *   <Input id="email" type="email" />
+ *   <FieldDescription>We'll never share it.</FieldDescription>
+ * </Field>
+ * ```
+ */
+function Field({ className, orientation = 'vertical', ...props }: FieldProps) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * FieldContent
+ *
+ * Wraps a control's label + description when they sit beside the control (the
+ * horizontal / checkbox-card layouts).
+ */
+function FieldContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn(
+        // nexus-allow-numeric: stacked label/description gap
+        'nx:group/field-content nx:flex nx:flex-1 nx:flex-col nx:gap-1.5 nx:leading-snug',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * FieldLabel
+ *
+ * A field's label (wraps `Label`). When it wraps a nested `Field` it becomes a
+ * selectable card (checkbox / radio card) that highlights when its control is
+ * checked.
+ */
+function FieldLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Label>) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(
+        // nexus-allow-numeric: label gap + card padding
+        'nx:group/field-label nx:peer/field-label nx:flex nx:w-fit nx:gap-2 nx:leading-snug nx:group-data-[disabled=true]/field:opacity-50',
+        'nx:has-[>[data-slot=field]]:w-full nx:has-[>[data-slot=field]]:flex-col nx:has-[>[data-slot=field]]:rounded-md nx:has-[>[data-slot=field]]:border nx:[&>*]:data-[slot=field]:p-4',
+        'nx:has-data-[state=checked]:border-border-primary nx:has-data-[state=checked]:bg-primary-subtle',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * FieldTitle
+ *
+ * A non-`<label>` title for a field group or card (use when the title isn't
+ * bound to a single control via `htmlFor`).
+ */
+function FieldTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        // nexus-allow-numeric: title icon gap
+        'nx:flex nx:w-fit nx:items-center nx:gap-2 nx:text-sm nx:leading-snug nx:font-medium nx:group-data-[disabled=true]/field:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * FieldDescription
+ *
+ * Helper text below a field's control.
+ */
+function FieldDescription({ className, ...props }: React.ComponentProps<'p'>) {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn(
+        'nx:text-sm nx:leading-normal nx:font-normal nx:text-muted-foreground nx:group-has-[[data-orientation=horizontal]]/field:text-balance',
+        'nx:last:mt-0 nx:nth-last-2:-mt-1 nx:[[data-variant=legend]+&]:-mt-1.5',
+        'nx:[&>a]:underline nx:[&>a]:underline-offset-4 nx:[&>a:hover]:text-primary-subtle-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * FieldSeparator
+ *
+ * A divider between fields, optionally with centered content (e.g. "OR").
+ */
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={!!children}
+      className={cn(
+        // nexus-allow-numeric: separator inset
+        'nx:relative nx:-my-2 nx:h-5 nx:text-sm nx:group-data-[variant=outline]/field-group:-mb-2',
+        className
+      )}
+      {...props}
+    >
+      <Separator className="nx:absolute nx:inset-0 nx:top-1/2" />
+      {children && (
+        <span
+          data-slot="field-separator-content"
+          // nexus-allow-numeric: separator label inset
+          className="nx:relative nx:mx-auto nx:block nx:w-fit nx:bg-background nx:px-2 nx:text-muted-foreground"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * FieldErrorProps
+ *
+ * Props for the FieldError component.
+ */
+interface FieldErrorProps extends React.ComponentProps<'div'> {
+  /**
+   * Validation errors to render. Deduplicated by message; a single error shows
+   * inline, multiple render as a list. Ignored when `children` is provided.
+   */
+  errors?: Array<{ message?: string } | undefined>;
+}
+
+/**
+ * FieldError
+ *
+ * The error message(s) for a field. Renders nothing when there's no content.
+ */
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: FieldErrorProps) {
+  const content = React.useMemo(() => {
+    if (children) {
+      return children;
+    }
+
+    if (!errors?.length) {
+      return null;
+    }
+
+    const uniqueErrors = [
+      ...new Map(errors.map((error) => [error?.message, error])).values(),
+    ];
+
+    if (uniqueErrors.length === 1) {
+      return uniqueErrors[0]?.message;
+    }
+
+    return (
+      // nexus-allow-numeric: error list inset
+      <ul className="nx:ml-4 nx:flex nx:list-disc nx:flex-col nx:gap-1">
+        {uniqueErrors.map(
+          (error, index) =>
+            error?.message && <li key={index}>{error.message}</li>
+        )}
+      </ul>
+    );
+  }, [children, errors]);
+
+  if (!content) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn(
+        'nx:text-sm nx:font-normal nx:text-error-subtle-foreground',
+        className
+      )}
+      {...props}
+    >
+      {content}
+    </div>
+  );
+}
+
+export {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  type FieldErrorProps,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  type FieldLegendProps,
+  type FieldProps,
+  FieldSeparator,
+  FieldSet,
+  FieldTitle,
+  fieldVariants,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -24,6 +24,7 @@ export * from '@/components/ui/command';
 export * from '@/components/ui/dialog';
 export * from '@/components/ui/dropdown-menu';
 export * from '@/components/ui/empty-state';
+export * from '@/components/ui/field';
 export * from '@/components/ui/form';
 export * from '@/components/ui/input';
 export * from '@/components/ui/input-group';


### PR DESCRIPTION
## Summary

Adapts shadcn/ui **field** into `@nexus/react` — the labeled-field **layout** primitive (label + control + description + error + a11y wiring), decoupled from any form library. It's the layer **Form (#176)** binds on top of, and it covers forms that don't use react-hook-form (native / server-action forms, settings panels, a lone search input) — which matters more under the mobile-first direction.

- **10 sub-components:** `Field` (`orientation` cva: vertical / horizontal / responsive), `FieldSet`, `FieldLegend` (`variant`: legend / label), `FieldGroup`, `FieldContent`, `FieldLabel`, `FieldTitle`, `FieldDescription`, `FieldSeparator`, `FieldError`.
- **Composes the shipped `Label` + `Separator`** — no new dependency.
- **Consistent with the shipped Form:** descriptions use `text-muted-foreground`, errors use `text-error-subtle-foreground` + `role="alert"` (matching `FormDescription` / `FormMessage`).
- **Checkbox-card `FieldLabel`** (a label wrapping a nested `Field`) maps shadcn's `border-primary` / `bg-primary/5` to `nx:border-border-primary` / `nx:bg-primary-subtle`; dropped the `dark:` + opacity tints.
- **First shipped component to use `@container`:** the `responsive` orientation adapts to the `FieldGroup`'s width via a named `@container/field-group` query — container-based, per `responsive.md` (not a viewport prefix). Verified compiling to `container:field-group/inline-size` + `@container field-group (min-width:28rem)`.
- `FieldError` dedupes its `errors` by message (one inline, many as a list) and renders nothing when empty.

## Scope note

Built **standalone** per this batch's user-approved assumption — the shipped `Form (#176)` is left untouched. The issue's "ideally refactor Form to compose Field" is an optional additive fast-follow, intentionally out of scope here. (Flagging explicitly so it can be revisited.)

## GitHub Issue

Closes #299

## Test Plan

- [x] `typecheck` clean (regenerates base-variants; `Field` showcase generates)
- [x] `eslint . --max-warnings 0` clean
- [x] `prettier --check` clean
- [x] `audit:storybook-coverage --component field` → 0 missing / 0 drift (`orientation` enum info-only; Click / Keyboard / Disabled stories added)
- [x] `build` clean; emitted CSS verified — named `@container/field-group` query, `state=checked` card highlight, `data-[invalid=true]` tint, `error-subtle-foreground` all present
- [x] `size-limit` — ESM 66.55 kB / 70 kB
- [ ] Storybook play-fns (Click label↔control wiring / Keyboard focus / Disabled + WithDataAttributes) — run in CI