### PR TITLE
feat(components): add drawer component (#290)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
         "embla-carousel-react",
         "react-day-picker",
         "react-hook-form",
-        "sonner"
+        "sonner",
+        "vaul"
       ],
       "limit": "85 kB"
     },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,6 +48,7 @@
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
+    "vaul": "^1.1.2",
     "vite": "^7.3.0",
     "vite-plugin-dts": "^4.5.4",
     "zod": "^4.4.3"
@@ -93,7 +94,8 @@
     "react-day-picker": "^9",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.77.0",
-    "sonner": "^2.0.7"
+    "sonner": "^2.0.7",
+    "vaul": "^1.1.2"
   },
   "peerDependenciesMeta": {
     "embla-carousel-react": {
@@ -106,6 +108,9 @@
       "optional": true
     },
     "sonner": {
+      "optional": true
+    },
+    "vaul": {
       "optional": true
     }
   },

--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -56,6 +56,12 @@
       "equivalents": { "ClickInteraction": ["OpenCloseInteraction"] }
     },
     {
+      "name": "Drawer",
+      "showcase": "AllVariants",
+      "interactions": ["ClickInteraction", "KeyboardInteraction"],
+      "equivalents": { "ClickInteraction": ["OpenCloseInteraction"] }
+    },
+    {
       "name": "DropdownMenu",
       "showcase": "AllVariants",
       "interactions": ["Disabled", "ClickInteraction", "KeyboardInteraction"],

--- a/packages/react/src/components/ui/Drawer.stories.tsx
+++ b/packages/react/src/components/ui/Drawer.stories.tsx
@@ -1,0 +1,252 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { Button } from './button';
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from './drawer';
+
+const meta: Meta<typeof Drawer> = {
+  title: 'Components/Drawer',
+  component: Drawer,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Drawer>;
+
+const DIRECTIONS = ['top', 'right', 'bottom', 'left'] as const;
+
+// ============================================
+// BASIC STORIES
+// ============================================
+
+// A bottom drawer (vaul's default direction) with the drag handle.
+export const Default: Story = {
+  render: () => (
+    <Drawer>
+      <DrawerTrigger asChild>
+        <Button variant="outline">Open Drawer</Button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>Move goal</DrawerTitle>
+          <DrawerDescription>
+            Drag down or press Escape to dismiss this drawer.
+          </DrawerDescription>
+        </DrawerHeader>
+        <p className="nx:px-4 nx:text-sm nx:text-foreground">
+          Drawer content goes here. On touch devices it can be dragged to
+          dismiss.
+        </p>
+        <DrawerFooter>
+          <Button>Submit</Button>
+          <DrawerClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  ),
+};
+
+// A right-edge drawer — the side-panel direction.
+export const Right: Story = {
+  render: () => (
+    <Drawer direction="right">
+      <DrawerTrigger asChild>
+        <Button variant="outline">Open Right</Button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>Settings</DrawerTitle>
+          <DrawerDescription>
+            A right drawer slides in from the trailing edge.
+          </DrawerDescription>
+        </DrawerHeader>
+        <DrawerFooter>
+          <DrawerClose asChild>
+            <Button>Close</Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  ),
+};
+
+// ============================================
+// INTERACTION TESTS
+// ============================================
+
+// Clicking the trigger opens the drawer; the footer button closes it.
+export const OpenCloseInteraction: Story = {
+  render: () => (
+    <Drawer>
+      <DrawerTrigger asChild>
+        <Button variant="outline">Open Drawer</Button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>Interaction Test</DrawerTitle>
+          <DrawerDescription>
+            Testing open and close behavior.
+          </DrawerDescription>
+        </DrawerHeader>
+        <DrawerFooter>
+          <DrawerClose asChild>
+            <Button>Dismiss</Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole('button', { name: 'Open Drawer' });
+    await userEvent.click(trigger);
+
+    // Content portals to document.body with role="dialog".
+    const drawer = await within(document.body).findByRole('dialog');
+    await expect(drawer).toHaveAttribute('data-slot', 'drawer-content');
+    await expect(
+      within(drawer).getByText('Interaction Test')
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      within(drawer).getByRole('button', { name: 'Dismiss' })
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector('[role="dialog"]')).toBeNull();
+    });
+  },
+};
+
+// Escape closes the drawer.
+export const KeyboardInteraction: Story = {
+  render: () => (
+    <Drawer>
+      <DrawerTrigger asChild>
+        <Button variant="outline">Open Drawer</Button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>Keyboard Test</DrawerTitle>
+          <DrawerDescription>Testing keyboard interactions.</DrawerDescription>
+        </DrawerHeader>
+        <DrawerFooter>
+          <DrawerClose asChild>
+            <Button>Close</Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole('button', { name: 'Open Drawer' });
+    await userEvent.click(trigger);
+
+    await within(document.body).findByRole('dialog');
+    await userEvent.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(document.querySelector('[role="dialog"]')).toBeNull();
+    });
+  },
+};
+
+// data-slot identifies every part of the open drawer.
+export const WithDataAttributes: Story = {
+  render: () => (
+    <Drawer>
+      <DrawerTrigger asChild>
+        <Button variant="outline">Open Drawer</Button>
+      </DrawerTrigger>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>Data Attributes</DrawerTitle>
+          <DrawerDescription>Testing data-slot attributes.</DrawerDescription>
+        </DrawerHeader>
+        <DrawerFooter>
+          <DrawerClose asChild>
+            <Button>Close</Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole('button', { name: 'Open Drawer' });
+    await userEvent.click(trigger);
+
+    await within(document.body).findByRole('dialog');
+
+    await waitFor(() => {
+      for (const slot of [
+        'drawer-overlay',
+        'drawer-content',
+        'drawer-header',
+        'drawer-title',
+        'drawer-description',
+        'drawer-footer',
+      ]) {
+        expect(
+          document.querySelector(`[data-slot="${slot}"]`)
+        ).toBeInTheDocument();
+      }
+    });
+
+    await userEvent.keyboard('{Escape}');
+  },
+};
+
+// ============================================
+// ALL VARIANTS GRID (every direction)
+// ============================================
+
+// A trigger per direction. Reused by the per-base variant generator; the static
+// grid shows the closed triggers (portal content only renders when open).
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:flex nx:flex-wrap nx:gap-4">
+      {DIRECTIONS.map((direction) => (
+        <Drawer key={direction} direction={direction}>
+          <DrawerTrigger asChild>
+            <Button variant="outline" className="nx:capitalize">
+              {direction}
+            </Button>
+          </DrawerTrigger>
+          <DrawerContent>
+            <DrawerHeader>
+              <DrawerTitle className="nx:capitalize">
+                {direction} drawer
+              </DrawerTitle>
+              <DrawerDescription>
+                Slides in from the {direction} edge.
+              </DrawerDescription>
+            </DrawerHeader>
+            <DrawerFooter>
+              <DrawerClose asChild>
+                <Button>Close</Button>
+              </DrawerClose>
+            </DrawerFooter>
+          </DrawerContent>
+        </Drawer>
+      ))}
+    </div>
+  ),
+};

--- a/packages/react/src/components/ui/drawer.tsx
+++ b/packages/react/src/components/ui/drawer.tsx
@@ -1,0 +1,203 @@
+import * as React from 'react';
+
+import { Drawer as DrawerPrimitive } from 'vaul';
+
+import { cn } from '@/lib/utils';
+
+/**
+ * Drawer
+ *
+ * Root for a gesture-driven drawer that slides in from a viewport edge with
+ * drag-to-dismiss (built on vaul). `vaul` is an optional peer dependency —
+ * install it in the consuming app.
+ *
+ * @example
+ * ```tsx
+ * <Drawer>
+ *   <DrawerTrigger asChild>
+ *     <Button>Open</Button>
+ *   </DrawerTrigger>
+ *   <DrawerContent>
+ *     <DrawerHeader>
+ *       <DrawerTitle>Title</DrawerTitle>
+ *       <DrawerDescription>Description.</DrawerDescription>
+ *     </DrawerHeader>
+ *     <DrawerFooter>
+ *       <DrawerClose asChild>
+ *         <Button variant="outline">Close</Button>
+ *       </DrawerClose>
+ *     </DrawerFooter>
+ *   </DrawerContent>
+ * </Drawer>
+ * ```
+ */
+const Drawer = DrawerPrimitive.Root;
+
+/**
+ * DrawerTrigger
+ *
+ * Button that opens the drawer. Use `asChild` to render as your own component.
+ */
+const DrawerTrigger = DrawerPrimitive.Trigger;
+
+/**
+ * DrawerPortal
+ *
+ * Portals the drawer content to document.body.
+ */
+const DrawerPortal = DrawerPrimitive.Portal;
+
+/**
+ * DrawerClose
+ *
+ * Button that closes the drawer. Use `asChild` to render as your own component.
+ */
+const DrawerClose = DrawerPrimitive.Close;
+
+/**
+ * DrawerOverlay
+ *
+ * Semi-transparent scrim behind the drawer content.
+ */
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        'nx:fixed nx:inset-0 nx:z-modal nx:bg-overlay',
+        'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
+        'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * DrawerContent
+ *
+ * The sliding panel. Renders inside a portal with an overlay; vaul's `direction`
+ * prop on the root picks which edge it slides from (defaults to `bottom`). The
+ * drag handle shows only for the bottom direction.
+ */
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal>
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          'nx:group/drawer-content nx:fixed nx:z-modal nx:flex nx:h-auto nx:flex-col nx:bg-container nx:shadow-lg',
+          'nx:data-[vaul-drawer-direction=top]:inset-x-0 nx:data-[vaul-drawer-direction=top]:top-0 nx:data-[vaul-drawer-direction=top]:mb-24 nx:data-[vaul-drawer-direction=top]:max-h-[80svh] nx:data-[vaul-drawer-direction=top]:rounded-b-lg nx:data-[vaul-drawer-direction=top]:border-b nx:data-[vaul-drawer-direction=top]:border-border-default',
+          'nx:data-[vaul-drawer-direction=bottom]:inset-x-0 nx:data-[vaul-drawer-direction=bottom]:bottom-0 nx:data-[vaul-drawer-direction=bottom]:mt-24 nx:data-[vaul-drawer-direction=bottom]:max-h-[80svh] nx:data-[vaul-drawer-direction=bottom]:rounded-t-lg nx:data-[vaul-drawer-direction=bottom]:border-t nx:data-[vaul-drawer-direction=bottom]:border-border-default',
+          'nx:data-[vaul-drawer-direction=right]:inset-y-0 nx:data-[vaul-drawer-direction=right]:right-0 nx:data-[vaul-drawer-direction=right]:w-3/4 nx:data-[vaul-drawer-direction=right]:border-l nx:data-[vaul-drawer-direction=right]:border-border-default nx:data-[vaul-drawer-direction=right]:sm:max-w-sm',
+          'nx:data-[vaul-drawer-direction=left]:inset-y-0 nx:data-[vaul-drawer-direction=left]:left-0 nx:data-[vaul-drawer-direction=left]:w-3/4 nx:data-[vaul-drawer-direction=left]:border-r nx:data-[vaul-drawer-direction=left]:border-border-default nx:data-[vaul-drawer-direction=left]:sm:max-w-sm',
+          className
+        )}
+        {...props}
+      >
+        <div className="nx:mx-auto nx:mt-4 nx:hidden nx:h-2 nx:w-[100px] nx:shrink-0 nx:rounded-full nx:bg-muted nx:group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+}
+
+/**
+ * DrawerHeader
+ *
+ * Container for the drawer title and description.
+ */
+function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn(
+        // nexus-allow-numeric: DrawerHeader sub-element rhythm
+        'nx:flex nx:flex-col nx:gap-1.5 nx:p-container nx:group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center nx:group-data-[vaul-drawer-direction=top]/drawer-content:text-center nx:md:text-left',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * DrawerFooter
+ *
+ * Container for the drawer action buttons. Pinned to the bottom of the panel.
+ */
+function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn(
+        // nexus-allow-numeric: DrawerFooter sub-element rhythm
+        'nx:mt-auto nx:flex nx:flex-col nx:gap-2 nx:p-container',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * DrawerTitle
+ *
+ * The accessible title of the drawer. Required for screen-reader labelling —
+ * vaul wires `aria-labelledby` to it.
+ */
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn(
+        'nx:text-lg nx:font-semibold nx:leading-none nx:tracking-tight',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * DrawerDescription
+ *
+ * Supporting text that provides additional context for the drawer.
+ */
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn('nx:text-sm nx:text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -26,6 +26,7 @@ export * from '@/components/ui/collapsible';
 export * from '@/components/ui/command';
 export * from '@/components/ui/context-menu';
 export * from '@/components/ui/dialog';
+export * from '@/components/ui/drawer';
 export * from '@/components/ui/dropdown-menu';
 export * from '@/components/ui/empty-state';
 export * from '@/components/ui/field';

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
         'react-day-picker',
         'react-hook-form',
         'sonner',
+        'vaul',
       ],
       output: {
         globals: {
@@ -46,6 +47,7 @@ export default defineConfig({
           'react-day-picker': 'ReactDayPicker',
           'react-hook-form': 'ReactHookForm',
           sonner: 'Sonner',
+          vaul: 'Vaul',
         },
       },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,7 +1151,7 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.3.tgz#81286f643b310d040eaac13b18e223130861d839"
   integrity sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==
 
-"@radix-ui/react-dialog@1.1.15", "@radix-ui/react-dialog@^1.1.15", "@radix-ui/react-dialog@^1.1.6":
+"@radix-ui/react-dialog@1.1.15", "@radix-ui/react-dialog@^1.1.1", "@radix-ui/react-dialog@^1.1.15", "@radix-ui/react-dialog@^1.1.6":
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz#1de3d7a7e9a17a9874d29c07f5940a18a119b632"
   integrity sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==
@@ -7729,6 +7729,13 @@ use-sync-external-store@^1.2.2, use-sync-external-store@^1.4.0, use-sync-externa
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
   integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
+
+vaul@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vaul/-/vaul-1.1.2.tgz#c959f8b9dc2ed4f7d99366caee433fbef91f5ba9"
+  integrity sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==
+  dependencies:
+    "@radix-ui/react-dialog" "^1.1.1"
 
 vfile-message@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
## Summary

- Adapts the shadcn **vaul** drawer into `@nexus/react` — gesture-driven edge drawer with drag-to-dismiss. `nx:` prefix, `data-slot` on every part, semantic tokens.
- **`vaul` is an optional peer dependency** (mirrors the other Wave 5 peers): externalized in `vite.config.ts` + ignored in root `size-limit`. **Consumers (incl. Atlas console) must install `vaul` themselves.** ESM is **81.09 kB / 85**. vaul **self-injects its slide keyframes at runtime** (`createElement('style')` → `head.append`), so there is no `vaul/style.css` import or CSS coupling — that's also why shadcn doesn't import it (and why vaul's `exports` map doesn't expose it).
- **Mirrors the sibling Sheet's tokens** for family consistency — `bg-container`, `border-border-default`, `shadow-lg`, the overlay fade, header/footer (`p-container`), and title/description — while keeping **vaul's `data-[vaul-drawer-direction]` model** instead of Sheet's `side` CVA (per the issue: the drag pattern, not a re-skin of Sheet). Root/Trigger/Portal/Close are bare aliases, matching Sheet.
- `max-h-[80svh]` (not raw `vh`) per the viewport-units rule. The `sm:max-w-sm` on the left/right directions is the documented full-viewport-overlay exception (same as Dialog/Sheet). **`DrawerTitle` is required for a11y** — vaul wires `aria-labelledby` to it; every story includes one.

## GitHub Issue

Closes #290

## Test Plan

- [x] `typecheck` / `eslint --max-warnings 0` / `prettier --check` — clean
- [x] `audit:storybook-coverage --component drawer` — 0 missing, 0 drift (OpenCloseInteraction + KeyboardInteraction; Disabled info-only)
- [x] `size-limit` — ESM 81.09 kB ≤ 85 kB; CSS 12.17 kB ≤ 30 kB
- [x] `dist/index.mjs` — `vaul` external, vaul code not inlined; drawer utilities (`data-[vaul-drawer-direction=*]`, `max-h-[80svh]`) emitted in CSS
- [ ] CI: Storybook play-fns (open via trigger → `role="dialog"`; close via button / Escape) + axe a11y