### PR TITLE
feat(console): ⌘K command palette (Phase 4a)

### DIFF
--- a/apps/console/src/app/root-layout.tsx
+++ b/apps/console/src/app/root-layout.tsx
@@ -1,7 +1,10 @@
+import { useEffect, useState } from 'react';
+
 import { SidebarInset, SidebarProvider } from '@nexus/react';
 import { Outlet } from '@tanstack/react-router';
 
 import { AppSidebar } from '../shell/app-sidebar';
+import { CommandPalette } from '../shell/command-palette';
 import { Topbar } from '../shell/topbar';
 
 /**
@@ -11,11 +14,26 @@ import { Topbar } from '../shell/topbar';
  * bar persist across navigations.
  */
 export function RootLayout() {
+  const [commandOpen, setCommandOpen] = useState(false);
+
+  // ⌘K / Ctrl+K toggles the command palette from anywhere — a global keyboard
+  // subscription, which is exactly what an effect is for.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setCommandOpen((prev) => !prev);
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, []);
+
   return (
     <SidebarProvider>
       <AppSidebar />
       <SidebarInset>
-        <Topbar />
+        <Topbar onSearchClick={() => setCommandOpen(true)} />
         {/* nx:text-foreground re-establishes the adaptive base text color for
             module content — without it, reused content that relies on inherited
             foreground (e.g. the typography showcase) renders black in dark mode. */}
@@ -23,6 +41,7 @@ export function RootLayout() {
           <Outlet />
         </main>
       </SidebarInset>
+      <CommandPalette open={commandOpen} onOpenChange={setCommandOpen} />
     </SidebarProvider>
   );
 }

--- a/apps/console/src/shell/command-palette.tsx
+++ b/apps/console/src/shell/command-palette.tsx
@@ -1,0 +1,248 @@
+import { useState } from 'react';
+
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@nexus/react';
+import {
+  IconAddressBook,
+  IconBriefcase,
+  IconInbox,
+  IconMoon,
+  IconPalette,
+  IconSun,
+  IconUsers,
+} from '@tabler/icons-react';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+
+import { useThemeContext } from '../app/theme-provider';
+import { crmKeys, fetchContacts } from '../lib/crm-api';
+import { fetchConversations, inboxKeys } from '../lib/inbox-api';
+import { fetchMembers, peopleKeys } from '../lib/people-api';
+import { fetchIssues, projectKeys } from '../lib/projects-api';
+
+import { MODULE_ITEMS } from './modules';
+
+interface CommandPaletteProps {
+  /** Whether the palette is open — lifted to the app shell (⌘K toggles it). */
+  open: boolean;
+  /** Open-state setter; also fires on Escape / click-outside / item select. */
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * The ⌘K command palette: a single search box over the whole console. With an
+ * empty query it's a launcher (jump to a module, run a quick action); once you
+ * type, it searches contacts, issues, conversations, and people by name in one
+ * list. cmdk owns the fuzzy filtering and keyboard nav; we feed it the records
+ * via the same TanStack Query keys the modules use, so an open after visiting a
+ * module is an instant cache hit.
+ */
+export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
+  const navigate = useNavigate();
+  const { theme, setTheme } = useThemeContext();
+  const [query, setQuery] = useState('');
+
+  // Prefetch the four record sets the moment the palette opens (not on type) so
+  // the lists are warm before the first keystroke — no empty-state flash.
+  const contacts = useQuery({
+    queryKey: crmKeys.contacts,
+    queryFn: fetchContacts,
+    enabled: open,
+  });
+  const issues = useQuery({
+    queryKey: projectKeys.issues,
+    queryFn: fetchIssues,
+    enabled: open,
+  });
+  const conversations = useQuery({
+    queryKey: inboxKeys.conversations,
+    queryFn: fetchConversations,
+    enabled: open,
+  });
+  const members = useQuery({
+    queryKey: peopleKeys.members,
+    queryFn: fetchMembers,
+    enabled: open,
+  });
+
+  // Reset the controlled query on every close path so the palette reopens blank
+  // rather than mid-search (it stays mounted, so the state would otherwise stick).
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setQuery('');
+    onOpenChange(next);
+  };
+
+  // Close first, then act — the palette never lingers behind a navigation.
+  const runCommand = (action: () => void) => {
+    handleOpenChange(false);
+    action();
+  };
+
+  // Mirrors the sidebar: built modules carry a static `route`; the rest fall
+  // through to the `/m/$module` "coming soon" placeholder.
+  const goToModule = (item: (typeof MODULE_ITEMS)[number]) => {
+    if ('route' in item) {
+      navigate({ to: item.route });
+      return;
+    }
+    navigate({ to: '/m/$module', params: { module: item.module } });
+  };
+
+  const hasQuery = query.trim().length > 0;
+
+  return (
+    <CommandDialog open={open} onOpenChange={handleOpenChange}>
+      <CommandInput
+        placeholder="Search or jump to…"
+        value={query}
+        onValueChange={setQuery}
+      />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+
+        <CommandGroup heading="Go to">
+          {MODULE_ITEMS.map((item) => {
+            const Icon = item.icon;
+            return (
+              <CommandItem
+                key={item.module}
+                value={`go-${item.module}`}
+                keywords={[item.label]}
+                onSelect={() => runCommand(() => goToModule(item))}
+              >
+                <Icon />
+                <span>{item.label}</span>
+              </CommandItem>
+            );
+          })}
+        </CommandGroup>
+
+        {hasQuery && (
+          <>
+            <CommandGroup heading="Contacts">
+              {(contacts.data?.contacts ?? []).map((contact) => (
+                <CommandItem
+                  key={contact.id}
+                  value={`contact-${contact.id}`}
+                  keywords={[contact.name, contact.email, contact.company]}
+                  onSelect={() =>
+                    runCommand(() =>
+                      navigate({ to: '/m/crm/$id', params: { id: contact.id } })
+                    )
+                  }
+                >
+                  <IconUsers />
+                  <span>{contact.name}</span>
+                  <span className="nx:text-muted-foreground nx:ml-auto nx:text-xs">
+                    {contact.company}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+
+            <CommandGroup heading="Issues">
+              {(issues.data?.issues ?? []).map((issue) => (
+                <CommandItem
+                  key={issue.id}
+                  value={`issue-${issue.id}`}
+                  keywords={[issue.key, issue.title]}
+                  onSelect={() =>
+                    runCommand(() =>
+                      navigate({
+                        to: '/m/projects/$id',
+                        params: { id: issue.id },
+                      })
+                    )
+                  }
+                >
+                  <IconBriefcase />
+                  <span>{issue.title}</span>
+                  <span className="nx:text-muted-foreground nx:ml-auto nx:text-xs">
+                    {issue.key}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+
+            <CommandGroup heading="Conversations">
+              {(conversations.data?.conversations ?? []).map((conversation) => (
+                <CommandItem
+                  key={conversation.id}
+                  value={`conversation-${conversation.id}`}
+                  keywords={[conversation.subject, conversation.customer]}
+                  onSelect={() =>
+                    runCommand(() =>
+                      navigate({
+                        to: '/m/inbox',
+                        search: { c: conversation.id },
+                      })
+                    )
+                  }
+                >
+                  <IconInbox />
+                  <span>{conversation.subject}</span>
+                  <span className="nx:text-muted-foreground nx:ml-auto nx:text-xs">
+                    {conversation.customer}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+
+            <CommandGroup heading="People">
+              {(members.data?.members ?? []).map((member) => (
+                <CommandItem
+                  key={member.id}
+                  value={`member-${member.id}`}
+                  keywords={[member.name, member.email, member.title]}
+                  onSelect={() =>
+                    runCommand(() =>
+                      navigate({
+                        to: '/m/people/$id',
+                        params: { id: member.id },
+                      })
+                    )
+                  }
+                >
+                  <IconAddressBook />
+                  <span>{member.name}</span>
+                  <span className="nx:text-muted-foreground nx:ml-auto nx:text-xs">
+                    {member.title}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </>
+        )}
+
+        <CommandGroup heading="Actions">
+          <CommandItem
+            value="toggle-theme"
+            keywords={['theme', 'dark', 'light', 'mode']}
+            onSelect={() =>
+              runCommand(() => setTheme((t) => ({ ...t, dark: !t.dark })))
+            }
+          >
+            {theme.dark ? <IconSun /> : <IconMoon />}
+            <span>Toggle theme</span>
+          </CommandItem>
+          <CommandItem
+            value="appearance-settings"
+            keywords={['appearance', 'theme', 'customize', 'settings']}
+            onSelect={() =>
+              runCommand(() => navigate({ to: '/design/appearance' }))
+            }
+          >
+            <IconPalette />
+            <span>Appearance settings</span>
+          </CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/apps/console/src/shell/command-palette.tsx
+++ b/apps/console/src/shell/command-palette.tsx
@@ -71,16 +71,25 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     enabled: open,
   });
 
-  // Reset the controlled query on every close path so the palette reopens blank
-  // rather than mid-search (it stays mounted, so the state would otherwise stick).
-  const handleOpenChange = (next: boolean) => {
-    if (!next) setQuery('');
-    onOpenChange(next);
-  };
+  // Reset the search when the palette closes so it reopens blank. ⌘K closes by
+  // flipping `open` externally, which Radix does not report through onOpenChange —
+  // so we reset on the open→closed prop edge to catch every close path (Escape,
+  // click-outside, item select, and ⌘K alike), not just Radix's own gestures.
+  const [wasOpen, setWasOpen] = useState(open);
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (!open) setQuery('');
+  }
+
+  const anyError =
+    contacts.isError ||
+    issues.isError ||
+    conversations.isError ||
+    members.isError;
 
   // Close first, then act — the palette never lingers behind a navigation.
   const runCommand = (action: () => void) => {
-    handleOpenChange(false);
+    onOpenChange(false);
     action();
   };
 
@@ -97,14 +106,18 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
   const hasQuery = query.trim().length > 0;
 
   return (
-    <CommandDialog open={open} onOpenChange={handleOpenChange}>
+    <CommandDialog open={open} onOpenChange={onOpenChange}>
       <CommandInput
         placeholder="Search or jump to…"
         value={query}
         onValueChange={setQuery}
       />
       <CommandList>
-        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandEmpty>
+          {anyError
+            ? 'Couldn’t load results. Please try again.'
+            : 'No results found.'}
+        </CommandEmpty>
 
         <CommandGroup heading="Go to">
           {MODULE_ITEMS.map((item) => {

--- a/apps/console/src/shell/topbar.tsx
+++ b/apps/console/src/shell/topbar.tsx
@@ -3,11 +3,16 @@ import { IconMoon, IconSearch, IconSun } from '@tabler/icons-react';
 
 import { useThemeContext } from '../app/theme-provider';
 
+interface TopbarProps {
+  /** Opens the ⌘K command palette — fired by the search button. */
+  onSearchClick: () => void;
+}
+
 /**
- * App-shell top bar: sidebar toggle, a ⌘K search placeholder (the palette
- * lands in Phase 4), and a dark-mode quick-toggle wired to the root theme.
+ * App-shell top bar: sidebar toggle, the ⌘K search button that opens the
+ * command palette, and a dark-mode quick-toggle wired to the root theme.
  */
-export function Topbar() {
+export function Topbar({ onSearchClick }: TopbarProps) {
   const { theme, setTheme } = useThemeContext();
 
   return (
@@ -16,8 +21,8 @@ export function Topbar() {
 
       <button
         type="button"
-        disabled
-        className="nx:border-border-default nx:bg-muted nx:text-muted-foreground nx:inline-flex nx:items-center nx:gap-2 nx:rounded-md nx:border nx:px-3 nx:py-1.5 nx:text-sm"
+        onClick={onSearchClick}
+        className="nx:border-border-default nx:bg-background nx:text-muted-foreground nx:hover:bg-background-hover nx:hover:text-foreground nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:inline-flex nx:items-center nx:gap-2 nx:rounded-md nx:border nx:px-3 nx:py-1.5 nx:text-sm nx:transition-colors nx:focus-visible:outline-2"
       >
         <IconSearch className="nx:size-4" />
         <span>Search…</span>


### PR DESCRIPTION
## Summary

Phase 4a — the first **cross-cutting** slice (after the five Phase 3 breadth modules): a **⌘K command palette** that spans the whole console. Where each Phase 3 module owns its own search/filter, this dogfoods one global surface over all of them — a single `CommandDialog` that is a **launcher** when empty and a **cross-module search** once you type.

- **`shell/command-palette.tsx`** — a `CommandDialog` (cmdk via `@nexus/react`) with three concerns:
  - **Go to** (always) — every workspace module, rendered from the same `MODULE_ITEMS` registry the sidebar uses, with the identical `'route' in item` discrimination (built modules → static route; the rest → the `/m/$module` placeholder). The palette's nav and the sidebar's nav can't drift.
  - **Search** (only when the query is non-empty) — **contacts, issues, conversations, and people** in one list, each group fed by that module's **own TanStack Query key** (`crmKeys.contacts`, `projectKeys.issues`, …) so opening the palette after visiting a module is a cache hit, not a refetch. Queries are `enabled: open` so all four warm the moment the palette opens — no empty-state flash before the first keystroke.
  - **Actions** (always) — toggle theme (reuses the topbar's `useThemeContext`), jump to Appearance settings.
- **`root-layout.tsx`** — lifts the open state, adds a global **⌘K / Ctrl+K** keydown (a browser-API subscription, so an effect), and mounts the palette once in the shell.
- **`topbar.tsx`** — the ⌘K button was a disabled stub; it now opens the palette (interactive bg + hover + focus ring).

**Item-value scheme (non-obvious):** cmdk dedupes items by `value` **globally** and folds `value` into its fuzzy match. Record ids collide across modules — a contact and a conversation are **both `c-01`** — so a raw `value={id}` would silently break selection and let one record's id match another. Values are therefore **type-prefixed** (`contact-${id}`, `conversation-${id}`, …) for global uniqueness, with the human-searchable text in `keywords`. The inbox record is the one navigation odd-one-out: it routes via `search: { c: id }` (`/m/inbox?c=…`), not a path param.

## Scope & known (advisor-validated)

- **Fuzzy matching is permissive** — a short query (e.g. "Marcus") can surface loosely-scored items across groups. That's cmdk's **default scorer, shipped by the `@nexus/react` `Command` component's filter** — a design-system-layer decision, not console-tunable here. Longer queries tighten as expected.
- **Search-button tap target** keeps the topbar's `py-1.5` density rather than the ~44px touch floor — bumping only this control would make it stand taller than its neighbours (`SidebarTrigger`, theme toggle) and break the `h-14` bar's alignment. The whole-topbar mobile pass is tracked in **#332** (mobile-first reframe).
- **Deferred to later Phase 4 slices:** notifications center, the empty/error/404/403 state pass, and the responsive sweep are their own slices per the plan — not this PR.

## Test Plan (browser-verified — light + dark, console clean throughout)

- [x] **⌘K** (and **Ctrl+K**) toggles the palette open/closed from anywhere; the **topbar Search button** opens it too
- [x] **Empty state** → "Go to" (all 8 modules, mirroring the sidebar) + "Actions" (Toggle theme · Appearance); no record groups
- [x] **Typing** surfaces the record groups; "Go to"/"Actions" hide when nothing in them matches
- [x] **Contact** select → `/m/crm/c-01` (path param)
- [x] **Issue** select → `/m/projects/i-02` (path param)
- [x] **Member** select → `/m/people/m-02` (path param)
- [x] **Conversation** select → `/m/inbox?c=c-04` (search param, the odd-one-out) — and the thread actually loads
- [x] **Toggle theme** action flips `<html>.dark` and closes the palette
- [x] **Escape** closes; **reopen** after a selection → query is **reset to blank** (the palette stays mounted, so the controlled query is cleared on every close path)
- [x] Type-prefixed values confirmed unique in the DOM (`contact-c-01`, `conversation-c-04`, …) — no cross-module collision
- [x] Dark mode renders correctly (dark popover, legible text)
- [x] `typecheck` + `eslint --max-warnings 0` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)