### PR TITLE
feat(console): adopt Nexus InputGroup for the data-table filter

### DIFF
--- a/apps/console/src/components/data-table.tsx
+++ b/apps/console/src/components/data-table.tsx
@@ -2,7 +2,9 @@ import { useState } from 'react';
 
 import {
   Button,
-  Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
   Table,
   TableBody,
   TableCell,
@@ -10,7 +12,11 @@ import {
   TableHeader,
   TableRow,
 } from '@nexus/react';
-import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+import {
+  IconChevronLeft,
+  IconChevronRight,
+  IconSearch,
+} from '@tabler/icons-react';
 import {
   type ColumnDef,
   type ColumnFiltersState,
@@ -82,13 +88,17 @@ export function DataTable<TData>({
   return (
     <div className="nx:space-y-4">
       {filterControl && (
-        <Input
-          placeholder={filterPlaceholder ?? 'Filter…'}
-          value={(filterControl.getFilterValue() as string) ?? ''}
-          onChange={(e) => filterControl.setFilterValue(e.target.value)}
-          aria-label={filterPlaceholder ?? 'Filter'}
-          className="nx:max-w-xs"
-        />
+        <InputGroup className="nx:max-w-xs">
+          <InputGroupAddon>
+            <IconSearch />
+          </InputGroupAddon>
+          <InputGroupInput
+            placeholder={filterPlaceholder ?? 'Filter…'}
+            value={(filterControl.getFilterValue() as string) ?? ''}
+            onChange={(e) => filterControl.setFilterValue(e.target.value)}
+            aria-label={filterPlaceholder ?? 'Filter'}
+          />
+        </InputGroup>
       )}
 
       <div className="nx:border-border-default nx:overflow-hidden nx:rounded-md nx:border">


### PR DESCRIPTION
## Summary

Wraps the shared data-table filter field in an `InputGroup` with a leading **search icon** (`InputGroupAddon` + `InputGroupInput`), replacing the bare `Input`. The filter is the table's only text control, so the search affordance makes its purpose obvious.

Behaviour is unchanged — the TanStack filter-value wiring, placeholder, `aria-label`, and `max-w-xs` width all carry over; only the visual affordance is added. Applies everywhere `DataTable` is used (CRM contacts, etc.).

## GitHub Issue

No issue to close — the InputGroup **component** (#300) already shipped in the component batch; this wires it into the console.

## Test Plan

- [x] `@nexus/console` typecheck clean (bare `Input` cleanly replaced)
- [x] `eslint . --max-warnings 0` clean
- [x] `prettier --check` clean
- [x] `@nexus/console` vite build clean
- [x] `audit:class-refs` clean
- [ ] CI: format-check, lint, build, typecheck, audit-tokens green (react-gated jobs skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)