### PR TITLE
feat(components): add context-menu component (#289)

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -58,6 +58,7 @@
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",
+    "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-hover-card": "^1.1.15",

--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -31,6 +31,15 @@
     { "name": "Checkbox", "showcase": "AllVariants" },
     { "name": "Collapsible", "showcase": "AllVariants" },
     {
+      "name": "ContextMenu",
+      "showcase": "AllVariants",
+      "interactions": ["Disabled", "ClickInteraction", "KeyboardInteraction"],
+      "equivalents": {
+        "ClickInteraction": ["OpenCloseInteraction"],
+        "Disabled": ["WithDisabledItems"]
+      }
+    },
+    {
       "name": "Dialog",
       "showcase": "AllVariants",
       "interactions": ["ClickInteraction", "KeyboardInteraction"],

--- a/packages/react/src/components/ui/ContextMenu.stories.tsx
+++ b/packages/react/src/components/ui/ContextMenu.stories.tsx
@@ -1,0 +1,497 @@
+import * as React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fireEvent, userEvent, waitFor, within } from 'storybook/test';
+
+import {
+  ContextMenu,
+  ContextMenuCheckboxItem,
+  ContextMenuContent,
+  ContextMenuGroup,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+} from './context-menu';
+
+const triggerClass =
+  'nx:flex nx:h-[96px] nx:w-full nx:max-w-md nx:select-none nx:items-center nx:justify-center nx:rounded-md nx:border nx:border-dashed nx:border-border-default nx:text-sm nx:text-muted-foreground';
+
+const meta: Meta<typeof ContextMenu> = {
+  title: 'Components/ContextMenu',
+  component: ContextMenu,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ContextMenu>;
+
+// ============================================
+// BASIC STORIES
+// ============================================
+
+export const Default: Story = {
+  render: (_args) => (
+    <ContextMenu>
+      <ContextMenuTrigger className={triggerClass}>
+        Right click here
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem>Back</ContextMenuItem>
+        <ContextMenuItem>Forward</ContextMenuItem>
+        <ContextMenuItem>Reload</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  ),
+};
+
+export const WithLabelsAndSeparators: Story = {
+  render: (_args) => (
+    <ContextMenu>
+      <ContextMenuTrigger className={triggerClass}>
+        Right click here
+      </ContextMenuTrigger>
+      <ContextMenuContent className="nx:w-56">
+        <ContextMenuLabel>Actions</ContextMenuLabel>
+        <ContextMenuSeparator />
+        <ContextMenuGroup>
+          <ContextMenuItem>
+            Back
+            <ContextMenuShortcut>⌘[</ContextMenuShortcut>
+          </ContextMenuItem>
+          <ContextMenuItem>
+            Forward
+            <ContextMenuShortcut>⌘]</ContextMenuShortcut>
+          </ContextMenuItem>
+          <ContextMenuItem>
+            Reload
+            <ContextMenuShortcut>⌘R</ContextMenuShortcut>
+          </ContextMenuItem>
+        </ContextMenuGroup>
+        <ContextMenuSeparator />
+        <ContextMenuItem>
+          View Source
+          <ContextMenuShortcut>⌘U</ContextMenuShortcut>
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  ),
+};
+
+export const WithCheckboxItems: Story = {
+  render: function CheckboxItemsStory() {
+    const [showBookmarks, setShowBookmarks] = React.useState(true);
+    const [showFullUrls, setShowFullUrls] = React.useState(false);
+
+    return (
+      <ContextMenu>
+        <ContextMenuTrigger className={triggerClass}>
+          Right click here
+        </ContextMenuTrigger>
+        <ContextMenuContent className="nx:w-56">
+          <ContextMenuLabel>Appearance</ContextMenuLabel>
+          <ContextMenuSeparator />
+          <ContextMenuCheckboxItem
+            checked={showBookmarks}
+            onCheckedChange={setShowBookmarks}
+          >
+            Show Bookmarks
+          </ContextMenuCheckboxItem>
+          <ContextMenuCheckboxItem
+            checked={showFullUrls}
+            onCheckedChange={setShowFullUrls}
+          >
+            Show Full URLs
+          </ContextMenuCheckboxItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    );
+  },
+};
+
+export const WithRadioItems: Story = {
+  render: function RadioItemsStory() {
+    const [person, setPerson] = React.useState('pedro');
+
+    return (
+      <ContextMenu>
+        <ContextMenuTrigger className={triggerClass}>
+          Right click here
+        </ContextMenuTrigger>
+        <ContextMenuContent className="nx:w-56">
+          <ContextMenuLabel>People</ContextMenuLabel>
+          <ContextMenuSeparator />
+          <ContextMenuRadioGroup value={person} onValueChange={setPerson}>
+            <ContextMenuRadioItem value="pedro">
+              Pedro Duarte
+            </ContextMenuRadioItem>
+            <ContextMenuRadioItem value="colm">Colm Tuite</ContextMenuRadioItem>
+          </ContextMenuRadioGroup>
+        </ContextMenuContent>
+      </ContextMenu>
+    );
+  },
+};
+
+export const WithSubMenu: Story = {
+  render: (_args) => (
+    <ContextMenu>
+      <ContextMenuTrigger className={triggerClass}>
+        Right click here
+      </ContextMenuTrigger>
+      <ContextMenuContent className="nx:w-56">
+        <ContextMenuItem>
+          Back
+          <ContextMenuShortcut>⌘[</ContextMenuShortcut>
+        </ContextMenuItem>
+        <ContextMenuItem>
+          Forward
+          <ContextMenuShortcut>⌘]</ContextMenuShortcut>
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuSub>
+          <ContextMenuSubTrigger>More Tools</ContextMenuSubTrigger>
+          <ContextMenuSubContent>
+            <ContextMenuItem>Save Page As...</ContextMenuItem>
+            <ContextMenuItem>Create Shortcut...</ContextMenuItem>
+            <ContextMenuItem>Name Window...</ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem>Developer Tools</ContextMenuItem>
+          </ContextMenuSubContent>
+        </ContextMenuSub>
+        <ContextMenuSeparator />
+        <ContextMenuItem>
+          Reload
+          <ContextMenuShortcut>⌘R</ContextMenuShortcut>
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  ),
+};
+
+export const WithDestructiveItem: Story = {
+  render: (_args) => (
+    <ContextMenu>
+      <ContextMenuTrigger className={triggerClass}>
+        Right click here
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem>Edit</ContextMenuItem>
+        <ContextMenuItem>Duplicate</ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem variant="destructive">Delete</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  ),
+};
+
+export const WithInsetItems: Story = {
+  render: (_args) => (
+    <ContextMenu>
+      <ContextMenuTrigger className={triggerClass}>
+        Right click here
+      </ContextMenuTrigger>
+      <ContextMenuContent className="nx:w-56">
+        <ContextMenuLabel inset>Actions</ContextMenuLabel>
+        <ContextMenuSeparator />
+        <ContextMenuItem inset>Back</ContextMenuItem>
+        <ContextMenuItem inset>Forward</ContextMenuItem>
+        <ContextMenuItem inset>Reload</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  ),
+};
+
+// ============================================
+// INTERACTION TESTS
+// ============================================
+
+export const OpenCloseInteraction: Story = {
+  render: (_args) => (
+    <ContextMenu>
+      <ContextMenuTrigger className={triggerClass}>
+        Right click here
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem>Item 1</ContextMenuItem>
+        <ContextMenuItem>Item 2</ContextMenuItem>
+        <ContextMenuItem>Item 3</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Menu should not be visible initially
+    const trigger = canvas.getByText('Right click here');
+    await expect(trigger).toBeInTheDocument();
+
+    // Open via right-click — context menus open on `contextmenu`, not click
+    await fireEvent.contextMenu(trigger, { clientX: 20, clientY: 20 });
+
+    // Menu content should now be visible
+    const menu = await within(document.body).findByRole('menu');
+    await expect(menu).toBeInTheDocument();
+    await expect(menu).toHaveAttribute('data-slot', 'context-menu-content');
+
+    // Items should be visible
+    const item1 = within(menu).getByRole('menuitem', { name: 'Item 1' });
+    await expect(item1).toBeInTheDocument();
+
+    // Close the menu by pressing Escape
+    await userEvent.keyboard('{Escape}');
+
+    // Wait for menu to be removed from DOM
+    await waitFor(() => {
+      expect(document.querySelector('[role="menu"]')).toBeNull();
+    });
+  },
+};
+
+export const KeyboardInteraction: Story = {
+  render: (_args) => (
+    <ContextMenu>
+      <ContextMenuTrigger className={triggerClass}>
+        Right click here
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem>First</ContextMenuItem>
+        <ContextMenuItem>Second</ContextMenuItem>
+        <ContextMenuItem>Third</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open via right-click
+    const trigger = canvas.getByText('Right click here');
+    await fireEvent.contextMenu(trigger, { clientX: 20, clientY: 20 });
+
+    // Menu should be open
+    const menu = await within(document.body).findByRole('menu');
+    await expect(menu).toBeInTheDocument();
+
+    // Navigate with arrow keys
+    await userEvent.keyboard('{ArrowDown}');
+    await userEvent.keyboard('{ArrowDown}');
+
+    // The second item should be highlighted
+    const secondItem = within(menu).getByRole('menuitem', { name: 'Second' });
+    await expect(secondItem).toHaveAttribute('data-highlighted');
+
+    // Close with Escape
+    await userEvent.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(document.querySelector('[role="menu"]')).toBeNull();
+    });
+  },
+};
+
+export const WithDisabledItems: Story = {
+  render: (_args) => (
+    <ContextMenu>
+      <ContextMenuTrigger className={triggerClass}>
+        Right click here
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuItem>Undo</ContextMenuItem>
+        <ContextMenuItem>Redo</ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem disabled>Cut</ContextMenuItem>
+        <ContextMenuItem disabled>Copy</ContextMenuItem>
+        <ContextMenuItem>Paste</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open via right-click
+    const trigger = canvas.getByText('Right click here');
+    await fireEvent.contextMenu(trigger, { clientX: 20, clientY: 20 });
+
+    const menu = await within(document.body).findByRole('menu');
+
+    // The disabled item is present and marked disabled. Do NOT click it —
+    // a disabled item has pointer-events: none, which makes click throw.
+    const disabledItem = within(menu).getByRole('menuitem', { name: 'Cut' });
+    await expect(disabledItem).toHaveAttribute('data-disabled');
+    await expect(disabledItem).toHaveAttribute('aria-disabled', 'true');
+
+    // An enabled item is reachable
+    const enabledItem = within(menu).getByRole('menuitem', { name: 'Paste' });
+    await expect(enabledItem).not.toHaveAttribute('data-disabled');
+
+    // Close
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(document.querySelector('[role="menu"]')).toBeNull();
+    });
+  },
+};
+
+export const WithDataAttributes: Story = {
+  render: (_args) => (
+    <ContextMenu>
+      <ContextMenuTrigger className={triggerClass}>
+        Right click here
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        <ContextMenuLabel>Label</ContextMenuLabel>
+        <ContextMenuSeparator />
+        <ContextMenuItem>Item</ContextMenuItem>
+        <ContextMenuItem variant="destructive">Destructive</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open via right-click
+    const trigger = canvas.getByText('Right click here');
+    await fireEvent.contextMenu(trigger, { clientX: 20, clientY: 20 });
+
+    // Wait for menu to be visible
+    await within(document.body).findByRole('menu');
+
+    // Check data-slot attributes
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="context-menu-content"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="context-menu-label"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="context-menu-separator"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="context-menu-item"]')
+      ).toBeInTheDocument();
+    });
+
+    // Check destructive variant
+    const destructiveItem = document.querySelector(
+      '[data-slot="context-menu-item"][data-variant="destructive"]'
+    );
+    await expect(destructiveItem).toBeInTheDocument();
+
+    // Close the menu and wait for complete cleanup
+    await userEvent.keyboard('{Escape}');
+
+    // Wait for menu to be fully removed from DOM (including aria-hidden cleanup)
+    await waitFor(() => {
+      expect(document.querySelector('[role="menu"]')).toBeNull();
+      // Ensure no lingering aria-hidden elements from Radix
+      expect(document.querySelector('[data-aria-hidden="true"]')).toBeNull();
+    });
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+export const AllVariants: Story = {
+  render: (_args) => (
+    <div className="nx:flex nx:flex-col nx:gap-8">
+      <div>
+        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          Basic Menu
+        </h3>
+        <ContextMenu>
+          <ContextMenuTrigger className={triggerClass}>
+            Right click here
+          </ContextMenuTrigger>
+          <ContextMenuContent>
+            <ContextMenuItem>Back</ContextMenuItem>
+            <ContextMenuItem>Forward</ContextMenuItem>
+            <ContextMenuItem>Reload</ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+      </div>
+
+      <div>
+        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          With Shortcuts
+        </h3>
+        <ContextMenu>
+          <ContextMenuTrigger className={triggerClass}>
+            Right click here
+          </ContextMenuTrigger>
+          <ContextMenuContent className="nx:w-48">
+            <ContextMenuItem>
+              Back
+              <ContextMenuShortcut>⌘[</ContextMenuShortcut>
+            </ContextMenuItem>
+            <ContextMenuItem>
+              Reload
+              <ContextMenuShortcut>⌘R</ContextMenuShortcut>
+            </ContextMenuItem>
+            <ContextMenuItem>
+              Inspect
+              <ContextMenuShortcut>⌘I</ContextMenuShortcut>
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+      </div>
+
+      <div>
+        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          With Destructive
+        </h3>
+        <ContextMenu>
+          <ContextMenuTrigger className={triggerClass}>
+            Right click here
+          </ContextMenuTrigger>
+          <ContextMenuContent>
+            <ContextMenuItem>Edit</ContextMenuItem>
+            <ContextMenuItem>Duplicate</ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem variant="destructive">Delete</ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+      </div>
+
+      <div>
+        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          With Submenu
+        </h3>
+        <ContextMenu>
+          <ContextMenuTrigger className={triggerClass}>
+            Right click here
+          </ContextMenuTrigger>
+          <ContextMenuContent>
+            <ContextMenuItem>Item 1</ContextMenuItem>
+            <ContextMenuSub>
+              <ContextMenuSubTrigger>More Options</ContextMenuSubTrigger>
+              <ContextMenuSubContent>
+                <ContextMenuItem>Sub Item 1</ContextMenuItem>
+                <ContextMenuItem>Sub Item 2</ContextMenuItem>
+              </ContextMenuSubContent>
+            </ContextMenuSub>
+            <ContextMenuItem>Item 2</ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+// ============================================
+// A11Y is tested automatically on ALL stories
+// via addon-a11y with test: 'error'
+// ============================================

--- a/packages/react/src/components/ui/context-menu.tsx
+++ b/packages/react/src/components/ui/context-menu.tsx
@@ -1,0 +1,498 @@
+import * as React from 'react';
+
+import * as ContextMenuPrimitive from '@radix-ui/react-context-menu';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { IconCheck, IconChevronRight, IconCircleFilled } from '@/lib/icons';
+import { cn } from '@/lib/utils';
+
+/**
+ * ContextMenu
+ *
+ * Root component for the context menu. Opens on right-click of its trigger.
+ *
+ * @example
+ * ```tsx
+ * <ContextMenu>
+ *   <ContextMenuTrigger>Right click here</ContextMenuTrigger>
+ *   <ContextMenuContent>
+ *     <ContextMenuItem>Item 1</ContextMenuItem>
+ *     <ContextMenuItem>Item 2</ContextMenuItem>
+ *   </ContextMenuContent>
+ * </ContextMenu>
+ * ```
+ */
+const ContextMenu = ContextMenuPrimitive.Root;
+
+/**
+ * ContextMenuTrigger
+ *
+ * The area that opens the context menu when right-clicked.
+ */
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
+
+/**
+ * ContextMenuGroup
+ *
+ * Groups related menu items together.
+ */
+const ContextMenuGroup = ContextMenuPrimitive.Group;
+
+/**
+ * ContextMenuPortal
+ *
+ * Portals the content to the body.
+ */
+const ContextMenuPortal = ContextMenuPrimitive.Portal;
+
+/**
+ * ContextMenuSub
+ *
+ * Contains a submenu.
+ */
+const ContextMenuSub = ContextMenuPrimitive.Sub;
+
+/**
+ * ContextMenuRadioGroup
+ *
+ * Groups radio items together.
+ */
+const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
+
+/**
+ * ContextMenuSubTriggerProps
+ *
+ * Props for the ContextMenuSubTrigger component.
+ */
+interface ContextMenuSubTriggerProps extends React.ComponentProps<
+  typeof ContextMenuPrimitive.SubTrigger
+> {
+  /**
+   * Indents the trigger to align with items that have a leading icon or checkbox.
+   * @default false
+   */
+  inset?: boolean;
+}
+
+/**
+ * ContextMenuSubTrigger
+ *
+ * The trigger for a submenu. Renders a chevron to indicate a submenu.
+ */
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: ContextMenuSubTriggerProps) {
+  return (
+    <ContextMenuPrimitive.SubTrigger
+      data-slot="context-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        // nexus-allow-numeric: menu item-tier rhythm
+        'nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2',
+        // nexus-allow-numeric: menu item-tier rhythm
+        'nx:rounded-sm nx:px-2 nx:py-control-sm nx:text-sm nx:outline-none',
+        'nx:focus:bg-background-hover nx:focus:text-foreground',
+        'nx:data-[state=open]:bg-background-hover',
+        'nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+        inset && 'nx:pl-8',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <IconChevronRight className="nx:ml-auto nx:size-4" />
+    </ContextMenuPrimitive.SubTrigger>
+  );
+}
+
+/**
+ * ContextMenuSubContentProps
+ *
+ * Props for the ContextMenuSubContent component.
+ */
+interface ContextMenuSubContentProps extends React.ComponentProps<
+  typeof ContextMenuPrimitive.SubContent
+> {}
+
+/**
+ * ContextMenuSubContent
+ *
+ * The content container for a submenu.
+ */
+function ContextMenuSubContent({
+  className,
+  ...props
+}: ContextMenuSubContentProps) {
+  return (
+    <ContextMenuPrimitive.SubContent
+      data-slot="context-menu-sub-content"
+      className={cn(
+        'nx:z-popover nx:min-w-[8rem] nx:overflow-hidden',
+        'nx:rounded-md nx:border nx:border-border-default',
+        // nexus-allow-numeric: popover chrome (sub-canonical inner padding)
+        'nx:bg-popover nx:p-1 nx:text-popover-foreground nx:shadow-lg',
+        'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
+        'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
+        'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',
+        'nx:data-[side=bottom]:slide-in-from-top-2',
+        'nx:data-[side=left]:slide-in-from-right-2',
+        'nx:data-[side=right]:slide-in-from-left-2',
+        'nx:data-[side=top]:slide-in-from-bottom-2',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * ContextMenuContentProps
+ *
+ * Props for the ContextMenuContent component.
+ */
+interface ContextMenuContentProps extends React.ComponentProps<
+  typeof ContextMenuPrimitive.Content
+> {}
+
+/**
+ * ContextMenuContent
+ *
+ * The context menu content container. Positions at the cursor.
+ *
+ * @example
+ * ```tsx
+ * <ContextMenuContent>
+ *   <ContextMenuItem>Back</ContextMenuItem>
+ *   <ContextMenuItem>Reload</ContextMenuItem>
+ * </ContextMenuContent>
+ * ```
+ */
+function ContextMenuContent({ className, ...props }: ContextMenuContentProps) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        data-slot="context-menu-content"
+        className={cn(
+          'nx:z-popover nx:max-h-(--radix-context-menu-content-available-height)',
+          'nx:min-w-[8rem] nx:overflow-x-hidden nx:overflow-y-auto',
+          'nx:rounded-md nx:border nx:border-border-default',
+          // nexus-allow-numeric: popover chrome (sub-canonical inner padding)
+          'nx:bg-popover nx:p-1 nx:text-popover-foreground nx:shadow-lg',
+          'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
+          'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
+          'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',
+          'nx:data-[side=bottom]:slide-in-from-top-2',
+          'nx:data-[side=left]:slide-in-from-right-2',
+          'nx:data-[side=right]:slide-in-from-left-2',
+          'nx:data-[side=top]:slide-in-from-bottom-2',
+          className
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  );
+}
+
+const contextMenuItemVariants = cva(
+  // nexus-allow-numeric: menu item-tier rhythm
+  'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2 nx:rounded-sm nx:px-2 nx:py-control-sm nx:text-sm nx:outline-none nx:transition-colors nx:focus:bg-background-hover nx:focus:text-foreground nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: '',
+        destructive:
+          'nx:text-error-subtle-foreground nx:focus:bg-error-background nx:focus:text-error-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+/**
+ * ContextMenuItemProps
+ *
+ * Props for the ContextMenuItem component.
+ */
+interface ContextMenuItemProps
+  extends
+    React.ComponentProps<typeof ContextMenuPrimitive.Item>,
+    VariantProps<typeof contextMenuItemVariants> {
+  /**
+   * Indents the item to align with items that have a leading icon or checkbox.
+   * @default false
+   */
+  inset?: boolean;
+}
+
+/**
+ * ContextMenuItem
+ *
+ * An individual menu item.
+ *
+ * @example
+ * ```tsx
+ * <ContextMenuItem>Back</ContextMenuItem>
+ * <ContextMenuItem variant="destructive">Delete</ContextMenuItem>
+ * ```
+ */
+function ContextMenuItem({
+  className,
+  inset,
+  variant = 'default',
+  ...props
+}: ContextMenuItemProps) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        contextMenuItemVariants({ variant }),
+        inset && 'nx:pl-8',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * ContextMenuCheckboxItemProps
+ *
+ * Props for the ContextMenuCheckboxItem component.
+ */
+interface ContextMenuCheckboxItemProps extends React.ComponentProps<
+  typeof ContextMenuPrimitive.CheckboxItem
+> {}
+
+/**
+ * ContextMenuCheckboxItem
+ *
+ * A menu item that can be checked/unchecked.
+ *
+ * @example
+ * ```tsx
+ * <ContextMenuCheckboxItem checked={showPanel} onCheckedChange={setShowPanel}>
+ *   Show Panel
+ * </ContextMenuCheckboxItem>
+ * ```
+ */
+function ContextMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: ContextMenuCheckboxItemProps) {
+  return (
+    <ContextMenuPrimitive.CheckboxItem
+      data-slot="context-menu-checkbox-item"
+      className={cn(
+        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
+        'nx:rounded-sm nx:py-control-sm nx:pl-8 nx:pr-2 nx:text-sm nx:outline-none',
+        'nx:transition-colors',
+        'nx:focus:bg-background-hover nx:focus:text-foreground',
+        'nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50',
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
+        <ContextMenuPrimitive.ItemIndicator>
+          <IconCheck className="nx:size-4" />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.CheckboxItem>
+  );
+}
+
+/**
+ * ContextMenuRadioItemProps
+ *
+ * Props for the ContextMenuRadioItem component.
+ */
+interface ContextMenuRadioItemProps extends React.ComponentProps<
+  typeof ContextMenuPrimitive.RadioItem
+> {}
+
+/**
+ * ContextMenuRadioItem
+ *
+ * A radio menu item for exclusive selection.
+ *
+ * @example
+ * ```tsx
+ * <ContextMenuRadioGroup value={position} onValueChange={setPosition}>
+ *   <ContextMenuRadioItem value="top">Top</ContextMenuRadioItem>
+ *   <ContextMenuRadioItem value="bottom">Bottom</ContextMenuRadioItem>
+ * </ContextMenuRadioGroup>
+ * ```
+ */
+function ContextMenuRadioItem({
+  className,
+  children,
+  ...props
+}: ContextMenuRadioItemProps) {
+  return (
+    <ContextMenuPrimitive.RadioItem
+      data-slot="context-menu-radio-item"
+      className={cn(
+        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
+        'nx:rounded-sm nx:py-control-sm nx:pl-8 nx:pr-2 nx:text-sm nx:outline-none',
+        'nx:transition-colors',
+        'nx:focus:bg-background-hover nx:focus:text-foreground',
+        'nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50',
+        className
+      )}
+      {...props}
+    >
+      <span className="nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
+        <ContextMenuPrimitive.ItemIndicator>
+          <IconCircleFilled className="nx:size-2" />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.RadioItem>
+  );
+}
+
+/**
+ * ContextMenuLabelProps
+ *
+ * Props for the ContextMenuLabel component.
+ */
+interface ContextMenuLabelProps extends React.ComponentProps<
+  typeof ContextMenuPrimitive.Label
+> {
+  /**
+   * Indents the label to align with items that have a leading icon or checkbox.
+   * @default false
+   */
+  inset?: boolean;
+}
+
+/**
+ * ContextMenuLabel
+ *
+ * A label for a group of menu items.
+ *
+ * @example
+ * ```tsx
+ * <ContextMenuLabel>Actions</ContextMenuLabel>
+ * ```
+ */
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: ContextMenuLabelProps) {
+  return (
+    <ContextMenuPrimitive.Label
+      data-slot="context-menu-label"
+      data-inset={inset}
+      className={cn(
+        // nexus-allow-numeric: menu label item-tier rhythm
+        'nx:px-2 nx:py-control-sm nx:text-sm nx:font-semibold',
+        inset && 'nx:pl-8',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * ContextMenuSeparatorProps
+ *
+ * Props for the ContextMenuSeparator component.
+ */
+interface ContextMenuSeparatorProps extends React.ComponentProps<
+  typeof ContextMenuPrimitive.Separator
+> {}
+
+/**
+ * ContextMenuSeparator
+ *
+ * A visual divider between menu items.
+ */
+function ContextMenuSeparator({
+  className,
+  ...props
+}: ContextMenuSeparatorProps) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn('nx:-mx-1 nx:my-1 nx:h-px nx:bg-muted', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * ContextMenuShortcutProps
+ *
+ * Props for the ContextMenuShortcut component.
+ */
+interface ContextMenuShortcutProps extends React.ComponentProps<'span'> {}
+
+/**
+ * ContextMenuShortcut
+ *
+ * Displays a keyboard shortcut hint.
+ *
+ * @example
+ * ```tsx
+ * <ContextMenuItem>
+ *   Reload <ContextMenuShortcut>⌘R</ContextMenuShortcut>
+ * </ContextMenuItem>
+ * ```
+ */
+function ContextMenuShortcut({
+  className,
+  ...props
+}: ContextMenuShortcutProps) {
+  return (
+    <span
+      data-slot="context-menu-shortcut"
+      className={cn(
+        'nx:ml-auto nx:text-xs nx:tracking-widest nx:text-muted-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  ContextMenu,
+  ContextMenuCheckboxItem,
+  type ContextMenuCheckboxItemProps,
+  ContextMenuContent,
+  type ContextMenuContentProps,
+  ContextMenuGroup,
+  ContextMenuItem,
+  type ContextMenuItemProps,
+  contextMenuItemVariants,
+  ContextMenuLabel,
+  type ContextMenuLabelProps,
+  ContextMenuPortal,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
+  type ContextMenuRadioItemProps,
+  ContextMenuSeparator,
+  type ContextMenuSeparatorProps,
+  ContextMenuShortcut,
+  type ContextMenuShortcutProps,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  type ContextMenuSubContentProps,
+  ContextMenuSubTrigger,
+  type ContextMenuSubTriggerProps,
+  ContextMenuTrigger,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -22,6 +22,7 @@ export * from '@/components/ui/card';
 export * from '@/components/ui/checkbox';
 export * from '@/components/ui/collapsible';
 export * from '@/components/ui/command';
+export * from '@/components/ui/context-menu';
 export * from '@/components/ui/dialog';
 export * from '@/components/ui/dropdown-menu';
 export * from '@/components/ui/empty-state';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1124,6 +1124,18 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz#a2c4c47af6337048ee78ff6dc0d090b390d2bb30"
   integrity sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==
 
+"@radix-ui/react-context-menu@^2.2.16":
+  version "2.2.16"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz#e7bf94a457b68af08f24ad696949144530faab50"
+  integrity sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-menu" "2.1.16"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+
 "@radix-ui/react-context@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.2.tgz#61628ef269a433382c364f6f1e3788a6dc213a36"


### PR DESCRIPTION
## Summary

- Adapts shadcn **context-menu** → Nexus, wrapping Radix `@radix-ui/react-context-menu`. It mirrors the shipped `dropdown-menu.tsx` surface exactly (same semantic tokens, `py-control-sm` item rhythm, `focus:bg-background-hover` roving-focus tint, destructive item cva, `shadow-lg` floating elevation) — ContextMenu and DropdownMenu are the same menu surface with different triggers, so cloning the sibling guarantees token + family consistency.
- **Structural deltas from the sibling** (the only differences the context-menu source introduces): the trigger is a right-click area (bare `Trigger` alias, no button), `Content` drops `sideOffset` (cursor-positioned, not side-anchored), and its `max-h` reads `--radix-context-menu-content-available-height`.
- Full surface: item (default / destructive), checkbox item, radio item + group, submenu (trigger + content), label, separator, shortcut, group, inset items.
- `nx:` prefix throughout, semantic tokens only, `data-slot` on every rendered element, the menu-item background-tint focus (no ring — Radix roving focus, per `components.md`).

## Bundle

Near-free: `@radix-ui/react-context-menu` shares a single `@radix-ui/react-menu@2.1.16` with the already-bundled dropdown-menu (verified via `yarn why`). ESM **74.64 kB** local / 80 kB limit (≈ +0.66 kB over HoverCard).

## GitHub Issue

Closes #289

## Test Plan

- [x] `typecheck`, `eslint --max-warnings 0`, `prettier` clean
- [x] `audit:storybook-coverage --component context-menu` → no gaps (Disabled / ClickInteraction / KeyboardInteraction via `WithDisabledItems` / `OpenCloseInteraction` config equivalents)
- [x] `size-limit` 74.64 kB ESM / 80 kB · CSS utility (`--radix-context-menu-content-available-height`) emitted in `dist/react.css`
- [x] Archetype grep clean: no `accent` / `dark:` / `outline-hidden` / `shadow-md` / opacity-hover / `bg-black`
- [ ] CI: story play-fns (right-click open via `fireEvent.contextMenu`, keyboard nav, disabled-item assertions) run green in the browser runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)