### PR TITLE
docs(responsive): reframe to mobile-first + desktop co-primary

### DIFF
--- a/.claude/rules/components.md
+++ b/.claude/rules/components.md
@@ -66,6 +66,8 @@ See [`tokens.md` § Light/Dark Theme Tokens](tokens.md#lightdark-theme-tokens) f
 
 Use padding for sizing, not fixed heights (`nx:px-4 nx:py-2`, not `nx:h-10 nx:px-4`) — fixed heights break in flex layouts. **Exceptions:** avatars, progress bars, modals may need fixed dimensions.
 
+**Touch targets (mobile-first):** interactive controls must clear a **~44px minimum tap-target** — tune `nx:p-*` so the rendered hit area meets it (or extend it with an `::after` overlay), not by shrinking the control. See [responsive.md § Touch targets](responsive.md#touch-targets).
+
 ## Responsive behaviour
 
 Component-internal responsive behaviour should use `@container` queries, not viewport breakpoints — a component adapts to its parent's width, not the viewport, so it renders consistently whether it lands in a sidebar or a hero. Viewport prefixes (`nx:lg:`, etc.) are reserved for page-shell decisions; full-viewport overlays (e.g. Dialog) are the documented exception, since their trigger is position relative to the viewport.

--- a/.claude/rules/responsive.md
+++ b/.claude/rules/responsive.md
@@ -1,24 +1,31 @@
 # Responsive Design Rules
 
-Nexus components are designed for **Standard (≥1024px)** as the primary target. Narrow (<1024px) is graceful degradation; Wide (≥1536px) gets breathing room when available. Standard spans `lg` (1024px floor — the prefix you reach for first when writing responsive consumer code) through `xl` (1280px — the design reference width components are tuned against).
+Nexus is designed **mobile-first and desktop-first**: **Narrow (mobile) and Standard (desktop) are both first-class targets** — neither is a degradation of the other. Author **mobile-first** — the base (unprefixed) utilities are the Narrow/mobile case, and min-width prefixes (`nx:lg:`, `nx:xl:`) layer on the wider tiers. Components are tuned against **two reference widths — a mobile reference (~390px) and a desktop reference (~1280px)** — and must read well at both. **Wide (≥1536px)** gets extra breathing room when available.
 
-> **Consumer-brand inversion.** The ≥1024px primary target is the Nexus reference brand's default (the `--breakpoint-*` tokens). Consumer brands building mobile-first products override by re-aiming `@theme { --breakpoint-* }` and treating a different tier as primary — the Narrow / Standard / Wide labels describe defaults, not hard-coded behaviour.
+> **Consumer-brand re-aiming.** The reference brand is co-primary (mobile + desktop) out of the box — mobile is _not_ an inversion of a desktop default. Consumer brands can still re-aim `@theme { --breakpoint-* }` to weight a particular tier for their product; the Narrow / Standard / Wide labels describe the reference brand's bands, not hard-coded behaviour.
 
 ## Display class table
 
 **This table is the single source of truth.** Other rule files (`components.md`) link here rather than duplicating these rows.
 
-| Tailwind class | Range (rem / px @16) | Nexus display class | Use as primary target? |
-| -------------- | -------------------- | ------------------- | ---------------------- |
-| `nx:sm:`       | 40rem / 640px+       | Narrow              | No (graceful)          |
-| `nx:md:`       | 48rem / 768px+       | Narrow              | No (graceful)          |
-| `nx:lg:`       | 64rem / 1024px+      | **Standard ★**      | Yes — floor            |
-| `nx:xl:`       | 80rem / 1280px+      | **Standard ★**      | Yes — reference        |
-| `nx:2xl:`      | 96rem / 1536px+      | Wide                | No (extended)          |
+| Tailwind class | Range (rem / px @16) | Nexus display class | Design target                                       |
+| -------------- | -------------------- | ------------------- | --------------------------------------------------- |
+| _(no prefix)_  | base / <640px        | Narrow              | ★ mobile foundation — style here first (~390px ref) |
+| `nx:sm:`       | 40rem / 640px+       | Narrow              | ★ first-class                                       |
+| `nx:md:`       | 48rem / 768px+       | Narrow              | ★ first-class                                       |
+| `nx:lg:`       | 64rem / 1024px+      | Standard            | ★ first-class — desktop floor                       |
+| `nx:xl:`       | 80rem / 1280px+      | Standard            | ★ first-class — desktop reference                   |
+| `nx:2xl:`      | 96rem / 1536px+      | Wide                | extra breathing room                                |
 
 **Narrow / Standard / Wide are documentation labels, not utilities.** There is no `nx:standard:` class. Contributors use the standard Tailwind class names (`nx:sm:`, `nx:md:`, `nx:lg:`, `nx:xl:`, `nx:2xl:`) in code; the display-class labels exist to anchor design and review conversations.
 
 > **Rem breakpoints track the user's font-size preference — not zoom.** Breakpoints are rem-based, so they respond to the browser's **default font-size** setting — in a media query, `rem` resolves against that browser default (a user preference), not against any `html { font-size }` the page itself sets. Full-page zoom is _not_ the mechanism: zoom scales every length unit, rem and px alike, so rem-vs-px makes no difference under it. The payoff is for a user who raises their base font size — each rem grows, the breakpoints fire at a _narrower_ viewport, and the layout drops to a roomier tier as the text enlarges (a px-based layout would ignore the preference). Example: doubling the base font to 32px turns `nx:lg:` (64rem) into a 2048px threshold and `nx:md:` (48rem) into 1536px, so a 1280px viewport that is normally Standard (`nx:xl:` matches) now reads Narrow — only `nx:sm:` (40rem → 1280px) still matches. This is intended accessibility behaviour: layout should follow text size. Test components at 100/150/200% zoom (for reflow) **and** with an enlarged browser default font (for breakpoint behaviour).
+
+## Touch targets
+
+Both Narrow (mobile) and Standard (desktop) are first-class, so every interactive control must be comfortably **tappable**, not just clickable. **Minimum interactive target: ~44px** (WCAG 2.5.5 Target Size · Apple HIG 44pt; Material's 48dp is the roomier bar). This is a **hit-area floor, not a visual-size mandate** — a control may look smaller as long as its tappable area clears ~44px on touch (extend it with padding, or an `::after` hit-area overlay as Sidebar does with `nx:after:-inset-2`).
+
+Because Nexus sizes by padding, not fixed height (see [components.md § Sizing Convention](components.md#sizing-convention)), meet the floor with padding — `nx:p-*` tuned so the rendered hit area reaches ~44px — not a hardcoded `nx:h-11`. Pointer-fine surfaces (mouse) may render denser; the touch case sets the floor.
 
 ## Decision tree — which responsive mechanism
 

--- a/apps/docs/app/_pages/Responsive.tsx
+++ b/apps/docs/app/_pages/Responsive.tsx
@@ -13,37 +13,43 @@ const BREAKPOINTS: {
   cls: string;
   size: string;
   display: string;
-  primary: string;
+  target: string;
 }[] = [
+  {
+    cls: '(no prefix)',
+    size: 'base / <640px',
+    display: 'Narrow',
+    target: '★ mobile foundation — style here first',
+  },
   {
     cls: 'nx:sm:',
     size: '40rem / 640px',
     display: 'Narrow',
-    primary: 'No (graceful)',
+    target: '★ first-class',
   },
   {
     cls: 'nx:md:',
     size: '48rem / 768px',
     display: 'Narrow',
-    primary: 'No (graceful)',
+    target: '★ first-class',
   },
   {
     cls: 'nx:lg:',
     size: '64rem / 1024px',
-    display: 'Standard ★',
-    primary: 'Yes — floor',
+    display: 'Standard',
+    target: '★ first-class — desktop floor',
   },
   {
     cls: 'nx:xl:',
     size: '80rem / 1280px',
-    display: 'Standard ★',
-    primary: 'Yes — reference',
+    display: 'Standard',
+    target: '★ first-class — desktop reference',
   },
   {
     cls: 'nx:2xl:',
     size: '96rem / 1536px',
     display: 'Wide',
-    primary: 'No (extended)',
+    target: 'extra breathing room',
   },
 ];
 
@@ -75,21 +81,24 @@ export function Responsive() {
       />
       <h1 className="nx:typography-heading-large">Responsive</h1>
       <p className="nx:typography-body-default nx:text-muted-foreground nx:mt-2 nx:mb-8 nx:max-w-[64ch]">
-        Nexus targets Standard (≥1024px) as the primary design target. Narrow
-        (&lt;1024px) is graceful degradation; Wide (≥1536px) gets breathing room
-        when available. Breakpoints are rem-based, so they track the
-        user&rsquo;s font-size preference — raise the base font and each
-        breakpoint fires at a narrower viewport, dropping the layout to a
-        roomier tier as the text enlarges.
+        Nexus is designed mobile-first and desktop-first — Narrow (mobile) and
+        Standard (desktop) are both first-class targets, neither a degradation
+        of the other. Author mobile-first: base styles are the mobile case, and
+        min-width prefixes layer on the wider tiers. Wide (≥1536px) gets extra
+        breathing room; interactive controls clear a ~44px minimum tap-target
+        for touch. Breakpoints are rem-based, so they track the user&rsquo;s
+        font-size preference — raise the base font and each breakpoint fires at
+        a narrower viewport, dropping the layout to a roomier tier as the text
+        enlarges.
       </p>
 
       {/* ── Breakpoints ─────────────────────────────────────── */}
       <section className="nx:mb-12">
         <h2 className="nx:typography-heading-small nx:mb-1">Breakpoints</h2>
         <p className="nx:typography-body-small nx:text-muted-foreground nx:mb-4 nx:max-w-[64ch]">
-          Five Tailwind classes mapped onto the Narrow / Standard / Wide display
-          labels. Standard spans <code>lg</code> (the floor) through{' '}
-          <code>xl</code> (the reference width components are tuned against).
+          Five Tailwind classes plus the unprefixed base, mapped onto the Narrow
+          / Standard / Wide labels. Components are tuned against two reference
+          widths — mobile ~390px and desktop ~1280px (<code>xl</code>).
         </p>
         <div className="nx:overflow-x-auto">
           <table className="nx:w-full nx:min-w-[560px] nx:border-collapse nx:text-sm">
@@ -100,7 +109,7 @@ export function Responsive() {
                 <th className="nx:py-2 nx:pr-3 nx:font-semibold">
                   Display class
                 </th>
-                <th className="nx:py-2 nx:font-semibold">Primary target?</th>
+                <th className="nx:py-2 nx:font-semibold">Design target</th>
               </tr>
             </thead>
             <tbody>
@@ -119,7 +128,7 @@ export function Responsive() {
                     {bp.display}
                   </td>
                   <td className="nx:py-2 nx:text-muted-foreground nx:text-xs">
-                    {bp.primary}
+                    {bp.target}
                   </td>
                 </tr>
               ))}

--- a/packages/core/tokens/semantic/breakpoints.json
+++ b/packages/core/tokens/semantic/breakpoints.json
@@ -6,7 +6,7 @@
       "unit": "rem"
     },
     "$type": "dimension",
-    "$description": "640px @ 16px root — narrow."
+    "$description": "640px @ 16px root — mobile / narrow (first-class)."
   },
   "breakpoint-md": {
     "$value": {
@@ -14,7 +14,7 @@
       "unit": "rem"
     },
     "$type": "dimension",
-    "$description": "768px @ 16px root — compact."
+    "$description": "768px @ 16px root — large phone / small tablet."
   },
   "breakpoint-lg": {
     "$value": {
@@ -22,7 +22,7 @@
       "unit": "rem"
     },
     "$type": "dimension",
-    "$description": "1024px @ 16px root — standard floor."
+    "$description": "1024px @ 16px root — desktop floor (first-class)."
   },
   "breakpoint-xl": {
     "$value": {
@@ -30,7 +30,7 @@
       "unit": "rem"
     },
     "$type": "dimension",
-    "$description": "1280px @ 16px root — standard reference."
+    "$description": "1280px @ 16px root — desktop reference width."
   },
   "breakpoint-2xl": {
     "$value": {
@@ -38,6 +38,6 @@
       "unit": "rem"
     },
     "$type": "dimension",
-    "$description": "1536px @ 16px root — wide."
+    "$description": "1536px @ 16px root — wide (extra breathing room)."
   }
 }


### PR DESCRIPTION
## Summary
- Reframe Nexus's responsive philosophy from **desktop-first** to **mobile-first + desktop co-primary** — both Narrow (mobile) and Standard (desktop) are first-class targets, authored mobile-first (base styles = mobile, min-width prefixes layer up).
- **`responsive.md`**: intro reframe; display-class table (`Primary target?` → **Design target**, both tiers ★ first-class, new base/<640px mobile-foundation row); new **Touch targets** section (~44px min tap-target, WCAG 2.5.5 / HIG).
- **`breakpoints.json`**: relabel `$description` strings — **values unchanged** (40/48/64/80/96rem), metadata-only (no regen).
- **`components.md`**: ~44px tap-target cross-ref in Sizing Convention.
- **apps/docs Responsive page**: public spec mirrors the rule (`primary`→`target` field, narrative + table).

No runtime/behavior changes — rules, token descriptions, and the docs spec page only.

## GitHub Issue
No single tracking issue (direction confirmed 2026-06-02 in working session). Follow-up **code** reframes (`useIsMobile`→`useIsNarrow`, `sidebar.tsx` + console `auth-layout.tsx` comments) tracked in #332.

## Test Plan
- [ ] No `graceful degradation` / `primary target` framing remains (grep clean)
- [ ] `breakpoints.json` values unchanged (40/48/64/80/96rem); descriptions metadata-only
- [ ] `/foundations/responsive` renders the co-primary table + ~44px note
- [ ] Behavior unchanged (docs/rules/token-descriptions only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
