### PR TITLE
feat(console): Analytics dashboard (Phase 3d)

### DIFF
--- a/apps/console/index.html
+++ b/apps/console/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Atlas — Nexus Console</title>
+    <!-- The categorical chart palette is a fixed (non-switchable) token set, so
+         it loads statically here — unlike the switchable theme axes, which load
+         at runtime via useTheme. Without it, chart series resolve
+         var(--nx-color-chart-categorical-N) to nothing and paint black. -->
+    <link rel="stylesheet" href="/themes/chart-categorical-default.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -23,6 +23,7 @@
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-hook-form": "^7.77.0",
+    "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.4.3",

--- a/apps/console/src/app/router.tsx
+++ b/apps/console/src/app/router.tsx
@@ -6,6 +6,8 @@ import {
 } from '@tanstack/react-router';
 import { z } from 'zod';
 
+import { AnalyticsRoute } from '../modules/analytics/analytics-route';
+import { analyticsSearchSchema } from '../modules/analytics/analytics-search';
 import { ForgotRoute } from '../modules/auth/forgot-route';
 import { LoginRoute } from '../modules/auth/login-route';
 import { SignupRoute } from '../modules/auth/signup-route';
@@ -133,6 +135,15 @@ const billingRoute = createRoute({
   component: BillingRoute,
 });
 
+// Analytics (Phase 3d). Static `/m/analytics` outranks `/m/$module`. The period
+// toggle rides in `?range`; a single-page dashboard otherwise.
+const analyticsRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: '/m/analytics',
+  validateSearch: analyticsSearchSchema,
+  component: AnalyticsRoute,
+});
+
 // People (Phase 3e). Static `/m/people` outranks `/m/$module`. Three facet
 // filters (role · department · status) ride in the search params.
 const peopleRoute = createRoute({
@@ -202,6 +213,7 @@ const routeTree = rootRoute.addChildren([
     projectsIssueDetailRoute,
     inboxRoute,
     billingRoute,
+    analyticsRoute,
     peopleRoute,
     peopleMemberDetailRoute,
     moduleRoute,

--- a/apps/console/src/hooks/useTheme.ts
+++ b/apps/console/src/hooks/useTheme.ts
@@ -156,14 +156,6 @@ export function useTheme() {
     loadCSS(`/themes/brands-${theme.brand}.css`, 'brand');
   }, [theme.brand]);
 
-  // The categorical chart palette is a fixed (non-switchable) token set that
-  // ships its own light/dark variants, so load it once — without it, chart
-  // series resolve `var(--nx-color-chart-categorical-N)` to nothing and paint
-  // black.
-  useEffect(() => {
-    loadCSS('/themes/chart-categorical-default.css', 'chart');
-  }, []);
-
   useEffect(() => {
     document.documentElement.setAttribute('data-style', theme.spacing);
   }, [theme.spacing]);

--- a/apps/console/src/hooks/useTheme.ts
+++ b/apps/console/src/hooks/useTheme.ts
@@ -156,6 +156,14 @@ export function useTheme() {
     loadCSS(`/themes/brands-${theme.brand}.css`, 'brand');
   }, [theme.brand]);
 
+  // The categorical chart palette is a fixed (non-switchable) token set that
+  // ships its own light/dark variants, so load it once — without it, chart
+  // series resolve `var(--nx-color-chart-categorical-N)` to nothing and paint
+  // black.
+  useEffect(() => {
+    loadCSS('/themes/chart-categorical-default.css', 'chart');
+  }, []);
+
   useEffect(() => {
     document.documentElement.setAttribute('data-style', theme.spacing);
   }, [theme.spacing]);

--- a/apps/console/src/lib/analytics-api.ts
+++ b/apps/console/src/lib/analytics-api.ts
@@ -1,0 +1,66 @@
+/**
+ * Analytics module API contract. A read-only reporting dashboard — no
+ * mutations, so this is just the range enum, the overview shape, the query-key
+ * factory (keyed by range so the period toggle refetches), and the fetcher.
+ */
+
+export const ANALYTICS_RANGES = ['7d', '30d', '90d'] as const;
+export type AnalyticsRange = (typeof ANALYTICS_RANGES)[number];
+
+/** Human label for each range, shown on the period toggle. */
+export const RANGE_LABELS: Record<AnalyticsRange, string> = {
+  '7d': '7 days',
+  '30d': '30 days',
+  '90d': '90 days',
+};
+
+/** How a KPI's raw number should be rendered in its stat card. */
+export type KpiFormat = 'currency' | 'number' | 'percent';
+
+export interface Kpi {
+  key: string;
+  label: string;
+  value: number;
+  format: KpiFormat;
+  /** Change vs the preceding period of the same length; positive = up. */
+  deltaPct: number;
+}
+
+/** One point on the shared time axis; drives all three trend charts. */
+export interface TrendPoint {
+  label: string;
+  revenue: number;
+  newUsers: number;
+  returningUsers: number;
+  sessions: number;
+}
+
+export interface TrafficSource {
+  source: string;
+  visits: number;
+  /** Fraction of total visits (0–1). */
+  share: number;
+}
+
+export interface AnalyticsOverview {
+  range: AnalyticsRange;
+  kpis: Kpi[];
+  trend: TrendPoint[];
+  sources: TrafficSource[];
+}
+
+export const analyticsKeys = {
+  all: ['analytics'] as const,
+  overview: (range: AnalyticsRange) =>
+    ['analytics', 'overview', range] as const,
+};
+
+export async function fetchAnalytics(
+  range: AnalyticsRange
+): Promise<AnalyticsOverview> {
+  const res = await fetch(`/api/analytics?range=${range}`);
+  if (!res.ok) {
+    throw new Error('Failed to load analytics');
+  }
+  return res.json();
+}

--- a/apps/console/src/mocks/analytics-fixtures.ts
+++ b/apps/console/src/mocks/analytics-fixtures.ts
@@ -1,0 +1,180 @@
+import type {
+  AnalyticsOverview,
+  AnalyticsRange,
+  TrendPoint,
+} from '../lib/analytics-api';
+
+/**
+ * Deterministic trend builder — a pure function of the point index (sin/cos
+ * ripple + gentle upward drift), so the curves look organic but never change
+ * between runs. NOT random data: no `Math.random`, no `Date.now`.
+ */
+function buildTrend(
+  labels: string[],
+  base: Omit<TrendPoint, 'label'>
+): TrendPoint[] {
+  return labels.map((label, i) => {
+    const ripple = Math.sin(i * 0.9) * 0.16 + Math.cos(i * 0.5) * 0.09;
+    const f = 1 + ripple + i * 0.018;
+    return {
+      label,
+      revenue: Math.round(base.revenue * f),
+      newUsers: Math.round(base.newUsers * f),
+      returningUsers: Math.round(base.returningUsers * f),
+      sessions: Math.round(base.sessions * f),
+    };
+  });
+}
+
+const OVERVIEWS: Record<AnalyticsRange, AnalyticsOverview> = {
+  '7d': {
+    range: '7d',
+    kpis: [
+      {
+        key: 'revenue',
+        label: 'Revenue',
+        value: 78400,
+        format: 'currency',
+        deltaPct: 12.4,
+      },
+      {
+        key: 'activeUsers',
+        label: 'Active users',
+        value: 8420,
+        format: 'number',
+        deltaPct: 5.2,
+      },
+      {
+        key: 'signups',
+        label: 'Signups',
+        value: 1128,
+        format: 'number',
+        deltaPct: 18.1,
+      },
+      {
+        key: 'conversion',
+        label: 'Conversion',
+        value: 3.8,
+        format: 'percent',
+        deltaPct: 6.2,
+      },
+    ],
+    trend: buildTrend(['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'], {
+      revenue: 9600,
+      newUsers: 134,
+      returningUsers: 312,
+      sessions: 1980,
+    }),
+    sources: [
+      { source: 'Organic search', visits: 3240, share: 0.38 },
+      { source: 'Direct', visits: 2130, share: 0.25 },
+      { source: 'Referral', visits: 1280, share: 0.15 },
+      { source: 'Social', visits: 1024, share: 0.12 },
+      { source: 'Email', visits: 853, share: 0.1 },
+    ],
+  },
+  '30d': {
+    range: '30d',
+    kpis: [
+      {
+        key: 'revenue',
+        label: 'Revenue',
+        value: 342800,
+        format: 'currency',
+        deltaPct: 8.7,
+      },
+      {
+        key: 'activeUsers',
+        label: 'Active users',
+        value: 24180,
+        format: 'number',
+        deltaPct: 6.4,
+      },
+      {
+        key: 'signups',
+        label: 'Signups',
+        value: 4690,
+        format: 'number',
+        deltaPct: 11.2,
+      },
+      {
+        key: 'conversion',
+        label: 'Conversion',
+        value: 4.1,
+        format: 'percent',
+        deltaPct: 3.1,
+      },
+    ],
+    trend: buildTrend(
+      [
+        'May 5',
+        'May 8',
+        'May 11',
+        'May 14',
+        'May 17',
+        'May 20',
+        'May 23',
+        'May 26',
+        'May 29',
+        'Jun 1',
+      ],
+      { revenue: 29800, newUsers: 392, returningUsers: 948, sessions: 5760 }
+    ),
+    sources: [
+      { source: 'Organic search', visits: 12840, share: 0.4 },
+      { source: 'Direct', visits: 7710, share: 0.24 },
+      { source: 'Referral', visits: 4820, share: 0.15 },
+      { source: 'Social', visits: 3850, share: 0.12 },
+      { source: 'Email', visits: 2890, share: 0.09 },
+    ],
+  },
+  '90d': {
+    range: '90d',
+    kpis: [
+      {
+        key: 'revenue',
+        label: 'Revenue',
+        value: 1084500,
+        format: 'currency',
+        deltaPct: 15.3,
+      },
+      {
+        key: 'activeUsers',
+        label: 'Active users',
+        value: 58640,
+        format: 'number',
+        deltaPct: 9.8,
+      },
+      {
+        key: 'signups',
+        label: 'Signups',
+        value: 13240,
+        format: 'number',
+        deltaPct: 7.5,
+      },
+      {
+        key: 'conversion',
+        label: 'Conversion',
+        value: 3.9,
+        format: 'percent',
+        deltaPct: -1.4,
+      },
+    ],
+    trend: buildTrend(
+      ['Mar 9', 'Mar 23', 'Apr 6', 'Apr 20', 'May 4', 'May 18', 'Jun 1'],
+      { revenue: 138000, newUsers: 1960, returningUsers: 4720, sessions: 27600 }
+    ),
+    sources: [
+      { source: 'Organic search', visits: 41200, share: 0.41 },
+      { source: 'Direct', visits: 23100, share: 0.23 },
+      { source: 'Referral', visits: 15080, share: 0.15 },
+      { source: 'Social', visits: 12060, share: 0.12 },
+      { source: 'Email', visits: 9040, share: 0.09 },
+    ],
+  },
+};
+
+/** Read-only — the dashboard never mutates analytics data, so no store. */
+export function analyticsOverview(range: AnalyticsRange): AnalyticsOverview {
+  return OVERVIEWS[range];
+}

--- a/apps/console/src/mocks/handlers.ts
+++ b/apps/console/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { delay, http, HttpResponse, type RequestHandler } from 'msw';
 
+import { ANALYTICS_RANGES, type AnalyticsRange } from '../lib/analytics-api';
 import type { User } from '../lib/auth-api';
 import type {
   BillingOverview,
@@ -15,6 +16,7 @@ import type {
 import type { Member, MemberDetail, MemberInput } from '../lib/people-api';
 import type { Issue, IssueInput } from '../lib/projects-api';
 
+import { analyticsOverview } from './analytics-fixtures';
 import { BILLING_OVERVIEW, INVOICES } from './billing-fixtures';
 import { CONTACTS } from './crm-fixtures';
 import { CONVERSATIONS } from './inbox-fixtures';
@@ -369,6 +371,19 @@ export const handlers: RequestHandler[] = [
 
   // --- Billing ---
   // The overview: current subscription + usage meters + the card on file.
+  // Read-only reporting dashboard. `?range` selects the period; an unknown
+  // value falls back to 30d so a stale or hand-typed URL never errors.
+  http.get('/api/analytics', async ({ request }) => {
+    await delay(500);
+    const param = new URL(request.url).searchParams.get('range');
+    const range: AnalyticsRange = ANALYTICS_RANGES.includes(
+      param as AnalyticsRange
+    )
+      ? (param as AnalyticsRange)
+      : '30d';
+    return HttpResponse.json(analyticsOverview(range));
+  }),
+
   http.get('/api/billing', async () => {
     await delay(500);
     return HttpResponse.json(billing);

--- a/apps/console/src/modules/analytics/analytics-charts.tsx
+++ b/apps/console/src/modules/analytics/analytics-charts.tsx
@@ -1,0 +1,139 @@
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@nexus/react';
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { TrendPoint } from '../../lib/analytics-api';
+
+// Fixed height overrides ChartContainer's default `aspect-video` so every
+// dashboard chart is the same height regardless of its grid column's width.
+const CHART_BOX = 'nx:h-[260px] nx:w-full';
+
+const revenueConfig = {
+  revenue: { label: 'Revenue', color: 'var(--nx-color-chart-categorical-1)' },
+} satisfies ChartConfig;
+
+/** Revenue over the period — the hero metric. Single series, so no legend. */
+export function RevenueChart({ data }: { data: TrendPoint[] }) {
+  return (
+    <ChartContainer config={revenueConfig} className={CHART_BOX}>
+      <AreaChart
+        accessibilityLayer
+        data={data}
+        margin={{ left: 12, right: 12, top: 8 }}
+      >
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+        />
+        <ChartTooltip content={<ChartTooltipContent indicator="dot" />} />
+        <Area
+          dataKey="revenue"
+          type="natural"
+          fill="var(--color-revenue)"
+          fillOpacity={0.3}
+          stroke="var(--color-revenue)"
+          strokeWidth={2}
+        />
+      </AreaChart>
+    </ChartContainer>
+  );
+}
+
+const audienceConfig = {
+  newUsers: { label: 'New', color: 'var(--nx-color-chart-categorical-2)' },
+  returningUsers: {
+    label: 'Returning',
+    color: 'var(--nx-color-chart-categorical-3)',
+  },
+} satisfies ChartConfig;
+
+/** New vs returning users, stacked per bucket = total audience. Two series → legend. */
+export function AudienceChart({ data }: { data: TrendPoint[] }) {
+  return (
+    <ChartContainer config={audienceConfig} className={CHART_BOX}>
+      <BarChart
+        accessibilityLayer
+        data={data}
+        margin={{ left: 12, right: 12, top: 8 }}
+      >
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+        />
+        <ChartTooltip content={<ChartTooltipContent indicator="dashed" />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        <Bar
+          dataKey="newUsers"
+          stackId="audience"
+          fill="var(--color-newUsers)"
+          radius={[0, 0, 4, 4]}
+        />
+        <Bar
+          dataKey="returningUsers"
+          stackId="audience"
+          fill="var(--color-returningUsers)"
+          radius={[4, 4, 0, 0]}
+        />
+      </BarChart>
+    </ChartContainer>
+  );
+}
+
+const sessionsConfig = {
+  sessions: { label: 'Sessions', color: 'var(--nx-color-chart-categorical-4)' },
+} satisfies ChartConfig;
+
+/** Session volume trend. Single series, so no legend. */
+export function SessionsChart({ data }: { data: TrendPoint[] }) {
+  return (
+    <ChartContainer config={sessionsConfig} className={CHART_BOX}>
+      <LineChart
+        accessibilityLayer
+        data={data}
+        margin={{ left: 12, right: 12, top: 8 }}
+      >
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+        />
+        {/* A trend line reads better scaled to its own range than to a 0
+            baseline (which would squeeze this high, flat series into a thin
+            top strip). Hidden — the tooltip carries exact values. */}
+        <YAxis hide domain={['dataMin', 'dataMax']} />
+        <ChartTooltip content={<ChartTooltipContent indicator="line" />} />
+        <Line
+          dataKey="sessions"
+          type="natural"
+          stroke="var(--color-sessions)"
+          strokeWidth={2}
+          dot={false}
+        />
+      </LineChart>
+    </ChartContainer>
+  );
+}

--- a/apps/console/src/modules/analytics/analytics-route.tsx
+++ b/apps/console/src/modules/analytics/analytics-route.tsx
@@ -1,0 +1,222 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  ToggleGroup,
+  ToggleGroupItem,
+} from '@nexus/react';
+import { IconTrendingDown, IconTrendingUp } from '@tabler/icons-react';
+import { useQuery } from '@tanstack/react-query';
+import { getRouteApi } from '@tanstack/react-router';
+
+import {
+  ANALYTICS_RANGES,
+  analyticsKeys,
+  type AnalyticsOverview,
+  type AnalyticsRange,
+  fetchAnalytics,
+  type Kpi,
+  RANGE_LABELS,
+  type TrafficSource,
+} from '../../lib/analytics-api';
+import { formatCurrency } from '../../lib/format';
+
+import { AudienceChart, RevenueChart, SessionsChart } from './analytics-charts';
+
+const analyticsRoute = getRouteApi('/app/m/analytics');
+
+export function AnalyticsRoute() {
+  const { range } = analyticsRoute.useSearch();
+  const navigate = analyticsRoute.useNavigate();
+  const { data, isPending, isError } = useQuery({
+    queryKey: analyticsKeys.overview(range),
+    queryFn: () => fetchAnalytics(range),
+  });
+
+  // Radix single-select emits '' when the active item is re-clicked; ignore it
+  // so the range can never wipe to blank.
+  const onRangeChange = (value: string) => {
+    if (value) {
+      navigate({ search: { range: value as AnalyticsRange } });
+    }
+  };
+
+  return (
+    <div className="nx:space-y-6 nx:p-6">
+      <header className="nx:flex nx:flex-wrap nx:items-start nx:justify-between nx:gap-4">
+        <div className="nx:space-y-1">
+          <h1 className="nx:typography-heading-large nx:text-foreground">
+            Analytics
+          </h1>
+          <p className="nx:text-muted-foreground">
+            Revenue, audience, and traffic across your workspace.
+          </p>
+        </div>
+        <ToggleGroup
+          type="single"
+          variant="outline"
+          value={range}
+          onValueChange={onRangeChange}
+          aria-label="Date range"
+        >
+          {ANALYTICS_RANGES.map((r) => (
+            <ToggleGroupItem key={r} value={r}>
+              {RANGE_LABELS[r]}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </header>
+
+      {isPending && <AnalyticsSkeleton />}
+      {isError && (
+        <p className="nx:text-error-foreground nx:text-sm">
+          Couldn&apos;t load analytics. Please try again.
+        </p>
+      )}
+      {data && <AnalyticsContent overview={data} />}
+    </div>
+  );
+}
+
+function AnalyticsContent({ overview }: { overview: AnalyticsOverview }) {
+  return (
+    <>
+      <div className="nx:grid nx:gap-6 nx:sm:grid-cols-2 nx:xl:grid-cols-4">
+        {overview.kpis.map((kpi) => (
+          <KpiCard key={kpi.key} kpi={kpi} />
+        ))}
+      </div>
+
+      <div className="nx:grid nx:gap-6 nx:lg:grid-cols-2">
+        <ChartCard title="Revenue">
+          <RevenueChart data={overview.trend} />
+        </ChartCard>
+        <ChartCard title="New vs returning users">
+          <AudienceChart data={overview.trend} />
+        </ChartCard>
+      </div>
+
+      <ChartCard title="Sessions">
+        <SessionsChart data={overview.trend} />
+      </ChartCard>
+
+      <SourcesCard sources={overview.sources} />
+    </>
+  );
+}
+
+function formatKpi(kpi: Kpi): string {
+  if (kpi.format === 'currency') {
+    return formatCurrency(kpi.value);
+  }
+  if (kpi.format === 'percent') {
+    return `${kpi.value}%`;
+  }
+  return kpi.value.toLocaleString();
+}
+
+function KpiCard({ kpi }: { kpi: Kpi }) {
+  const up = kpi.deltaPct >= 0;
+  const TrendIcon = up ? IconTrendingUp : IconTrendingDown;
+
+  return (
+    <Card className="nx:space-y-1 nx:p-6">
+      <p className="nx:text-muted-foreground nx:text-sm">{kpi.label}</p>
+      <p className="nx:typography-heading-medium nx:text-foreground nx:tabular-nums">
+        {formatKpi(kpi)}
+      </p>
+      <p
+        className={`nx:flex nx:items-center nx:gap-1 nx:text-xs nx:tabular-nums ${
+          up
+            ? 'nx:text-success-subtle-foreground'
+            : 'nx:text-error-subtle-foreground'
+        }`}
+      >
+        <TrendIcon className="nx:size-3.5 nx:shrink-0" />
+        <span>
+          {up ? '+' : ''}
+          {kpi.deltaPct}% vs previous period
+        </span>
+      </p>
+    </Card>
+  );
+}
+
+function ChartCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  );
+}
+
+function SourcesCard({ sources }: { sources: TrafficSource[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Top traffic sources</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Source</TableHead>
+              <TableHead className="nx:text-right">Visits</TableHead>
+              <TableHead className="nx:text-right">Share</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sources.map((source) => (
+              <TableRow key={source.source}>
+                <TableCell className="nx:text-foreground nx:font-medium">
+                  {source.source}
+                </TableCell>
+                <TableCell className="nx:text-right nx:tabular-nums">
+                  {source.visits.toLocaleString()}
+                </TableCell>
+                <TableCell className="nx:text-right nx:tabular-nums">
+                  {Math.round(source.share * 100)}%
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+function AnalyticsSkeleton() {
+  return (
+    <div className="nx:space-y-6">
+      <div className="nx:grid nx:gap-6 nx:sm:grid-cols-2 nx:xl:grid-cols-4">
+        {Array.from({ length: 4 }, (_, i) => (
+          <Skeleton key={i} className="nx:h-28" />
+        ))}
+      </div>
+      <div className="nx:grid nx:gap-6 nx:lg:grid-cols-2">
+        <Skeleton className="nx:h-80" />
+        <Skeleton className="nx:h-80" />
+      </div>
+      <Skeleton className="nx:h-80" />
+      <Skeleton className="nx:h-64" />
+    </div>
+  );
+}

--- a/apps/console/src/modules/analytics/analytics-search.ts
+++ b/apps/console/src/modules/analytics/analytics-search.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+import { ANALYTICS_RANGES } from '../../lib/analytics-api';
+
+/**
+ * The `/m/analytics` view contract — a single `range` facet driving the period
+ * toggle. `.default('30d')` keeps it optional for `<Link to="/m/analytics">`;
+ * `.catch('30d')` recovers a stale/invalid `?range=foo` instead of erroring.
+ */
+export const analyticsSearchSchema = z.object({
+  range: z.enum(ANALYTICS_RANGES).default('30d').catch('30d'),
+});
+
+export type AnalyticsView = z.infer<typeof analyticsSearchSchema>;

--- a/apps/console/src/shell/modules.ts
+++ b/apps/console/src/shell/modules.ts
@@ -35,7 +35,12 @@ export const MODULE_ITEMS = [
     icon: IconCreditCard,
     route: '/m/billing',
   },
-  { label: 'Analytics', module: 'analytics', icon: IconChartBar },
+  {
+    label: 'Analytics',
+    module: 'analytics',
+    icon: IconChartBar,
+    route: '/m/analytics',
+  },
   {
     label: 'People',
     module: 'people',


### PR DESCRIPTION
## Summary

The last Phase 3 breadth module — a read-only **reporting dashboard** at `/m/analytics`, and the **first consumer of the `@nexus/react` Chart kit** (#360, epic #305).

**Data layer** (read-only — no mutations, no store):
- `lib/analytics-api.ts` — `AnalyticsRange` (`7d`/`30d`/`90d`), `Kpi`/`TrendPoint`/`TrafficSource`/`AnalyticsOverview`, `analyticsKeys.overview(range)` (range in the key so the toggle refetches), `fetchAnalytics`.
- `mocks/analytics-fixtures.ts` — deterministic per-range data (a sin/cos trend builder — no `Math.random`/`Date.now`).
- `mocks/handlers.ts` — `GET /api/analytics?range=` validating the range, falling back to `30d`.
- `modules/analytics/analytics-search.ts` — the `?range` zod schema (`.default('30d').catch('30d')`).

**Dashboard** (`modules/analytics/`):
- A period **`ToggleGroup`** (segmented, `type="single"`) bound to `?range`. Deselect-guarded — Radix emits `''` on re-click, which we ignore so the range can't blank.
- 4 **KPI stat cards** — value + delta vs the prior period, tinted with `success-subtle-foreground` / `error-subtle-foreground` + a trend icon.
- 3 **trend charts** (`analytics-charts.tsx`) sharing one per-range series: Revenue **Area** (single, no legend), new-vs-returning **stacked Bar** (two series + legend), Sessions **Line** (single, hidden `YAxis domain={['dataMin','dataMax']}` so the flat high series uses its own range, not a 0 baseline).
- A **Top traffic sources** `Table`.

**New dogfooding coverage:** the Chart kit (`ChartContainer` / `ChartTooltip` / `ChartLegend`) and `ToggleGroup` — both first use in any Atlas module.

### Notes for reviewers
- **`useTheme.ts` loads `chart-categorical-default.css`.** The console manages its own token set (it deliberately doesn't import `@nexus/tailwind`), and the chart palette was the one axis its theme loader never pulled — so `var(--nx-color-chart-categorical-N)` resolved to nothing and every series painted **black**. Caught in the browser; the one-line load fixes it (the file is committed under `public/themes/`).
- **`recharts` added to the console's own `dependencies`** — it's an *optional peer* of `@nexus/react` (not bundled), so a direct consumer must provide it, same as the console already does for `react-hook-form` / `sonner`.
- **Demo scope:** read-only (no drill-down / export — the plan's `drill-down` would re-port the detail-route depth shipped 4× already; `export` omitted). The shared-series-across-three-chart-types is intentional (one time axis, three metrics).

## GitHub Issue

Part of the Atlas plan (`docs/plans/atlas-company-os.md`); consumes the Chart kit from #360 / epic #305.

## Test Plan

- [x] `yarn workspace @nexus/console typecheck` — clean
- [x] `eslint` — clean
- [x] Browser-verified in the console (light + the active dark theme): all three charts render in the categorical palette at the correct height, the Sessions line spans its range, KPI deltas tint correctly (incl. the 90d **negative** conversion → red), the period toggle drives `?range` and refetches, 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)