### PR TITLE
feat(console): Billing module — plan, usage, payment, invoices (Phase 3c)

### DIFF
--- a/apps/console/src/app/router.tsx
+++ b/apps/console/src/app/router.tsx
@@ -10,6 +10,7 @@ import { ForgotRoute } from '../modules/auth/forgot-route';
 import { LoginRoute } from '../modules/auth/login-route';
 import { SignupRoute } from '../modules/auth/signup-route';
 import { VerifyRoute } from '../modules/auth/verify-route';
+import { BillingRoute } from '../modules/billing/billing-route';
 import { ComingSoon } from '../modules/coming-soon';
 import { ContactDetailRoute } from '../modules/crm/contact-detail-route';
 import { ContactsRoute } from '../modules/crm/contacts-route';
@@ -121,6 +122,14 @@ const inboxRoute = createRoute({
   component: InboxRoute,
 });
 
+// Billing (Phase 3c). Static `/m/billing` outranks `/m/$module`. Single-page
+// dashboard — no search params.
+const billingRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: '/m/billing',
+  component: BillingRoute,
+});
+
 // One shared placeholder backs every not-yet-built module.
 const moduleRoute = createRoute({
   getParentRoute: () => appRoute,
@@ -174,6 +183,7 @@ const routeTree = rootRoute.addChildren([
     projectsIssuesRoute,
     projectsIssueDetailRoute,
     inboxRoute,
+    billingRoute,
     moduleRoute,
   ]),
   authRoute.addChildren([loginRoute, signupRoute, verifyRoute, forgotRoute]),

--- a/apps/console/src/lib/billing-api.ts
+++ b/apps/console/src/lib/billing-api.ts
@@ -67,8 +67,8 @@ export const PLAN_TIERS: PlanTier[] = [
 
 export type BillingCycle = 'monthly' | 'annual';
 
-/** Whether the subscription is live or wound down (still active until renewal). */
-export type SubscriptionStatus = 'active' | 'canceled';
+/** Live, or canceling at period end — still active until {@link Subscription.renewsAt}. */
+export type SubscriptionStatus = 'active' | 'canceling';
 
 /** The customer's live subscription — what the overview renders. */
 export type Subscription = {
@@ -167,7 +167,7 @@ async function mutateSubscription(
   return (await res.json()) as { subscription: Subscription };
 }
 
-/** Switch tier and/or billing cycle — also reactivates a canceled subscription. */
+/** Switch tier and/or billing cycle — also reactivates a canceling subscription. */
 export const changePlan = (selection: PlanSelection) =>
   mutateSubscription('/api/billing/subscription', 'PATCH', selection);
 

--- a/apps/console/src/lib/billing-api.ts
+++ b/apps/console/src/lib/billing-api.ts
@@ -1,0 +1,180 @@
+/**
+ * Billing API client. Thin typed wrappers over the mock endpoints served by MSW
+ * (`src/mocks/handlers.ts`) — there is no real backend. Mirrors the CRM /
+ * Projects / Inbox shape: a single query-key object, `as const` enums, and
+ * fetch/mutate fns.
+ *
+ * Two deliberately distinct shapes (the list/detail discipline again): the
+ * static {@link PLAN_TIERS} catalog (what the change-plan picker renders — every
+ * tier with both prices + features) vs the live {@link Subscription} (what the
+ * overview renders — the current tier, cycle, status, and renewal date).
+ */
+
+/** Plan tiers — the single source for {@link PlanTierId} and the catalog order. */
+export const PLAN_TIER_IDS = ['starter', 'pro', 'scale'] as const;
+export type PlanTierId = (typeof PLAN_TIER_IDS)[number];
+
+/** A catalog entry — static product data, not the customer's subscription. */
+export type PlanTier = {
+  id: PlanTierId;
+  name: string;
+  /** Whole-dollar price per month, billed monthly. */
+  monthlyPrice: number;
+  /** Whole-dollar effective price per month, billed annually. */
+  annualPrice: number;
+  blurb: string;
+  features: string[];
+};
+
+/** The plan catalog the change-plan picker renders. */
+export const PLAN_TIERS: PlanTier[] = [
+  {
+    id: 'starter',
+    name: 'Starter',
+    monthlyPrice: 0,
+    annualPrice: 0,
+    blurb: 'For trying things out.',
+    features: ['1 workspace', 'Up to 3 seats', 'Community support'],
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    monthlyPrice: 29,
+    annualPrice: 24,
+    blurb: 'For growing teams that need room to scale.',
+    features: [
+      'Unlimited workspaces',
+      'Up to 25 seats',
+      'Priority support',
+      'Advanced analytics',
+    ],
+  },
+  {
+    id: 'scale',
+    name: 'Scale',
+    monthlyPrice: 99,
+    annualPrice: 79,
+    blurb: 'For larger orgs with security and compliance needs.',
+    features: [
+      'Everything in Pro',
+      'Unlimited seats',
+      'SSO & SAML',
+      'Dedicated manager',
+      'Audit log',
+    ],
+  },
+];
+
+export type BillingCycle = 'monthly' | 'annual';
+
+/** Whether the subscription is live or wound down (still active until renewal). */
+export type SubscriptionStatus = 'active' | 'canceled';
+
+/** The customer's live subscription — what the overview renders. */
+export type Subscription = {
+  tier: PlanTierId;
+  cycle: BillingCycle;
+  status: SubscriptionStatus;
+  /** ISO date the current period ends — the renewal date, or end-of-access. */
+  renewsAt: string;
+};
+
+/** A metered resource — rendered as a labelled Progress bar. */
+export type UsageMeter = {
+  id: string;
+  label: string;
+  used: number;
+  limit: number;
+  /** Display suffix, e.g. `seats`, `GB`. */
+  unit: string;
+};
+
+/** The card on file — masked, like every payment UI. */
+export type PaymentMethod = {
+  brand: string;
+  last4: string;
+  expMonth: number;
+  expYear: number;
+};
+
+/** Invoice lifecycle — single source for {@link InvoiceStatus} + the badge. */
+export const INVOICE_STATUSES = ['paid', 'open', 'failed'] as const;
+export type InvoiceStatus = (typeof INVOICE_STATUSES)[number];
+
+export type Invoice = {
+  id: string;
+  /** Human-readable identifier, e.g. `INV-2026-0007`. */
+  number: string;
+  /** ISO date (YYYY-MM-DD) the invoice was issued. */
+  date: string;
+  /** Amount in dollars, with cents — render with {@link formatMoney}. */
+  amount: number;
+  status: InvoiceStatus;
+};
+
+/** The billing overview payload — current subscription + usage + card on file. */
+export type BillingOverview = {
+  subscription: Subscription;
+  usage: UsageMeter[];
+  paymentMethod: PaymentMethod;
+};
+
+/** The editable subscription fields — `status` and `renewsAt` are server-set. */
+export type PlanSelection = {
+  tier: PlanTierId;
+  cycle: BillingCycle;
+};
+
+/**
+ * TanStack Query keys for the Billing module — declared once so the overview,
+ * invoices, and mutations can't drift apart.
+ */
+export const billingKeys = {
+  all: ['billing'] as const,
+  overview: ['billing', 'overview'] as const,
+  invoices: ['billing', 'invoices'] as const,
+};
+
+export async function fetchBilling(): Promise<BillingOverview> {
+  const res = await fetch('/api/billing');
+  if (!res.ok) {
+    throw new Error('Failed to load billing. Please try again.');
+  }
+  return (await res.json()) as BillingOverview;
+}
+
+export async function fetchInvoices(): Promise<{ invoices: Invoice[] }> {
+  const res = await fetch('/api/billing/invoices');
+  if (!res.ok) {
+    throw new Error('Failed to load invoices. Please try again.');
+  }
+  return (await res.json()) as { invoices: Invoice[] };
+}
+
+async function mutateSubscription(
+  url: string,
+  method: 'POST' | 'PATCH',
+  body?: PlanSelection
+): Promise<{ subscription: Subscription }> {
+  const res = await fetch(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    throw new Error('Failed to update your subscription. Please try again.');
+  }
+  return (await res.json()) as { subscription: Subscription };
+}
+
+/** Switch tier and/or billing cycle — also reactivates a canceled subscription. */
+export const changePlan = (selection: PlanSelection) =>
+  mutateSubscription('/api/billing/subscription', 'PATCH', selection);
+
+/** Wind down at period end — stays active until `renewsAt`. */
+export const cancelSubscription = () =>
+  mutateSubscription('/api/billing/cancel', 'POST');
+
+/** Undo a pending cancellation — back to `active`. */
+export const reactivateSubscription = () =>
+  mutateSubscription('/api/billing/reactivate', 'POST');

--- a/apps/console/src/lib/format.ts
+++ b/apps/console/src/lib/format.ts
@@ -14,6 +14,12 @@ const currencyFmt = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 0,
 });
 
+// Cents-precise — for invoice line amounts, where whole-dollar would read wrong.
+const moneyFmt = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
 const dateFmt = new Intl.DateTimeFormat('en-US', {
   month: 'short',
   day: 'numeric',
@@ -31,6 +37,7 @@ const dateTimeFmt = new Intl.DateTimeFormat('en-US', {
 });
 
 export const formatCurrency = (value: number) => currencyFmt.format(value);
+export const formatMoney = (value: number) => moneyFmt.format(value);
 export const formatDate = (iso: string) => dateFmt.format(new Date(iso));
 export const formatDateTime = (iso: string) =>
   dateTimeFmt.format(new Date(iso));

--- a/apps/console/src/mocks/billing-fixtures.ts
+++ b/apps/console/src/mocks/billing-fixtures.ts
@@ -1,0 +1,86 @@
+import type { BillingOverview, Invoice } from '../lib/billing-api';
+
+/**
+ * Deterministic seed billing state. The customer is on Pro / monthly, active,
+ * renewing on a fixed future date (no `new Date()` — keeps the demo stable and
+ * lets a fresh invoice sort predictably). Usage spans a comfortable, a high, and
+ * a near-cap meter so the bars and the at-capacity label treatment both show.
+ */
+export const BILLING_OVERVIEW: BillingOverview = {
+  subscription: {
+    tier: 'pro',
+    cycle: 'monthly',
+    status: 'active',
+    renewsAt: '2026-07-01',
+  },
+  usage: [
+    { id: 'seats', label: 'Seats', used: 18, limit: 25, unit: 'seats' },
+    { id: 'storage', label: 'Storage', used: 88, limit: 100, unit: 'GB' },
+    { id: 'projects', label: 'Projects', used: 9, limit: 10, unit: 'projects' },
+  ],
+  paymentMethod: { brand: 'Visa', last4: '4242', expMonth: 8, expYear: 2027 },
+};
+
+/**
+ * Past invoices, newest first. Amounts carry cents (rendered with `formatMoney`,
+ * not the whole-dollar `formatCurrency`); statuses span paid / open / failed so
+ * the table's status badge has variety.
+ */
+export const INVOICES: Invoice[] = [
+  {
+    id: 'inv-08',
+    number: 'INV-0008',
+    date: '2026-06-01',
+    amount: 29.0,
+    status: 'open',
+  },
+  {
+    id: 'inv-07',
+    number: 'INV-0007',
+    date: '2026-05-01',
+    amount: 29.0,
+    status: 'paid',
+  },
+  {
+    id: 'inv-06',
+    number: 'INV-0006',
+    date: '2026-04-01',
+    amount: 43.5,
+    status: 'paid',
+  },
+  {
+    id: 'inv-05',
+    number: 'INV-0005',
+    date: '2026-03-01',
+    amount: 29.0,
+    status: 'failed',
+  },
+  {
+    id: 'inv-04',
+    number: 'INV-0004',
+    date: '2026-02-01',
+    amount: 29.0,
+    status: 'paid',
+  },
+  {
+    id: 'inv-03',
+    number: 'INV-0003',
+    date: '2026-01-01',
+    amount: 29.0,
+    status: 'paid',
+  },
+  {
+    id: 'inv-02',
+    number: 'INV-0002',
+    date: '2025-12-01',
+    amount: 35.2,
+    status: 'paid',
+  },
+  {
+    id: 'inv-01',
+    number: 'INV-0001',
+    date: '2025-11-01',
+    amount: 29.0,
+    status: 'paid',
+  },
+];

--- a/apps/console/src/mocks/handlers.ts
+++ b/apps/console/src/mocks/handlers.ts
@@ -1,6 +1,11 @@
 import { delay, http, HttpResponse, type RequestHandler } from 'msw';
 
 import type { User } from '../lib/auth-api';
+import type {
+  BillingOverview,
+  Invoice,
+  PlanSelection,
+} from '../lib/billing-api';
 import type { ActivityItem, Contact, ContactInput } from '../lib/crm-api';
 import type {
   Conversation,
@@ -9,6 +14,7 @@ import type {
 } from '../lib/inbox-api';
 import type { Issue, IssueInput } from '../lib/projects-api';
 
+import { BILLING_OVERVIEW, INVOICES } from './billing-fixtures';
 import { CONTACTS } from './crm-fixtures';
 import { CONVERSATIONS } from './inbox-fixtures';
 import { ISSUES } from './projects-fixtures';
@@ -92,6 +98,15 @@ const conversationsStore: ConversationDetail[] = CONVERSATIONS.map((c) => ({
   ...c,
   messages: c.messages.map((m) => ({ ...m })),
 }));
+
+// In-memory Billing store (same session lifecycle). The subscription mutates
+// (change plan / cancel / reactivate); usage, the card, and invoices are read-only.
+const billing: BillingOverview = {
+  subscription: { ...BILLING_OVERVIEW.subscription },
+  usage: BILLING_OVERVIEW.usage.map((u) => ({ ...u })),
+  paymentMethod: { ...BILLING_OVERVIEW.paymentMethod },
+};
+const invoicesStore: Invoice[] = INVOICES.map((i) => ({ ...i }));
 
 /**
  * MSW request handlers — there is no real backend. Auth is a two-step flow: a
@@ -344,4 +359,41 @@ export const handlers: RequestHandler[] = [
       return HttpResponse.json({ conversation });
     }
   ),
+
+  // --- Billing ---
+  // The overview: current subscription + usage meters + the card on file.
+  http.get('/api/billing', async () => {
+    await delay(500);
+    return HttpResponse.json(billing);
+  }),
+
+  // Past invoices (the transactions table). Read-only; newest first.
+  http.get('/api/billing/invoices', async () => {
+    await delay(400);
+    return HttpResponse.json({ invoices: invoicesStore });
+  }),
+
+  // Change tier and/or cycle — also clears a pending cancellation.
+  http.patch('/api/billing/subscription', async ({ request }) => {
+    await delay(300);
+    const { tier, cycle } = (await request.json()) as PlanSelection;
+    billing.subscription.tier = tier;
+    billing.subscription.cycle = cycle;
+    billing.subscription.status = 'active';
+    return HttpResponse.json({ subscription: billing.subscription });
+  }),
+
+  // Cancel: wind down at period end — stays active until renewsAt.
+  http.post('/api/billing/cancel', async () => {
+    await delay(300);
+    billing.subscription.status = 'canceled';
+    return HttpResponse.json({ subscription: billing.subscription });
+  }),
+
+  // Reactivate: undo a pending cancellation.
+  http.post('/api/billing/reactivate', async () => {
+    await delay(300);
+    billing.subscription.status = 'active';
+    return HttpResponse.json({ subscription: billing.subscription });
+  }),
 ];

--- a/apps/console/src/mocks/handlers.ts
+++ b/apps/console/src/mocks/handlers.ts
@@ -386,7 +386,7 @@ export const handlers: RequestHandler[] = [
   // Cancel: wind down at period end — stays active until renewsAt.
   http.post('/api/billing/cancel', async () => {
     await delay(300);
-    billing.subscription.status = 'canceled';
+    billing.subscription.status = 'canceling';
     return HttpResponse.json({ subscription: billing.subscription });
   }),
 

--- a/apps/console/src/modules/billing/billing-route.tsx
+++ b/apps/console/src/modules/billing/billing-route.tsx
@@ -109,7 +109,7 @@ function PlanCard({
   const queryClient = useQueryClient();
   const tier = planTier(subscription.tier);
   const price = tierPrice(tier, subscription.cycle);
-  const canceled = subscription.status === 'canceled';
+  const canceling = subscription.status === 'canceling';
 
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: billingKeys.overview });
@@ -149,7 +149,7 @@ function PlanCard({
               ? 'Free'
               : `${formatCurrency(price)}/mo · billed ${subscription.cycle}`}
           </span>
-          {canceled ? (
+          {canceling ? (
             <Badge variant="warning">Canceling</Badge>
           ) : (
             <Badge variant="success">Active</Badge>
@@ -157,8 +157,8 @@ function PlanCard({
         </div>
 
         <p className="nx:text-muted-foreground nx:text-sm">
-          {canceled
-            ? `Your plan is canceled and ends on ${formatDate(subscription.renewsAt)}. You'll keep access until then.`
+          {canceling
+            ? `Your plan is set to cancel on ${formatDate(subscription.renewsAt)}. You'll keep access until then.`
             : `Renews on ${formatDate(subscription.renewsAt)}.`}
         </p>
 
@@ -166,7 +166,7 @@ function PlanCard({
           <Button variant="outline" onClick={onChangePlan}>
             Change plan
           </Button>
-          {canceled ? (
+          {canceling ? (
             <Button
               variant="secondary"
               onClick={() => reactivateMutation.mutate()}

--- a/apps/console/src/modules/billing/billing-route.tsx
+++ b/apps/console/src/modules/billing/billing-route.tsx
@@ -1,0 +1,391 @@
+import { useState } from 'react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Progress,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  toast,
+} from '@nexus/react';
+import { IconCreditCard } from '@tabler/icons-react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  billingKeys,
+  type BillingOverview,
+  cancelSubscription,
+  fetchBilling,
+  fetchInvoices,
+  type Invoice,
+  type PaymentMethod,
+  reactivateSubscription,
+  type Subscription,
+  type UsageMeter,
+} from '../../lib/billing-api';
+import { formatCurrency, formatDate, formatMoney } from '../../lib/format';
+
+import { InvoiceStatusBadge, planTier, tierPrice } from './billing-ui';
+import { PlanSheet } from './plan-sheet';
+
+export function BillingRoute() {
+  const { data, isPending, isError } = useQuery({
+    queryKey: billingKeys.overview,
+    queryFn: fetchBilling,
+  });
+
+  return (
+    <div className="nx:space-y-6 nx:p-6">
+      <header className="nx:space-y-1">
+        <h1 className="nx:typography-heading-large nx:text-foreground">
+          Billing
+        </h1>
+        <p className="nx:text-muted-foreground">
+          Your plan, usage, payment method, and invoice history.
+        </p>
+      </header>
+
+      {isPending && <BillingSkeleton />}
+      {isError && (
+        <p className="nx:text-error-foreground nx:text-sm">
+          Couldn&apos;t load billing. Please try again.
+        </p>
+      )}
+      {data && <BillingContent overview={data} />}
+    </div>
+  );
+}
+
+function BillingContent({ overview }: { overview: BillingOverview }) {
+  const [planOpen, setPlanOpen] = useState(false);
+
+  return (
+    <>
+      <div className="nx:grid nx:gap-6 nx:lg:grid-cols-3">
+        <PlanCard
+          subscription={overview.subscription}
+          onChangePlan={() => setPlanOpen(true)}
+        />
+        <PaymentCard method={overview.paymentMethod} />
+      </div>
+
+      <UsageCard usage={overview.usage} />
+      <InvoicesCard />
+
+      <PlanSheet
+        open={planOpen}
+        onOpenChange={setPlanOpen}
+        subscription={overview.subscription}
+      />
+    </>
+  );
+}
+
+function PlanCard({
+  subscription,
+  onChangePlan,
+}: {
+  subscription: Subscription;
+  onChangePlan: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const tier = planTier(subscription.tier);
+  const price = tierPrice(tier, subscription.cycle);
+  const canceled = subscription.status === 'canceled';
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: billingKeys.overview });
+
+  const cancelMutation = useMutation({
+    mutationFn: cancelSubscription,
+    onSuccess: () => {
+      invalidate();
+      toast.success('Subscription canceled', {
+        description: `Active until ${formatDate(subscription.renewsAt)}.`,
+      });
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const reactivateMutation = useMutation({
+    mutationFn: reactivateSubscription,
+    onSuccess: () => {
+      invalidate();
+      toast.success('Subscription resumed');
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  return (
+    <Card className="nx:lg:col-span-2">
+      <CardHeader>
+        <CardTitle>Current plan</CardTitle>
+      </CardHeader>
+      <CardContent className="nx:space-y-4">
+        <div className="nx:flex nx:flex-wrap nx:items-baseline nx:gap-x-3 nx:gap-y-1">
+          <span className="nx:typography-heading-medium nx:text-foreground">
+            {tier.name}
+          </span>
+          <span className="nx:text-muted-foreground">
+            {price === 0
+              ? 'Free'
+              : `${formatCurrency(price)}/mo · billed ${subscription.cycle}`}
+          </span>
+          {canceled ? (
+            <Badge variant="warning">Canceling</Badge>
+          ) : (
+            <Badge variant="success">Active</Badge>
+          )}
+        </div>
+
+        <p className="nx:text-muted-foreground nx:text-sm">
+          {canceled
+            ? `Your plan is canceled and ends on ${formatDate(subscription.renewsAt)}. You'll keep access until then.`
+            : `Renews on ${formatDate(subscription.renewsAt)}.`}
+        </p>
+
+        <div className="nx:flex nx:flex-wrap nx:gap-2">
+          <Button variant="outline" onClick={onChangePlan}>
+            Change plan
+          </Button>
+          {canceled ? (
+            <Button
+              variant="secondary"
+              onClick={() => reactivateMutation.mutate()}
+              loading={reactivateMutation.isPending}
+            >
+              Resume plan
+            </Button>
+          ) : (
+            <CancelButton
+              planName={tier.name}
+              renewsAt={subscription.renewsAt}
+              onConfirm={() => cancelMutation.mutate()}
+            />
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function CancelButton({
+  planName,
+  renewsAt,
+  onConfirm,
+}: {
+  planName: string;
+  renewsAt: string;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button
+          variant="ghost"
+          className="nx:text-error-foreground nx:hover:bg-error-background nx:hover:text-error-foreground"
+        >
+          Cancel subscription
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Cancel subscription?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Your {planName} plan stays active until {formatDate(renewsAt)}.
+            After that your workspace moves to the free Starter tier.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Keep plan</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            className="nx:bg-error-background nx:text-error-foreground nx:hover:bg-error-background-hover"
+          >
+            Cancel subscription
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function PaymentCard({ method }: { method: PaymentMethod }) {
+  const update = () =>
+    toast.info('Payment method updates are disabled in this demo.');
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Payment method</CardTitle>
+      </CardHeader>
+      <CardContent className="nx:space-y-4">
+        <div className="nx:flex nx:items-center nx:gap-3">
+          <div className="nx:bg-muted nx:text-muted-foreground nx:flex nx:size-10 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-md">
+            <IconCreditCard />
+          </div>
+          <div className="nx:min-w-0">
+            <p className="nx:text-foreground nx:font-medium">
+              {method.brand} ···· {method.last4}
+            </p>
+            <p className="nx:text-muted-foreground nx:text-sm nx:tabular-nums">
+              Expires {String(method.expMonth).padStart(2, '0')}/
+              {method.expYear}
+            </p>
+          </div>
+        </div>
+        <Button variant="outline" onClick={update}>
+          Update
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function UsageCard({ usage }: { usage: UsageMeter[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Usage this period</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="nx:grid nx:gap-6 nx:sm:grid-cols-3">
+          {usage.map((meter) => (
+            <UsageMeterBar key={meter.id} meter={meter} />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function UsageMeterBar({ meter }: { meter: UsageMeter }) {
+  const pct = Math.min(100, Math.round((meter.used / meter.limit) * 100));
+  // Tint the figure near the cap — the bar itself has no warning variant.
+  const nearCap = meter.used / meter.limit >= 0.9;
+
+  return (
+    <div className="nx:space-y-2">
+      <div className="nx:flex nx:items-baseline nx:justify-between nx:gap-2">
+        <span className="nx:text-foreground nx:text-sm nx:font-medium">
+          {meter.label}
+        </span>
+        <span
+          className={`nx:text-xs nx:tabular-nums ${nearCap ? 'nx:text-warning-foreground' : 'nx:text-muted-foreground'}`}
+        >
+          {meter.used} / {meter.limit} {meter.unit}
+        </span>
+      </div>
+      <Progress value={pct} aria-label={`${meter.label} usage`} />
+    </div>
+  );
+}
+
+function InvoicesCard() {
+  const { data, isPending, isError } = useQuery({
+    queryKey: billingKeys.invoices,
+    queryFn: fetchInvoices,
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Invoices</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isPending && <InvoicesSkeleton />}
+        {isError && (
+          <p className="nx:text-error-foreground nx:text-sm">
+            Couldn&apos;t load invoices.
+          </p>
+        )}
+        {data && <InvoicesTable invoices={data.invoices} />}
+      </CardContent>
+    </Card>
+  );
+}
+
+function InvoicesTable({ invoices }: { invoices: Invoice[] }) {
+  const download = (number: string) =>
+    toast.info(`Downloading ${number} is disabled in this demo.`);
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Date</TableHead>
+          <TableHead>Amount</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="nx:text-right">Receipt</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.map((invoice) => (
+          <TableRow key={invoice.id}>
+            <TableCell className="nx:text-muted-foreground nx:tabular-nums">
+              {invoice.number}
+            </TableCell>
+            <TableCell>{formatDate(invoice.date)}</TableCell>
+            <TableCell className="nx:tabular-nums">
+              {formatMoney(invoice.amount)}
+            </TableCell>
+            <TableCell>
+              <InvoiceStatusBadge status={invoice.status} />
+            </TableCell>
+            <TableCell className="nx:text-right">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => download(invoice.number)}
+              >
+                Download
+              </Button>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+function BillingSkeleton() {
+  return (
+    <div className="nx:space-y-6">
+      <div className="nx:grid nx:gap-6 nx:lg:grid-cols-3">
+        <Skeleton className="nx:h-48 nx:lg:col-span-2" />
+        <Skeleton className="nx:h-48" />
+      </div>
+      <Skeleton className="nx:h-32" />
+      <Skeleton className="nx:h-64" />
+    </div>
+  );
+}
+
+function InvoicesSkeleton() {
+  return (
+    <div className="nx:space-y-3">
+      {Array.from({ length: 5 }, (_, i) => (
+        <Skeleton key={i} className="nx:h-9 nx:w-full" />
+      ))}
+    </div>
+  );
+}

--- a/apps/console/src/modules/billing/billing-ui.tsx
+++ b/apps/console/src/modules/billing/billing-ui.tsx
@@ -1,0 +1,35 @@
+import { Badge, type BadgeProps } from '@nexus/react';
+
+import {
+  type BillingCycle,
+  type InvoiceStatus,
+  PLAN_TIERS,
+  type PlanTier,
+  type PlanTierId,
+} from '../../lib/billing-api';
+
+const INVOICE_STATUS_META: Record<
+  InvoiceStatus,
+  { label: string; variant: BadgeProps['variant'] }
+> = {
+  paid: { label: 'Paid', variant: 'success' },
+  open: { label: 'Open', variant: 'information' },
+  failed: { label: 'Failed', variant: 'error' },
+};
+
+/** The invoice status badge, shared by the invoices table. */
+export function InvoiceStatusBadge({ status }: { status: InvoiceStatus }) {
+  const { label, variant } = INVOICE_STATUS_META[status];
+  return <Badge variant={variant}>{label}</Badge>;
+}
+
+/** The catalog entry for a tier id — every id is present in {@link PLAN_TIERS}. */
+export function planTier(id: PlanTierId): PlanTier {
+  const tier = PLAN_TIERS.find((t) => t.id === id);
+  if (!tier) throw new Error(`Unknown plan tier: ${id}`);
+  return tier;
+}
+
+/** The effective per-month price for a tier on a given billing cycle. */
+export const tierPrice = (tier: PlanTier, cycle: BillingCycle) =>
+  cycle === 'annual' ? tier.annualPrice : tier.monthlyPrice;

--- a/apps/console/src/modules/billing/plan-sheet.tsx
+++ b/apps/console/src/modules/billing/plan-sheet.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from 'react';
+
+import {
+  Button,
+  Label,
+  RadioGroup,
+  RadioGroupItem,
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  Switch,
+  toast,
+} from '@nexus/react';
+import { IconCheck } from '@tabler/icons-react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import {
+  type BillingCycle,
+  billingKeys,
+  changePlan,
+  PLAN_TIERS,
+  type PlanTierId,
+  type Subscription,
+} from '../../lib/billing-api';
+import { formatCurrency } from '../../lib/format';
+
+import { planTier, tierPrice } from './billing-ui';
+
+interface PlanSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The live subscription — the picker pre-selects its tier + cycle. */
+  subscription: Subscription;
+}
+
+export function PlanSheet({
+  open,
+  onOpenChange,
+  subscription,
+}: PlanSheetProps) {
+  const queryClient = useQueryClient();
+  const [tier, setTier] = useState<PlanTierId>(subscription.tier);
+  const [cycle, setCycle] = useState<BillingCycle>(subscription.cycle);
+
+  // Re-sync to the live subscription each time the sheet opens — the instance is
+  // persistent, so without this an abandoned selection survives into the next
+  // open (the reset-on-open pattern from the CRM/Projects edit sheets).
+  useEffect(() => {
+    if (open) {
+      setTier(subscription.tier);
+      setCycle(subscription.cycle);
+    }
+  }, [open, subscription.tier, subscription.cycle]);
+
+  const mutation = useMutation({
+    mutationFn: () => changePlan({ tier, cycle }),
+    onSuccess: ({ subscription: updated }) => {
+      queryClient.invalidateQueries({ queryKey: billingKeys.overview });
+      toast.success('Plan updated', {
+        description: `You're now on ${planTier(updated.tier).name}, billed ${updated.cycle}.`,
+      });
+      onOpenChange(false);
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+
+  const unchanged = tier === subscription.tier && cycle === subscription.cycle;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="nx:flex nx:w-full nx:flex-col nx:sm:max-w-md"
+      >
+        <SheetHeader>
+          <SheetTitle>Change plan</SheetTitle>
+          <SheetDescription>
+            Pick a tier and billing cycle. Changes take effect immediately.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="nx:min-h-0 nx:flex-1 nx:space-y-5 nx:overflow-y-auto nx:px-4">
+          <div className="nx:border-border-default nx:flex nx:items-center nx:justify-between nx:gap-4 nx:rounded-lg nx:border nx:p-3">
+            <div className="nx:space-y-0.5">
+              <Label htmlFor="billing-cycle">Annual billing</Label>
+              <p className="nx:text-muted-foreground nx:text-sm">
+                Save with a yearly commitment.
+              </p>
+            </div>
+            <Switch
+              id="billing-cycle"
+              checked={cycle === 'annual'}
+              onCheckedChange={(on) => setCycle(on ? 'annual' : 'monthly')}
+            />
+          </div>
+
+          <RadioGroup
+            value={tier}
+            // Radio values are PLAN_TIERS ids, so the value is always a PlanTierId.
+            onValueChange={(value) => setTier(value as PlanTierId)}
+            className="nx:space-y-3"
+          >
+            {PLAN_TIERS.map((plan) => {
+              const selected = tier === plan.id;
+              const price = tierPrice(plan, cycle);
+              return (
+                <Label
+                  key={plan.id}
+                  htmlFor={`tier-${plan.id}`}
+                  className={`nx:flex nx:cursor-pointer nx:gap-3 nx:rounded-lg nx:border nx:p-4 ${selected ? 'nx:border-border-primary nx:bg-primary-subtle' : 'nx:border-border-default'}`}
+                >
+                  <RadioGroupItem
+                    value={plan.id}
+                    id={`tier-${plan.id}`}
+                    className="nx:mt-1"
+                  />
+                  <div className="nx:flex-1 nx:space-y-1">
+                    <div className="nx:flex nx:items-baseline nx:justify-between nx:gap-2">
+                      <span className="nx:text-foreground nx:font-medium">
+                        {plan.name}
+                      </span>
+                      <span className="nx:text-foreground nx:text-sm">
+                        {price === 0 ? 'Free' : `${formatCurrency(price)}/mo`}
+                      </span>
+                    </div>
+                    <p className="nx:text-muted-foreground nx:text-sm">
+                      {plan.blurb}
+                    </p>
+                    <ul className="nx:text-muted-foreground nx:space-y-1 nx:pt-1 nx:text-sm">
+                      {plan.features.map((feature) => (
+                        <li
+                          key={feature}
+                          className="nx:flex nx:items-center nx:gap-2"
+                        >
+                          <IconCheck className="nx:text-success-subtle-foreground nx:size-4 nx:shrink-0" />
+                          {feature}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </Label>
+              );
+            })}
+          </RadioGroup>
+        </div>
+
+        <SheetFooter>
+          <Button
+            onClick={() => mutation.mutate()}
+            loading={mutation.isPending}
+            disabled={unchanged}
+          >
+            {unchanged ? 'No changes' : 'Update plan'}
+          </Button>
+          <SheetClose asChild>
+            <Button type="button" variant="outline">
+              Cancel
+            </Button>
+          </SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/console/src/shell/modules.ts
+++ b/apps/console/src/shell/modules.ts
@@ -29,7 +29,12 @@ export const MODULE_ITEMS = [
     route: '/m/projects',
   },
   { label: 'Inbox', module: 'inbox', icon: IconInbox, route: '/m/inbox' },
-  { label: 'Billing', module: 'billing', icon: IconCreditCard },
+  {
+    label: 'Billing',
+    module: 'billing',
+    icon: IconCreditCard,
+    route: '/m/billing',
+  },
   { label: 'Analytics', module: 'analytics', icon: IconChartBar },
   { label: 'People', module: 'people', icon: IconAddressBook },
   { label: 'Settings', module: 'settings', icon: IconSettings },


### PR DESCRIPTION
## Summary

Phase 3c — the third **breadth** module: **Billing**, a single-page account dashboard backed by MSW mocks. Where Projects reused the CRM record-loop and Inbox dogfooded a master/detail split, Billing dogfoods **three components no other module has touched** — `Progress`, `RadioGroup`, and `AlertDialog` — across a settings-style surface: current plan, usage meters, payment method, and invoice history.

- **`lib/billing-api.ts`** — typed client with a deliberate **catalog/subscription split**: the static `PLAN_TIERS` catalog (every tier, both prices, per-tier feature lists — what the picker renders) vs the live `Subscription` (current tier / cycle / status / renewal — what the overview renders). Single-sourced `PLAN_TIER_IDS` + `INVOICE_STATUSES` (`as const` → union types); shared `billingKeys` query-key object; one `mutateSubscription` helper behind `changePlan` / `cancelSubscription` / `reactivateSubscription`.
- **Single-page dashboard at `/m/billing`** (no search params) — current-plan card (col-span-2) + payment card, then usage and invoices full-width.
- **Change-plan Sheet** — a `RadioGroup` of tiers (each with its feature list) and a monthly/annual `Switch` that **re-prices reactively**; **reset-on-open** so an abandoned selection never survives into the next open (the CRM/Projects edit-sheet pattern).
- **Cancel** flows through an `AlertDialog` and **winds down at period end** — the subscription stays `active` until `renewsAt`, shows a *Canceling* badge, and offers a **Resume** path to undo it (not an immediate drop to Free).
- **Usage meters** render as labelled `Progress` bars; the figure tints **warning near the cap** (≥90%) since the bar itself has no warning variant.
- **Invoices** — a raw `Table` (number / date / amount / status badge / download stub); amounts use a new cents-aware `formatMoney` alongside the existing whole-dollar `formatCurrency`.
- **MSW handlers** — GET overview + invoices, PATCH subscription (tier/cycle, also reactivates), POST cancel / reactivate against a mutable in-memory store.
- `route` added to the Billing module-registry entry → Billing is no longer "coming soon".

**Scope:** payment-method update and invoice download are toast stubs (they add no new component coverage); proration math, downgrade guards, and seat management are out of scope for a component-dogfooding slice.

## Test Plan (browser-verified — light + dark)

- [x] Sidebar **Billing** links to `/m/billing` and renders the dashboard, not the "coming soon" placeholder
- [x] Current-plan card: tier name + effective price + cycle, **Active** badge, renewal date
- [x] **Change plan** → Sheet opens pre-selected to the live tier+cycle; **Annual** Switch re-prices Pro→$24 / Scale→$79 reactively; selecting a different tier enables **Update plan**; success toasts + invalidates the overview
- [x] **Reset-on-open** → change a selection, close without saving, reopen → snaps back to the live subscription
- [x] **Cancel** → AlertDialog confirm → **Canceling** badge + "active until <renewsAt>" + **Resume**; Resume → back to **Active**
- [x] **Usage** → three `Progress` meters; Projects (9/10) tints the figure warning near the cap; Storage (88/100) + Seats (18/25) stay muted
- [x] **Invoices** → 8 rows newest-first; status badges (Paid / Open / Failed); amounts show cents; table scrolls internally on mobile (no page overflow)
- [x] **Light + dark** adapt via semantic tokens (the light-mode pass caught a white-checkmark token slip — `success-foreground` → `success-subtle-foreground`)
- [x] `typecheck`, `eslint`, `prettier --check` clean; console clean through every interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo-scope note (architecture review)

The subscription model is intentionally two-state — `status: 'active' | 'canceling'` with a static `renewsAt`. Frozen demo time means there is no lapsed/expired state to represent and no billing period to recompute on a plan change, so the model stops there. A real backend would use the Stripe-style `status` + `cancelAtPeriodEnd` split with a server-recomputed period end and proration. This is a conscious simplification, not an oversight — like every MSW mock in Atlas.

Review feedback applied: the winding-down state was renamed `'canceled'` → `'canceling'` (commit c15fa28) so the data reads as active-but-ending and matches the *Canceling* badge.
