### PR TITLE
fix(components): elevate popover-family content with shadow-lg

### DIFF
--- a/packages/react/src/components/ui/dropdown-menu.tsx
+++ b/packages/react/src/components/ui/dropdown-menu.tsx
@@ -185,7 +185,7 @@ function DropdownMenuContent({
           'nx:min-w-[8rem] nx:overflow-x-hidden nx:overflow-y-auto',
           'nx:rounded-md nx:border nx:border-border-default',
           // nexus-allow-numeric: popover chrome (sub-canonical inner padding)
-          'nx:bg-popover nx:p-1 nx:text-popover-foreground nx:shadow-md',
+          'nx:bg-popover nx:p-1 nx:text-popover-foreground nx:shadow-lg',
           'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
           'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
           'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',

--- a/packages/react/src/components/ui/hover-card.tsx
+++ b/packages/react/src/components/ui/hover-card.tsx
@@ -90,7 +90,7 @@ function HoverCardContent({
         sideOffset={sideOffset}
         className={cn(
           'nx:z-popover nx:w-64 nx:p-container nx:outline-none',
-          'nx:rounded-md nx:border nx:border-border-default nx:bg-popover nx:text-popover-foreground nx:shadow-base',
+          'nx:rounded-md nx:border nx:border-border-default nx:bg-popover nx:text-popover-foreground nx:shadow-lg',
           'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
           'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
           'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',

--- a/packages/react/src/components/ui/popover.tsx
+++ b/packages/react/src/components/ui/popover.tsx
@@ -72,7 +72,7 @@ function PopoverContent({
         sideOffset={sideOffset}
         className={cn(
           'nx:z-popover nx:w-72 nx:p-container nx:outline-none',
-          'nx:rounded-md nx:border nx:border-border-default nx:bg-popover nx:text-popover-foreground nx:shadow-md',
+          'nx:rounded-md nx:border nx:border-border-default nx:bg-popover nx:text-popover-foreground nx:shadow-lg',
           'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
           'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
           'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',

--- a/packages/react/src/components/ui/select.tsx
+++ b/packages/react/src/components/ui/select.tsx
@@ -168,7 +168,7 @@ function SelectContent({
         data-slot="select-content"
         className={cn(
           'nx:relative nx:z-popover nx:max-h-96 nx:min-w-[8rem] nx:overflow-hidden',
-          'nx:rounded-md nx:border nx:border-border-default nx:bg-popover nx:text-popover-foreground nx:shadow-md',
+          'nx:rounded-md nx:border nx:border-border-default nx:bg-popover nx:text-popover-foreground nx:shadow-lg',
           'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
           'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
           'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',


### PR DESCRIPTION
## Summary

`nx:shadow-md` is **inert** — Nexus has no `shadow-md` token (the scale is `xs / sm / base / lg / xl`). Three floating content panels referenced it and so rendered with **no elevation shadow**:

- `PopoverContent` (popover.tsx)
- `SelectContent` (select.tsx)
- `DropdownMenuSubContent` (dropdown-menu.tsx)

This maps all three to **`nx:shadow-lg`** — the elevation already used by `DropdownMenuContent` (main), `Dialog`, `AlertDialog`, and `Sheet`. It also aligns the just-added **HoverCard** (which shipped with `nx:shadow-base`) onto the same `nx:shadow-lg`, so the whole floating-panel family now shares one elevation.

Found while adapting HoverCard (#291). Surgical: 4 className edits, no new tokens/deps; ESM + CSS size unchanged.

## Test Plan

- [ ] CI: typecheck, lint, format, Bundle Size, Storybook render + axe for Popover / Select / DropdownMenu / HoverCard
- [ ] Popover/Select content visibly elevates (had no shadow before)