### PR TITLE
feat(components): add navigation-menu component (#293)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "react-hook-form",
         "sonner"
       ],
-      "limit": "80 kB"
+      "limit": "85 kB"
     },
     {
       "name": "@nexus/react (CSS)",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -64,6 +64,7 @@
     "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-menubar": "^1.1.16",
+    "@radix-ui/react-navigation-menu": "^1.2.14",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-radio-group": "^1.3.8",

--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -78,6 +78,12 @@
       }
     },
     { "name": "NativeSelect", "showcase": "AllVariants" },
+    {
+      "name": "NavigationMenu",
+      "showcase": "AllVariants",
+      "interactions": ["ClickInteraction", "KeyboardInteraction"],
+      "equivalents": { "ClickInteraction": ["OpenCloseInteraction"] }
+    },
     { "name": "Pagination", "showcase": "AllVariants" },
     {
       "name": "Popover",

--- a/packages/react/src/components/ui/NavigationMenu.stories.tsx
+++ b/packages/react/src/components/ui/NavigationMenu.stories.tsx
@@ -1,0 +1,375 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import {
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuIndicator,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+  navigationMenuTriggerStyle,
+} from './navigation-menu';
+
+const meta: Meta<typeof NavigationMenu> = {
+  title: 'Components/NavigationMenu',
+  component: NavigationMenu,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof NavigationMenu>;
+
+// ============================================
+// BASIC STORIES
+// ============================================
+
+export const Default: Story = {
+  render: (_args) => (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="nx:grid nx:w-[320px] nx:gap-1 nx:p-2">
+              <li>
+                <NavigationMenuLink href="#analytics">
+                  Analytics
+                </NavigationMenuLink>
+              </li>
+              <li>
+                <NavigationMenuLink href="#automation">
+                  Automation
+                </NavigationMenuLink>
+              </li>
+              <li>
+                <NavigationMenuLink href="#reports">Reports</NavigationMenuLink>
+              </li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Company</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="nx:grid nx:w-[320px] nx:gap-1 nx:p-2">
+              <li>
+                <NavigationMenuLink href="#about">About</NavigationMenuLink>
+              </li>
+              <li>
+                <NavigationMenuLink href="#careers">Careers</NavigationMenuLink>
+              </li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  ),
+};
+
+export const WithSimpleLink: Story = {
+  render: (_args) => (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuLink
+            href="#docs"
+            className={navigationMenuTriggerStyle()}
+          >
+            Docs
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuLink
+            href="#pricing"
+            className={navigationMenuTriggerStyle()}
+          >
+            Pricing
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  ),
+};
+
+export const WithoutViewport: Story = {
+  render: (_args) => (
+    <NavigationMenu viewport={false}>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="nx:grid nx:w-[320px] nx:gap-1 nx:p-2">
+              <li>
+                <NavigationMenuLink href="#analytics">
+                  Analytics
+                </NavigationMenuLink>
+              </li>
+              <li>
+                <NavigationMenuLink href="#reports">Reports</NavigationMenuLink>
+              </li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  ),
+};
+
+export const WithIndicator: Story = {
+  render: (_args) => (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="nx:grid nx:w-[320px] nx:gap-1 nx:p-2">
+              <li>
+                <NavigationMenuLink href="#analytics">
+                  Analytics
+                </NavigationMenuLink>
+              </li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Company</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="nx:grid nx:w-[320px] nx:gap-1 nx:p-2">
+              <li>
+                <NavigationMenuLink href="#about">About</NavigationMenuLink>
+              </li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        <NavigationMenuIndicator />
+      </NavigationMenuList>
+    </NavigationMenu>
+  ),
+};
+
+// ============================================
+// INTERACTION TESTS
+// ============================================
+
+export const OpenCloseInteraction: Story = {
+  render: (_args) => (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="nx:grid nx:w-[320px] nx:gap-1 nx:p-2">
+              <li>
+                <NavigationMenuLink href="#analytics">
+                  Analytics
+                </NavigationMenuLink>
+              </li>
+              <li>
+                <NavigationMenuLink href="#reports">Reports</NavigationMenuLink>
+              </li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole('button', { name: /Products/i });
+    await expect(trigger).toHaveAttribute('data-state', 'closed');
+
+    // Open the flyout by clicking the trigger
+    await userEvent.click(trigger);
+    await waitFor(() => expect(trigger).toHaveAttribute('data-state', 'open'));
+
+    // The flyout links render in-tree (no portal)
+    const link = await canvas.findByRole('link', { name: 'Analytics' });
+    await expect(link).toBeInTheDocument();
+
+    // Close with Escape
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(trigger).toHaveAttribute('data-state', 'closed')
+    );
+  },
+};
+
+export const KeyboardInteraction: Story = {
+  render: (_args) => (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="nx:grid nx:w-[320px] nx:gap-1 nx:p-2">
+              <li>
+                <NavigationMenuLink href="#analytics">
+                  Analytics
+                </NavigationMenuLink>
+              </li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: /Products/i });
+
+    // Focus the trigger and open with the keyboard
+    await userEvent.tab();
+    await expect(trigger).toHaveFocus();
+
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(trigger).toHaveAttribute('data-state', 'open'));
+
+    // Close with Escape
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(trigger).toHaveAttribute('data-state', 'closed')
+    );
+  },
+};
+
+export const WithDataAttributes: Story = {
+  render: (_args) => (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="nx:grid nx:w-[320px] nx:gap-1 nx:p-2">
+              <li>
+                <NavigationMenuLink href="#analytics">
+                  Analytics
+                </NavigationMenuLink>
+              </li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Root carries data-slot + data-viewport
+    const root = canvasElement.querySelector('[data-slot="navigation-menu"]');
+    await expect(root).toBeInTheDocument();
+    await expect(root).toHaveAttribute('data-viewport', 'true');
+
+    // List + Item slots present
+    await expect(
+      canvasElement.querySelector('[data-slot="navigation-menu-list"]')
+    ).toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-slot="navigation-menu-item"]')
+    ).toBeInTheDocument();
+
+    // Trigger slot
+    const trigger = canvas.getByRole('button', { name: /Products/i });
+    await expect(trigger).toHaveAttribute(
+      'data-slot',
+      'navigation-menu-trigger'
+    );
+
+    // Open → content + link slots render
+    await userEvent.click(trigger);
+    await waitFor(() => {
+      expect(
+        canvasElement.querySelector('[data-slot="navigation-menu-content"]')
+      ).toBeInTheDocument();
+      expect(
+        canvasElement.querySelector('[data-slot="navigation-menu-link"]')
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.keyboard('{Escape}');
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID
+// ============================================
+
+export const AllVariants: Story = {
+  render: (_args) => (
+    <div className="nx:flex nx:flex-col nx:gap-8">
+      <div>
+        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          With Flyout Triggers
+        </h3>
+        <NavigationMenu aria-label="Flyout navigation">
+          <NavigationMenuList>
+            <NavigationMenuItem>
+              <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+              <NavigationMenuContent>
+                <ul className="nx:grid nx:w-[320px] nx:gap-1 nx:p-2">
+                  <li>
+                    <NavigationMenuLink href="#analytics">
+                      Analytics
+                    </NavigationMenuLink>
+                  </li>
+                  <li>
+                    <NavigationMenuLink href="#reports">
+                      Reports
+                    </NavigationMenuLink>
+                  </li>
+                </ul>
+              </NavigationMenuContent>
+            </NavigationMenuItem>
+            <NavigationMenuItem>
+              <NavigationMenuTrigger>Company</NavigationMenuTrigger>
+              <NavigationMenuContent>
+                <ul className="nx:grid nx:w-[320px] nx:gap-1 nx:p-2">
+                  <li>
+                    <NavigationMenuLink href="#about">About</NavigationMenuLink>
+                  </li>
+                </ul>
+              </NavigationMenuContent>
+            </NavigationMenuItem>
+          </NavigationMenuList>
+        </NavigationMenu>
+      </div>
+
+      <div>
+        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          Simple Links (no flyout)
+        </h3>
+        <NavigationMenu aria-label="Simple links navigation">
+          <NavigationMenuList>
+            <NavigationMenuItem>
+              <NavigationMenuLink
+                href="#docs"
+                className={navigationMenuTriggerStyle()}
+              >
+                Docs
+              </NavigationMenuLink>
+            </NavigationMenuItem>
+            <NavigationMenuItem>
+              <NavigationMenuLink
+                href="#pricing"
+                className={navigationMenuTriggerStyle()}
+              >
+                Pricing
+              </NavigationMenuLink>
+            </NavigationMenuItem>
+          </NavigationMenuList>
+        </NavigationMenu>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+// ============================================
+// A11Y is tested automatically on ALL stories
+// via addon-a11y with test: 'error'
+// ============================================

--- a/packages/react/src/components/ui/navigation-menu.tsx
+++ b/packages/react/src/components/ui/navigation-menu.tsx
@@ -1,0 +1,327 @@
+import * as React from 'react';
+
+import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu';
+import { cva } from 'class-variance-authority';
+
+import { IconChevronDown } from '@/lib/icons';
+import { cn } from '@/lib/utils';
+
+/**
+ * NavigationMenuProps
+ *
+ * Props for the NavigationMenu component.
+ */
+interface NavigationMenuProps extends React.ComponentProps<
+  typeof NavigationMenuPrimitive.Root
+> {
+  /**
+   * Render the shared flyout viewport panel beneath the menu. Set `false` to
+   * render each item's content inline under its own trigger instead.
+   * @default true
+   */
+  viewport?: boolean;
+}
+
+/**
+ * NavigationMenu
+ *
+ * Root component for top-level site navigation with flyout panels.
+ * Declares the `navmenu` container so the flyout positioning adapts to the
+ * menu's own width (see NavigationMenuContent / NavigationMenuViewport).
+ *
+ * @example
+ * ```tsx
+ * <NavigationMenu>
+ *   <NavigationMenuList>
+ *     <NavigationMenuItem>
+ *       <NavigationMenuTrigger>Products</NavigationMenuTrigger>
+ *       <NavigationMenuContent>...</NavigationMenuContent>
+ *     </NavigationMenuItem>
+ *   </NavigationMenuList>
+ * </NavigationMenu>
+ * ```
+ */
+function NavigationMenu({
+  className,
+  children,
+  viewport = true,
+  ...props
+}: NavigationMenuProps) {
+  return (
+    <NavigationMenuPrimitive.Root
+      data-slot="navigation-menu"
+      data-viewport={viewport}
+      className={cn(
+        'nx:group/navigation-menu nx:@container/navmenu nx:relative nx:flex nx:w-full nx:items-center nx:justify-center',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {viewport && <NavigationMenuViewport />}
+    </NavigationMenuPrimitive.Root>
+  );
+}
+
+/**
+ * NavigationMenuListProps
+ *
+ * Props for the NavigationMenuList component.
+ */
+interface NavigationMenuListProps extends React.ComponentProps<
+  typeof NavigationMenuPrimitive.List
+> {}
+
+/**
+ * NavigationMenuList
+ *
+ * The horizontal list of top-level navigation items.
+ */
+function NavigationMenuList({ className, ...props }: NavigationMenuListProps) {
+  return (
+    <NavigationMenuPrimitive.List
+      data-slot="navigation-menu-list"
+      className={cn(
+        // nexus-allow-numeric: nav list rhythm
+        'nx:group nx:flex nx:flex-1 nx:list-none nx:items-center nx:justify-center nx:gap-1',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * NavigationMenuItemProps
+ *
+ * Props for the NavigationMenuItem component.
+ */
+interface NavigationMenuItemProps extends React.ComponentProps<
+  typeof NavigationMenuPrimitive.Item
+> {}
+
+/**
+ * NavigationMenuItem
+ *
+ * A single top-level navigation item (trigger + content).
+ */
+function NavigationMenuItem({ className, ...props }: NavigationMenuItemProps) {
+  return (
+    <NavigationMenuPrimitive.Item
+      data-slot="navigation-menu-item"
+      className={cn('nx:relative', className)}
+      {...props}
+    />
+  );
+}
+
+const navigationMenuTriggerStyle = cva(
+  // nexus-allow-numeric: nav trigger rhythm
+  'nx:group nx:inline-flex nx:w-max nx:items-center nx:justify-center nx:rounded-md nx:bg-background nx:px-4 nx:py-2 nx:text-sm nx:font-medium nx:outline-none nx:transition-colors nx:hover:bg-background-hover nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:pointer-events-none nx:disabled:opacity-50 nx:data-[state=open]:bg-background-hover nx:data-[state=open]:text-foreground'
+);
+
+/**
+ * NavigationMenuTriggerProps
+ *
+ * Props for the NavigationMenuTrigger component.
+ */
+interface NavigationMenuTriggerProps extends React.ComponentProps<
+  typeof NavigationMenuPrimitive.Trigger
+> {}
+
+/**
+ * NavigationMenuTrigger
+ *
+ * A top-level trigger that opens its flyout content. Renders a chevron that
+ * rotates when open.
+ */
+function NavigationMenuTrigger({
+  className,
+  children,
+  ...props
+}: NavigationMenuTriggerProps) {
+  return (
+    <NavigationMenuPrimitive.Trigger
+      data-slot="navigation-menu-trigger"
+      className={cn(navigationMenuTriggerStyle(), 'nx:group', className)}
+      {...props}
+    >
+      {children}{' '}
+      <IconChevronDown
+        className="nx:relative nx:top-px nx:ml-1 nx:size-3 nx:transition nx:duration-300 nx:group-data-[state=open]:rotate-180"
+        aria-hidden="true"
+      />
+    </NavigationMenuPrimitive.Trigger>
+  );
+}
+
+/**
+ * NavigationMenuContentProps
+ *
+ * Props for the NavigationMenuContent component.
+ */
+interface NavigationMenuContentProps extends React.ComponentProps<
+  typeof NavigationMenuPrimitive.Content
+> {}
+
+/**
+ * NavigationMenuContent
+ *
+ * The flyout panel for a navigation item. Below the `navmenu` container's `md`
+ * width it stacks in-flow (full width); at/above it becomes an absolute panel.
+ */
+function NavigationMenuContent({
+  className,
+  ...props
+}: NavigationMenuContentProps) {
+  return (
+    <NavigationMenuPrimitive.Content
+      data-slot="navigation-menu-content"
+      className={cn(
+        // nexus-allow-numeric: flyout chrome rhythm
+        'nx:top-0 nx:left-0 nx:w-full nx:p-2 nx:pr-2.5',
+        'nx:data-[motion=from-end]:slide-in-from-right-52 nx:data-[motion=from-start]:slide-in-from-left-52',
+        'nx:data-[motion=to-end]:slide-out-to-right-52 nx:data-[motion=to-start]:slide-out-to-left-52',
+        'nx:data-[motion^=from-]:animate-in nx:data-[motion^=from-]:fade-in nx:data-[motion^=to-]:animate-out nx:data-[motion^=to-]:fade-out',
+        // @container conversion of shadcn's `md:absolute md:w-auto`
+        'nx:@md/navmenu:absolute nx:@md/navmenu:w-auto',
+        'nx:group-data-[viewport=false]/navigation-menu:top-full',
+        // nexus-allow-numeric: inline-content offset
+        'nx:group-data-[viewport=false]/navigation-menu:mt-1.5',
+        'nx:group-data-[viewport=false]/navigation-menu:overflow-hidden nx:group-data-[viewport=false]/navigation-menu:rounded-md',
+        'nx:group-data-[viewport=false]/navigation-menu:border nx:group-data-[viewport=false]/navigation-menu:border-border-default',
+        'nx:group-data-[viewport=false]/navigation-menu:bg-popover nx:group-data-[viewport=false]/navigation-menu:text-popover-foreground',
+        'nx:group-data-[viewport=false]/navigation-menu:shadow-lg nx:group-data-[viewport=false]/navigation-menu:duration-200',
+        'nx:group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out nx:group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 nx:group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95',
+        'nx:group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in nx:group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 nx:group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * NavigationMenuViewportProps
+ *
+ * Props for the NavigationMenuViewport component.
+ */
+interface NavigationMenuViewportProps extends React.ComponentProps<
+  typeof NavigationMenuPrimitive.Viewport
+> {}
+
+/**
+ * NavigationMenuViewport
+ *
+ * The shared flyout container that holds the active item's content. Sized to
+ * the Radix-measured content width at/above the `navmenu` container's `md`
+ * width; full-width below it.
+ */
+function NavigationMenuViewport({
+  className,
+  ...props
+}: NavigationMenuViewportProps) {
+  return (
+    <div className="nx:absolute nx:top-full nx:left-0 nx:isolate nx:z-popover nx:flex nx:justify-center">
+      <NavigationMenuPrimitive.Viewport
+        data-slot="navigation-menu-viewport"
+        className={cn(
+          // nexus-allow-numeric: viewport panel offset
+          'nx:origin-top-center nx:relative nx:mt-1.5 nx:h-[var(--radix-navigation-menu-viewport-height)] nx:w-full nx:overflow-hidden',
+          'nx:rounded-md nx:border nx:border-border-default nx:bg-popover nx:text-popover-foreground nx:shadow-lg',
+          'nx:data-[state=closed]:animate-out nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:animate-in nx:data-[state=open]:zoom-in-90',
+          // @container conversion of shadcn's `md:w-[var(...)]`
+          'nx:@md/navmenu:w-[var(--radix-navigation-menu-viewport-width)]',
+          className
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+/**
+ * NavigationMenuLinkProps
+ *
+ * Props for the NavigationMenuLink component.
+ */
+interface NavigationMenuLinkProps extends React.ComponentProps<
+  typeof NavigationMenuPrimitive.Link
+> {}
+
+/**
+ * NavigationMenuLink
+ *
+ * A navigable link inside a flyout panel.
+ */
+function NavigationMenuLink({ className, ...props }: NavigationMenuLinkProps) {
+  return (
+    <NavigationMenuPrimitive.Link
+      data-slot="navigation-menu-link"
+      className={cn(
+        // nexus-allow-numeric: link rhythm
+        'nx:flex nx:flex-col nx:gap-1 nx:rounded-sm nx:p-2 nx:text-sm nx:outline-none nx:transition-colors',
+        'nx:hover:bg-background-hover nx:hover:text-foreground',
+        'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
+        'nx:data-[active=true]:bg-background-hover nx:data-[active=true]:text-foreground',
+        'nx:[&_svg:not([class*=size-])]:size-4 nx:[&_svg:not([class*=text-])]:text-muted-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * NavigationMenuIndicatorProps
+ *
+ * Props for the NavigationMenuIndicator component.
+ */
+interface NavigationMenuIndicatorProps extends React.ComponentProps<
+  typeof NavigationMenuPrimitive.Indicator
+> {}
+
+/**
+ * NavigationMenuIndicator
+ *
+ * A small arrow that points from the active trigger to its flyout.
+ */
+function NavigationMenuIndicator({
+  className,
+  ...props
+}: NavigationMenuIndicatorProps) {
+  return (
+    <NavigationMenuPrimitive.Indicator
+      data-slot="navigation-menu-indicator"
+      className={cn(
+        // nexus-allow-numeric: indicator rail height
+        'nx:top-full nx:z-[1] nx:flex nx:h-1.5 nx:items-end nx:justify-center nx:overflow-hidden',
+        'nx:data-[state=hidden]:animate-out nx:data-[state=hidden]:fade-out nx:data-[state=visible]:animate-in nx:data-[state=visible]:fade-in',
+        className
+      )}
+      {...props}
+    >
+      <div className="nx:relative nx:top-[60%] nx:size-2 nx:rotate-45 nx:rounded-tl-sm nx:bg-border-default nx:shadow-sm" />
+    </NavigationMenuPrimitive.Indicator>
+  );
+}
+
+export {
+  NavigationMenu,
+  NavigationMenuContent,
+  type NavigationMenuContentProps,
+  NavigationMenuIndicator,
+  type NavigationMenuIndicatorProps,
+  NavigationMenuItem,
+  type NavigationMenuItemProps,
+  NavigationMenuLink,
+  type NavigationMenuLinkProps,
+  NavigationMenuList,
+  type NavigationMenuListProps,
+  type NavigationMenuProps,
+  NavigationMenuTrigger,
+  type NavigationMenuTriggerProps,
+  navigationMenuTriggerStyle,
+  NavigationMenuViewport,
+  type NavigationMenuViewportProps,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -37,6 +37,7 @@ export * from '@/components/ui/kbd';
 export * from '@/components/ui/label';
 export * from '@/components/ui/menubar';
 export * from '@/components/ui/native-select';
+export * from '@/components/ui/navigation-menu';
 export * from '@/components/ui/pagination';
 export * from '@/components/ui/popover';
 export * from '@/components/ui/progress';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1278,6 +1278,26 @@
     "@radix-ui/react-roving-focus" "1.1.11"
     "@radix-ui/react-use-controllable-state" "1.2.2"
 
+"@radix-ui/react-navigation-menu@^1.2.14":
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz#4e6d1172be3c89752e564f8721706f78574ad7dd"
+  integrity sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==
+  dependencies:
+    "@radix-ui/primitive" "1.1.3"
+    "@radix-ui/react-collection" "1.1.7"
+    "@radix-ui/react-compose-refs" "1.1.2"
+    "@radix-ui/react-context" "1.1.2"
+    "@radix-ui/react-direction" "1.1.1"
+    "@radix-ui/react-dismissable-layer" "1.1.11"
+    "@radix-ui/react-id" "1.1.1"
+    "@radix-ui/react-presence" "1.1.5"
+    "@radix-ui/react-primitive" "2.1.3"
+    "@radix-ui/react-use-callback-ref" "1.1.1"
+    "@radix-ui/react-use-controllable-state" "1.2.2"
+    "@radix-ui/react-use-layout-effect" "1.1.1"
+    "@radix-ui/react-use-previous" "1.1.1"
+    "@radix-ui/react-visually-hidden" "1.2.3"
+
 "@radix-ui/react-popover@^1.1.15":
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-popover/-/react-popover-1.1.15.tgz#9c852f93990a687ebdc949b2c3de1f37cdc4c5d5"


### PR DESCRIPTION
## Summary

- Adapts shadcn **navigation-menu** → Nexus, wrapping Radix `@radix-ui/react-navigation-menu`. Top-level site navigation with flyout panels: `NavigationMenu` (root + optional shared `Viewport`), `List`, `Item`, `Trigger` (rotating chevron), `Content`, `Link`, `Indicator`.
- `nx:` prefix throughout, semantic tokens only, `data-slot` on every rendered element.

## Responsive: `md:` → `@container` (per your call)

shadcn positions the flyout with two **viewport** prefixes (`md:absolute md:w-auto` on Content, `md:w-[…]` on Viewport). Per the chosen direction, these are converted to a named **`@container/navmenu`** query (28rem) — internal responsive follows the component's own width, not the viewport (`responsive.md` decision), so no viewport-exception entry is added.

**One consequence worth flagging:** for the container query to measure a meaningful width, the Root is now **full-width** (`nx:w-full`) instead of shadcn's content-hugging `max-w-max`. Without that change `container-type: inline-size` on a `max-w-max` element measures only the triggers-row (~200px), so the 28rem query would never fire and the flyout would stay stacked on desktop. Full-width Root → the query measures the nav's available (page-shell) width → flyout becomes an absolute panel at ≥448px, stacks below it (mobile-first-correct). Triggers stay centered via the List's `justify-center`. This mirrors Field's shipped `@container/field-group` pattern.

## Other adaptation notes

- **Canonical focus ring on Trigger + Link** (Tab-reachable controls, and NavMenu doesn't move focus on hover) — not the roving-focus tint used by menu items.
- `shadow` → `nx:shadow-lg` (Nexus has no `shadow-md`); dropped shadcn's fixed `h-9` (padding-based sizing); `bg-accent`/`accent-foreground` → `bg-background-hover`/`foreground`; dropped shadcn's `**:…focus:ring-0` link-ring suppressors (Nexus links keep their a11y ring).
- Kept the `viewport` boolean prop (Radix API).

## Bundle

`@radix-ui/react-navigation-menu` has its **own substrate** (not the shared menu/popper), so it adds real weight: ESM **79.18 kB**. Bumped the ESM `size-limit` ceiling **80 → 85 kB**. This is the last bundle increase in the batch — the remaining Wave 5 deps are externalized optional peers.

## GitHub Issue

Closes #293

## Test Plan

- [x] `typecheck`, `eslint --max-warnings 0`, `prettier` clean
- [x] `audit:storybook-coverage --component navigation-menu` → 0 missing / 0 drift (ClickInteraction / KeyboardInteraction via `OpenCloseInteraction` equivalent)
- [x] `@container/navmenu` declaration + `@container navmenu (min-width:28rem)` query both emit in `dist/react.css`
- [x] `size-limit` 79.18 kB ESM / 85 kB
- [x] Archetype grep clean: no `accent` / `dark:` / viewport-prefix / `shadow-md` / `ring-*` / `h-9`
- [ ] CI: play-fns (click open/close, keyboard open) green in the browser runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)