### PR TITLE
feat(console): UI states gallery (/design/flows)

### DIFF
--- a/apps/console/src/app/router.tsx
+++ b/apps/console/src/app/router.tsx
@@ -18,6 +18,7 @@ import { ContactDetailRoute } from '../modules/crm/contact-detail-route';
 import { ContactsRoute } from '../modules/crm/contacts-route';
 import { contactsSearchSchema } from '../modules/crm/contacts-search';
 import { AppearanceRoute } from '../modules/design-system/appearance-route';
+import { FlowsRoute } from '../modules/design-system/flows-route';
 import { ReferenceRoute } from '../modules/design-system/reference-route';
 import { ScenesRoute } from '../modules/design-system/scenes-route';
 import { InboxRoute } from '../modules/inbox/inbox-route';
@@ -87,6 +88,12 @@ const appearanceRoute = createRoute({
   getParentRoute: () => appRoute,
   path: '/design/appearance',
   component: AppearanceRoute,
+});
+
+const flowsRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: '/design/flows',
+  component: FlowsRoute,
 });
 
 // CRM Contacts (Phase 2a). The static `/m/crm` path outranks the dynamic
@@ -207,6 +214,7 @@ const routeTree = rootRoute.addChildren([
     referenceRoute,
     scenesRoute,
     appearanceRoute,
+    flowsRoute,
     crmContactsRoute,
     crmContactDetailRoute,
     projectsIssuesRoute,

--- a/apps/console/src/modules/analytics/analytics-route.tsx
+++ b/apps/console/src/modules/analytics/analytics-route.tsx
@@ -202,7 +202,7 @@ function SourcesCard({ sources }: { sources: TrafficSource[] }) {
   );
 }
 
-function AnalyticsSkeleton() {
+export function AnalyticsSkeleton() {
   return (
     <div className="nx:space-y-6">
       <div className="nx:grid nx:gap-6 nx:sm:grid-cols-2 nx:xl:grid-cols-4">

--- a/apps/console/src/modules/billing/billing-route.tsx
+++ b/apps/console/src/modules/billing/billing-route.tsx
@@ -186,7 +186,7 @@ function PlanCard({
   );
 }
 
-function CancelButton({
+export function CancelButton({
   planName,
   renewsAt,
   onConfirm,
@@ -276,7 +276,7 @@ function UsageCard({ usage }: { usage: UsageMeter[] }) {
   );
 }
 
-function UsageMeterBar({ meter }: { meter: UsageMeter }) {
+export function UsageMeterBar({ meter }: { meter: UsageMeter }) {
   const pct = Math.min(100, Math.round((meter.used / meter.limit) * 100));
   // Tint the figure near the cap — the bar itself has no warning variant.
   const nearCap = meter.used / meter.limit >= 0.9;
@@ -364,7 +364,7 @@ function InvoicesTable({ invoices }: { invoices: Invoice[] }) {
   );
 }
 
-function BillingSkeleton() {
+export function BillingSkeleton() {
   return (
     <div className="nx:space-y-6">
       <div className="nx:grid nx:gap-6 nx:lg:grid-cols-3">
@@ -377,7 +377,7 @@ function BillingSkeleton() {
   );
 }
 
-function InvoicesSkeleton() {
+export function InvoicesSkeleton() {
   return (
     <div className="nx:space-y-3">
       {Array.from({ length: 5 }, (_, i) => (

--- a/apps/console/src/modules/crm/contact-detail-route.tsx
+++ b/apps/console/src/modules/crm/contact-detail-route.tsx
@@ -194,7 +194,7 @@ function ActivityIcon({ kind }: { kind: ActivityKind }) {
   return <Icon className="nx:size-4" />;
 }
 
-function DetailSkeleton() {
+export function DetailSkeleton() {
   return (
     <div className="nx:space-y-6">
       <div className="nx:flex nx:items-center nx:gap-4">

--- a/apps/console/src/modules/crm/contacts-route.tsx
+++ b/apps/console/src/modules/crm/contacts-route.tsx
@@ -96,7 +96,7 @@ export function ContactsRoute() {
   );
 }
 
-function ContactsSkeleton() {
+export function ContactsSkeleton() {
   return (
     <div className="nx:space-y-4">
       <Skeleton className="nx:h-9 nx:max-w-xs" />
@@ -109,7 +109,7 @@ function ContactsSkeleton() {
   );
 }
 
-function ContactsEmpty() {
+export function ContactsEmpty() {
   return (
     <EmptyState className="nx:border nx:border-border-default">
       <EmptyStateHeader>

--- a/apps/console/src/modules/design-system/flows-route.tsx
+++ b/apps/console/src/modules/design-system/flows-route.tsx
@@ -31,7 +31,10 @@ import { DataTable } from '../../components/data-table';
 import { ErrorState } from '../../components/error-state';
 import { NotFoundState } from '../../components/not-found-state';
 import type { Subscription, UsageMeter } from '../../lib/billing-api';
-import { NotificationsSkeleton } from '../../shell/notifications-menu';
+import {
+  NotificationsError,
+  NotificationsSkeleton,
+} from '../../shell/notifications-menu';
 import { AnalyticsSkeleton } from '../analytics/analytics-route';
 import {
   BillingSkeleton,
@@ -85,9 +88,7 @@ const DEMO_COLUMNS: ColumnDef<DemoRow>[] = [
 /**
  * The Flows gallery — a design/QA catalog of every conditional UI state in the
  * console (loading, error, not-found, empty, form-validation, dialogs, toasts,
- * auth, status). Each cell renders the *real* component, imported from its
- * module, so the gallery can never drift from production: a renamed or
- * restructured state breaks this import at compile time.
+ * auth, status), each rendered from the real component imported from its module.
  */
 export function FlowsRoute() {
   const [contactOpen, setContactOpen] = useState(false);
@@ -176,9 +177,7 @@ export function FlowsRoute() {
           />
         </Sample>
         <Sample label="Notifications · cold-load error (popover chrome)" span>
-          <p className="nx:text-error-foreground nx:px-3 nx:py-6 nx:text-center nx:text-sm">
-            Couldn’t load notifications. Please try again.
-          </p>
+          <NotificationsError />
         </Sample>
       </Section>
 

--- a/apps/console/src/modules/design-system/flows-route.tsx
+++ b/apps/console/src/modules/design-system/flows-route.tsx
@@ -1,0 +1,433 @@
+import { type ReactNode, useState } from 'react';
+
+import {
+  Alert,
+  AlertDescription,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  Badge,
+  Button,
+  cn,
+  EmptyState,
+  EmptyStateDescription,
+  EmptyStateHeader,
+  EmptyStateMedia,
+  EmptyStateTitle,
+  toast,
+} from '@nexus/react';
+import { IconLayoutDashboard } from '@tabler/icons-react';
+import { Link } from '@tanstack/react-router';
+import type { ColumnDef } from '@tanstack/react-table';
+
+import { NotFound } from '../../app/not-found';
+import { DataTable } from '../../components/data-table';
+import { ErrorState } from '../../components/error-state';
+import { NotFoundState } from '../../components/not-found-state';
+import type { Subscription, UsageMeter } from '../../lib/billing-api';
+import { NotificationsSkeleton } from '../../shell/notifications-menu';
+import { AnalyticsSkeleton } from '../analytics/analytics-route';
+import {
+  BillingSkeleton,
+  CancelButton,
+  InvoicesSkeleton,
+  UsageMeterBar,
+} from '../billing/billing-route';
+import { PlanSheet } from '../billing/plan-sheet';
+import { DetailSkeleton as ContactDetailSkeleton } from '../crm/contact-detail-route';
+import { ContactFormSheet } from '../crm/contact-form-sheet';
+import { ContactsEmpty, ContactsSkeleton } from '../crm/contacts-route';
+import { ThreadSkeleton } from '../inbox/conversation-thread';
+import { EmptyPane, ListSkeleton } from '../inbox/inbox-route';
+import { DetailSkeleton as MemberDetailSkeleton } from '../people/member-detail-route';
+import { MemberFormSheet } from '../people/member-form-sheet';
+import { PeopleEmpty, PeopleSkeleton } from '../people/people-route';
+import { DetailSkeleton as IssueDetailSkeleton } from '../projects/issue-detail-route';
+import { IssueFormSheet } from '../projects/issue-form-sheet';
+import { IssuesEmpty, IssuesSkeleton } from '../projects/issues-route';
+
+// Mocks for the components that take data props — the gallery renders them in
+// isolation, with no live query behind them.
+const MOCK_SUBSCRIPTION: Subscription = {
+  tier: 'pro',
+  cycle: 'monthly',
+  status: 'active',
+  renewsAt: '2026-07-01',
+};
+
+const USAGE_NORMAL: UsageMeter = {
+  id: 'seats',
+  label: 'Seats',
+  used: 12,
+  limit: 25,
+  unit: 'seats',
+};
+const USAGE_NEAR_CAP: UsageMeter = {
+  id: 'storage',
+  label: 'Storage',
+  used: 96,
+  limit: 100,
+  unit: 'GB',
+};
+
+type DemoRow = { name: string; email: string };
+const DEMO_COLUMNS: ColumnDef<DemoRow>[] = [
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'email', header: 'Email' },
+];
+
+/**
+ * The Flows gallery — a design/QA catalog of every conditional UI state in the
+ * console (loading, error, not-found, empty, form-validation, dialogs, toasts,
+ * auth, status). Each cell renders the *real* component, imported from its
+ * module, so the gallery can never drift from production: a renamed or
+ * restructured state breaks this import at compile time.
+ */
+export function FlowsRoute() {
+  const [contactOpen, setContactOpen] = useState(false);
+  const [issueOpen, setIssueOpen] = useState(false);
+  const [memberOpen, setMemberOpen] = useState(false);
+  const [planOpen, setPlanOpen] = useState(false);
+
+  return (
+    <div className="nx:space-y-10 nx:p-6">
+      <header className="nx:space-y-1">
+        <h1 className="nx:typography-heading-large nx:text-foreground">
+          Flows
+        </h1>
+        <p className="nx:text-muted-foreground nx:max-w-2xl">
+          Every conditional UI state in the console, in one place — rendered
+          from the real components so you can review states you’d otherwise only
+          see by triggering the runtime condition (a failed fetch, an empty
+          dataset, a bad URL).
+        </p>
+      </header>
+
+      <Section
+        title="Loading skeletons"
+        description="Shown for ~500ms while a query resolves, then replaced — hard to catch in normal use."
+      >
+        <Sample label="Contacts list">
+          <ContactsSkeleton />
+        </Sample>
+        <Sample label="Issues list">
+          <IssuesSkeleton />
+        </Sample>
+        <Sample label="People directory">
+          <PeopleSkeleton />
+        </Sample>
+        <Sample label="Invoices card">
+          <InvoicesSkeleton />
+        </Sample>
+        <Sample label="Analytics dashboard" span>
+          <AnalyticsSkeleton />
+        </Sample>
+        <Sample label="Billing page" span>
+          <BillingSkeleton />
+        </Sample>
+        <Sample label="Contact detail">
+          <ContactDetailSkeleton />
+        </Sample>
+        <Sample label="Issue detail">
+          <IssueDetailSkeleton />
+        </Sample>
+        <Sample label="Member detail">
+          <MemberDetailSkeleton />
+        </Sample>
+        <Sample label="Notifications panel" className="nx:max-w-sm nx:p-0">
+          <NotificationsSkeleton />
+        </Sample>
+        <Sample
+          label="Inbox list"
+          className="nx:flex nx:h-96 nx:flex-col nx:p-0"
+        >
+          <ListSkeleton />
+        </Sample>
+        <Sample
+          label="Inbox thread"
+          span
+          className="nx:flex nx:h-96 nx:flex-col nx:p-0"
+        >
+          <ThreadSkeleton />
+        </Sample>
+      </Section>
+
+      <Section
+        title="Error states"
+        description="A load-error needs a fetch to fail, so these are effectively unreachable in normal use. Bordered variants match a bordered-skeleton slot; borderless ones sit in an already-framed container."
+      >
+        <Sample label="ErrorState · bordered (Contacts / Issues / People)">
+          <ErrorState
+            message="Couldn't load contacts."
+            onRetry={() => toast.info('Retry is a no-op in the gallery.')}
+            bordered
+          />
+        </Sample>
+        <Sample label="ErrorState · borderless (Analytics / Billing / Inbox)">
+          <ErrorState
+            message="Couldn't load analytics."
+            onRetry={() => toast.info('Retry is a no-op in the gallery.')}
+          />
+        </Sample>
+        <Sample label="Notifications · cold-load error (popover chrome)" span>
+          <p className="nx:text-error-foreground nx:px-3 nx:py-6 nx:text-center nx:text-sm">
+            Couldn’t load notifications. Please try again.
+          </p>
+        </Sample>
+      </Section>
+
+      <Section
+        title="Not found · 404"
+        description="Reached by an invalid record id (detail routes) or an unmatched URL (route-level)."
+      >
+        <Sample label="NotFoundState · record detail">
+          <NotFoundState
+            title="Contact not found"
+            description="This contact doesn't exist, or may have been removed."
+          >
+            <Link to="/m/crm">Back to Contacts</Link>
+          </NotFoundState>
+        </Sample>
+        <Sample label="Route-level 404 · unmatched URL">
+          <NotFound />
+        </Sample>
+      </Section>
+
+      <Section
+        title="Empty states"
+        description="Unreachable today — fixtures always seed rows — so this is the only way to see a zeroed module."
+      >
+        <Sample label="Contacts · no records">
+          <ContactsEmpty />
+        </Sample>
+        <Sample label="Issues · no records">
+          <IssuesEmpty />
+        </Sample>
+        <Sample label="People · no records">
+          <PeopleEmpty />
+        </Sample>
+        <Sample
+          label="Inbox · no conversation selected"
+          className="nx:flex nx:min-h-64 nx:p-0"
+        >
+          <EmptyPane />
+        </Sample>
+        <Sample label="Data table · filtered to zero (“No results.”)" span>
+          <DataTable
+            columns={DEMO_COLUMNS}
+            data={[]}
+            filterColumn="name"
+            filterPlaceholder="Filter by name…"
+          />
+        </Sample>
+        <Sample label="Coming soon · unbuilt module">
+          <EmptyState className="nx:min-h-64">
+            <EmptyStateHeader>
+              <EmptyStateMedia variant="icon">
+                <IconLayoutDashboard />
+              </EmptyStateMedia>
+              <EmptyStateTitle>Dashboard</EmptyStateTitle>
+              <EmptyStateDescription>
+                This module isn’t built yet — it lands in a later Atlas phase.
+                The shell, routing, theming, and mock-API layer are already
+                wired for it.
+              </EmptyStateDescription>
+            </EmptyStateHeader>
+          </EmptyState>
+        </Sample>
+      </Section>
+
+      <Section
+        title="Form validation"
+        description="Open a sheet and submit with empty fields to see inline + root-level errors. Submitting valid data creates a throwaway record that resets on reload."
+      >
+        <Sample label="Create contact / issue / member · invite" span>
+          <div className="nx:flex nx:flex-wrap nx:gap-2">
+            <Button variant="outline" onClick={() => setContactOpen(true)}>
+              Open contact form
+            </Button>
+            <Button variant="outline" onClick={() => setIssueOpen(true)}>
+              Open issue form
+            </Button>
+            <Button variant="outline" onClick={() => setMemberOpen(true)}>
+              Open member form
+            </Button>
+            <Button variant="outline" onClick={() => setPlanOpen(true)}>
+              Open plan picker
+            </Button>
+          </div>
+        </Sample>
+      </Section>
+
+      <Section
+        title="Dialogs"
+        description="Destructive confirmations — the real AlertDialog flows."
+      >
+        <Sample label="Cancel subscription">
+          <CancelButton
+            planName="Pro"
+            renewsAt="2026-07-01"
+            onConfirm={() => toast.success('Subscription canceled (demo).')}
+          />
+        </Sample>
+        <Sample label="Delete account">
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="destructive">Delete account</Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This permanently deletes your account and removes all of your
+                  data. This action cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  variant="destructive"
+                  onClick={() => toast.error('Account deleted (demo).')}
+                >
+                  Delete account
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </Sample>
+      </Section>
+
+      <Section
+        title="Toasts"
+        description="Transient feedback — fires and auto-dismisses. Click to trigger."
+      >
+        <Sample label="success / error / info" span>
+          <div className="nx:flex nx:flex-wrap nx:gap-2">
+            <Button
+              variant="outline"
+              onClick={() => toast.success('Contact created')}
+            >
+              Success toast
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => toast.error('Something went wrong')}
+            >
+              Error toast
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => toast.info('Updates are disabled in this demo.')}
+            >
+              Info toast
+            </Button>
+          </div>
+        </Sample>
+      </Section>
+
+      <Section
+        title="Auth errors"
+        description="The bad-credentials / bad-OTP alert shared by the login, signup, and verify screens."
+      >
+        <Sample label="Sign-in error" span>
+          <Alert variant="destructive">
+            <AlertDescription>
+              Incorrect email or password. Please try again.
+            </AlertDescription>
+          </Alert>
+        </Sample>
+      </Section>
+
+      <Section
+        title="Status & meters"
+        description="The subscription badges and the usage meter’s near-cap warning tint."
+      >
+        <Sample label="Subscription status badges">
+          <div className="nx:flex nx:flex-wrap nx:items-center nx:gap-2">
+            <Badge variant="success">Active</Badge>
+            <Badge variant="warning">Canceling</Badge>
+          </div>
+        </Sample>
+        <Sample label="Usage meters · normal vs near-cap">
+          <div className="nx:grid nx:gap-6 nx:sm:grid-cols-2">
+            <UsageMeterBar meter={USAGE_NORMAL} />
+            <UsageMeterBar meter={USAGE_NEAR_CAP} />
+          </div>
+        </Sample>
+      </Section>
+
+      {/* Live form sheets, mounted once and toggled by the triggers above. */}
+      <ContactFormSheet open={contactOpen} onOpenChange={setContactOpen} />
+      <IssueFormSheet open={issueOpen} onOpenChange={setIssueOpen} />
+      <MemberFormSheet open={memberOpen} onOpenChange={setMemberOpen} />
+      <PlanSheet
+        open={planOpen}
+        onOpenChange={setPlanOpen}
+        subscription={MOCK_SUBSCRIPTION}
+      />
+    </div>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="nx:space-y-4">
+      <div className="nx:space-y-1">
+        <h2 className="nx:typography-heading-medium nx:text-foreground">
+          {title}
+        </h2>
+        {description && (
+          <p className="nx:text-muted-foreground nx:max-w-3xl nx:text-sm">
+            {description}
+          </p>
+        )}
+      </div>
+      <div className="nx:grid nx:gap-4 nx:lg:grid-cols-2">{children}</div>
+    </section>
+  );
+}
+
+function Sample({
+  label,
+  span,
+  className,
+  children,
+}: {
+  label: string;
+  /** Span both columns of the section grid. */
+  span?: boolean;
+  /** Extra classes for the framing box — e.g. a fixed height + flex for
+   * skeletons that assume a sized parent, or `nx:p-0` to drop the default pad. */
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={cn(span && 'nx:lg:col-span-2')}>
+      <p className="nx:typography-label-small nx:text-muted-foreground nx:mb-2">
+        {label}
+      </p>
+      <div
+        className={cn(
+          'nx:border-border-default nx:bg-background nx:rounded-lg nx:border nx:p-4',
+          className
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/modules/inbox/conversation-thread.tsx
+++ b/apps/console/src/modules/inbox/conversation-thread.tsx
@@ -252,7 +252,7 @@ function MessageBubble({ message }: { message: Message }) {
   );
 }
 
-function ThreadSkeleton() {
+export function ThreadSkeleton() {
   return (
     <div className="nx:flex nx:min-h-0 nx:flex-1 nx:flex-col">
       <div className="nx:border-border-default nx:space-y-2 nx:border-b nx:px-6 nx:py-4">

--- a/apps/console/src/modules/inbox/inbox-route.tsx
+++ b/apps/console/src/modules/inbox/inbox-route.tsx
@@ -101,7 +101,7 @@ export function InboxRoute() {
   );
 }
 
-function ListSkeleton() {
+export function ListSkeleton() {
   return (
     <div className="nx:flex-1 nx:space-y-4 nx:p-4">
       {Array.from({ length: 8 }, (_, i) => (
@@ -114,7 +114,7 @@ function ListSkeleton() {
   );
 }
 
-function EmptyPane() {
+export function EmptyPane() {
   return (
     <EmptyState>
       <EmptyStateHeader>

--- a/apps/console/src/modules/people/member-detail-route.tsx
+++ b/apps/console/src/modules/people/member-detail-route.tsx
@@ -144,7 +144,7 @@ function Field({ label, value }: { label: string; value: string }) {
   );
 }
 
-function DetailSkeleton() {
+export function DetailSkeleton() {
   return (
     <div className="nx:space-y-6">
       <div className="nx:flex nx:items-center nx:gap-4">

--- a/apps/console/src/modules/people/people-route.tsx
+++ b/apps/console/src/modules/people/people-route.tsx
@@ -92,7 +92,7 @@ export function PeopleRoute() {
   );
 }
 
-function PeopleSkeleton() {
+export function PeopleSkeleton() {
   return (
     <div className="nx:space-y-4">
       <Skeleton className="nx:h-9 nx:max-w-xs" />
@@ -105,7 +105,7 @@ function PeopleSkeleton() {
   );
 }
 
-function PeopleEmpty() {
+export function PeopleEmpty() {
   return (
     <EmptyState className="nx:border nx:border-border-default">
       <EmptyStateHeader>

--- a/apps/console/src/modules/projects/issue-detail-route.tsx
+++ b/apps/console/src/modules/projects/issue-detail-route.tsx
@@ -169,7 +169,7 @@ function Row({ label, children }: { label: string; children: ReactNode }) {
   );
 }
 
-function DetailSkeleton() {
+export function DetailSkeleton() {
   return (
     <div className="nx:space-y-6">
       <div className="nx:space-y-2">

--- a/apps/console/src/modules/projects/issues-route.tsx
+++ b/apps/console/src/modules/projects/issues-route.tsx
@@ -70,7 +70,7 @@ export function IssuesRoute() {
   );
 }
 
-function IssuesSkeleton() {
+export function IssuesSkeleton() {
   return (
     <div className="nx:space-y-4">
       <Skeleton className="nx:h-9 nx:max-w-xs" />
@@ -83,7 +83,7 @@ function IssuesSkeleton() {
   );
 }
 
-function IssuesEmpty() {
+export function IssuesEmpty() {
   return (
     <EmptyState className="nx:border nx:border-border-default">
       <EmptyStateHeader>

--- a/apps/console/src/shell/app-sidebar.tsx
+++ b/apps/console/src/shell/app-sidebar.tsx
@@ -22,6 +22,7 @@ import {
   IconLayoutGrid,
   IconLogout,
   IconPalette,
+  IconRoute,
   IconUserCircle,
 } from '@tabler/icons-react';
 import {
@@ -39,6 +40,7 @@ const DESIGN_ITEMS = [
   { label: 'Reference', to: '/design/reference', icon: IconComponents },
   { label: 'Scenes', to: '/design/scenes', icon: IconLayoutGrid },
   { label: 'Appearance', to: '/design/appearance', icon: IconPalette },
+  { label: 'Flows', to: '/design/flows', icon: IconRoute },
 ] as const;
 
 /**

--- a/apps/console/src/shell/notifications-menu.tsx
+++ b/apps/console/src/shell/notifications-menu.tsx
@@ -168,11 +168,7 @@ export function NotificationsMenu() {
         {/* Only on a cold-load failure — `data` is retained on a background
             refetch error (each mark-read invalidates), so gating on `!data`
             keeps the stale list instead of stacking an error above it. */}
-        {isError && !data && (
-          <p className="nx:text-error-foreground nx:px-3 nx:py-6 nx:text-center nx:text-sm">
-            Couldn’t load notifications. Please try again.
-          </p>
-        )}
+        {isError && !data && <NotificationsError />}
         {data && (
           <ul className="nx:max-h-96 nx:overflow-y-auto nx:p-1">
             {data.notifications.map((n) => {
@@ -231,5 +227,13 @@ export function NotificationsSkeleton() {
         </div>
       ))}
     </div>
+  );
+}
+
+export function NotificationsError() {
+  return (
+    <p className="nx:text-error-foreground nx:px-3 nx:py-6 nx:text-center nx:text-sm">
+      Couldn’t load notifications. Please try again.
+    </p>
   );
 }

--- a/apps/console/src/shell/notifications-menu.tsx
+++ b/apps/console/src/shell/notifications-menu.tsx
@@ -164,19 +164,7 @@ export function NotificationsMenu() {
         </div>
         <Separator />
 
-        {isPending && (
-          <div className="nx:space-y-3 nx:p-3">
-            {[0, 1, 2].map((i) => (
-              <div key={i} className="nx:flex nx:items-start nx:gap-3">
-                <Skeleton className="nx:size-4 nx:shrink-0 nx:rounded-full" />
-                <div className="nx:flex-1 nx:space-y-1">
-                  <Skeleton className="nx:h-3 nx:w-3/4" />
-                  <Skeleton className="nx:h-3 nx:w-1/2" />
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
+        {isPending && <NotificationsSkeleton />}
         {/* Only on a cold-load failure — `data` is retained on a background
             refetch error (each mark-read invalidates), so gating on `!data`
             keeps the stale list instead of stacking an error above it. */}
@@ -227,5 +215,21 @@ export function NotificationsMenu() {
         )}
       </PopoverContent>
     </Popover>
+  );
+}
+
+export function NotificationsSkeleton() {
+  return (
+    <div className="nx:space-y-3 nx:p-3">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className="nx:flex nx:items-start nx:gap-3">
+          <Skeleton className="nx:size-4 nx:shrink-0 nx:rounded-full" />
+          <div className="nx:flex-1 nx:space-y-1">
+            <Skeleton className="nx:h-3 nx:w-3/4" />
+            <Skeleton className="nx:h-3 nx:w-1/2" />
+          </div>
+        </div>
+      ))}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- New **Flows** gallery at `/design/flows` — a design/QA catalog that renders every conditional UI state in the console in one scrolling page, so states normally only reachable by triggering a runtime condition (a failed fetch, an empty dataset, a bad URL) can be reviewed at a glance.
- **9 sections:** loading skeletons (12), error states (bordered + borderless `ErrorState` + the notifications cold-error), 404s (`NotFoundState` + route-level `NotFound`), empties (module empties + `DataTable` "No results." + a Coming-soon sample), form validation (live sheets behind triggers), dialogs (cancel-subscription + delete-account), toasts, auth errors, and status badges + usage meters.
- **Faithful by construction:** the gallery imports the *real* components. Route-private skeletons/empties get an `export` keyword (non-behavioral) and are imported; `ErrorState`/`NotFoundState`/route-404/form sheets are imported as-is; only trivial one-liners over `@nexus/react` primitives (auth `Alert`, status `Badge`s, a `ComingSoon` sample) are inline-authored. A renamed or restructured state breaks the import at compile time — so the gallery can't silently drift from production.
- New **Flows** entry in the Design System sidebar group; route hangs off `appRoute` beside the other `/design/*` routes (so it inherits the app QueryClient + MSW — the live form sheets work).

## GitHub Issue

No linked issue — user-requested design/QA tool.

## Test Plan

- [x] `yarn workspace @nexus/console typecheck` + `eslint` clean
- [x] Browser-verified `/design/flows` (light + dark): all 9 sections render, **0 console errors/warnings**
- [x] Live form sheet opens; empty submit surfaces real rhf+zod validation (field + root)
- [ ] (reviewer) skim each section for faithful rendering

**Known gap (out of scope):** Notifications has no empty-state design, so it isn't a gallery cell — can't render a state that doesn't exist.