### PR TITLE
Add dismissible badge affordances to Badge

### DIFF
--- a/packages/react/src/components/ui/Badge.stories.tsx
+++ b/packages/react/src/components/ui/Badge.stories.tsx
@@ -1,11 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { IconCheck, IconX } from '@tabler/icons-react';
-import { expect, within } from 'storybook/test';
+import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { SPACING_MODES } from '../../stories/spacing-modes';
 import { expectHeightPinnedAcrossModes } from '../../stories/test-utils';
 
-import { Badge } from './badge';
+import { Badge, BadgeAction, BadgeDot } from './badge';
+
+const dismissAction = fn();
+const keyboardDismissAction = fn();
+const disabledDismissAction = fn();
 
 const meta: Meta<typeof Badge> = {
   title: 'Components/Badge',
@@ -259,6 +263,104 @@ export const WithBothIcons: Story = {
 };
 
 // ============================================
+// COMPOSABLE AFFORDANCES
+// ============================================
+
+export const WithDot: Story = {
+  render: (_args) => (
+    <Badge variant="success" fill="light" isCaps={false}>
+      <BadgeDot />
+      Live
+    </Badge>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const badge = canvas.getByText('Live');
+    const dot = canvasElement.querySelector('[data-slot="badge-dot"]');
+
+    await expect(badge).toBeInTheDocument();
+    await expect(dot).toBeInTheDocument();
+    await expect(dot).toHaveAttribute('aria-hidden', 'true');
+  },
+};
+
+export const Dismissible: Story = {
+  render: (_args) => (
+    <Badge variant="secondary" isCaps={false}>
+      Synced
+      <BadgeAction aria-label="Dismiss synced badge" onClick={dismissAction}>
+        <IconX aria-hidden />
+      </BadgeAction>
+    </Badge>
+  ),
+  play: async ({ canvasElement }) => {
+    dismissAction.mockClear();
+
+    const canvas = within(canvasElement);
+    const action = canvas.getByRole('button', {
+      name: 'Dismiss synced badge',
+    });
+
+    await userEvent.click(action);
+    await expect(dismissAction).toHaveBeenCalledTimes(1);
+    await expect(action).toHaveAttribute('data-slot', 'badge-action');
+  },
+};
+
+export const KeyboardDismissible: Story = {
+  render: (_args) => (
+    <Badge variant="default" fill="light" isCaps={false}>
+      Filter
+      <BadgeAction
+        aria-label="Remove filter badge"
+        onClick={keyboardDismissAction}
+      >
+        <IconX aria-hidden />
+      </BadgeAction>
+    </Badge>
+  ),
+  play: async ({ canvasElement }) => {
+    keyboardDismissAction.mockClear();
+
+    const canvas = within(canvasElement);
+    const action = canvas.getByRole('button', {
+      name: 'Remove filter badge',
+    });
+
+    await userEvent.tab();
+    await expect(action).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
+    await expect(keyboardDismissAction).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const DisabledAction: Story = {
+  render: (_args) => (
+    <Badge variant="secondary" fill="light" isCaps={false}>
+      Locked
+      <BadgeAction
+        aria-label="Remove locked badge"
+        disabled
+        onClick={disabledDismissAction}
+      >
+        <IconX aria-hidden />
+      </BadgeAction>
+    </Badge>
+  ),
+  play: async ({ canvasElement }) => {
+    disabledDismissAction.mockClear();
+
+    const canvas = within(canvasElement);
+    const action = canvas.getByRole('button', {
+      name: 'Remove locked badge',
+    });
+
+    await expect(action).toBeDisabled();
+    await expect(disabledDismissAction).not.toHaveBeenCalled();
+  },
+};
+
+// ============================================
 // NUMBER BADGES
 // ============================================
 
@@ -458,6 +560,31 @@ export const AllVariants: Story = {
           </Badge>
           <Badge variant="error" isCaps={false} rightIcon={<IconX />}>
             Label
+          </Badge>
+        </div>
+      </div>
+
+      {/* Composable Affordances */}
+      <div>
+        <h3 className="nx:text-foreground nx:mb-3 nx:text-sm nx:font-medium">
+          Composable Affordances
+        </h3>
+        <div className="nx:flex nx:flex-wrap nx:items-center nx:gap-2">
+          <Badge variant="success" fill="light" isCaps={false}>
+            <BadgeDot />
+            Live
+          </Badge>
+          <Badge variant="secondary" isCaps={false}>
+            Synced
+            <BadgeAction aria-label="Dismiss synced badge">
+              <IconX aria-hidden />
+            </BadgeAction>
+          </Badge>
+          <Badge variant="information" fill="light" isCaps={false}>
+            Preview
+            <BadgeAction aria-label="Dismiss preview badge">
+              <IconX aria-hidden />
+            </BadgeAction>
           </Badge>
         </div>
       </div>

--- a/packages/react/src/components/ui/Badge.stories.tsx
+++ b/packages/react/src/components/ui/Badge.stories.tsx
@@ -360,6 +360,30 @@ export const DisabledAction: Story = {
   },
 };
 
+export const ActionAsChild: Story = {
+  render: (_args) => (
+    <Badge variant="secondary" fill="light" isCaps={false}>
+      Details
+      <BadgeAction asChild>
+        <a href="https://example.com/badge-action" aria-label="Open details">
+          <IconX aria-hidden />
+        </a>
+      </BadgeAction>
+    </Badge>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const action = canvas.getByRole('link', { name: 'Open details' });
+
+    await expect(action).toHaveAttribute(
+      'href',
+      'https://example.com/badge-action'
+    );
+    await expect(action).toHaveAttribute('data-slot', 'badge-action');
+    await expect(action).not.toHaveAttribute('type');
+  },
+};
+
 // ============================================
 // NUMBER BADGES
 // ============================================

--- a/packages/react/src/components/ui/badge.tsx
+++ b/packages/react/src/components/ui/badge.tsx
@@ -165,6 +165,23 @@ interface BadgeProps
   rightIcon?: React.ReactNode;
 }
 
+interface BadgeActionProps extends React.ComponentProps<'button'> {
+  /**
+   * When true, renders as child element using Radix Slot.
+   * Useful for rendering a custom control while keeping badge action styles.
+   * @default false
+   * @example
+   * ```tsx
+   * <BadgeAction asChild>
+   *   <a href="/dismiss">Dismiss</a>
+   * </BadgeAction>
+   * ```
+   */
+  asChild?: boolean;
+}
+
+type BadgeDotProps = React.ComponentProps<'span'>;
+
 function Badge({
   className,
   variant,
@@ -238,4 +255,49 @@ function Badge({
   );
 }
 
-export { Badge, type BadgeProps, badgeVariants };
+function BadgeAction({
+  className,
+  asChild = false,
+  type = 'button',
+  ...props
+}: BadgeActionProps) {
+  const Comp = asChild ? Slot : 'button';
+
+  return (
+    <Comp
+      type={type}
+      data-slot="badge-action"
+      className={cn(
+        // nexus-allow-numeric: chip action affordance
+        'nx:inline-flex nx:size-3.5 nx:items-center nx:justify-center nx:rounded-sm nx:p-0 nx:text-current nx:opacity-70 nx:transition-opacity nx:hover:opacity-100 nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:pointer-events-none nx:disabled:opacity-40 nx:[&_svg]:size-3.5',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function BadgeDot({ className, ...props }: BadgeDotProps) {
+  return (
+    <span
+      data-slot="badge-dot"
+      aria-hidden="true"
+      className={cn(
+        // nexus-allow-numeric: chip dot affordance
+        'nx:size-1.5 nx:rounded-full nx:bg-current nx:opacity-75',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Badge,
+  BadgeAction,
+  type BadgeActionProps,
+  BadgeDot,
+  type BadgeDotProps,
+  type BadgeProps,
+  badgeVariants,
+};

--- a/packages/react/src/components/ui/badge.tsx
+++ b/packages/react/src/components/ui/badge.tsx
@@ -261,17 +261,21 @@ function BadgeAction({
   type = 'button',
   ...props
 }: BadgeActionProps) {
-  const Comp = asChild ? Slot : 'button';
+  const classes = cn(
+    // nexus-allow-numeric: chip action affordance
+    'nx:inline-flex nx:size-3.5 nx:items-center nx:justify-center nx:rounded-sm nx:p-0 nx:text-current nx:opacity-70 nx:transition-opacity nx:hover:opacity-100 nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:pointer-events-none nx:disabled:opacity-40 nx:[&_svg]:size-3.5',
+    className
+  );
+
+  if (asChild) {
+    return <Slot data-slot="badge-action" className={classes} {...props} />;
+  }
 
   return (
-    <Comp
+    <button
       type={type}
       data-slot="badge-action"
-      className={cn(
-        // nexus-allow-numeric: chip action affordance
-        'nx:inline-flex nx:size-3.5 nx:items-center nx:justify-center nx:rounded-sm nx:p-0 nx:text-current nx:opacity-70 nx:transition-opacity nx:hover:opacity-100 nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:pointer-events-none nx:disabled:opacity-40 nx:[&_svg]:size-3.5',
-        className
-      )}
+      className={classes}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- Added `BadgeAction` and `BadgeDot` to the existing Badge component so 21st.dev-style badge patterns map cleanly into Nexus.
- Extended Badge stories with dot, dismissible, keyboard, and disabled interaction coverage.
- Kept the implementation aligned with Nexus conventions: `data-slot`, `nx:` utilities, and semantic focus styling.

## Testing
- Storybook interaction tests passed for the Badge stories.
- Badge story coverage audit passed.
- Full repo lint passed.
- React typecheck passed.