### PR TITLE
feat(components): add hover-card component

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -60,6 +60,7 @@
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-progress": "^1.1.8",

--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -47,6 +47,7 @@
     },
     { "name": "EmptyState", "showcase": "AllVariants" },
     { "name": "Field", "showcase": "AllVariants" },
+    { "name": "HoverCard", "showcase": "AllVariants" },
     {
       "name": "Input",
       "showcase": "AllVariants",

--- a/packages/react/src/components/ui/HoverCard.stories.tsx
+++ b/packages/react/src/components/ui/HoverCard.stories.tsx
@@ -1,0 +1,127 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { Button } from './button';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from './hover-card';
+
+const meta: Meta<typeof HoverCard> = {
+  title: 'Components/HoverCard',
+  component: HoverCard,
+};
+
+export default meta;
+type Story = StoryObj<typeof HoverCard>;
+
+// A profile-preview card revealed on hover.
+export const Default: Story = {
+  render: () => (
+    <HoverCard>
+      <HoverCardTrigger asChild>
+        <Button variant="link">@nexus</Button>
+      </HoverCardTrigger>
+      <HoverCardContent>
+        <div className="nx:flex nx:flex-col nx:gap-1">
+          <p className="nx:text-sm nx:font-semibold nx:text-foreground">
+            @nexus
+          </p>
+          <p className="nx:text-sm nx:text-muted-foreground">
+            The AI-native design system. Joined March 2026.
+          </p>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  ),
+};
+
+// Hovering the trigger opens the card; moving away closes it.
+export const OpenCloseInteraction: Story = {
+  render: () => (
+    <HoverCard openDelay={0} closeDelay={0}>
+      <HoverCardTrigger asChild>
+        <Button variant="link">@nexus</Button>
+      </HoverCardTrigger>
+      <HoverCardContent>Joined March 2026</HoverCardContent>
+    </HoverCard>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: '@nexus' });
+
+    await userEvent.hover(trigger);
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="hover-card-content"]')
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.unhover(trigger);
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="hover-card-content"]')
+      ).toBeNull();
+    });
+  },
+};
+
+// Focusing the trigger via keyboard opens the card (a11y).
+export const KeyboardInteraction: Story = {
+  render: () => (
+    <HoverCard openDelay={0} closeDelay={0}>
+      <HoverCardTrigger asChild>
+        <Button variant="link">@nexus</Button>
+      </HoverCardTrigger>
+      <HoverCardContent>Joined March 2026</HoverCardContent>
+    </HoverCard>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: '@nexus' });
+
+    await userEvent.tab();
+    await expect(trigger).toHaveFocus();
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="hover-card-content"]')
+      ).toBeInTheDocument();
+    });
+  },
+};
+
+// data-slot identifies the root (via trigger/content), trigger, and content.
+export const WithDataAttributes: Story = {
+  render: () => (
+    <HoverCard defaultOpen>
+      <HoverCardTrigger asChild>
+        <Button variant="link">@nexus</Button>
+      </HoverCardTrigger>
+      <HoverCardContent>Content</HoverCardContent>
+    </HoverCard>
+  ),
+  play: async ({ canvasElement }) => {
+    await expect(
+      canvasElement.querySelector('[data-slot="hover-card-trigger"]')
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="hover-card-content"]')
+      ).toBeInTheDocument();
+    });
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+// The (closed) trigger across bases — the card portals to the body, so the
+// showcase renders the resting trigger. Reused by the per-base variant generator.
+export const AllVariants: Story = {
+  render: () => (
+    <HoverCard>
+      <HoverCardTrigger asChild>
+        <Button variant="link">@nexus</Button>
+      </HoverCardTrigger>
+      <HoverCardContent>Joined March 2026</HoverCardContent>
+    </HoverCard>
+  ),
+};

--- a/packages/react/src/components/ui/hover-card.tsx
+++ b/packages/react/src/components/ui/hover-card.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+
+import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * HoverCardProps
+ *
+ * Props for the HoverCard root.
+ */
+interface HoverCardProps extends React.ComponentProps<
+  typeof HoverCardPrimitive.Root
+> {}
+
+/**
+ * HoverCard
+ *
+ * A popover-style card revealed when the user hovers (or focuses) the trigger —
+ * for rich previews (profile cards, link previews). Opens on hover intent, not
+ * click; for click-driven content use `Popover`.
+ *
+ * @example
+ * ```tsx
+ * <HoverCard>
+ *   <HoverCardTrigger asChild>
+ *     <a href="/users/nexus">@nexus</a>
+ *   </HoverCardTrigger>
+ *   <HoverCardContent>Joined March 2026 · 1.2k followers</HoverCardContent>
+ * </HoverCard>
+ * ```
+ */
+function HoverCard({ ...props }: HoverCardProps) {
+  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />;
+}
+
+/**
+ * HoverCardTriggerProps
+ *
+ * Props for the HoverCardTrigger.
+ */
+interface HoverCardTriggerProps extends React.ComponentProps<
+  typeof HoverCardPrimitive.Trigger
+> {}
+
+/**
+ * HoverCardTrigger
+ *
+ * The element that reveals the card on hover / focus. Use `asChild` to render
+ * as your own element (a link, an avatar).
+ */
+function HoverCardTrigger({ ...props }: HoverCardTriggerProps) {
+  return (
+    <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+  );
+}
+
+/**
+ * HoverCardContentProps
+ *
+ * Props for the HoverCardContent component.
+ */
+interface HoverCardContentProps extends React.ComponentProps<
+  typeof HoverCardPrimitive.Content
+> {}
+
+/**
+ * HoverCardContent
+ *
+ * The floating card, anchored to the trigger and portaled to the body.
+ *
+ * @example
+ * ```tsx
+ * <HoverCardContent align="start" sideOffset={8}>
+ *   <p>Preview content</p>
+ * </HoverCardContent>
+ * ```
+ */
+function HoverCardContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ...props
+}: HoverCardContentProps) {
+  return (
+    <HoverCardPrimitive.Portal>
+      <HoverCardPrimitive.Content
+        data-slot="hover-card-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'nx:z-popover nx:w-64 nx:p-container nx:outline-none',
+          'nx:rounded-md nx:border nx:border-border-default nx:bg-popover nx:text-popover-foreground nx:shadow-base',
+          'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
+          'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
+          'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',
+          'nx:data-[side=bottom]:slide-in-from-top-2 nx:data-[side=left]:slide-in-from-right-2',
+          'nx:data-[side=right]:slide-in-from-left-2 nx:data-[side=top]:slide-in-from-bottom-2',
+          className
+        )}
+        {...props}
+      />
+    </HoverCardPrimitive.Portal>
+  );
+}
+
+export {
+  HoverCard,
+  HoverCardContent,
+  type HoverCardContentProps,
+  type HoverCardProps,
+  HoverCardTrigger,
+  type HoverCardTriggerProps,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -27,6 +27,7 @@ export * from '@/components/ui/dropdown-menu';
 export * from '@/components/ui/empty-state';
 export * from '@/components/ui/field';
 export * from '@/components/ui/form';
+export * from '@/components/ui/hover-card';
 export * from '@/components/ui/input';
 export * from '@/components/ui/input-group';
 export * from '@/components/ui/input-otp';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1197,6 +1197,21 @@
     "@radix-ui/react-primitive" "2.1.3"
     "@radix-ui/react-use-callback-ref" "1.1.1"
 
+"@radix-ui/react-hover-card@^1.1.15":
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz#9bc7ed55c37a9032acdfcc7cfa5c73b117cffe5e"
+  integrity sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-dismissable-layer" "1.1.11"
+    "@radix-ui/react-popper" "1.2.8"
+    "@radix-ui/react-portal" "1.1.9"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+
 "@radix-ui/react-id@1.1.1", "@radix-ui/react-id@^1.1.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.1.tgz#1404002e79a03fe062b7e3864aa01e24bd1471f7"


### PR DESCRIPTION
## Summary

- **Hover Card** (`#291`) adapted from shadcn/ui into `@nexus/react` (Radix HoverCard, `@radix-ui/react-hover-card` unified-import rewrite). Reveals a floating card on **hover / focus intent** (not click) — for profile/link previews; for click-driven content use `Popover`.
- `data-slot` on root, trigger, and portaled content. Content mirrors the shipped Popover surface: `nx:z-popover`, `nx:p-container`, `nx:bg-popover`, border, and the fade/zoom open/close animations.
- **Shadow correctness:** uses `nx:shadow-base`, **not** the popover family's `nx:shadow-md`. Nexus has no `shadow-md` token (scale is `xs/sm/base/lg/xl`), so `nx:shadow-md` is inert — copying it would leave the floating card with no elevation. `shadow-base` is the faithful medium-tier mapping of shadcn's `shadow-md`.
- Stories: Default (profile preview), OpenCloseInteraction (hover opens / unhover closes, asserted via the portaled `data-slot` node), KeyboardInteraction (focus opens), WithDataAttributes (`defaultOpen`), render-based `AllVariants` (resting trigger — the card portals to the body).
- Bundle: ESM ~74 kB / 80 kB ceiling — only ~0.9 kB added (HoverCard shares the already-bundled Radix popper).

## Note (pre-existing, not in this PR)

While mapping the shadow, I found the shipped **Popover** and **Select** content also use the inert `nx:shadow-md` → they currently render with no elevation shadow. Out of scope for this PR (separate shipped components); flagging for a focused follow-up.

## GitHub Issue

Closes #291

## Test Plan

- [ ] CI: typecheck, lint, story-coverage audit (0/0), Bundle Size, Storybook play-fns (hover/focus open, unhover close) + axe
- [ ] `AllVariants` renders across 5 bases × 2 themes