### PR TITLE
feat(components): add toggle + toggle-group components

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "react-hook-form",
         "sonner"
       ],
-      "limit": "75 kB"
+      "limit": "80 kB"
     },
     {
       "name": "@nexus/react (CSS)",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -69,6 +69,8 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@radix-ui/react-toggle": "^1.1.10",
+    "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tabler/icons-react": "^3.36.1",
     "class-variance-authority": "^0.7.1",

--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -107,6 +107,8 @@
         "KeyboardInteraction": ["TypeInteraction"]
       }
     },
+    { "name": "Toggle", "showcase": "AllVariants" },
+    { "name": "ToggleGroup", "showcase": "AllVariants" },
     { "name": "Tooltip", "showcase": "AllVariants" }
   ]
 }

--- a/packages/react/src/components/ui/Toggle.stories.tsx
+++ b/packages/react/src/components/ui/Toggle.stories.tsx
@@ -1,0 +1,171 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { IconBold, IconItalic } from '@tabler/icons-react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { Toggle } from './toggle';
+
+const meta: Meta<typeof Toggle> = {
+  title: 'Components/Toggle',
+  component: Toggle,
+};
+
+export default meta;
+type Story = StoryObj<typeof Toggle>;
+
+// A single two-state button.
+export const Default: Story = {
+  render: () => (
+    <Toggle aria-label="Bold">
+      <IconBold />
+    </Toggle>
+  ),
+};
+
+// The two variants: borderless default and bordered outline.
+export const Variants: Story = {
+  render: () => (
+    <div className="nx:flex nx:gap-3">
+      <Toggle variant="default" aria-label="Bold">
+        <IconBold />
+      </Toggle>
+      <Toggle variant="outline" aria-label="Italic">
+        <IconItalic />
+      </Toggle>
+    </div>
+  ),
+};
+
+// The three sizes.
+export const Sizes: Story = {
+  render: () => (
+    <div className="nx:flex nx:items-center nx:gap-3">
+      <Toggle size="sm" aria-label="Small">
+        <IconBold />
+      </Toggle>
+      <Toggle size="default" aria-label="Default">
+        <IconBold />
+      </Toggle>
+      <Toggle size="lg" aria-label="Large">
+        <IconBold />
+      </Toggle>
+    </div>
+  ),
+};
+
+// A toggle with text alongside the icon, shown pressed.
+export const WithText: Story = {
+  render: () => (
+    <Toggle aria-label="Bold" defaultPressed>
+      <IconBold />
+      Bold
+    </Toggle>
+  ),
+};
+
+// Clicking toggles the pressed state and fires onPressedChange.
+export const ClickInteraction: Story = {
+  args: { onPressedChange: fn() },
+  render: (args) => (
+    <Toggle aria-label="Bold" onPressedChange={args.onPressedChange}>
+      <IconBold />
+    </Toggle>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: 'Bold' });
+    await expect(toggle).toHaveAttribute('data-state', 'off');
+    await userEvent.click(toggle);
+    await expect(args.onPressedChange).toHaveBeenCalledWith(true);
+    await expect(toggle).toHaveAttribute('data-state', 'on');
+  },
+};
+
+// Enter/Space toggles when focused.
+export const KeyboardInteraction: Story = {
+  args: { onPressedChange: fn() },
+  render: (args) => (
+    <Toggle aria-label="Italic" onPressedChange={args.onPressedChange}>
+      <IconItalic />
+    </Toggle>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: 'Italic' });
+    await userEvent.tab();
+    await expect(toggle).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
+    await expect(args.onPressedChange).toHaveBeenCalledWith(true);
+  },
+};
+
+// A disabled toggle does not respond to clicks.
+export const Disabled: Story = {
+  args: { onPressedChange: fn() },
+  render: (args) => (
+    <Toggle aria-label="Bold" disabled onPressedChange={args.onPressedChange}>
+      <IconBold />
+    </Toggle>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: 'Bold' });
+    await expect(toggle).toBeDisabled();
+    // No click: a disabled toggle has pointer-events: none, which makes
+    // userEvent.click throw. The disabled attribute is the sufficient signal.
+    await expect(args.onPressedChange).not.toHaveBeenCalled();
+  },
+};
+
+// data-slot identifies the component; data-variant / data-size reflect props.
+export const WithDataAttributes: Story = {
+  render: () => (
+    <Toggle aria-label="Bold" variant="outline" size="sm">
+      <IconBold />
+    </Toggle>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: 'Bold' });
+    await expect(toggle).toHaveAttribute('data-slot', 'toggle');
+    await expect(toggle).toHaveAttribute('data-variant', 'outline');
+    await expect(toggle).toHaveAttribute('data-size', 'sm');
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// Variants × on/off states, then the three sizes. Reused by the per-base
+// variant generator. The pressed (on) row exercises the data-[state=on] fill.
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-4">
+      <div className="nx:flex nx:items-center nx:gap-3">
+        <Toggle aria-label="Default off">
+          <IconBold />
+        </Toggle>
+        <Toggle aria-label="Default on" defaultPressed>
+          <IconBold />
+        </Toggle>
+        <Toggle variant="outline" aria-label="Outline off">
+          <IconItalic />
+        </Toggle>
+        <Toggle variant="outline" aria-label="Outline on" defaultPressed>
+          <IconItalic />
+        </Toggle>
+      </div>
+      <div className="nx:flex nx:items-center nx:gap-3">
+        <Toggle size="sm" aria-label="Small">
+          <IconBold />
+        </Toggle>
+        <Toggle size="default" aria-label="Medium">
+          <IconBold />
+        </Toggle>
+        <Toggle size="lg" aria-label="Large">
+          <IconBold />
+        </Toggle>
+      </div>
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/ToggleGroup.stories.tsx
+++ b/packages/react/src/components/ui/ToggleGroup.stories.tsx
@@ -1,0 +1,248 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  IconAlignCenter,
+  IconAlignLeft,
+  IconAlignRight,
+  IconBold,
+  IconItalic,
+  IconUnderline,
+} from '@tabler/icons-react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { ToggleGroup, ToggleGroupItem } from './toggle-group';
+
+const meta: Meta<typeof ToggleGroup> = {
+  title: 'Components/ToggleGroup',
+  component: ToggleGroup,
+};
+
+export default meta;
+type Story = StoryObj<typeof ToggleGroup>;
+
+// Single-select: behaves like a radio group (exactly one item pressed).
+export const Default: Story = {
+  render: () => (
+    <ToggleGroup type="single" defaultValue="left">
+      <ToggleGroupItem value="left" aria-label="Align left">
+        <IconAlignLeft />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="center" aria-label="Align center">
+        <IconAlignCenter />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="right" aria-label="Align right">
+        <IconAlignRight />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  ),
+};
+
+// Multiple-select: any number of items pressed at once.
+export const Multiple: Story = {
+  render: () => (
+    <ToggleGroup type="multiple" defaultValue={['bold']}>
+      <ToggleGroupItem value="bold" aria-label="Bold">
+        <IconBold />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="italic" aria-label="Italic">
+        <IconItalic />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="underline" aria-label="Underline">
+        <IconUnderline />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  ),
+};
+
+// The outline variant, applied to the whole group via context.
+export const Outline: Story = {
+  render: () => (
+    <ToggleGroup type="single" variant="outline" defaultValue="left">
+      <ToggleGroupItem value="left" aria-label="Align left">
+        <IconAlignLeft />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="center" aria-label="Align center">
+        <IconAlignCenter />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="right" aria-label="Align right">
+        <IconAlignRight />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  ),
+};
+
+// Joined (spacing 0, segmented) vs separated (spacing 2, individual pills).
+export const Spacing: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-4">
+      <ToggleGroup type="single" variant="outline" defaultValue="left">
+        <ToggleGroupItem value="left" aria-label="Align left">
+          <IconAlignLeft />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="center" aria-label="Align center">
+          <IconAlignCenter />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="right" aria-label="Align right">
+          <IconAlignRight />
+        </ToggleGroupItem>
+      </ToggleGroup>
+      <ToggleGroup
+        type="single"
+        variant="outline"
+        spacing={2}
+        defaultValue="left"
+      >
+        <ToggleGroupItem value="left" aria-label="Align left (spaced)">
+          <IconAlignLeft />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="center" aria-label="Align center (spaced)">
+          <IconAlignCenter />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="right" aria-label="Align right (spaced)">
+          <IconAlignRight />
+        </ToggleGroupItem>
+      </ToggleGroup>
+    </div>
+  ),
+};
+
+// Clicking an item selects it (and deselects the previously selected one).
+export const ClickInteraction: Story = {
+  render: () => (
+    <ToggleGroup type="single" defaultValue="left">
+      <ToggleGroupItem value="left" aria-label="Align left">
+        <IconAlignLeft />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="center" aria-label="Align center">
+        <IconAlignCenter />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="right" aria-label="Align right">
+        <IconAlignRight />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const center = canvas.getByRole('radio', { name: 'Align center' });
+    await expect(center).toHaveAttribute('data-state', 'off');
+    await userEvent.click(center);
+    await expect(center).toHaveAttribute('data-state', 'on');
+    await expect(
+      canvas.getByRole('radio', { name: 'Align left' })
+    ).toHaveAttribute('data-state', 'off');
+  },
+};
+
+// Arrow keys move the roving focus within the group.
+export const KeyboardInteraction: Story = {
+  render: () => (
+    <ToggleGroup type="single" defaultValue="left">
+      <ToggleGroupItem value="left" aria-label="Align left">
+        <IconAlignLeft />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="center" aria-label="Align center">
+        <IconAlignCenter />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.tab();
+    await expect(
+      canvas.getByRole('radio', { name: 'Align left' })
+    ).toHaveFocus();
+    await userEvent.keyboard('{ArrowRight}');
+    await expect(
+      canvas.getByRole('radio', { name: 'Align center' })
+    ).toHaveFocus();
+  },
+};
+
+// A disabled group disables all its items.
+export const Disabled: Story = {
+  render: () => (
+    <ToggleGroup type="single" defaultValue="left" disabled>
+      <ToggleGroupItem value="left" aria-label="Align left">
+        <IconAlignLeft />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="center" aria-label="Align center">
+        <IconAlignCenter />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('radio', { name: 'Align left' })
+    ).toBeDisabled();
+  },
+};
+
+// The group carries data-slot / data-variant / data-size; items carry data-slot.
+export const WithDataAttributes: Story = {
+  render: () => (
+    <ToggleGroup type="single" variant="outline" size="sm" defaultValue="left">
+      <ToggleGroupItem value="left" aria-label="Align left">
+        <IconAlignLeft />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="center" aria-label="Align center">
+        <IconAlignCenter />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const group = canvasElement.querySelector('[data-slot="toggle-group"]');
+    await expect(group).toHaveAttribute('data-variant', 'outline');
+    await expect(group).toHaveAttribute('data-size', 'sm');
+    await expect(
+      canvasElement.querySelector('[data-slot="toggle-group-item"]')
+    ).toBeInTheDocument();
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// Single + multiple, default + outline, joined + spaced. Reused by the per-base
+// variant generator.
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-4">
+      <ToggleGroup type="single" defaultValue="left">
+        <ToggleGroupItem value="left" aria-label="Align left">
+          <IconAlignLeft />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="center" aria-label="Align center">
+          <IconAlignCenter />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="right" aria-label="Align right">
+          <IconAlignRight />
+        </ToggleGroupItem>
+      </ToggleGroup>
+      <ToggleGroup type="multiple" variant="outline" defaultValue={['bold']}>
+        <ToggleGroupItem value="bold" aria-label="Bold">
+          <IconBold />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="italic" aria-label="Italic">
+          <IconItalic />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="underline" aria-label="Underline">
+          <IconUnderline />
+        </ToggleGroupItem>
+      </ToggleGroup>
+      <ToggleGroup
+        type="single"
+        variant="outline"
+        spacing={2}
+        defaultValue="left"
+      >
+        <ToggleGroupItem value="left" aria-label="Spaced left">
+          <IconAlignLeft />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="center" aria-label="Spaced center">
+          <IconAlignCenter />
+        </ToggleGroupItem>
+      </ToggleGroup>
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/toggle-group.tsx
+++ b/packages/react/src/components/ui/toggle-group.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react';
+
+import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
+import type { VariantProps } from 'class-variance-authority';
+
+import { toggleVariants } from '@/components/ui/toggle';
+import { cn } from '@/lib/utils';
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & { spacing?: number }
+>({
+  size: 'default',
+  variant: 'default',
+  spacing: 0,
+});
+
+/**
+ * ToggleGroupProps
+ *
+ * Props for the ToggleGroup component.
+ */
+// A `type` intersection (not an `interface extends`) because Radix's
+// ToggleGroup.Root props are a discriminated union (single | multiple) —
+// extending a union from an interface drops `children`.
+type ToggleGroupProps = React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    /**
+     * Gap between items, in spacing-scale units. `0` (default) joins the items
+     * into a segmented control — shared borders, only the ends rounded; a
+     * positive value separates them into individual pills.
+     *
+     * @default 0
+     */
+    spacing?: number;
+  };
+
+/**
+ * ToggleGroup
+ *
+ * A set of related `ToggleGroupItem`s sharing `variant` / `size` via context.
+ * `type="single"` behaves like a radio group; `type="multiple"` allows several
+ * items pressed at once.
+ *
+ * @example
+ * ```tsx
+ * <ToggleGroup type="single" defaultValue="left">
+ *   <ToggleGroupItem value="left" aria-label="Align left">
+ *     <IconAlignLeft />
+ *   </ToggleGroupItem>
+ *   <ToggleGroupItem value="center" aria-label="Align center">
+ *     <IconAlignCenter />
+ *   </ToggleGroupItem>
+ * </ToggleGroup>
+ * ```
+ */
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  children,
+  ...props
+}: ToggleGroupProps) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      // Spacing-scale gap via the runtime spacing var (Nexus resets the base
+      // --spacing, so Tailwind's --spacing() function is unavailable here).
+      style={
+        spacing
+          ? ({ gap: `var(--nx-spacing-${spacing})` } as React.CSSProperties)
+          : undefined
+      }
+      className={cn(
+        'nx:flex nx:w-fit nx:items-center nx:rounded-md',
+        className
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size, spacing }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  );
+}
+
+/**
+ * ToggleGroupItemProps
+ *
+ * Props for the ToggleGroupItem component.
+ */
+interface ToggleGroupItemProps
+  extends
+    React.ComponentProps<typeof ToggleGroupPrimitive.Item>,
+    VariantProps<typeof toggleVariants> {}
+
+/**
+ * ToggleGroupItem
+ *
+ * A single item within a `ToggleGroup`. Inherits `variant` / `size` from the
+ * group unless overridden.
+ */
+function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ...props
+}: ToggleGroupItemProps) {
+  const context = React.useContext(ToggleGroupContext);
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        'nx:min-w-0 nx:shrink-0',
+        // When joined (spacing=0): drop inner rounding/borders so items share
+        // edges; round only the group's ends.
+        'nx:data-[spacing=0]:rounded-none nx:data-[spacing=0]:first:rounded-l-md nx:data-[spacing=0]:last:rounded-r-md nx:data-[spacing=0]:data-[variant=outline]:border-l-0 nx:data-[spacing=0]:data-[variant=outline]:first:border-l',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  );
+}
+
+export {
+  ToggleGroup,
+  ToggleGroupItem,
+  type ToggleGroupItemProps,
+  type ToggleGroupProps,
+};

--- a/packages/react/src/components/ui/toggle.tsx
+++ b/packages/react/src/components/ui/toggle.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+
+import * as TogglePrimitive from '@radix-ui/react-toggle';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const toggleVariants = cva(
+  'nx:inline-flex nx:items-center nx:justify-center nx:rounded-md nx:text-sm nx:font-medium nx:whitespace-nowrap nx:transition-colors nx:outline-none nx:hover:bg-background-hover nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:pointer-events-none nx:disabled:opacity-50 nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error nx:data-[state=on]:bg-muted nx:data-[state=on]:text-foreground nx:[&_svg]:pointer-events-none nx:[&_svg]:shrink-0 nx:[&_svg]:size-4',
+  {
+    variants: {
+      variant: {
+        default: 'nx:bg-transparent',
+        outline: 'nx:border nx:border-border-default nx:bg-transparent',
+      },
+      size: {
+        default: 'nx:px-control-md nx:py-control-md nx:gap-control-md',
+        sm: 'nx:px-control-sm nx:py-control-sm nx:gap-control-sm nx:text-xs',
+        lg: 'nx:px-control-lg nx:py-control-lg nx:gap-control-lg',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+/**
+ * ToggleProps
+ *
+ * Props for the Toggle component.
+ */
+interface ToggleProps
+  extends
+    React.ComponentProps<typeof TogglePrimitive.Root>,
+    VariantProps<typeof toggleVariants> {}
+
+/**
+ * Toggle
+ *
+ * A two-state button that is either on or off — e.g. a formatting control
+ * (Bold / Italic). For a set of related toggles, use `ToggleGroup`.
+ *
+ * @example
+ * ```tsx
+ * <Toggle aria-label="Bold">
+ *   <IconBold />
+ * </Toggle>
+ * ```
+ */
+function Toggle({ className, variant, size, ...props }: ToggleProps) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      data-variant={variant}
+      data-size={size}
+      className={cn(toggleVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Toggle, type ToggleProps, toggleVariants };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -49,6 +49,8 @@ export * from '@/components/ui/switch';
 export * from '@/components/ui/table';
 export * from '@/components/ui/tabs';
 export * from '@/components/ui/textarea';
+export * from '@/components/ui/toggle';
+export * from '@/components/ui/toggle-group';
 export * from '@/components/ui/tooltip';
 
 // Primitives

--- a/yarn.lock
+++ b/yarn.lock
@@ -1431,6 +1431,28 @@
     "@radix-ui/react-roving-focus" "1.1.11"
     "@radix-ui/react-use-controllable-state" "1.2.2"
 
+"@radix-ui/react-toggle-group@^1.1.11":
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz#e513d6ffdb07509b400ab5b26f2523747c0d51c1"
+  integrity sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-direction" "1.1.1"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-roving-focus" "1.1.11"
+    "@radix-ui/react-toggle" "1.1.10"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+
+"@radix-ui/react-toggle@1.1.10", "@radix-ui/react-toggle@^1.1.10":
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz#b04ba0f9609599df666fce5b2f38109a197f08cf"
+  integrity sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+
 "@radix-ui/react-tooltip@^1.2.8":
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz#3f50267e25bccfc9e20bb3036bfd9ab4c2c30c2c"


### PR DESCRIPTION
## Summary

- **Toggle** (`#296`) and **ToggleGroup** (`#297`) adapted from shadcn/ui into `@nexus/react`, shipped as one PR since ToggleGroup reuses Toggle's exported `toggleVariants` cva (documented exception to one-PR-per-component).
- Radix wiring: `@radix-ui/react-toggle` + `@radix-ui/react-toggle-group` added as per-primitive deps (unified-import rewrite — no `radix-ui` meta-package).
- `nx:` prefix, semantic tokens, `data-slot`/`data-variant`/`data-size`, canonical outline focus ring, role-padding sizing (`px-/py-/gap-control-*`). No fixed heights, no `dark:` on semantic tokens.
- ToggleGroup `spacing` prop: `0` (default) joins items into a segmented control (shared borders, ends rounded); a positive value separates them into pills (gap via the runtime `--nx-spacing-*` var, since Nexus resets the base `--spacing`).
- Stories cover variant×size, Click/Keyboard/Disabled interactions, data-attributes, and a render-based `AllVariants` (base-variants showcase, opted in via `base-variants.config.json`).
- Bumped `@nexus/react` ESM size-limit ceiling 75→80 kB (bundle is 70.8 kB local; CI measures ~3-4 kB higher, so this keeps margin and likely covers the next Wave-3 component).

## Design note — on-state token (reviewer's call)

The on/pressed state uses **`bg-muted`** + `text-foreground` — the recipe-faithful mapping of shadcn's `bg-accent` selected state. One nuance carries over from shadcn: Nexus's `muted` and `background-hover` resolve to the **same** primitive (`{base.50}` light / `{base.900}` dark) in every base, so a *hovered-off* toggle transiently shows the same shade as an *on* toggle (reverts the instant the pointer leaves). This is shadcn-parity behaviour.

**Open fork for the design call:** if Toggle should read as a *binary control* (like Switch, which uses `bg-primary-background` for its on-state) rather than a *neutral formatting button* (shadcn's choice), the on-state can move to `primary-background` for an unmistakable pressed cue — at the cost of every selected ToggleGroup segment rendering a solid brand fill. Flagging rather than deciding silently, given the tabs (#93) precedent. Trivial to swap (pre-production, no backcompat).

## GitHub Issue

Closes #296
Closes #297

## Test Plan

- [ ] CI: typecheck, lint, story-coverage audit (0/0 for both), Bundle Size, Storybook play-fns (Toggle + ToggleGroup Click/Keyboard/Disabled)
- [ ] `AllVariants` renders correctly across 5 bases × 2 themes (base-variants grid)