### PR TITLE
refactor(components): use Spinner in Button loading state

### DIFF
--- a/packages/react/src/components/ui/button.tsx
+++ b/packages/react/src/components/ui/button.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 
-import { IconLoader2 } from '@/lib/icons';
+import { Spinner } from '@/components/ui/spinner';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
@@ -94,7 +94,7 @@ function Button({
       {loading ? (
         <>
           {children}
-          <IconLoader2 className="nx:animate-spin" aria-hidden="true" />
+          <Spinner aria-hidden="true" />
         </>
       ) : (
         children


### PR DESCRIPTION
## Summary

Reconciles Button's loading indicator onto the shipped **Spinner** component (a fast-follow from the #282–#304 component batch — Spinner #304 and Button #204 shipped standalone; this unifies them).

- Button's loading branch now renders `<Spinner aria-hidden="true" />` instead of an inline `<IconLoader2 className="nx:animate-spin" aria-hidden>` — the spinner glyph now has a **single source**.
- The in-button spinner inherits `nx:motion-reduce:animate-none`, so it **freezes under `prefers-reduced-motion`** instead of spinning — behaviour the raw `IconLoader2` lacked. (Verified the rule is emitted in `dist/react.css`.)
- `aria-hidden` keeps the spinner decorative inside the already-`aria-busy` button, so the loading state is announced once (by the button), not twice — the same a11y contract the inline icon had.

No public API change: the `loading` prop, `aria-busy`, and `data-loading` are untouched. The 6 Atlas console consumers of `<Button loading>` are unaffected.

## GitHub Issue

No tracked issue — additive reconciliation fast-follow from the #282–#304 shadcn-parity component batch (reconciling Button→Spinner was called out in that batch's plan as an optional follow-up).

## Test Plan

- [x] `typecheck` clean
- [x] `eslint . --max-warnings 0` clean
- [x] `prettier --check` clean
- [x] `vite build` + `size-limit` clean (ESM 82.64/88 kB — flat; Spinner was already bundled)
- [x] `motion-reduce:animate-none` confirmed present in built CSS
- [ ] CI: Button story play-fns (assert `aria-busy`/`data-loading`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)