### PR TITLE
feat(console): adopt Nexus EmptyState across modules

### DIFF
--- a/apps/console/src/modules/crm/contact-detail-route.tsx
+++ b/apps/console/src/modules/crm/contact-detail-route.tsx
@@ -8,6 +8,11 @@ import {
   CardContent,
   CardHeader,
   CardTitle,
+  EmptyState,
+  EmptyStateContent,
+  EmptyStateDescription,
+  EmptyStateHeader,
+  EmptyStateTitle,
   Separator,
   Skeleton,
   Tabs,
@@ -190,22 +195,23 @@ function DetailSkeleton() {
   );
 }
 
-// App-local not-found — the polished @nexus/react EmptyState is tracked in #282.
 function NotFound() {
   return (
-    <div className="nx:border-border-default nx:flex nx:flex-col nx:items-center nx:justify-center nx:gap-3 nx:rounded-md nx:border nx:border-dashed nx:p-12 nx:text-center">
-      <h2 className="nx:typography-heading-medium nx:text-foreground">
-        Contact not found
-      </h2>
-      <p className="nx:text-muted-foreground nx:max-w-sm">
-        This contact doesn&apos;t exist, or may have been removed.
-      </p>
-      <Link
-        to="/m/crm"
-        className="nx:text-primary-subtle-foreground nx:hover:underline"
-      >
-        Back to Contacts
-      </Link>
-    </div>
+    <EmptyState className="nx:border nx:border-border-default">
+      <EmptyStateHeader>
+        <EmptyStateTitle>Contact not found</EmptyStateTitle>
+        <EmptyStateDescription>
+          This contact doesn&apos;t exist, or may have been removed.
+        </EmptyStateDescription>
+      </EmptyStateHeader>
+      <EmptyStateContent>
+        <Link
+          to="/m/crm"
+          className="nx:text-primary-subtle-foreground nx:hover:underline"
+        >
+          Back to Contacts
+        </Link>
+      </EmptyStateContent>
+    </EmptyState>
   );
 }

--- a/apps/console/src/modules/crm/contacts-route.tsx
+++ b/apps/console/src/modules/crm/contacts-route.tsx
@@ -1,6 +1,14 @@
 import { useState } from 'react';
 
-import { Button, Skeleton } from '@nexus/react';
+import {
+  Button,
+  EmptyState,
+  EmptyStateDescription,
+  EmptyStateHeader,
+  EmptyStateMedia,
+  EmptyStateTitle,
+  Skeleton,
+} from '@nexus/react';
 import { IconPlus, IconUsers } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import { getRouteApi } from '@tanstack/react-router';
@@ -98,20 +106,19 @@ function ContactsSkeleton() {
   );
 }
 
-// App-local empty state — the polished @nexus/react EmptyState is tracked in #282.
 function ContactsEmpty() {
   return (
-    <div className="nx:border-border-default nx:flex nx:flex-col nx:items-center nx:justify-center nx:gap-3 nx:rounded-md nx:border nx:border-dashed nx:p-12 nx:text-center">
-      <div className="nx:bg-muted nx:text-muted-foreground nx:flex nx:size-12 nx:items-center nx:justify-center nx:rounded-full">
-        <IconUsers />
-      </div>
-      <h2 className="nx:typography-heading-medium nx:text-foreground">
-        No contacts yet
-      </h2>
-      <p className="nx:text-muted-foreground nx:max-w-sm">
-        Contacts you add will show up here, ready to sort, filter, and work in
-        bulk.
-      </p>
-    </div>
+    <EmptyState className="nx:border nx:border-border-default">
+      <EmptyStateHeader>
+        <EmptyStateMedia variant="icon">
+          <IconUsers />
+        </EmptyStateMedia>
+        <EmptyStateTitle>No contacts yet</EmptyStateTitle>
+        <EmptyStateDescription>
+          Contacts you add will show up here, ready to sort, filter, and work in
+          bulk.
+        </EmptyStateDescription>
+      </EmptyStateHeader>
+    </EmptyState>
   );
 }

--- a/apps/console/src/modules/inbox/inbox-route.tsx
+++ b/apps/console/src/modules/inbox/inbox-route.tsx
@@ -1,4 +1,11 @@
-import { Skeleton } from '@nexus/react';
+import {
+  EmptyState,
+  EmptyStateDescription,
+  EmptyStateHeader,
+  EmptyStateMedia,
+  EmptyStateTitle,
+  Skeleton,
+} from '@nexus/react';
 import { IconInbox } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import { getRouteApi } from '@tanstack/react-router';
@@ -82,16 +89,16 @@ function ListError() {
 
 function EmptyPane() {
   return (
-    <div className="nx:flex nx:flex-1 nx:flex-col nx:items-center nx:justify-center nx:gap-3 nx:p-12 nx:text-center">
-      <div className="nx:bg-muted nx:text-muted-foreground nx:flex nx:size-12 nx:items-center nx:justify-center nx:rounded-full">
-        <IconInbox />
-      </div>
-      <h2 className="nx:typography-heading-medium nx:text-foreground">
-        No conversation selected
-      </h2>
-      <p className="nx:text-muted-foreground nx:max-w-sm">
-        Pick a conversation from the list to read the thread and reply.
-      </p>
-    </div>
+    <EmptyState>
+      <EmptyStateHeader>
+        <EmptyStateMedia variant="icon">
+          <IconInbox />
+        </EmptyStateMedia>
+        <EmptyStateTitle>No conversation selected</EmptyStateTitle>
+        <EmptyStateDescription>
+          Pick a conversation from the list to read the thread and reply.
+        </EmptyStateDescription>
+      </EmptyStateHeader>
+    </EmptyState>
   );
 }

--- a/apps/console/src/modules/people/people-route.tsx
+++ b/apps/console/src/modules/people/people-route.tsx
@@ -1,6 +1,14 @@
 import { useState } from 'react';
 
-import { Button, Skeleton } from '@nexus/react';
+import {
+  Button,
+  EmptyState,
+  EmptyStateDescription,
+  EmptyStateHeader,
+  EmptyStateMedia,
+  EmptyStateTitle,
+  Skeleton,
+} from '@nexus/react';
 import { IconUserPlus, IconUsers } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import { getRouteApi } from '@tanstack/react-router';
@@ -94,20 +102,19 @@ function PeopleSkeleton() {
   );
 }
 
-// App-local empty state — the polished @nexus/react EmptyState is tracked in #282.
 function PeopleEmpty() {
   return (
-    <div className="nx:border-border-default nx:flex nx:flex-col nx:items-center nx:justify-center nx:gap-3 nx:rounded-md nx:border nx:border-dashed nx:p-12 nx:text-center">
-      <div className="nx:bg-muted nx:text-muted-foreground nx:flex nx:size-12 nx:items-center nx:justify-center nx:rounded-full">
-        <IconUsers />
-      </div>
-      <h2 className="nx:typography-heading-medium nx:text-foreground">
-        No members yet
-      </h2>
-      <p className="nx:text-muted-foreground nx:max-w-sm">
-        Invite teammates and they&apos;ll show up here, ready to filter by role,
-        department, and status.
-      </p>
-    </div>
+    <EmptyState className="nx:border nx:border-border-default">
+      <EmptyStateHeader>
+        <EmptyStateMedia variant="icon">
+          <IconUsers />
+        </EmptyStateMedia>
+        <EmptyStateTitle>No members yet</EmptyStateTitle>
+        <EmptyStateDescription>
+          Invite teammates and they&apos;ll show up here, ready to filter by
+          role, department, and status.
+        </EmptyStateDescription>
+      </EmptyStateHeader>
+    </EmptyState>
   );
 }

--- a/apps/console/src/modules/projects/issues-route.tsx
+++ b/apps/console/src/modules/projects/issues-route.tsx
@@ -1,6 +1,14 @@
 import { useState } from 'react';
 
-import { Button, Skeleton } from '@nexus/react';
+import {
+  Button,
+  EmptyState,
+  EmptyStateDescription,
+  EmptyStateHeader,
+  EmptyStateMedia,
+  EmptyStateTitle,
+  Skeleton,
+} from '@nexus/react';
 import { IconBriefcase, IconPlus } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 
@@ -72,20 +80,19 @@ function IssuesSkeleton() {
   );
 }
 
-// App-local empty state — the polished @nexus/react EmptyState is tracked in #282.
 function IssuesEmpty() {
   return (
-    <div className="nx:border-border-default nx:flex nx:flex-col nx:items-center nx:justify-center nx:gap-3 nx:rounded-md nx:border nx:border-dashed nx:p-12 nx:text-center">
-      <div className="nx:bg-muted nx:text-muted-foreground nx:flex nx:size-12 nx:items-center nx:justify-center nx:rounded-full">
-        <IconBriefcase />
-      </div>
-      <h2 className="nx:typography-heading-medium nx:text-foreground">
-        No issues yet
-      </h2>
-      <p className="nx:text-muted-foreground nx:max-w-sm">
-        Issues you create will show up here, ready to sort, filter, and work
-        through.
-      </p>
-    </div>
+    <EmptyState className="nx:border nx:border-border-default">
+      <EmptyStateHeader>
+        <EmptyStateMedia variant="icon">
+          <IconBriefcase />
+        </EmptyStateMedia>
+        <EmptyStateTitle>No issues yet</EmptyStateTitle>
+        <EmptyStateDescription>
+          Issues you create will show up here, ready to sort, filter, and work
+          through.
+        </EmptyStateDescription>
+      </EmptyStateHeader>
+    </EmptyState>
   );
 }


### PR DESCRIPTION
## Summary

Adopts the shipped `@nexus/react` **EmptyState** component (from the #282–#304 component batch) across the Atlas console, replacing five hand-rolled empty / placeholder states:

| Module | State | Notes |
| --- | --- | --- |
| CRM | `ContactsEmpty` (contacts list) | icon + title + description |
| CRM | `NotFound` (contact detail) | no icon; keeps its **"Back to Contacts"** link in `EmptyStateContent` |
| Projects | `IssuesEmpty` (issues list) | icon + title + description |
| People | `PeopleEmpty` (members list) | icon + title + description |
| Inbox | `EmptyPane` (no-selection reading pane) | icon + title + description |

Four of these were explicitly tagged in code (`// App-local empty state — tracked in #282`) as awaiting the DS component; the inbox no-selection pane is the same visual pattern and is adopted for consistency.

**This is an adoption, not a no-op swap** — the DS `EmptyState` restyles slightly vs the hand-rolled markup: a smaller `rounded-lg` `size-10` medallion (was `rounded-full` `size-12`), an `xsmall` title (was `heading-medium`), and tighter padding. Content (icons, copy, the not-found link) is preserved verbatim. The five independent dashed-border boxes now share one component, so empty-state styling has a single source.

## GitHub Issue

No issue to close — the EmptyState **component** (#282) already shipped in the component batch; this wires it into the console. (Removes the four `tracked in #282` placeholders.)

## Test Plan

- [x] `@nexus/console` typecheck clean
- [x] `eslint . --max-warnings 0` clean
- [x] `prettier --check` clean
- [x] `@nexus/console` vite build clean
- [x] `audit:class-refs` clean (241 files, all semantic refs resolve)
- [x] Confirmed `typography-heading-xsmall` / `typography-body-small` / `border-dashed` are emitted in the built console CSS (console runs its own Tailwind via `@source`, not `dist/react.css`)
- [ ] CI: format-check, lint, build, typecheck, audit-tokens green (react-gated jobs skip for a console-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)