### PR TITLE
feat(console): adopt Nexus Kbd for shortcut hints

### DIFF
--- a/apps/console/src/modules/inbox/conversation-thread.tsx
+++ b/apps/console/src/modules/inbox/conversation-thread.tsx
@@ -9,6 +9,8 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
+  Kbd,
+  KbdGroup,
   ScrollArea,
   Skeleton,
   Textarea,
@@ -156,7 +158,12 @@ function ThreadContent({ conversation }: { conversation: ConversationDetail }) {
         />
         <div className="nx:mt-3 nx:flex nx:items-center nx:justify-between nx:gap-2">
           <p className="nx:text-muted-foreground nx:text-xs">
-            Replies as {conversation.assignee} · ⌘↵ to send
+            Replies as {conversation.assignee} ·{' '}
+            <KbdGroup>
+              <Kbd>⌘</Kbd>
+              <Kbd>↵</Kbd>
+            </KbdGroup>{' '}
+            to send
           </p>
           <Button
             onClick={handleSend}

--- a/apps/console/src/shell/topbar.tsx
+++ b/apps/console/src/shell/topbar.tsx
@@ -1,4 +1,4 @@
-import { Button, SidebarTrigger } from '@nexus/react';
+import { Button, Kbd, KbdGroup, SidebarTrigger } from '@nexus/react';
 import { IconMoon, IconSearch, IconSun } from '@tabler/icons-react';
 
 import { useThemeContext } from '../app/theme-provider';
@@ -21,9 +21,10 @@ export function Topbar() {
       >
         <IconSearch className="nx:size-4" />
         <span>Search…</span>
-        <kbd className="nx:bg-background nx:ml-2 nx:rounded nx:px-1.5 nx:text-xs">
-          ⌘K
-        </kbd>
+        <KbdGroup className="nx:ml-2">
+          <Kbd>⌘</Kbd>
+          <Kbd>K</Kbd>
+        </KbdGroup>
       </button>
 
       <div className="nx:flex-1" />


### PR DESCRIPTION
## Summary

Adopts the shipped `@nexus/react` **Kbd / KbdGroup** component for the two keyboard-shortcut hints in the console, replacing ad-hoc per-site markup:

- **Topbar** search placeholder — the raw `<kbd>⌘K</kbd>` (one chip) becomes a `KbdGroup` of two keycaps (`⌘` and `K`), the idiomatic chord rendering.
- **Inbox** composer footer — the plain-text `⌘↵ to send` hint now renders `⌘` and `↵` as `Kbd` keycaps.

Both now share the design-system keycap styling (muted rounded chip, `label-small` type) instead of hand-rolled `<kbd>`/plain-text. Content is otherwise unchanged.

## GitHub Issue

No issue to close — the Kbd **component** (#302) already shipped in the component batch; this wires it into the console.

## Test Plan

- [x] `@nexus/console` typecheck clean
- [x] `eslint . --max-warnings 0` clean
- [x] `prettier --check` clean
- [x] `@nexus/console` vite build clean
- [x] `audit:class-refs` clean
- [x] Confirmed `typography-label-small` is emitted in the built console CSS
- [ ] CI: format-check, lint, build, typecheck, audit-tokens green (react-gated jobs skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)