### PR TITLE
feat(components): add menubar component (#292)

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,6 +63,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-menubar": "^1.1.16",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-radio-group": "^1.3.8",

--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -68,6 +68,15 @@
     { "name": "InputGroup", "showcase": "AllVariants" },
     { "name": "Item", "showcase": "AllVariants" },
     { "name": "Kbd", "showcase": "AllVariants" },
+    {
+      "name": "Menubar",
+      "showcase": "AllVariants",
+      "interactions": ["Disabled", "ClickInteraction", "KeyboardInteraction"],
+      "equivalents": {
+        "ClickInteraction": ["OpenCloseInteraction"],
+        "Disabled": ["WithDisabledItems"]
+      }
+    },
     { "name": "NativeSelect", "showcase": "AllVariants" },
     { "name": "Pagination", "showcase": "AllVariants" },
     {

--- a/packages/react/src/components/ui/Menubar.stories.tsx
+++ b/packages/react/src/components/ui/Menubar.stories.tsx
@@ -1,0 +1,437 @@
+import * as React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import {
+  Menubar,
+  MenubarCheckboxItem,
+  MenubarContent,
+  MenubarItem,
+  MenubarLabel,
+  MenubarMenu,
+  MenubarRadioGroup,
+  MenubarRadioItem,
+  MenubarSeparator,
+  MenubarShortcut,
+  MenubarSub,
+  MenubarSubContent,
+  MenubarSubTrigger,
+  MenubarTrigger,
+} from './menubar';
+
+const meta: Meta<typeof Menubar> = {
+  title: 'Components/Menubar',
+  component: Menubar,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Menubar>;
+
+// ============================================
+// BASIC STORIES
+// ============================================
+
+export const Default: Story = {
+  render: (_args) => (
+    <Menubar>
+      <MenubarMenu>
+        <MenubarTrigger>File</MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem>
+            New Tab
+            <MenubarShortcut>⌘T</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem>
+            New Window
+            <MenubarShortcut>⌘N</MenubarShortcut>
+          </MenubarItem>
+          <MenubarItem>New Incognito Window</MenubarItem>
+          <MenubarSeparator />
+          <MenubarItem>Print</MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+      <MenubarMenu>
+        <MenubarTrigger>Edit</MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem>Undo</MenubarItem>
+          <MenubarItem>Redo</MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+      <MenubarMenu>
+        <MenubarTrigger>View</MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem>Reload</MenubarItem>
+          <MenubarItem>Toggle Fullscreen</MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+    </Menubar>
+  ),
+};
+
+export const WithCheckboxItems: Story = {
+  render: function CheckboxItemsStory() {
+    const [showBookmarks, setShowBookmarks] = React.useState(true);
+    const [showFullUrls, setShowFullUrls] = React.useState(false);
+
+    return (
+      <Menubar>
+        <MenubarMenu>
+          <MenubarTrigger>View</MenubarTrigger>
+          <MenubarContent>
+            <MenubarLabel>Appearance</MenubarLabel>
+            <MenubarSeparator />
+            <MenubarCheckboxItem
+              checked={showBookmarks}
+              onCheckedChange={setShowBookmarks}
+            >
+              Show Bookmarks
+            </MenubarCheckboxItem>
+            <MenubarCheckboxItem
+              checked={showFullUrls}
+              onCheckedChange={setShowFullUrls}
+            >
+              Show Full URLs
+            </MenubarCheckboxItem>
+          </MenubarContent>
+        </MenubarMenu>
+      </Menubar>
+    );
+  },
+};
+
+export const WithRadioItems: Story = {
+  render: function RadioItemsStory() {
+    const [profile, setProfile] = React.useState('benoit');
+
+    return (
+      <Menubar>
+        <MenubarMenu>
+          <MenubarTrigger>Profiles</MenubarTrigger>
+          <MenubarContent>
+            <MenubarLabel>People</MenubarLabel>
+            <MenubarSeparator />
+            <MenubarRadioGroup value={profile} onValueChange={setProfile}>
+              <MenubarRadioItem value="benoit">Benoit</MenubarRadioItem>
+              <MenubarRadioItem value="luis">Luis</MenubarRadioItem>
+            </MenubarRadioGroup>
+          </MenubarContent>
+        </MenubarMenu>
+      </Menubar>
+    );
+  },
+};
+
+export const WithSubMenu: Story = {
+  render: (_args) => (
+    <Menubar>
+      <MenubarMenu>
+        <MenubarTrigger>File</MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem>New Tab</MenubarItem>
+          <MenubarSeparator />
+          <MenubarSub>
+            <MenubarSubTrigger>Share</MenubarSubTrigger>
+            <MenubarSubContent>
+              <MenubarItem>Email Link</MenubarItem>
+              <MenubarItem>Messages</MenubarItem>
+              <MenubarItem>Notes</MenubarItem>
+            </MenubarSubContent>
+          </MenubarSub>
+          <MenubarSeparator />
+          <MenubarItem>Print</MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+    </Menubar>
+  ),
+};
+
+export const WithInsetItems: Story = {
+  render: (_args) => (
+    <Menubar>
+      <MenubarMenu>
+        <MenubarTrigger>View</MenubarTrigger>
+        <MenubarContent>
+          <MenubarLabel inset>Appearance</MenubarLabel>
+          <MenubarSeparator />
+          <MenubarItem inset>Reload</MenubarItem>
+          <MenubarItem inset>Force Reload</MenubarItem>
+          <MenubarItem inset>Toggle Fullscreen</MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+    </Menubar>
+  ),
+};
+
+// ============================================
+// INTERACTION TESTS
+// ============================================
+
+export const OpenCloseInteraction: Story = {
+  render: (_args) => (
+    <Menubar>
+      <MenubarMenu>
+        <MenubarTrigger>File</MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem>New Tab</MenubarItem>
+          <MenubarItem>New Window</MenubarItem>
+          <MenubarItem>Print</MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+    </Menubar>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Menu should not be visible initially
+    const trigger = canvas.getByRole('menuitem', { name: 'File' });
+    await expect(trigger).toBeInTheDocument();
+
+    // Open the menu by clicking its trigger
+    await userEvent.click(trigger);
+
+    // Menu content should now be visible
+    const menu = await within(document.body).findByRole('menu');
+    await expect(menu).toBeInTheDocument();
+    await expect(menu).toHaveAttribute('data-slot', 'menubar-content');
+
+    // Items should be visible
+    const item = within(menu).getByRole('menuitem', { name: 'New Tab' });
+    await expect(item).toBeInTheDocument();
+
+    // Close the menu by pressing Escape
+    await userEvent.keyboard('{Escape}');
+
+    // Wait for menu to be removed from DOM
+    await waitFor(() => {
+      expect(document.querySelector('[role="menu"]')).toBeNull();
+    });
+  },
+};
+
+export const KeyboardInteraction: Story = {
+  render: (_args) => (
+    <Menubar>
+      <MenubarMenu>
+        <MenubarTrigger>File</MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem>New Tab</MenubarItem>
+          <MenubarItem>New Window</MenubarItem>
+          <MenubarItem>Print</MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+    </Menubar>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open the menu
+    const trigger = canvas.getByRole('menuitem', { name: 'File' });
+    await userEvent.click(trigger);
+
+    // Menu should be open
+    const menu = await within(document.body).findByRole('menu');
+    await expect(menu).toBeInTheDocument();
+
+    // Navigate with arrow keys
+    await userEvent.keyboard('{ArrowDown}');
+    await userEvent.keyboard('{ArrowDown}');
+
+    // The second item should be highlighted
+    const secondItem = within(menu).getByRole('menuitem', {
+      name: 'New Window',
+    });
+    await expect(secondItem).toHaveAttribute('data-highlighted');
+
+    // Close with Escape
+    await userEvent.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(document.querySelector('[role="menu"]')).toBeNull();
+    });
+  },
+};
+
+export const WithDisabledItems: Story = {
+  render: (_args) => (
+    <Menubar>
+      <MenubarMenu>
+        <MenubarTrigger>Edit</MenubarTrigger>
+        <MenubarContent>
+          <MenubarItem>Undo</MenubarItem>
+          <MenubarItem>Redo</MenubarItem>
+          <MenubarSeparator />
+          <MenubarItem disabled>Cut</MenubarItem>
+          <MenubarItem disabled>Copy</MenubarItem>
+          <MenubarItem>Paste</MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+    </Menubar>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open the menu
+    const trigger = canvas.getByRole('menuitem', { name: 'Edit' });
+    await userEvent.click(trigger);
+
+    const menu = await within(document.body).findByRole('menu');
+
+    // The disabled item is present and marked disabled. Do NOT click it —
+    // a disabled item has pointer-events: none, which makes click throw.
+    const disabledItem = within(menu).getByRole('menuitem', { name: 'Cut' });
+    await expect(disabledItem).toHaveAttribute('data-disabled');
+    await expect(disabledItem).toHaveAttribute('aria-disabled', 'true');
+
+    // An enabled item is reachable
+    const enabledItem = within(menu).getByRole('menuitem', { name: 'Paste' });
+    await expect(enabledItem).not.toHaveAttribute('data-disabled');
+
+    // Close
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(document.querySelector('[role="menu"]')).toBeNull();
+    });
+  },
+};
+
+export const WithDataAttributes: Story = {
+  render: (_args) => (
+    <Menubar>
+      <MenubarMenu>
+        <MenubarTrigger>File</MenubarTrigger>
+        <MenubarContent>
+          <MenubarLabel>Actions</MenubarLabel>
+          <MenubarSeparator />
+          <MenubarItem>Open</MenubarItem>
+          <MenubarItem variant="destructive">Delete</MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+    </Menubar>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open the menu
+    const trigger = canvas.getByRole('menuitem', { name: 'File' });
+    await userEvent.click(trigger);
+
+    // Wait for menu to be visible
+    await within(document.body).findByRole('menu');
+
+    // Check data-slot attributes
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="menubar-content"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="menubar-label"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="menubar-separator"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="menubar-item"]')
+      ).toBeInTheDocument();
+    });
+
+    // Check destructive variant
+    const destructiveItem = document.querySelector(
+      '[data-slot="menubar-item"][data-variant="destructive"]'
+    );
+    await expect(destructiveItem).toBeInTheDocument();
+
+    // The bar root carries its data-slot
+    await expect(
+      canvas.getByRole('menubar').closest('[data-slot="menubar"]')
+    ).toBeInTheDocument();
+
+    // Close the menu and wait for complete cleanup
+    await userEvent.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(document.querySelector('[role="menu"]')).toBeNull();
+      expect(document.querySelector('[data-aria-hidden="true"]')).toBeNull();
+    });
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+export const AllVariants: Story = {
+  render: (_args) => (
+    <div className="nx:flex nx:flex-col nx:gap-8">
+      <div>
+        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          Standard Menubar
+        </h3>
+        <Menubar>
+          <MenubarMenu>
+            <MenubarTrigger>File</MenubarTrigger>
+            <MenubarContent>
+              <MenubarItem>
+                New Tab
+                <MenubarShortcut>⌘T</MenubarShortcut>
+              </MenubarItem>
+              <MenubarItem>New Window</MenubarItem>
+              <MenubarSeparator />
+              <MenubarSub>
+                <MenubarSubTrigger>Share</MenubarSubTrigger>
+                <MenubarSubContent>
+                  <MenubarItem>Email Link</MenubarItem>
+                  <MenubarItem>Messages</MenubarItem>
+                </MenubarSubContent>
+              </MenubarSub>
+              <MenubarSeparator />
+              <MenubarItem>Print</MenubarItem>
+            </MenubarContent>
+          </MenubarMenu>
+          <MenubarMenu>
+            <MenubarTrigger>Edit</MenubarTrigger>
+            <MenubarContent>
+              <MenubarItem>Undo</MenubarItem>
+              <MenubarItem>Redo</MenubarItem>
+            </MenubarContent>
+          </MenubarMenu>
+          <MenubarMenu>
+            <MenubarTrigger>View</MenubarTrigger>
+            <MenubarContent>
+              <MenubarItem>Reload</MenubarItem>
+              <MenubarItem>Toggle Fullscreen</MenubarItem>
+            </MenubarContent>
+          </MenubarMenu>
+        </Menubar>
+      </div>
+
+      <div>
+        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          With Destructive Item
+        </h3>
+        <Menubar>
+          <MenubarMenu>
+            <MenubarTrigger>Actions</MenubarTrigger>
+            <MenubarContent>
+              <MenubarItem>Edit</MenubarItem>
+              <MenubarItem>Duplicate</MenubarItem>
+              <MenubarSeparator />
+              <MenubarItem variant="destructive">Delete</MenubarItem>
+            </MenubarContent>
+          </MenubarMenu>
+        </Menubar>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+// ============================================
+// A11Y is tested automatically on ALL stories
+// via addon-a11y with test: 'error'
+// ============================================

--- a/packages/react/src/components/ui/menubar.tsx
+++ b/packages/react/src/components/ui/menubar.tsx
@@ -1,0 +1,549 @@
+import * as React from 'react';
+
+import * as MenubarPrimitive from '@radix-ui/react-menubar';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { IconCheck, IconChevronRight, IconCircleFilled } from '@/lib/icons';
+import { cn } from '@/lib/utils';
+
+/**
+ * MenubarProps
+ *
+ * Props for the Menubar component.
+ */
+interface MenubarProps extends React.ComponentProps<
+  typeof MenubarPrimitive.Root
+> {}
+
+/**
+ * Menubar
+ *
+ * Root component — a horizontal bar of menus (desktop-app style).
+ *
+ * @example
+ * ```tsx
+ * <Menubar>
+ *   <MenubarMenu>
+ *     <MenubarTrigger>File</MenubarTrigger>
+ *     <MenubarContent>
+ *       <MenubarItem>New Tab</MenubarItem>
+ *     </MenubarContent>
+ *   </MenubarMenu>
+ * </Menubar>
+ * ```
+ */
+function Menubar({ className, ...props }: MenubarProps) {
+  return (
+    <MenubarPrimitive.Root
+      data-slot="menubar"
+      className={cn(
+        // nexus-allow-numeric: toolbar chrome rhythm
+        'nx:flex nx:items-center nx:gap-1 nx:rounded-md nx:border nx:border-border-default nx:bg-background nx:p-1 nx:shadow-xs',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * MenubarMenu
+ *
+ * Groups a trigger with its content. One per top-level menu.
+ */
+const MenubarMenu = MenubarPrimitive.Menu;
+
+/**
+ * MenubarGroup
+ *
+ * Groups related menu items together.
+ */
+const MenubarGroup = MenubarPrimitive.Group;
+
+/**
+ * MenubarPortal
+ *
+ * Portals the content to the body.
+ */
+const MenubarPortal = MenubarPrimitive.Portal;
+
+/**
+ * MenubarRadioGroup
+ *
+ * Groups radio items together.
+ */
+const MenubarRadioGroup = MenubarPrimitive.RadioGroup;
+
+/**
+ * MenubarSub
+ *
+ * Contains a submenu.
+ */
+const MenubarSub = MenubarPrimitive.Sub;
+
+/**
+ * MenubarTriggerProps
+ *
+ * Props for the MenubarTrigger component.
+ */
+interface MenubarTriggerProps extends React.ComponentProps<
+  typeof MenubarPrimitive.Trigger
+> {}
+
+/**
+ * MenubarTrigger
+ *
+ * A top-level menu trigger in the bar. Opens its menu on click.
+ */
+function MenubarTrigger({ className, ...props }: MenubarTriggerProps) {
+  return (
+    <MenubarPrimitive.Trigger
+      data-slot="menubar-trigger"
+      className={cn(
+        // nexus-allow-numeric: bar trigger rhythm (tighter than menu items)
+        'nx:flex nx:select-none nx:items-center nx:rounded-sm nx:px-2 nx:py-1',
+        'nx:text-sm nx:font-medium nx:outline-none',
+        'nx:focus:bg-background-hover nx:focus:text-foreground',
+        'nx:data-[state=open]:bg-background-hover nx:data-[state=open]:text-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * MenubarSubTriggerProps
+ *
+ * Props for the MenubarSubTrigger component.
+ */
+interface MenubarSubTriggerProps extends React.ComponentProps<
+  typeof MenubarPrimitive.SubTrigger
+> {
+  /**
+   * Indents the trigger to align with items that have a leading icon or checkbox.
+   * @default false
+   */
+  inset?: boolean;
+}
+
+/**
+ * MenubarSubTrigger
+ *
+ * The trigger for a submenu. Renders a chevron to indicate a submenu.
+ */
+function MenubarSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: MenubarSubTriggerProps) {
+  return (
+    <MenubarPrimitive.SubTrigger
+      data-slot="menubar-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        // nexus-allow-numeric: menu item-tier rhythm
+        'nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2',
+        // nexus-allow-numeric: menu item-tier rhythm
+        'nx:rounded-sm nx:px-2 nx:py-control-sm nx:text-sm nx:outline-none',
+        'nx:focus:bg-background-hover nx:focus:text-foreground',
+        'nx:data-[state=open]:bg-background-hover',
+        'nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+        inset && 'nx:pl-8',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <IconChevronRight className="nx:ml-auto nx:size-4" />
+    </MenubarPrimitive.SubTrigger>
+  );
+}
+
+/**
+ * MenubarSubContentProps
+ *
+ * Props for the MenubarSubContent component.
+ */
+interface MenubarSubContentProps extends React.ComponentProps<
+  typeof MenubarPrimitive.SubContent
+> {}
+
+/**
+ * MenubarSubContent
+ *
+ * The content container for a submenu.
+ */
+function MenubarSubContent({ className, ...props }: MenubarSubContentProps) {
+  return (
+    <MenubarPrimitive.SubContent
+      data-slot="menubar-sub-content"
+      className={cn(
+        'nx:z-popover nx:min-w-[8rem] nx:overflow-hidden',
+        'nx:rounded-md nx:border nx:border-border-default',
+        // nexus-allow-numeric: popover chrome (sub-canonical inner padding)
+        'nx:bg-popover nx:p-1 nx:text-popover-foreground nx:shadow-lg',
+        'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
+        'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
+        'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',
+        'nx:data-[side=bottom]:slide-in-from-top-2',
+        'nx:data-[side=left]:slide-in-from-right-2',
+        'nx:data-[side=right]:slide-in-from-left-2',
+        'nx:data-[side=top]:slide-in-from-bottom-2',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * MenubarContentProps
+ *
+ * Props for the MenubarContent component.
+ */
+interface MenubarContentProps extends React.ComponentProps<
+  typeof MenubarPrimitive.Content
+> {}
+
+/**
+ * MenubarContent
+ *
+ * The menu content container. Anchors below its trigger.
+ *
+ * @example
+ * ```tsx
+ * <MenubarContent>
+ *   <MenubarItem>New Tab</MenubarItem>
+ *   <MenubarItem>New Window</MenubarItem>
+ * </MenubarContent>
+ * ```
+ */
+function MenubarContent({
+  className,
+  align = 'start',
+  alignOffset = -4,
+  sideOffset = 8,
+  ...props
+}: MenubarContentProps) {
+  return (
+    <MenubarPrimitive.Portal>
+      <MenubarPrimitive.Content
+        data-slot="menubar-content"
+        align={align}
+        alignOffset={alignOffset}
+        sideOffset={sideOffset}
+        className={cn(
+          'nx:z-popover nx:min-w-[12rem] nx:overflow-hidden',
+          'nx:rounded-md nx:border nx:border-border-default',
+          // nexus-allow-numeric: popover chrome (sub-canonical inner padding)
+          'nx:bg-popover nx:p-1 nx:text-popover-foreground nx:shadow-lg',
+          'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
+          'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
+          'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',
+          'nx:data-[side=bottom]:slide-in-from-top-2',
+          'nx:data-[side=left]:slide-in-from-right-2',
+          'nx:data-[side=right]:slide-in-from-left-2',
+          'nx:data-[side=top]:slide-in-from-bottom-2',
+          className
+        )}
+        {...props}
+      />
+    </MenubarPrimitive.Portal>
+  );
+}
+
+const menubarItemVariants = cva(
+  // nexus-allow-numeric: menu item-tier rhythm
+  'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2 nx:rounded-sm nx:px-2 nx:py-control-sm nx:text-sm nx:outline-none nx:transition-colors nx:focus:bg-background-hover nx:focus:text-foreground nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: '',
+        destructive:
+          'nx:text-error-subtle-foreground nx:focus:bg-error-background nx:focus:text-error-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+/**
+ * MenubarItemProps
+ *
+ * Props for the MenubarItem component.
+ */
+interface MenubarItemProps
+  extends
+    React.ComponentProps<typeof MenubarPrimitive.Item>,
+    VariantProps<typeof menubarItemVariants> {
+  /**
+   * Indents the item to align with items that have a leading icon or checkbox.
+   * @default false
+   */
+  inset?: boolean;
+}
+
+/**
+ * MenubarItem
+ *
+ * An individual menu item.
+ *
+ * @example
+ * ```tsx
+ * <MenubarItem>New Tab</MenubarItem>
+ * <MenubarItem variant="destructive">Delete</MenubarItem>
+ * ```
+ */
+function MenubarItem({
+  className,
+  inset,
+  variant = 'default',
+  ...props
+}: MenubarItemProps) {
+  return (
+    <MenubarPrimitive.Item
+      data-slot="menubar-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        menubarItemVariants({ variant }),
+        inset && 'nx:pl-8',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * MenubarCheckboxItemProps
+ *
+ * Props for the MenubarCheckboxItem component.
+ */
+interface MenubarCheckboxItemProps extends React.ComponentProps<
+  typeof MenubarPrimitive.CheckboxItem
+> {}
+
+/**
+ * MenubarCheckboxItem
+ *
+ * A menu item that can be checked/unchecked.
+ *
+ * @example
+ * ```tsx
+ * <MenubarCheckboxItem checked={showStatusBar} onCheckedChange={setShowStatusBar}>
+ *   Status Bar
+ * </MenubarCheckboxItem>
+ * ```
+ */
+function MenubarCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: MenubarCheckboxItemProps) {
+  return (
+    <MenubarPrimitive.CheckboxItem
+      data-slot="menubar-checkbox-item"
+      className={cn(
+        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
+        'nx:rounded-sm nx:py-control-sm nx:pl-8 nx:pr-2 nx:text-sm nx:outline-none',
+        'nx:transition-colors',
+        'nx:focus:bg-background-hover nx:focus:text-foreground',
+        'nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50',
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
+        <MenubarPrimitive.ItemIndicator>
+          <IconCheck className="nx:size-4" />
+        </MenubarPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </MenubarPrimitive.CheckboxItem>
+  );
+}
+
+/**
+ * MenubarRadioItemProps
+ *
+ * Props for the MenubarRadioItem component.
+ */
+interface MenubarRadioItemProps extends React.ComponentProps<
+  typeof MenubarPrimitive.RadioItem
+> {}
+
+/**
+ * MenubarRadioItem
+ *
+ * A radio menu item for exclusive selection.
+ *
+ * @example
+ * ```tsx
+ * <MenubarRadioGroup value={position} onValueChange={setPosition}>
+ *   <MenubarRadioItem value="top">Top</MenubarRadioItem>
+ *   <MenubarRadioItem value="bottom">Bottom</MenubarRadioItem>
+ * </MenubarRadioGroup>
+ * ```
+ */
+function MenubarRadioItem({
+  className,
+  children,
+  ...props
+}: MenubarRadioItemProps) {
+  return (
+    <MenubarPrimitive.RadioItem
+      data-slot="menubar-radio-item"
+      className={cn(
+        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
+        'nx:rounded-sm nx:py-control-sm nx:pl-8 nx:pr-2 nx:text-sm nx:outline-none',
+        'nx:transition-colors',
+        'nx:focus:bg-background-hover nx:focus:text-foreground',
+        'nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50',
+        className
+      )}
+      {...props}
+    >
+      <span className="nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
+        <MenubarPrimitive.ItemIndicator>
+          <IconCircleFilled className="nx:size-2" />
+        </MenubarPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </MenubarPrimitive.RadioItem>
+  );
+}
+
+/**
+ * MenubarLabelProps
+ *
+ * Props for the MenubarLabel component.
+ */
+interface MenubarLabelProps extends React.ComponentProps<
+  typeof MenubarPrimitive.Label
+> {
+  /**
+   * Indents the label to align with items that have a leading icon or checkbox.
+   * @default false
+   */
+  inset?: boolean;
+}
+
+/**
+ * MenubarLabel
+ *
+ * A label for a group of menu items.
+ *
+ * @example
+ * ```tsx
+ * <MenubarLabel>Appearance</MenubarLabel>
+ * ```
+ */
+function MenubarLabel({ className, inset, ...props }: MenubarLabelProps) {
+  return (
+    <MenubarPrimitive.Label
+      data-slot="menubar-label"
+      data-inset={inset}
+      className={cn(
+        // nexus-allow-numeric: menu label item-tier rhythm
+        'nx:px-2 nx:py-control-sm nx:text-sm nx:font-semibold',
+        inset && 'nx:pl-8',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * MenubarSeparatorProps
+ *
+ * Props for the MenubarSeparator component.
+ */
+interface MenubarSeparatorProps extends React.ComponentProps<
+  typeof MenubarPrimitive.Separator
+> {}
+
+/**
+ * MenubarSeparator
+ *
+ * A visual divider between menu items.
+ */
+function MenubarSeparator({ className, ...props }: MenubarSeparatorProps) {
+  return (
+    <MenubarPrimitive.Separator
+      data-slot="menubar-separator"
+      className={cn('nx:-mx-1 nx:my-1 nx:h-px nx:bg-muted', className)}
+      {...props}
+    />
+  );
+}
+
+/**
+ * MenubarShortcutProps
+ *
+ * Props for the MenubarShortcut component.
+ */
+interface MenubarShortcutProps extends React.ComponentProps<'span'> {}
+
+/**
+ * MenubarShortcut
+ *
+ * Displays a keyboard shortcut hint.
+ *
+ * @example
+ * ```tsx
+ * <MenubarItem>
+ *   New Tab <MenubarShortcut>⌘T</MenubarShortcut>
+ * </MenubarItem>
+ * ```
+ */
+function MenubarShortcut({ className, ...props }: MenubarShortcutProps) {
+  return (
+    <span
+      data-slot="menubar-shortcut"
+      className={cn(
+        'nx:ml-auto nx:text-xs nx:tracking-widest nx:text-muted-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Menubar,
+  MenubarCheckboxItem,
+  type MenubarCheckboxItemProps,
+  MenubarContent,
+  type MenubarContentProps,
+  MenubarGroup,
+  MenubarItem,
+  type MenubarItemProps,
+  menubarItemVariants,
+  MenubarLabel,
+  type MenubarLabelProps,
+  MenubarMenu,
+  MenubarPortal,
+  type MenubarProps,
+  MenubarRadioGroup,
+  MenubarRadioItem,
+  type MenubarRadioItemProps,
+  MenubarSeparator,
+  type MenubarSeparatorProps,
+  MenubarShortcut,
+  type MenubarShortcutProps,
+  MenubarSub,
+  MenubarSubContent,
+  type MenubarSubContentProps,
+  MenubarSubTrigger,
+  type MenubarSubTriggerProps,
+  MenubarTrigger,
+  type MenubarTriggerProps,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -35,6 +35,7 @@ export * from '@/components/ui/input-otp';
 export * from '@/components/ui/item';
 export * from '@/components/ui/kbd';
 export * from '@/components/ui/label';
+export * from '@/components/ui/menubar';
 export * from '@/components/ui/native-select';
 export * from '@/components/ui/pagination';
 export * from '@/components/ui/popover';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1262,6 +1262,22 @@
     aria-hidden "^1.2.4"
     react-remove-scroll "^2.6.3"
 
+"@radix-ui/react-menubar@^1.1.16":
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz#5edf7ea2ff7aa7e3ba896b35cf577f122160121c"
+  integrity sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-collection" "1.1.7"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-direction" "1.1.1"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-menu" "2.1.16"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-roving-focus" "1.1.11"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+
 "@radix-ui/react-popover@^1.1.15":
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-popover/-/react-popover-1.1.15.tgz#9c852f93990a687ebdc949b2c3de1f37cdc4c5d5"


### PR DESCRIPTION
## Summary

- Adapts shadcn **menubar** → Nexus, wrapping Radix `@radix-ui/react-menubar`. A horizontal, desktop-app-style bar of menus.
- **Reuses the menu-family surface** (dropdown / context-menu): item (default / destructive), checkbox item, radio item + group, submenu (trigger + content), label, separator, shortcut, group, inset items — identical tokens (`py-control-sm` rhythm, `focus:bg-background-hover` roving-focus tint, destructive cva, `shadow-lg` floating content). The whole menu family now reads consistently.
- **Bar-specific pieces:** `Menubar` Root (the bar — `shadow-xs` resting elevation), `MenubarMenu`, `MenubarTrigger` (opens on click), `MenubarContent` (`min-w-12rem`, anchored below the trigger with `align`/`alignOffset`/`sideOffset`).
- `nx:` prefix throughout, semantic tokens only, `data-slot` on every rendered element.

## Adaptation notes (judgment calls)

- **Dropped shadcn's fixed `h-9` on the bar Root** — Nexus sizes by padding, not fixed height (`components.md` § Sizing Convention). The bar height is content-driven (`p-1` + trigger padding).
- **`MenubarTrigger` focus = roving-focus background tint, not the outline ring.** Radix Menubar uses roving focus and switches focus on hover once a menu is open, so a `:focus-visible` ring would flash for pointer users. This follows the menu-family / `components.md` § Surface exception map (roving focus → tint), matching shadcn. (The Tabs trigger takes the ring; Menubar triggers are menu-openers, so they follow the menu pattern.)
- **`shadow-md` → `shadow-lg`** on Content (Nexus has no `shadow-md`; `shadow-lg` is the floating-panel elevation, consistent with the rest of the menu family after #352).

## Bundle

Near-free: `@radix-ui/react-menubar` shares the already-bundled `@radix-ui/react-menu@2.1.16` (verified via `yarn why`). ESM **75.92 kB** local / 80 kB limit.

## GitHub Issue

Closes #292

## Test Plan

- [x] `typecheck`, `eslint --max-warnings 0`, `prettier` clean
- [x] `audit:storybook-coverage --component menubar` → no gaps (Disabled / ClickInteraction / KeyboardInteraction via `WithDisabledItems` / `OpenCloseInteraction` equivalents)
- [x] `size-limit` 75.92 kB ESM / 80 kB · `shadow-xs` + `min-w-[12rem]` emitted in `dist/react.css`
- [x] Archetype grep clean: no `accent` / `dark:` / `outline-hidden` / `shadow-md` / opacity-hover / `h-9`
- [ ] CI: story play-fns (click open/close, keyboard nav, disabled-item assertions) green in the browser runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)