### PR TITLE
refactor(console): collapse Flows loading skeletons to one cell

### DIFF
--- a/apps/console/src/modules/analytics/analytics-route.tsx
+++ b/apps/console/src/modules/analytics/analytics-route.tsx
@@ -202,7 +202,7 @@ function SourcesCard({ sources }: { sources: TrafficSource[] }) {
   );
 }
 
-export function AnalyticsSkeleton() {
+function AnalyticsSkeleton() {
   return (
     <div className="nx:space-y-6">
       <div className="nx:grid nx:gap-6 nx:sm:grid-cols-2 nx:xl:grid-cols-4">

--- a/apps/console/src/modules/billing/billing-route.tsx
+++ b/apps/console/src/modules/billing/billing-route.tsx
@@ -364,7 +364,7 @@ function InvoicesTable({ invoices }: { invoices: Invoice[] }) {
   );
 }
 
-export function BillingSkeleton() {
+function BillingSkeleton() {
   return (
     <div className="nx:space-y-6">
       <div className="nx:grid nx:gap-6 nx:lg:grid-cols-3">

--- a/apps/console/src/modules/crm/contact-detail-route.tsx
+++ b/apps/console/src/modules/crm/contact-detail-route.tsx
@@ -194,7 +194,7 @@ function ActivityIcon({ kind }: { kind: ActivityKind }) {
   return <Icon className="nx:size-4" />;
 }
 
-export function DetailSkeleton() {
+function DetailSkeleton() {
   return (
     <div className="nx:space-y-6">
       <div className="nx:flex nx:items-center nx:gap-4">

--- a/apps/console/src/modules/design-system/flows-route.tsx
+++ b/apps/console/src/modules/design-system/flows-route.tsx
@@ -22,23 +22,12 @@ import { DataTable } from '../../components/data-table';
 import { ErrorState } from '../../components/error-state';
 import { NotFoundState } from '../../components/not-found-state';
 import type { Subscription, UsageMeter } from '../../lib/billing-api';
-import {
-  NotificationsError,
-  NotificationsSkeleton,
-} from '../../shell/notifications-menu';
-import { AnalyticsSkeleton } from '../analytics/analytics-route';
-import {
-  BillingSkeleton,
-  CancelButton,
-  UsageMeterBar,
-} from '../billing/billing-route';
+import { NotificationsError } from '../../shell/notifications-menu';
+import { CancelButton, UsageMeterBar } from '../billing/billing-route';
 import { PlanSheet } from '../billing/plan-sheet';
-import { DetailSkeleton as ContactDetailSkeleton } from '../crm/contact-detail-route';
 import { ContactFormSheet } from '../crm/contact-form-sheet';
 import { ContactsEmpty, ContactsSkeleton } from '../crm/contacts-route';
-import { ThreadSkeleton } from '../inbox/conversation-thread';
-import { EmptyPane, ListSkeleton } from '../inbox/inbox-route';
-import { DetailSkeleton as IssueDetailSkeleton } from '../projects/issue-detail-route';
+import { EmptyPane } from '../inbox/inbox-route';
 
 // Mocks for the components that take data props — the gallery renders them in
 // isolation, with no live query behind them.
@@ -98,39 +87,11 @@ export function FlowsRoute() {
       </header>
 
       <Section
-        title="Loading skeletons"
-        description="Shown for ~500ms while a query resolves, then replaced — hard to catch in normal use."
+        title="Loading skeleton"
+        description="While a query resolves (~500ms) a route paints Skeleton placeholders shaped like its content, then swaps in the data. Every route uses the same Skeleton primitive — shown once here; only the arrangement differs per screen."
       >
-        <Sample label="List / table · Contacts, Issues, People">
+        <Sample label="Content loading" span>
           <ContactsSkeleton />
-        </Sample>
-        <Sample label="Record detail · Contacts, People">
-          <ContactDetailSkeleton />
-        </Sample>
-        <Sample label="Issue detail">
-          <IssueDetailSkeleton />
-        </Sample>
-        <Sample label="Analytics dashboard" span>
-          <AnalyticsSkeleton />
-        </Sample>
-        <Sample label="Billing page" span>
-          <BillingSkeleton />
-        </Sample>
-        <Sample label="Notifications panel" className="nx:max-w-sm nx:p-0">
-          <NotificationsSkeleton />
-        </Sample>
-        <Sample
-          label="Inbox list"
-          className="nx:flex nx:h-96 nx:flex-col nx:p-0"
-        >
-          <ListSkeleton />
-        </Sample>
-        <Sample
-          label="Inbox thread"
-          span
-          className="nx:flex nx:h-96 nx:flex-col nx:p-0"
-        >
-          <ThreadSkeleton />
         </Sample>
       </Section>
 

--- a/apps/console/src/modules/inbox/conversation-thread.tsx
+++ b/apps/console/src/modules/inbox/conversation-thread.tsx
@@ -252,7 +252,7 @@ function MessageBubble({ message }: { message: Message }) {
   );
 }
 
-export function ThreadSkeleton() {
+function ThreadSkeleton() {
   return (
     <div className="nx:flex nx:min-h-0 nx:flex-1 nx:flex-col">
       <div className="nx:border-border-default nx:space-y-2 nx:border-b nx:px-6 nx:py-4">

--- a/apps/console/src/modules/inbox/inbox-route.tsx
+++ b/apps/console/src/modules/inbox/inbox-route.tsx
@@ -101,7 +101,7 @@ export function InboxRoute() {
   );
 }
 
-export function ListSkeleton() {
+function ListSkeleton() {
   return (
     <div className="nx:flex-1 nx:space-y-4 nx:p-4">
       {Array.from({ length: 8 }, (_, i) => (

--- a/apps/console/src/modules/projects/issue-detail-route.tsx
+++ b/apps/console/src/modules/projects/issue-detail-route.tsx
@@ -169,7 +169,7 @@ function Row({ label, children }: { label: string; children: ReactNode }) {
   );
 }
 
-export function DetailSkeleton() {
+function DetailSkeleton() {
   return (
     <div className="nx:space-y-6">
       <div className="nx:space-y-2">

--- a/apps/console/src/shell/notifications-menu.tsx
+++ b/apps/console/src/shell/notifications-menu.tsx
@@ -214,7 +214,7 @@ export function NotificationsMenu() {
   );
 }
 
-export function NotificationsSkeleton() {
+function NotificationsSkeleton() {
   return (
     <div className="nx:space-y-3 nx:p-3">
       {[0, 1, 2].map((i) => (


### PR DESCRIPTION
## Summary

Per feedback, eight per-screen loading-skeleton layouts add no utility over one — a skeleton is a skeleton; the arrangement differing per route isn't worth a cell each.

- Collapsed the **Loading skeleton** section from 8 cells to a single representative "Content loading" cell (the list/table skeleton).
- Reverted the seven now-unused skeleton `export`s back to private (`DetailSkeleton` ×2, `AnalyticsSkeleton`, `BillingSkeleton`, `ListSkeleton`, `ThreadSkeleton`, `NotificationsSkeleton`) — each is still used internally by its own route.

The other 8 sections (errors, 404s, empties, forms, dialogs, toasts, auth, status) are unchanged.

## Test Plan

- [x] `typecheck` + `eslint` clean
- [x] Browser-verified `/design/flows`: the Loading section is one cell, all 7 old skeleton cells gone, the other sections intact, **0 console errors**