### PR TITLE
feat(console): render the coming-soon placeholder with EmptyState

### DIFF
--- a/apps/console/src/modules/coming-soon.tsx
+++ b/apps/console/src/modules/coming-soon.tsx
@@ -1,3 +1,10 @@
+import {
+  EmptyState,
+  EmptyStateDescription,
+  EmptyStateHeader,
+  EmptyStateMedia,
+  EmptyStateTitle,
+} from '@nexus/react';
 import { useParams } from '@tanstack/react-router';
 
 import { MODULE_ITEMS } from '../shell/modules';
@@ -11,19 +18,24 @@ export function ComingSoon() {
   // `from` is the route ID, which the pathless `_app` layout route prefixes
   // with `/app` (the URL stays `/m/$module`).
   const { module } = useParams({ from: '/app/m/$module' });
-  const label = MODULE_ITEMS.find((m) => m.module === module)?.label ?? module;
+  const item = MODULE_ITEMS.find((m) => m.module === module);
+  const label = item?.label ?? module;
+  const Icon = item?.icon;
+
   return (
-    <div className="nx:flex nx:min-h-[60vh] nx:flex-col nx:items-center nx:justify-center nx:gap-3 nx:p-6 nx:text-center">
-      <span className="nx:typography-label-small nx:text-muted-foreground-subtle nx:uppercase nx:tracking-wide">
-        Atlas module
-      </span>
-      <h2 className="nx:typography-heading-large nx:text-foreground">
-        {label}
-      </h2>
-      <p className="nx:typography-body-default nx:text-muted-foreground nx:max-w-md">
-        This module isn’t built yet — it lands in a later Atlas phase. The
-        shell, routing, theming, and mock-API layer are already wired for it.
-      </p>
-    </div>
+    <EmptyState className="nx:min-h-[60vh]">
+      <EmptyStateHeader>
+        {Icon && (
+          <EmptyStateMedia variant="icon">
+            <Icon />
+          </EmptyStateMedia>
+        )}
+        <EmptyStateTitle>{label}</EmptyStateTitle>
+        <EmptyStateDescription>
+          This module isn’t built yet — it lands in a later Atlas phase. The
+          shell, routing, theming, and mock-API layer are already wired for it.
+        </EmptyStateDescription>
+      </EmptyStateHeader>
+    </EmptyState>
   );
 }


### PR DESCRIPTION
## Summary

Converts the shared `/m/$module` **"coming soon" placeholder** (what unbuilt modules — **Dashboard**, **Settings**, etc. — render) from hand-rolled markup to the Nexus **EmptyState** component:

- the module's own nav icon → `EmptyStateMedia` medallion (`variant="icon"`)
- the module name → `EmptyStateTitle`
- the "not built yet" copy → `EmptyStateDescription`
- keeps the centered `min-h-[60vh]` placement

This unifies the placeholder with the empty states already adopted across the console (#365, #367) and gives it a visual anchor (the icon medallion) it lacked. Drops the ad-hoc "Atlas module" eyebrow and the oversized `heading-large` in favour of the design-system empty-state treatment.

Prompted by the question "the dashboard has no empty state — is that intentional?": the Dashboard isn't a built data view, so there's no empty-*data* state; it renders this shared placeholder, which is now an EmptyState.

## GitHub Issue

No issue to close — the EmptyState component (#282) already shipped; this extends its adoption to the coming-soon placeholder.

## Test Plan

- [x] `@nexus/console` typecheck / `eslint --max-warnings 0` / `prettier --check` clean
- [x] `@nexus/console` vite build + `audit:class-refs` clean
- [x] **Runtime-verified** (dev server + Playwright): `/m/dashboard` renders the EmptyState — icon medallion + "Dashboard" title + description, vertically centered
- [ ] CI: format-check, lint, build, typecheck, audit-tokens green (react-gated jobs skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)