### PR TITLE
feat(components): add slider component

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -67,6 +67,7 @@
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
+    "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -87,6 +87,7 @@
       "showcase": "AllVariants",
       "interactions": ["ClickInteraction", "KeyboardInteraction"]
     },
+    { "name": "Slider", "showcase": "AllVariants" },
     { "name": "Show", "showcase": "AllAxes", "sourceDir": "primitives" },
     { "name": "Hide", "showcase": "AllAxes", "sourceDir": "primitives" },
     { "name": "Spinner", "showcase": "AllVariants" },

--- a/packages/react/src/components/ui/Slider.stories.tsx
+++ b/packages/react/src/components/ui/Slider.stories.tsx
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import { Slider } from './slider';
+
+const meta: Meta<typeof Slider> = {
+  title: 'Components/Slider',
+  component: Slider,
+  decorators: [
+    (Story) => (
+      <div className="nx:w-64">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Slider>;
+
+// A single-value slider.
+export const Default: Story = {
+  render: () => (
+    <Slider defaultValue={[50]} max={100} step={1} aria-label="Volume" />
+  ),
+};
+
+// Two thumbs define a range.
+export const Range: Story = {
+  render: () => (
+    <Slider
+      defaultValue={[25, 75]}
+      max={100}
+      step={1}
+      aria-label="Price range"
+    />
+  ),
+};
+
+// Larger step increments snap the thumb.
+export const Steps: Story = {
+  render: () => (
+    <Slider defaultValue={[40]} max={100} step={10} aria-label="Brightness" />
+  ),
+};
+
+// Vertical orientation.
+export const Vertical: Story = {
+  render: () => (
+    <div className="nx:flex nx:h-48 nx:justify-center">
+      <Slider
+        defaultValue={[50]}
+        max={100}
+        step={1}
+        orientation="vertical"
+        aria-label="Vertical volume"
+      />
+    </div>
+  ),
+};
+
+// Arrow keys move the focused thumb and update aria-valuenow.
+export const KeyboardInteraction: Story = {
+  args: { onValueChange: fn() },
+  render: (args) => (
+    <Slider
+      defaultValue={[50]}
+      max={100}
+      step={1}
+      aria-label="Volume"
+      onValueChange={args.onValueChange}
+    />
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const thumb = canvas.getByRole('slider');
+    await expect(thumb).toHaveAttribute('aria-valuenow', '50');
+    await userEvent.tab();
+    await expect(thumb).toHaveFocus();
+    await userEvent.keyboard('{ArrowRight}');
+    await expect(thumb).toHaveAttribute('aria-valuenow', '51');
+    await expect(args.onValueChange).toHaveBeenCalledWith([51]);
+  },
+};
+
+// A disabled slider does not respond to interaction.
+export const Disabled: Story = {
+  render: () => (
+    <Slider disabled defaultValue={[50]} max={100} aria-label="Volume" />
+  ),
+  play: async ({ canvasElement }) => {
+    const slider = canvasElement.querySelector('[data-slot="slider"]');
+    // Radix marks the disabled state with data-disabled on the root; the thumb
+    // is dimmed via the root's opacity, and interaction is blocked by Radix.
+    await expect(slider).toHaveAttribute('data-disabled');
+    await expect(
+      canvasElement.querySelector('[data-slot="slider"]')
+    ).toBeInTheDocument();
+  },
+};
+
+// data-slot identifies the root, track, range, and thumb.
+export const WithDataAttributes: Story = {
+  render: () => <Slider defaultValue={[50]} max={100} aria-label="Volume" />,
+  play: async ({ canvasElement }) => {
+    await expect(
+      canvasElement.querySelector('[data-slot="slider"]')
+    ).toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-slot="slider-track"]')
+    ).toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-slot="slider-range"]')
+    ).toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-slot="slider-thumb"]')
+    ).toBeInTheDocument();
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// Single, range, and disabled sliders. Reused by the per-base variant generator.
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-64 nx:flex-col nx:gap-8">
+      <Slider defaultValue={[50]} max={100} step={1} aria-label="Single" />
+      <Slider defaultValue={[25, 75]} max={100} step={1} aria-label="Range" />
+      <Slider disabled defaultValue={[40]} max={100} aria-label="Disabled" />
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/slider.tsx
+++ b/packages/react/src/components/ui/slider.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+
+import * as SliderPrimitive from '@radix-ui/react-slider';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * SliderProps
+ *
+ * Props for the Slider component.
+ */
+interface SliderProps extends React.ComponentProps<
+  typeof SliderPrimitive.Root
+> {}
+
+/**
+ * Slider
+ *
+ * A value / range slider built on Radix Slider. Renders one thumb per value, so
+ * a single `defaultValue={[50]}` is a value slider and `defaultValue={[25, 75]}`
+ * is a range slider. Supports steps, keyboard, and vertical orientation.
+ *
+ * @example
+ * ```tsx
+ * <Slider defaultValue={[50]} max={100} step={1} />
+ * <Slider defaultValue={[25, 75]} max={100} step={1} />
+ * ```
+ */
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
+  ...props
+}: SliderProps) {
+  // Derive the thumb count from the controlled/uncontrolled value; fall back to
+  // a two-thumb range spanning the track when neither is provided.
+  const values = React.useMemo(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max]
+  );
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        'nx:relative nx:flex nx:w-full nx:touch-none nx:items-center nx:select-none nx:data-[disabled]:opacity-50 nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:min-h-44 nx:data-[orientation=vertical]:w-auto nx:data-[orientation=vertical]:flex-col',
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:bg-muted nx:data-[orientation=horizontal]:h-1.5 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-1.5"
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className="nx:absolute nx:bg-primary-background nx:data-[orientation=horizontal]:h-full nx:data-[orientation=vertical]:w-full"
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          key={index}
+          // Radix names the thumb (role="slider") from its own aria-label, not
+          // the Root's — forward it to the thumb (and keep it off the role-less
+          // Root span, where it would be a prohibited ARIA attribute).
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledby}
+          className="nx:block nx:size-4 nx:shrink-0 nx:rounded-full nx:border nx:border-border-primary nx:bg-background nx:transition-colors nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  );
+}
+
+export { Slider, type SliderProps };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -44,6 +44,7 @@ export * from '@/components/ui/separator';
 export * from '@/components/ui/sheet';
 export * from '@/components/ui/sidebar';
 export * from '@/components/ui/skeleton';
+export * from '@/components/ui/slider';
 export * from '@/components/ui/sonner';
 export * from '@/components/ui/spinner';
 export * from '@/components/ui/switch';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,6 +1390,23 @@
   dependencies:
     "@radix-ui/react-primitive" "2.1.4"
 
+"@radix-ui/react-slider@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slider/-/react-slider-1.3.6.tgz#409453110b8f34ca00972750b80cd792f0b23a8c"
+  integrity sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==
+  dependencies:
+    "@radix-ui/number" "1.1.1"
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-collection" "1.1.7"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-direction" "1.1.1"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+    "@radix-ui/react-use-previous" "1.1.1"
+    "@radix-ui/react-use-size" "1.1.1"
+
 "@radix-ui/react-slot@1.2.3":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.2.3.tgz#502d6e354fc847d4169c3bc5f189de777f68cfe1"


### PR DESCRIPTION
## Summary

- **Slider** (`#295`) adapted from shadcn/ui into `@nexus/react` (Radix Slider, `@radix-ui/react-slider` unified-import rewrite).
- Renders **one thumb per value**, so `defaultValue={[50]}` is a value slider and `defaultValue={[25, 75]}` is a range slider. Supports `step`, full keyboard, and vertical orientation.
- Token mapping: track → `nx:bg-muted`, range → `nx:bg-primary-background`, thumb border → `nx:border-border-primary`, thumb fill → `nx:bg-background` (adaptive, not a literal white). Canonical **outline** focus ring on the thumb (dropped shadcn's box-shadow `ring-*` + `shadow-sm`, per the no-shadow-on-focusable-controls rule).
- **a11y:** forwards `aria-label` / `aria-labelledby` to each thumb (the `role="slider"` element Radix names from its *own* aria-label), and keeps them off the role-less Root span (where they'd be a prohibited ARIA attribute). Consumers pass a label per slider.
- `data-slot` on root/track/range/thumb. No variant/size props.
- Stories: Default, Range, Steps, Vertical, KeyboardInteraction (asserts `aria-valuenow` after ArrowRight), Disabled (asserts `data-disabled`, no click), WithDataAttributes, render-based `AllVariants`.
- Bundle: ESM ~73 kB / 80 kB ceiling.

## GitHub Issue

Closes #295

## Test Plan

- [ ] CI: typecheck, lint, story-coverage audit (0/0), Bundle Size, Storybook play-fns + axe (slider thumb has an accessible name)
- [ ] `AllVariants` renders across 5 bases × 2 themes