### PR TITLE
refactor(console): fold invoices skeleton into the list skeleton cell

### DIFF
--- a/apps/console/src/modules/billing/billing-route.tsx
+++ b/apps/console/src/modules/billing/billing-route.tsx
@@ -377,7 +377,7 @@ export function BillingSkeleton() {
   );
 }
 
-export function InvoicesSkeleton() {
+function InvoicesSkeleton() {
   return (
     <div className="nx:space-y-3">
       {Array.from({ length: 5 }, (_, i) => (

--- a/apps/console/src/modules/design-system/flows-route.tsx
+++ b/apps/console/src/modules/design-system/flows-route.tsx
@@ -30,7 +30,6 @@ import { AnalyticsSkeleton } from '../analytics/analytics-route';
 import {
   BillingSkeleton,
   CancelButton,
-  InvoicesSkeleton,
   UsageMeterBar,
 } from '../billing/billing-route';
 import { PlanSheet } from '../billing/plan-sheet';
@@ -110,9 +109,6 @@ export function FlowsRoute() {
         </Sample>
         <Sample label="Issue detail">
           <IssueDetailSkeleton />
-        </Sample>
-        <Sample label="Invoices card">
-          <InvoicesSkeleton />
         </Sample>
         <Sample label="Analytics dashboard" span>
           <AnalyticsSkeleton />


### PR DESCRIPTION
## Summary

Follow-up to the Flows gallery dedup (#383). Per review feedback, the invoices skeleton is the same "rows loading" pattern as the list/table skeleton, so it doesn't earn its own cell — removed the **Invoices card** cell and reverted the now-unused `InvoicesSkeleton` export back to private (it's still used internally by `InvoicesCard`).

Skeletons section is now 8 unique cells.

## Test Plan

- [x] `typecheck` + `eslint` clean
- [x] Browser-verified `/design/flows`: Invoices cell gone, 8 skeleton cells remain, **0 console errors**