### PR TITLE
feat(console): adopt Nexus ToggleGroup for CRM view switcher

### DIFF
--- a/apps/console/src/modules/crm/contacts-toolbar.tsx
+++ b/apps/console/src/modules/crm/contacts-toolbar.tsx
@@ -22,6 +22,8 @@ import {
   PopoverTrigger,
   Separator,
   toast,
+  ToggleGroup,
+  ToggleGroupItem,
 } from '@nexus/react';
 import {
   IconBookmark,
@@ -71,25 +73,31 @@ function ViewSwitcher({
   view,
   setSearch,
 }: Pick<ContactsToolbarProps, 'view' | 'setSearch'>) {
+  // Radix single-select emits '' when the active item is re-clicked; ignore it
+  // so the view can never wipe to blank.
+  const onViewChange = (value: string) => {
+    if (value) {
+      setSearch({ view: value as ContactsView['view'] });
+    }
+  };
+
   return (
-    <div className="nx:inline-flex nx:gap-1">
-      <Button
-        variant={view === 'table' ? 'default' : 'ghost'}
-        size="sm"
-        onClick={() => setSearch({ view: 'table' })}
-      >
+    <ToggleGroup
+      type="single"
+      variant="outline"
+      value={view}
+      onValueChange={onViewChange}
+      aria-label="Contacts view"
+    >
+      <ToggleGroupItem value="table">
         <IconTable />
         Table
-      </Button>
-      <Button
-        variant={view === 'board' ? 'default' : 'ghost'}
-        size="sm"
-        onClick={() => setSearch({ view: 'board' })}
-      >
+      </ToggleGroupItem>
+      <ToggleGroupItem value="board">
         <IconLayoutKanban />
         Board
-      </Button>
-    </div>
+      </ToggleGroupItem>
+    </ToggleGroup>
   );
 }
 


### PR DESCRIPTION
## Summary

Replaces the hand-rolled CRM contacts **ViewSwitcher** (two `<Button>`s with a conditional `default`/`ghost` variant to show the active view) with a single-select `ToggleGroup` — the same component and idiom the **Analytics** range selector already uses (`type="single"`, `variant="outline"`, `aria-label`).

- A guard ignores Radix's `''`-on-re-click emit (mirrors the analytics handler) so the view can never wipe to blank.
- The group gets an `aria-label="Contacts view"`; the table/board options keep their icons + labels.

This unifies the two view-toggle UIs in the console on one component, and replaces ad-hoc `variant` branching with the component's own selected-state styling.

## GitHub Issue

No issue to close — the ToggleGroup **component** (#297) already shipped in the component batch; this wires it into the console.

## Test Plan

- [x] `@nexus/console` typecheck clean
- [x] `eslint . --max-warnings 0` clean
- [x] `prettier --check` clean
- [x] `@nexus/console` vite build clean
- [x] `audit:class-refs` clean
- [ ] CI: format-check, lint, build, typecheck, audit-tokens green (react-gated jobs skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)