### PR TITLE
docs(agent): document modern web guidance policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,9 @@
 # Agent Instructions
 
 @RTK.md
+
+Modern Web Guidance browser support: Chrome 111+, Edge 111+, Firefox 113+,
+Safari 15.4+, and Samsung Internet 22+. Treat OKLCH as the browser-floor
+feature; do not assume every Baseline 2023 feature is safe without checking
+support against these versions. Use progressive enhancement or fallbacks for
+features outside this floor.

--- a/RTK.md
+++ b/RTK.md
@@ -15,6 +15,19 @@ This file is the Codex-facing entrypoint for the Nexus design-system repo. The e
   - `apps/console`: token/theme exploration UI.
   - `apps/docs`: documentation site.
 
+## Modern Web Guidance Policy
+
+Modern Web Guidance is installed outside the repo for agent use. For HTML, CSS,
+client-side JavaScript, accessibility, forms, layout, performance, overlays, and
+browser-platform work, search Modern Web Guidance first and adapt its guidance to
+Nexus conventions.
+
+Browser support is Chrome 111+, Edge 111+, Firefox 113+, Safari 15.4+, and
+Samsung Internet 22+. OKLCH is the browser-floor feature and is documented as
+Baseline 2023, but do not treat all Baseline 2023 features as safe by default.
+Check the specific feature's support against this browser floor and use
+progressive enhancement or fallbacks where the floor does not cover it.
+
 ## Command Reference
 
 Run commands from the repo root.


### PR DESCRIPTION
## Summary

- Add Modern Web Guidance browser support policy to the root agent instructions.
- Add Codex-facing guidance to search Modern Web Guidance first for frontend/browser-platform work and adapt it to Nexus conventions.
- Clarify that OKLCH is the browser-floor feature, not a blanket allowance for every Baseline 2023 feature without checking support.

## GitHub Issue

N/A

## Test Plan

- [x] `git diff --check HEAD~1..HEAD -- AGENTS.md RTK.md`
- [ ] `yarn prettier --check AGENTS.md RTK.md` (blocked: local `prettier` binary is not installed in this worktree)
