### PR TITLE
feat(components): add collapsible component

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -57,6 +57,7 @@
     "@radix-ui/react-aspect-ratio": "^1.1.8",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.7",

--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -29,6 +29,7 @@
     { "name": "ButtonGroup", "showcase": "AllVariants" },
     { "name": "Card", "showcase": "AllVariants" },
     { "name": "Checkbox", "showcase": "AllVariants" },
+    { "name": "Collapsible", "showcase": "AllVariants" },
     {
       "name": "Dialog",
       "showcase": "AllVariants",

--- a/packages/react/src/components/ui/Collapsible.stories.tsx
+++ b/packages/react/src/components/ui/Collapsible.stories.tsx
@@ -1,0 +1,195 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { IconSelector } from '@tabler/icons-react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { Button } from './button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from './collapsible';
+
+const meta: Meta<typeof Collapsible> = {
+  title: 'Components/Collapsible',
+  component: Collapsible,
+};
+
+export default meta;
+type Story = StoryObj<typeof Collapsible>;
+
+// A trigger composed with a ghost Button, toggling a content region.
+export const Default: Story = {
+  render: () => (
+    <Collapsible className="nx:flex nx:w-72 nx:flex-col nx:gap-2">
+      <div className="nx:flex nx:items-center nx:justify-between nx:gap-4">
+        <span className="nx:text-sm nx:font-medium nx:text-foreground">
+          @nexus starred 3 repositories
+        </span>
+        <CollapsibleTrigger asChild>
+          <Button variant="ghost" size="sm" aria-label="Toggle repositories">
+            <IconSelector />
+          </Button>
+        </CollapsibleTrigger>
+      </div>
+      <div className="nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-foreground">
+        @radix-ui/react-collapsible
+      </div>
+      <CollapsibleContent className="nx:flex nx:flex-col nx:gap-2">
+        <div className="nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-foreground">
+          @radix-ui/react-toggle
+        </div>
+        <div className="nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-foreground">
+          @radix-ui/react-slider
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+};
+
+// Open by default, showing the revealed content region.
+export const Open: Story = {
+  render: () => (
+    <Collapsible defaultOpen className="nx:flex nx:w-72 nx:flex-col nx:gap-2">
+      <CollapsibleTrigger asChild>
+        <Button variant="outline">Toggle details</Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-muted-foreground">
+        Revealed content shown while open.
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+};
+
+// Clicking the trigger expands the content and fires onOpenChange.
+export const ClickInteraction: Story = {
+  args: { onOpenChange: fn() },
+  render: (args) => (
+    <Collapsible
+      onOpenChange={args.onOpenChange}
+      className="nx:flex nx:w-72 nx:flex-col nx:gap-2"
+    >
+      <CollapsibleTrigger asChild>
+        <Button variant="outline">Toggle details</Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-foreground">
+        Now you see me.
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Toggle details' });
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(trigger);
+    await expect(args.onOpenChange).toHaveBeenCalledWith(true);
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    await expect(canvas.getByText('Now you see me.')).toBeVisible();
+  },
+};
+
+// Enter/Space toggles the collapsible when the trigger is focused.
+export const KeyboardInteraction: Story = {
+  args: { onOpenChange: fn() },
+  render: (args) => (
+    <Collapsible
+      onOpenChange={args.onOpenChange}
+      className="nx:flex nx:w-72 nx:flex-col nx:gap-2"
+    >
+      <CollapsibleTrigger asChild>
+        <Button variant="outline">Toggle details</Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-foreground">
+        Keyboard-revealed content.
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Toggle details' });
+    await userEvent.tab();
+    await expect(trigger).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
+    await expect(args.onOpenChange).toHaveBeenCalledWith(true);
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  },
+};
+
+// A disabled collapsible: the trigger cannot toggle the content.
+export const Disabled: Story = {
+  args: { onOpenChange: fn() },
+  render: (args) => (
+    <Collapsible
+      disabled
+      onOpenChange={args.onOpenChange}
+      className="nx:flex nx:w-72 nx:flex-col nx:gap-2"
+    >
+      <CollapsibleTrigger asChild>
+        <Button variant="outline">Toggle details</Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-foreground">
+        Unreachable while disabled.
+      </CollapsibleContent>
+    </Collapsible>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Toggle details' });
+    // No click: a disabled trigger stays closed; the disabled attribute and
+    // the never-fired onOpenChange are the signals.
+    await expect(trigger).toBeDisabled();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await expect(args.onOpenChange).not.toHaveBeenCalled();
+  },
+};
+
+// data-slot identifies the root, trigger, and content.
+export const WithDataAttributes: Story = {
+  render: () => (
+    <Collapsible defaultOpen className="nx:flex nx:w-72 nx:flex-col nx:gap-2">
+      <CollapsibleTrigger asChild>
+        <Button variant="outline">Toggle details</Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent>Content</CollapsibleContent>
+    </Collapsible>
+  ),
+  play: async ({ canvasElement }) => {
+    await expect(
+      canvasElement.querySelector('[data-slot="collapsible"]')
+    ).toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-slot="collapsible-trigger"]')
+    ).toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-slot="collapsible-content"]')
+    ).toBeInTheDocument();
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// Closed (resting) and open states side by side. Reused by the per-base
+// variant generator.
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-6">
+      <Collapsible className="nx:flex nx:w-64 nx:flex-col nx:gap-2">
+        <CollapsibleTrigger asChild>
+          <Button variant="outline">Closed by default</Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-muted-foreground">
+          Hidden until toggled.
+        </CollapsibleContent>
+      </Collapsible>
+      <Collapsible defaultOpen className="nx:flex nx:w-64 nx:flex-col nx:gap-2">
+        <CollapsibleTrigger asChild>
+          <Button variant="outline">Open by default</Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-muted-foreground">
+          Visible on first render.
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/collapsible.tsx
+++ b/packages/react/src/components/ui/collapsible.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+
+import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * CollapsibleProps
+ *
+ * Props for the Collapsible root.
+ */
+interface CollapsibleProps extends React.ComponentProps<
+  typeof CollapsiblePrimitive.Root
+> {}
+
+/**
+ * Collapsible
+ *
+ * A single expand/collapse disclosure region. The trigger toggles a content
+ * area that animates open and closed.
+ *
+ * @example
+ * ```tsx
+ * <Collapsible>
+ *   <CollapsibleTrigger asChild>
+ *     <Button variant="ghost">Toggle details</Button>
+ *   </CollapsibleTrigger>
+ *   <CollapsibleContent>Hidden details…</CollapsibleContent>
+ * </Collapsible>
+ * ```
+ */
+function Collapsible({ ...props }: CollapsibleProps) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />;
+}
+
+/**
+ * CollapsibleTriggerProps
+ *
+ * Props for the CollapsibleTrigger.
+ */
+interface CollapsibleTriggerProps extends React.ComponentProps<
+  typeof CollapsiblePrimitive.CollapsibleTrigger
+> {}
+
+/**
+ * CollapsibleTrigger
+ *
+ * The control that toggles the collapsible. Unstyled by design — compose it
+ * with `asChild` around a `Button` (or any control) to give it an appearance.
+ */
+function CollapsibleTrigger({ ...props }: CollapsibleTriggerProps) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  );
+}
+
+/**
+ * CollapsibleContentProps
+ *
+ * Props for the CollapsibleContent.
+ */
+interface CollapsibleContentProps extends React.ComponentProps<
+  typeof CollapsiblePrimitive.CollapsibleContent
+> {}
+
+/**
+ * CollapsibleContent
+ *
+ * The region revealed when the collapsible is open. Animates its height open /
+ * closed via the `collapsible-down` / `collapsible-up` keyframes.
+ */
+function CollapsibleContent({ className, ...props }: CollapsibleContentProps) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      className={cn(
+        'nx:overflow-hidden nx:data-[state=closed]:animate-collapsible-up nx:data-[state=open]:animate-collapsible-down',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Collapsible,
+  CollapsibleContent,
+  type CollapsibleContentProps,
+  type CollapsibleProps,
+  CollapsibleTrigger,
+  type CollapsibleTriggerProps,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -20,6 +20,7 @@ export * from '@/components/ui/button';
 export * from '@/components/ui/button-group';
 export * from '@/components/ui/card';
 export * from '@/components/ui/checkbox';
+export * from '@/components/ui/collapsible';
 export * from '@/components/ui/command';
 export * from '@/components/ui/dialog';
 export * from '@/components/ui/dropdown-menu';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,7 +1095,7 @@
     "@radix-ui/react-use-previous" "1.1.1"
     "@radix-ui/react-use-size" "1.1.1"
 
-"@radix-ui/react-collapsible@1.1.12":
+"@radix-ui/react-collapsible@1.1.12", "@radix-ui/react-collapsible@^1.1.12":
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz#e2cc69a4490a2920f97c3c3150b0bf21281e3c49"
   integrity sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==


### PR DESCRIPTION
## Summary

- **Collapsible** (`#288`) adapted from shadcn/ui into `@nexus/react` — a single expand/collapse disclosure region wrapping Radix Collapsible (`@radix-ui/react-collapsible`, unified-import rewrite).
- `Collapsible` (Root) and `CollapsibleTrigger` are unstyled by design — the trigger is meant to be composed with `asChild` around a `Button` (mirrors shadcn).
- `CollapsibleContent` animates its height open/closed via the `collapsible-down` / `collapsible-up` keyframes (keyed to `--radix-collapsible-content-height`), **consistent with Accordion's content animation** — a deliberate Tier-A enhancement over bare shadcn (which ships the content unanimated). Verified the utilities + keyframes emit into `dist/react.css`.
- `data-slot` on all three parts. No variant/size props (like AspectRatio), so no `data-variant`/`data-size`.
- Stories: Default, Open, ClickInteraction, KeyboardInteraction, Disabled, WithDataAttributes, render-based `AllVariants` (closed + open states; base-variants showcase).
- Bundle: ESM ~70.9 kB (≈+0.1 kB — Radix Collapsible was already in the tree transitively via Accordion, so adding it as a direct dep just merges the lockfile key). Well under the 80 kB ceiling.

## GitHub Issue

Closes #288

## Test Plan

- [ ] CI: typecheck, lint, story-coverage audit (0/0), Bundle Size, Storybook play-fns (Click/Keyboard expand via `aria-expanded`)
- [ ] `AllVariants` renders across 5 bases × 2 themes (base-variants grid)