### PR TITLE
feat(console): adopt Nexus EmptyState in detail not-found states

### DIFF
--- a/apps/console/src/modules/people/member-detail-route.tsx
+++ b/apps/console/src/modules/people/member-detail-route.tsx
@@ -8,6 +8,11 @@ import {
   CardContent,
   CardHeader,
   CardTitle,
+  EmptyState,
+  EmptyStateContent,
+  EmptyStateDescription,
+  EmptyStateHeader,
+  EmptyStateTitle,
   Separator,
   Skeleton,
 } from '@nexus/react';
@@ -139,22 +144,23 @@ function DetailSkeleton() {
   );
 }
 
-// App-local not-found — the polished @nexus/react EmptyState is tracked in #282.
 function NotFound() {
   return (
-    <div className="nx:border-border-default nx:flex nx:flex-col nx:items-center nx:justify-center nx:gap-3 nx:rounded-md nx:border nx:border-dashed nx:p-12 nx:text-center">
-      <h2 className="nx:typography-heading-medium nx:text-foreground">
-        Member not found
-      </h2>
-      <p className="nx:text-muted-foreground nx:max-w-sm">
-        This member doesn&apos;t exist, or may have been removed.
-      </p>
-      <Link
-        to="/m/people"
-        className="nx:text-primary-subtle-foreground nx:hover:underline"
-      >
-        Back to People
-      </Link>
-    </div>
+    <EmptyState className="nx:border nx:border-border-default">
+      <EmptyStateHeader>
+        <EmptyStateTitle>Member not found</EmptyStateTitle>
+        <EmptyStateDescription>
+          This member doesn&apos;t exist, or may have been removed.
+        </EmptyStateDescription>
+      </EmptyStateHeader>
+      <EmptyStateContent>
+        <Link
+          to="/m/people"
+          className="nx:text-primary-subtle-foreground nx:hover:underline"
+        >
+          Back to People
+        </Link>
+      </EmptyStateContent>
+    </EmptyState>
   );
 }

--- a/apps/console/src/modules/projects/issue-detail-route.tsx
+++ b/apps/console/src/modules/projects/issue-detail-route.tsx
@@ -9,6 +9,11 @@ import {
   CardContent,
   CardHeader,
   CardTitle,
+  EmptyState,
+  EmptyStateContent,
+  EmptyStateDescription,
+  EmptyStateHeader,
+  EmptyStateTitle,
   Separator,
   Skeleton,
 } from '@nexus/react';
@@ -164,22 +169,23 @@ function DetailSkeleton() {
   );
 }
 
-// App-local not-found — the polished @nexus/react EmptyState is tracked in #282.
 function NotFound() {
   return (
-    <div className="nx:border-border-default nx:flex nx:flex-col nx:items-center nx:justify-center nx:gap-3 nx:rounded-md nx:border nx:border-dashed nx:p-12 nx:text-center">
-      <h2 className="nx:typography-heading-medium nx:text-foreground">
-        Issue not found
-      </h2>
-      <p className="nx:text-muted-foreground nx:max-w-sm">
-        This issue doesn&apos;t exist, or may have been removed.
-      </p>
-      <Link
-        to="/m/projects"
-        className="nx:text-primary-subtle-foreground nx:hover:underline"
-      >
-        Back to Issues
-      </Link>
-    </div>
+    <EmptyState className="nx:border nx:border-border-default">
+      <EmptyStateHeader>
+        <EmptyStateTitle>Issue not found</EmptyStateTitle>
+        <EmptyStateDescription>
+          This issue doesn&apos;t exist, or may have been removed.
+        </EmptyStateDescription>
+      </EmptyStateHeader>
+      <EmptyStateContent>
+        <Link
+          to="/m/projects"
+          className="nx:text-primary-subtle-foreground nx:hover:underline"
+        >
+          Back to Issues
+        </Link>
+      </EmptyStateContent>
+    </EmptyState>
   );
 }


### PR DESCRIPTION
## Summary

Completes the EmptyState adoption from #365. The first sweep replaced five empty states but the survey missed two **not-found** states in the detail routes — both still tagged `// App-local not-found — tracked in #282`:

- **Projects** issue detail — `NotFound`
- **People** member detail — `NotFound`

Both were the same hand-rolled dashed-border box (title + description + a "Back to …" link). They now use the design-system `EmptyState`, matching the CRM contact-detail `NotFound` already converted in #365 (the "Back to …" link moves into `EmptyStateContent`). This removes the last two `tracked in #282` placeholders in the console.

## GitHub Issue

No issue to close — finishes wiring the EmptyState component (#282), continuation of #365.

## Test Plan

- [x] `@nexus/console` typecheck clean
- [x] `eslint . --max-warnings 0` clean
- [x] `prettier --check` clean
- [x] `@nexus/console` vite build clean
- [x] `audit:class-refs` clean
- [ ] CI: format-check, lint, build, typecheck, audit-tokens green (react-gated jobs skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)