### PR TITLE
feat(console): resizable inbox split-pane on desktop

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -23,6 +23,7 @@
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-hook-form": "^7.77.0",
+    "react-resizable-panels": "^4.11.2",
     "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "tw-animate-css": "^1.4.0",

--- a/apps/console/src/hooks/use-media-query.ts
+++ b/apps/console/src/hooks/use-media-query.ts
@@ -1,0 +1,30 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+/**
+ * useMediaQuery
+ *
+ * Subscribes to a CSS media query and re-renders when it starts/stops matching.
+ * Reads the current match synchronously via `useSyncExternalStore`, so there is
+ * no first-render flash — important when layout branches on the result.
+ *
+ * @example
+ * ```tsx
+ * const isDesktop = useMediaQuery('(min-width: 64rem)');
+ * ```
+ */
+export function useMediaQuery(query: string): boolean {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const mql = window.matchMedia(query);
+      mql.addEventListener('change', onStoreChange);
+      return () => mql.removeEventListener('change', onStoreChange);
+    },
+    [query]
+  );
+
+  return useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(query).matches,
+    () => false
+  );
+}

--- a/apps/console/src/modules/inbox/inbox-route.tsx
+++ b/apps/console/src/modules/inbox/inbox-route.tsx
@@ -4,12 +4,16 @@ import {
   EmptyStateHeader,
   EmptyStateMedia,
   EmptyStateTitle,
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
   Skeleton,
 } from '@nexus/react';
 import { IconInbox } from '@tabler/icons-react';
 import { useQuery } from '@tanstack/react-query';
 import { getRouteApi } from '@tanstack/react-router';
 
+import { useMediaQuery } from '../../hooks/use-media-query';
 import { fetchConversations, inboxKeys } from '../../lib/inbox-api';
 
 import { ConversationList } from './conversation-list';
@@ -24,6 +28,24 @@ export function InboxRoute() {
   });
   const { c } = inboxRoute.useSearch();
   const conversations = data?.conversations;
+  // The resizable split is a desktop affordance; below lg the panes toggle one
+  // at a time (driven by `c`), so that layout renders instead of a drag handle.
+  const isDesktop = useMediaQuery('(min-width: 64rem)');
+
+  const listPane = (
+    <>
+      {isPending && <ListSkeleton />}
+      {isError && <ListError />}
+      {conversations && (
+        <ConversationList conversations={conversations} activeId={c} />
+      )}
+    </>
+  );
+
+  // key={c} remounts on conversation switch so a drafted reply doesn't bleed
+  // into the next thread's composer (cached data still renders immediately, so
+  // there's no skeleton flash).
+  const threadPane = c ? <ConversationThread id={c} key={c} /> : <EmptyPane />;
 
   return (
     // 3.5rem = the Topbar's fixed h-14, so the two-pane fills the rest of the
@@ -39,29 +61,39 @@ export function InboxRoute() {
         </p>
       </header>
 
-      <div className="nx:border-border-default nx:flex nx:min-h-0 nx:flex-1 nx:overflow-hidden nx:rounded-lg nx:border">
-        {/* List pane — full-width on mobile, fixed on desktop; hidden on mobile
-            once a thread is open so the thread gets the whole screen. */}
-        <aside
-          className={`nx:border-border-default nx:w-full nx:min-h-0 nx:min-w-0 nx:flex-col nx:lg:flex nx:lg:w-80 nx:lg:border-r ${c ? 'nx:hidden' : 'nx:flex'}`}
+      {isDesktop ? (
+        <ResizablePanelGroup
+          orientation="horizontal"
+          className="nx:border-border-default nx:min-h-0 nx:flex-1 nx:overflow-hidden nx:rounded-lg nx:border"
         >
-          {isPending && <ListSkeleton />}
-          {isError && <ListError />}
-          {conversations && (
-            <ConversationList conversations={conversations} activeId={c} />
-          )}
-        </aside>
-
-        {/* Thread pane — hidden on mobile until a conversation is selected. */}
-        <section
-          className={`nx:min-h-0 nx:min-w-0 nx:flex-1 nx:flex-col nx:lg:flex ${c ? 'nx:flex' : 'nx:hidden'}`}
-        >
-          {/* key={c} remounts on conversation switch so a drafted reply doesn't
-              bleed into the next thread's composer (cached data still renders
-              immediately, so there's no skeleton flash). */}
-          {c ? <ConversationThread id={c} key={c} /> : <EmptyPane />}
-        </section>
-      </div>
+          <ResizablePanel
+            defaultSize="28%"
+            minSize="20%"
+            maxSize="45%"
+            className="nx:flex nx:min-h-0 nx:flex-col"
+          >
+            {listPane}
+          </ResizablePanel>
+          <ResizableHandle withHandle aria-label="Resize conversation list" />
+          <ResizablePanel className="nx:flex nx:min-h-0 nx:flex-col">
+            {threadPane}
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      ) : (
+        // Below lg only one pane shows at a time, toggled by `c`.
+        <div className="nx:border-border-default nx:flex nx:min-h-0 nx:flex-1 nx:overflow-hidden nx:rounded-lg nx:border">
+          <aside
+            className={`nx:min-h-0 nx:w-full nx:min-w-0 nx:flex-col ${c ? 'nx:hidden' : 'nx:flex'}`}
+          >
+            {listPane}
+          </aside>
+          <section
+            className={`nx:min-h-0 nx:min-w-0 nx:flex-1 nx:flex-col ${c ? 'nx:flex' : 'nx:hidden'}`}
+          >
+            {threadPane}
+          </section>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Makes the inbox **list ↔ thread** split drag-resizable on desktop, using the Nexus `Resizable*` components. Adds `react-resizable-panels@^4.11.2` as a console dependency (it's an optional peer of `@nexus/react`, so consumers install it themselves; the lockfile already had the resolution so `--frozen-lockfile` is unaffected).

### Design decisions (made explicit)

- **Desktop-only affordance.** Resize applies at ≥`lg` (64rem). Below `lg` the inbox keeps its existing single-pane toggle (list **or** thread, driven by the selected conversation). The two layouts are **conditionally rendered** via a small `useMediaQuery` hook — a pure-CSS dual render would mount the thread/composer twice.
- **Shared panes.** The list/thread panes are extracted to shared JSX so neither branch duplicates them; only the active branch mounts (no double-fetch / double-composer).
- **Ephemeral by design.** `react-resizable-panels` v4 has no `autoSaveId`, and the default **28 / 72** split is a good resting state, so the split resets to it on reload rather than carrying manual `localStorage` persistence.
- New `apps/console/src/hooks/use-media-query.ts` — `useSyncExternalStore`-based, reads the match synchronously (no first-render flash).

## GitHub Issue

No issue to close — the Resizable **component** (#294) already shipped in the component batch; this wires it into the console (the one Tier-1+Resizable item the user greenlit that needs a new peer dep).

## Test Plan

- [x] `@nexus/console` typecheck clean (validated against the real v4 `orientation` API)
- [x] `eslint . --max-warnings 0` clean
- [x] `prettier --check` clean
- [x] `@nexus/console` vite build clean — `react-resizable-panels` bundles into the console output
- [x] `yarn install --frozen-lockfile` clean (lockfile already in sync; no yarn.lock change)
- [x] `audit:class-refs` clean
- [ ] CI: format-check, lint, build, typecheck, audit-tokens green (react-gated jobs skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)