### PR TITLE
feat(console): adopt Nexus Breadcrumb on detail routes

### DIFF
--- a/apps/console/src/modules/crm/contact-detail-route.tsx
+++ b/apps/console/src/modules/crm/contact-detail-route.tsx
@@ -3,6 +3,12 @@ import { useState } from 'react';
 import {
   Avatar,
   AvatarFallback,
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
   Button,
   Card,
   CardContent,
@@ -21,7 +27,6 @@ import {
   TabsTrigger,
 } from '@nexus/react';
 import {
-  IconArrowLeft,
   IconFlag,
   IconMail,
   IconNote,
@@ -51,13 +56,19 @@ export function ContactDetailRoute() {
 
   return (
     <div className="nx:space-y-6 nx:p-6">
-      <Link
-        to="/m/crm"
-        className="nx:text-muted-foreground nx:hover:text-foreground nx:inline-flex nx:items-center nx:gap-1 nx:text-sm"
-      >
-        <IconArrowLeft className="nx:size-4" />
-        Contacts
-      </Link>
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link to="/m/crm">Contacts</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>{data?.contact.name ?? 'Contact'}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
 
       {isPending && <DetailSkeleton />}
       {isError && <NotFound />}

--- a/apps/console/src/modules/people/member-detail-route.tsx
+++ b/apps/console/src/modules/people/member-detail-route.tsx
@@ -3,6 +3,12 @@ import { useState } from 'react';
 import {
   Avatar,
   AvatarFallback,
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
   Button,
   Card,
   CardContent,
@@ -16,7 +22,7 @@ import {
   Separator,
   Skeleton,
 } from '@nexus/react';
-import { IconArrowLeft, IconPencil } from '@tabler/icons-react';
+import { IconPencil } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import { Link, useParams } from '@tanstack/react-router';
 
@@ -39,13 +45,19 @@ export function MemberDetailRoute() {
 
   return (
     <div className="nx:space-y-6 nx:p-6">
-      <Link
-        to="/m/people"
-        className="nx:text-muted-foreground nx:hover:text-foreground nx:inline-flex nx:items-center nx:gap-1 nx:text-sm"
-      >
-        <IconArrowLeft className="nx:size-4" />
-        People
-      </Link>
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link to="/m/people">People</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>{data?.member.name ?? 'Member'}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
 
       {isPending && <DetailSkeleton />}
       {isError && <NotFound />}

--- a/apps/console/src/modules/projects/issue-detail-route.tsx
+++ b/apps/console/src/modules/projects/issue-detail-route.tsx
@@ -4,6 +4,12 @@ import { useState } from 'react';
 import {
   Avatar,
   AvatarFallback,
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
   Button,
   Card,
   CardContent,
@@ -17,7 +23,7 @@ import {
   Separator,
   Skeleton,
 } from '@nexus/react';
-import { IconArrowLeft, IconPencil } from '@tabler/icons-react';
+import { IconPencil } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import { Link, useParams } from '@tanstack/react-router';
 
@@ -40,13 +46,19 @@ export function IssueDetailRoute() {
 
   return (
     <div className="nx:space-y-6 nx:p-6">
-      <Link
-        to="/m/projects"
-        className="nx:text-muted-foreground nx:hover:text-foreground nx:inline-flex nx:items-center nx:gap-1 nx:text-sm"
-      >
-        <IconArrowLeft className="nx:size-4" />
-        Issues
-      </Link>
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild>
+              <Link to="/m/projects">Issues</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>{data?.issue.title ?? 'Issue'}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
 
       {isPending && <DetailSkeleton />}
       {isError && <NotFound />}


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `← Back` links at the top of the three detail routes with a design-system **Breadcrumb** trail (parent list → current record):

| Route | Trail |
| --- | --- |
| CRM contact detail | `Contacts / {contact name}` |
| Projects issue detail | `Issues / {issue title}` |
| People member detail | `People / {member name}` |

- The parent crumb is the router `<Link>` (via `BreadcrumbLink asChild`) and doubles as the back affordance.
- The current record is a `BreadcrumbPage`, sourced from the loaded query data (falls back to the entity word — "Contact" / "Issue" / "Member" — during the brief load).
- Drops the now-unused `IconArrowLeft` import from each file.

This is an adoption (a back-link → a breadcrumb trail), not a no-op swap: the back-arrow affordance is replaced by the standard breadcrumb hierarchy used across console-style apps.

## GitHub Issue

No issue to close — the Breadcrumb **component** (#285) already shipped in the component batch; this wires it into the console.

## Test Plan

- [x] `@nexus/console` typecheck clean (confirms no orphaned `IconArrowLeft`)
- [x] `eslint . --max-warnings 0` clean
- [x] `prettier --check` clean
- [x] `@nexus/console` vite build clean
- [x] `audit:class-refs` clean
- [ ] CI: format-check, lint, build, typecheck, audit-tokens green (react-gated jobs skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)