### PR TITLE
chore(browser): add MWG browser floor audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       react: ${{ steps.filter.outputs.react }}
+      browser: ${{ steps.filter.outputs.browser }}
       # `packages` is true if `packages/**` changed OR if `apps/**` changed
       # outside `apps/docs/**`. See the two paths-filter steps below.
       packages: ${{ steps.filter.outputs.packages == 'true' || steps.filter-apps.outputs.apps == 'true' }}
@@ -53,6 +54,13 @@ jobs:
               - 'packages/test-utils/**'
             packages:
               - 'packages/**'
+            browser:
+              - 'package.json'
+              - 'scripts/audit-browser-support.js'
+              - 'scripts/audit-browser-support.test.js'
+              - 'README.md'
+              - 'AGENTS.md'
+              - 'RTK.md'
             ci:
               - '.github/workflows/**'
 
@@ -79,7 +87,10 @@ jobs:
     name: Format Check
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true'
+    if: >-
+      needs.changes.outputs.packages == 'true' ||
+      needs.changes.outputs.browser == 'true' ||
+      needs.changes.outputs.ci == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -100,7 +111,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true'
+    if: >-
+      needs.changes.outputs.packages == 'true' ||
+      needs.changes.outputs.browser == 'true' ||
+      needs.changes.outputs.ci == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -129,6 +143,27 @@ jobs:
   # ============================================
   # Build (affected packages only)
   # ============================================
+
+  audit-browser-support:
+    name: Audit Browser Support
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.browser == 'true' || needs.changes.outputs.ci == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Audit browser support floor
+        run: yarn audit:browser-support
 
   build:
     name: Build
@@ -233,7 +268,10 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.react == 'true' || needs.changes.outputs.ci == 'true'
+    if: >-
+      needs.changes.outputs.react == 'true' ||
+      needs.changes.outputs.browser == 'true' ||
+      needs.changes.outputs.ci == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -443,6 +481,7 @@ jobs:
       - changes
       - format-check
       - lint
+      - audit-browser-support
       - build
       - typecheck
       - test-unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
               - 'README.md'
               - 'AGENTS.md'
               - 'RTK.md'
+              - '.claude/rules/tokens.md'
             ci:
               - '.github/workflows/**'
 

--- a/README.md
+++ b/README.md
@@ -56,3 +56,8 @@ Each command runs from the repo root.
 | Samsung Internet | 22              |
 
 Design tokens use OKLCH color (Baseline 2023). Browsers below these versions do not support OKLCH and will not receive hex fallbacks. Consumers needing older browser support must pin to the last pre-OKLCH-migration tag.
+
+The same floor is encoded in root `package.json#browserslist`. Run
+`yarn audit:browser-support` before adopting a new Modern Web Guidance browser
+feature; the audit script records which MWG-recommended features are safe to
+adopt, deferred, or limited to progressive enhancement at this floor.

--- a/RTK.md
+++ b/RTK.md
@@ -26,7 +26,10 @@ Browser support is Chrome 111+, Edge 111+, Firefox 113+, Safari 15.4+, and
 Samsung Internet 22+. OKLCH is the browser-floor feature and is documented as
 Baseline 2023, but do not treat all Baseline 2023 features as safe by default.
 Check the specific feature's support against this browser floor and use
-progressive enhancement or fallbacks where the floor does not cover it.
+progressive enhancement or fallbacks where the floor does not cover it. The
+canonical floor is also encoded in root `package.json#browserslist`; run
+`yarn audit:browser-support` when adopting or reclassifying browser-platform
+features from Modern Web Guidance.
 
 ## Command Reference
 
@@ -43,6 +46,7 @@ yarn lint
 yarn test
 yarn test:unit
 yarn test:storybook
+yarn audit:browser-support
 yarn audit:contrast
 yarn audit:storybook-coverage
 ```

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "typecheck": "turbo run typecheck",
     "tokens:modular": "yarn workspace @nexus/core build:tokens:modular && node scripts/sync-console-themes.js && node scripts/sync-docs-themes.js",
     "tokens:tailwind": "cd packages/core && yarn build:tailwind && cp dist/tailwind/* ../../packages/tailwind/",
+    "audit:browser-support": "node scripts/audit-browser-support.js",
     "audit:contrast": "yarn workspace @nexus/core audit:contrast",
     "audit:storybook-coverage": "yarn workspace @nexus/react audit:storybook-coverage",
     "validate:spacing-modes": "yarn workspace @nexus/core validate:spacing-modes",
@@ -88,6 +89,13 @@
   "engines": {
     "node": ">=20.19.0"
   },
+  "browserslist": [
+    "Chrome >= 111",
+    "Edge >= 111",
+    "Firefox >= 113",
+    "Safari >= 15.4",
+    "Samsung >= 22"
+  ],
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
       "eslint --fix",

--- a/scripts/audit-browser-support.js
+++ b/scripts/audit-browser-support.js
@@ -1,0 +1,323 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..');
+const PACKAGE_JSON = path.join(REPO_ROOT, 'package.json');
+
+export const BROWSER_FLOOR = Object.freeze({
+  chrome: 111,
+  edge: 111,
+  firefox: 113,
+  safari: 15.4,
+  samsung: 22,
+});
+
+export const EXPECTED_BROWSERSLIST = Object.freeze([
+  'Chrome >= 111',
+  'Edge >= 111',
+  'Firefox >= 113',
+  'Safari >= 15.4',
+  'Samsung >= 22',
+]);
+
+export const FEATURE_POLICIES = Object.freeze([
+  {
+    id: 'oklch',
+    name: 'OKLCH color',
+    policy: 'adopt',
+    support: {
+      chrome: 111,
+      edge: 111,
+      firefox: 113,
+      safari: 15.4,
+      samsung: 22,
+    },
+    guide: 'css',
+    note: 'Nexus uses OKLCH as the browser-floor feature and does not emit hex fallbacks.',
+  },
+  {
+    id: 'color-scheme',
+    name: 'color-scheme',
+    policy: 'adopt',
+    support: {
+      chrome: 81,
+      edge: 81,
+      firefox: 96,
+      safari: 13,
+      samsung: 13,
+    },
+    guide: 'css / dark-mode',
+    note: 'Safe to use for native browser UI theming at the Nexus floor.',
+  },
+  {
+    id: 'light-dark',
+    name: 'light-dark()',
+    policy: 'defer',
+    support: {
+      chrome: 123,
+      edge: 123,
+      firefox: 120,
+      safari: 17.5,
+      samsung: 27,
+    },
+    guide: 'dark-mode',
+    note: 'Use existing .dark semantic-token overrides until this clears the floor.',
+  },
+  {
+    id: 'popover-api',
+    name: 'Popover API',
+    policy: 'defer',
+    support: {
+      chrome: 114,
+      edge: 114,
+      firefox: 125,
+      safari: 17,
+      samsung: 23,
+    },
+    guide: 'html',
+    note: 'Keep Radix primitives for core overlays unless native use is progressive-enhanced.',
+  },
+  {
+    id: 'dialog-closedby',
+    name: '<dialog closedby>',
+    policy: 'defer',
+    support: {
+      chrome: 134,
+      edge: 134,
+      firefox: null,
+      safari: null,
+      samsung: null,
+    },
+    guide: 'html',
+    note: 'Do not depend on closedby for platform dismiss behavior at the current floor.',
+  },
+  {
+    id: 'anchor-positioning',
+    name: 'CSS Anchor Positioning',
+    policy: 'defer',
+    support: {
+      chrome: 125,
+      edge: 125,
+      firefox: null,
+      safari: null,
+      samsung: null,
+    },
+    guide: 'css-layout',
+    note: 'Use Radix positioning or feature-detected enhancement for anchored overlays.',
+  },
+  {
+    id: 'container-style-queries',
+    name: 'Container style queries',
+    policy: 'defer',
+    support: {
+      chrome: 111,
+      edge: 111,
+      firefox: null,
+      safari: 18,
+      samsung: 22,
+    },
+    guide: 'design-token-reactivity',
+    note: 'Firefox lacks support; keep data attributes/classes for core token reactivity.',
+  },
+  {
+    id: 'scroll-state-queries',
+    name: 'Container scroll-state queries',
+    policy: 'defer',
+    support: {
+      chrome: 133,
+      edge: 133,
+      firefox: null,
+      safari: null,
+      samsung: null,
+    },
+    guide: 'scrollability-affordance-hints',
+    note: 'Use non-critical enhancement or IntersectionObserver fallback for required hints.',
+  },
+  {
+    id: 'field-sizing',
+    name: 'field-sizing: content',
+    policy: 'defer',
+    support: {
+      chrome: 123,
+      edge: 123,
+      firefox: null,
+      safari: 26.2,
+      samsung: null,
+    },
+    guide: 'form-fields-automatically-fit-contents',
+    note: 'Use as progressive enhancement only; fixed-size fields remain the fallback.',
+  },
+  {
+    id: 'scrollbar-color',
+    name: 'scrollbar-color / scrollbar-width',
+    policy: 'defer',
+    support: {
+      chrome: 121,
+      edge: 121,
+      firefox: 64,
+      safari: 26.2,
+      samsung: null,
+    },
+    guide: 'customize-scrollbar-color-and-thickness',
+    note: 'Radix ScrollArea remains the design-system default; native styling is enhancement-only.',
+  },
+]);
+
+const BROWSER_LABELS = Object.freeze({
+  chrome: 'Chrome',
+  edge: 'Edge',
+  firefox: 'Firefox',
+  safari: 'Safari',
+  samsung: 'Samsung Internet',
+});
+
+const POLICY_LABELS = Object.freeze({
+  adopt: 'Adopt',
+  defer: 'Defer',
+});
+
+function compareVersions(actual, required) {
+  if (required === null) return false;
+  return actual >= required;
+}
+
+function formatSupportValue(value) {
+  return value === null ? 'unsupported' : `${value}+`;
+}
+
+function formatSupportSummary(feature) {
+  return Object.entries(BROWSER_LABELS)
+    .map(([browser, label]) => {
+      return `${label} ${formatSupportValue(feature.support[browser])}`;
+    })
+    .join(', ');
+}
+
+export function isFeatureSafeAtFloor(feature, floor = BROWSER_FLOOR) {
+  return Object.keys(BROWSER_LABELS).every((browser) => {
+    return compareVersions(floor[browser], feature.support[browser]);
+  });
+}
+
+export function evaluateFeaturePolicies(
+  features = FEATURE_POLICIES,
+  floor = BROWSER_FLOOR
+) {
+  return features.map((feature) => {
+    const floorSafe = isFeatureSafeAtFloor(feature, floor);
+    let problem = null;
+
+    if (feature.policy === 'adopt' && !floorSafe) {
+      problem = 'marked adopt, but does not clear the browser floor';
+    }
+
+    if (feature.policy === 'defer' && floorSafe) {
+      problem = 'marked defer, but now clears the browser floor';
+    }
+
+    return {
+      ...feature,
+      floorSafe,
+      problem,
+      supportSummary: formatSupportSummary(feature),
+    };
+  });
+}
+
+export function normalizeBrowserslist(value) {
+  if (Array.isArray(value)) return value;
+  if (value && Array.isArray(value.production)) return value.production;
+  return [];
+}
+
+export function compareBrowserslist(actual, expected = EXPECTED_BROWSERSLIST) {
+  const actualSet = new Set(actual);
+  const expectedSet = new Set(expected);
+
+  return {
+    missing: expected.filter((target) => !actualSet.has(target)),
+    extra: actual.filter((target) => !expectedSet.has(target)),
+  };
+}
+
+export function auditBrowserSupport(packageJson) {
+  const browserslist = normalizeBrowserslist(packageJson.browserslist);
+  const browserslistDiff = compareBrowserslist(browserslist);
+  const features = evaluateFeaturePolicies();
+  const featureProblems = features.filter((feature) => feature.problem);
+
+  return {
+    browserslist,
+    browserslistDiff,
+    features,
+    featureProblems,
+    ok:
+      browserslistDiff.missing.length === 0 &&
+      browserslistDiff.extra.length === 0 &&
+      featureProblems.length === 0,
+  };
+}
+
+function loadPackageJson(file = PACKAGE_JSON) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function printResult(result) {
+  process.stdout.write('audit-browser-support: Nexus browser floor\n');
+  for (const [browser, label] of Object.entries(BROWSER_LABELS)) {
+    process.stdout.write(`  ${label}: ${BROWSER_FLOOR[browser]}+\n`);
+  }
+
+  process.stdout.write('\nBrowserslist targets:\n');
+  for (const target of result.browserslist) {
+    process.stdout.write(`  ${target}\n`);
+  }
+
+  process.stdout.write('\nMWG feature policies:\n');
+  for (const feature of result.features) {
+    const status = feature.floorSafe ? 'floor-safe' : 'outside floor';
+    process.stdout.write(
+      `  ${feature.id}: ${POLICY_LABELS[feature.policy]} (${status}) — ${feature.guide}\n`
+    );
+  }
+
+  if (result.ok) {
+    process.stdout.write('\naudit-browser-support: all checks passed.\n');
+    return;
+  }
+
+  if (result.browserslistDiff.missing.length > 0) {
+    process.stdout.write('\nMissing Browserslist target(s):\n');
+    for (const target of result.browserslistDiff.missing) {
+      process.stdout.write(`  ${target}\n`);
+    }
+  }
+
+  if (result.browserslistDiff.extra.length > 0) {
+    process.stdout.write('\nUnexpected Browserslist target(s):\n');
+    for (const target of result.browserslistDiff.extra) {
+      process.stdout.write(`  ${target}\n`);
+    }
+  }
+
+  if (result.featureProblems.length > 0) {
+    process.stdout.write('\nFeature policy mismatch(es):\n');
+    for (const feature of result.featureProblems) {
+      process.stdout.write(
+        `  ${feature.id}: ${feature.problem}. Support: ${feature.supportSummary}. ${feature.note}\n`
+      );
+    }
+  }
+}
+
+function main() {
+  const result = auditBrowserSupport(loadPackageJson());
+  printResult(result);
+  process.exit(result.ok ? 0 : 1);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/audit-browser-support.js
+++ b/scripts/audit-browser-support.js
@@ -68,7 +68,7 @@ export const FEATURE_POLICIES = Object.freeze([
   {
     id: 'popover-api',
     name: 'Popover API',
-    policy: 'defer',
+    policy: 'intentional-divergence',
     support: {
       chrome: 114,
       edge: 114,
@@ -96,7 +96,7 @@ export const FEATURE_POLICIES = Object.freeze([
   {
     id: 'anchor-positioning',
     name: 'CSS Anchor Positioning',
-    policy: 'defer',
+    policy: 'fallback',
     support: {
       chrome: 125,
       edge: 125,
@@ -110,7 +110,7 @@ export const FEATURE_POLICIES = Object.freeze([
   {
     id: 'container-style-queries',
     name: 'Container style queries',
-    policy: 'defer',
+    policy: 'fallback',
     support: {
       chrome: 111,
       edge: 111,
@@ -124,7 +124,7 @@ export const FEATURE_POLICIES = Object.freeze([
   {
     id: 'scroll-state-queries',
     name: 'Container scroll-state queries',
-    policy: 'defer',
+    policy: 'progressive-enhancement',
     support: {
       chrome: 133,
       edge: 133,
@@ -138,7 +138,7 @@ export const FEATURE_POLICIES = Object.freeze([
   {
     id: 'field-sizing',
     name: 'field-sizing: content',
-    policy: 'defer',
+    policy: 'progressive-enhancement',
     support: {
       chrome: 123,
       edge: 123,
@@ -152,7 +152,7 @@ export const FEATURE_POLICIES = Object.freeze([
   {
     id: 'scrollbar-color',
     name: 'scrollbar-color / scrollbar-width',
-    policy: 'defer',
+    policy: 'intentional-divergence',
     support: {
       chrome: 121,
       edge: 121,
@@ -173,9 +173,32 @@ const BROWSER_LABELS = Object.freeze({
   samsung: 'Samsung Internet',
 });
 
-const POLICY_LABELS = Object.freeze({
-  adopt: 'Adopt',
-  defer: 'Defer',
+export const FEATURE_POLICY_DEFINITIONS = Object.freeze({
+  adopt: {
+    label: 'Adopt',
+    requiresFloorSupport: true,
+    reconsiderWhenFloorSafe: false,
+  },
+  'progressive-enhancement': {
+    label: 'Progressive enhancement',
+    requiresFloorSupport: false,
+    reconsiderWhenFloorSafe: false,
+  },
+  fallback: {
+    label: 'Fallback required',
+    requiresFloorSupport: false,
+    reconsiderWhenFloorSafe: false,
+  },
+  'intentional-divergence': {
+    label: 'Intentional divergence',
+    requiresFloorSupport: false,
+    reconsiderWhenFloorSafe: false,
+  },
+  defer: {
+    label: 'Defer',
+    requiresFloorSupport: false,
+    reconsiderWhenFloorSafe: true,
+  },
 });
 
 function compareVersions(actual, required) {
@@ -207,14 +230,17 @@ export function evaluateFeaturePolicies(
 ) {
   return features.map((feature) => {
     const floorSafe = isFeatureSafeAtFloor(feature, floor);
+    const policy = FEATURE_POLICY_DEFINITIONS[feature.policy];
     let problem = null;
 
-    if (feature.policy === 'adopt' && !floorSafe) {
-      problem = 'marked adopt, but does not clear the browser floor';
+    if (!policy) {
+      problem = `uses unknown policy "${feature.policy}"`;
+    } else if (policy.requiresFloorSupport && !floorSafe) {
+      problem = `marked ${policy.label.toLowerCase()}, but does not clear the browser floor`;
     }
 
-    if (feature.policy === 'defer' && floorSafe) {
-      problem = 'marked defer, but now clears the browser floor';
+    if (!problem && policy.reconsiderWhenFloorSafe && floorSafe) {
+      problem = `marked ${policy.label.toLowerCase()}, but now clears the browser floor`;
     }
 
     return {
@@ -278,8 +304,11 @@ function printResult(result) {
   process.stdout.write('\nMWG feature policies:\n');
   for (const feature of result.features) {
     const status = feature.floorSafe ? 'floor-safe' : 'outside floor';
+    const policy =
+      FEATURE_POLICY_DEFINITIONS[feature.policy]?.label ??
+      `Unknown policy "${feature.policy}"`;
     process.stdout.write(
-      `  ${feature.id}: ${POLICY_LABELS[feature.policy]} (${status}) — ${feature.guide}\n`
+      `  ${feature.id}: ${policy} (${status}) — ${feature.guide}\n`
     );
   }
 

--- a/scripts/audit-browser-support.test.js
+++ b/scripts/audit-browser-support.test.js
@@ -7,6 +7,7 @@ import {
   evaluateFeaturePolicies,
   EXPECTED_BROWSERSLIST,
   FEATURE_POLICIES,
+  FEATURE_POLICY_DEFINITIONS,
   isFeatureSafeAtFloor,
 } from './audit-browser-support.js';
 
@@ -42,6 +43,14 @@ describe('audit-browser-support', () => {
   it('keeps feature policies aligned with floor support', () => {
     const results = evaluateFeaturePolicies();
 
+    expect(Object.keys(FEATURE_POLICY_DEFINITIONS).sort()).toEqual([
+      'adopt',
+      'defer',
+      'fallback',
+      'intentional-divergence',
+      'progressive-enhancement',
+    ]);
+
     expect(results).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -52,7 +61,19 @@ describe('audit-browser-support', () => {
         }),
         expect.objectContaining({
           id: 'field-sizing',
-          policy: 'defer',
+          policy: 'progressive-enhancement',
+          floorSafe: false,
+          problem: null,
+        }),
+        expect.objectContaining({
+          id: 'popover-api',
+          policy: 'intentional-divergence',
+          floorSafe: false,
+          problem: null,
+        }),
+        expect.objectContaining({
+          id: 'container-style-queries',
+          policy: 'fallback',
           floorSafe: false,
           problem: null,
         }),
@@ -108,6 +129,32 @@ describe('audit-browser-support', () => {
       expect.objectContaining({
         floorSafe: true,
         problem: 'marked defer, but now clears the browser floor',
+      })
+    );
+  });
+
+  it('flags unknown feature policies', () => {
+    const results = evaluateFeaturePolicies([
+      {
+        id: 'misspelled-policy',
+        name: 'Misspelled Policy',
+        policy: 'adpot',
+        support: {
+          chrome: 111,
+          edge: 111,
+          firefox: 113,
+          safari: 15.4,
+          samsung: 22,
+        },
+        guide: 'css',
+        note: 'test fixture',
+      },
+    ]);
+
+    expect(results[0]).toEqual(
+      expect.objectContaining({
+        floorSafe: true,
+        problem: 'uses unknown policy "adpot"',
       })
     );
   });

--- a/scripts/audit-browser-support.test.js
+++ b/scripts/audit-browser-support.test.js
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  auditBrowserSupport,
+  BROWSER_FLOOR,
+  compareBrowserslist,
+  evaluateFeaturePolicies,
+  EXPECTED_BROWSERSLIST,
+  FEATURE_POLICIES,
+  isFeatureSafeAtFloor,
+} from './audit-browser-support.js';
+
+describe('audit-browser-support', () => {
+  it('matches the documented Nexus browser floor', () => {
+    expect(BROWSER_FLOOR).toEqual({
+      chrome: 111,
+      edge: 111,
+      firefox: 113,
+      safari: 15.4,
+      samsung: 22,
+    });
+
+    expect(EXPECTED_BROWSERSLIST).toEqual([
+      'Chrome >= 111',
+      'Edge >= 111',
+      'Firefox >= 113',
+      'Safari >= 15.4',
+      'Samsung >= 22',
+    ]);
+  });
+
+  it('treats OKLCH as floor-safe and Popover API as outside the floor', () => {
+    const oklch = FEATURE_POLICIES.find((feature) => feature.id === 'oklch');
+    const popover = FEATURE_POLICIES.find(
+      (feature) => feature.id === 'popover-api'
+    );
+
+    expect(isFeatureSafeAtFloor(oklch)).toBe(true);
+    expect(isFeatureSafeAtFloor(popover)).toBe(false);
+  });
+
+  it('keeps feature policies aligned with floor support', () => {
+    const results = evaluateFeaturePolicies();
+
+    expect(results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'oklch',
+          policy: 'adopt',
+          floorSafe: true,
+          problem: null,
+        }),
+        expect.objectContaining({
+          id: 'field-sizing',
+          policy: 'defer',
+          floorSafe: false,
+          problem: null,
+        }),
+      ])
+    );
+  });
+
+  it('flags unsupported features that are marked adopt', () => {
+    const results = evaluateFeaturePolicies([
+      {
+        id: 'future-api',
+        name: 'Future API',
+        policy: 'adopt',
+        support: {
+          chrome: 999,
+          edge: 999,
+          firefox: 999,
+          safari: 999,
+          samsung: 999,
+        },
+        guide: 'css',
+        note: 'test fixture',
+      },
+    ]);
+
+    expect(results[0]).toEqual(
+      expect.objectContaining({
+        floorSafe: false,
+        problem: 'marked adopt, but does not clear the browser floor',
+      })
+    );
+  });
+
+  it('flags stale deferrals when the floor supports every browser', () => {
+    const results = evaluateFeaturePolicies([
+      {
+        id: 'old-api',
+        name: 'Old API',
+        policy: 'defer',
+        support: {
+          chrome: 1,
+          edge: 1,
+          firefox: 1,
+          safari: 1,
+          samsung: 1,
+        },
+        guide: 'html',
+        note: 'test fixture',
+      },
+    ]);
+
+    expect(results[0]).toEqual(
+      expect.objectContaining({
+        floorSafe: true,
+        problem: 'marked defer, but now clears the browser floor',
+      })
+    );
+  });
+
+  it('detects drift from the canonical Browserslist targets', () => {
+    expect(compareBrowserslist(['Chrome >= 111'])).toEqual({
+      missing: [
+        'Edge >= 111',
+        'Firefox >= 113',
+        'Safari >= 15.4',
+        'Samsung >= 22',
+      ],
+      extra: [],
+    });
+  });
+
+  it('passes for a package using the canonical targets', () => {
+    const result = auditBrowserSupport({
+      browserslist: [...EXPECTED_BROWSERSLIST],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.browserslistDiff).toEqual({ missing: [], extra: [] });
+    expect(result.featureProblems).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
             'packages/**/src/**/*.test.{ts,tsx}',
             'packages/**/scripts/**/*.test.{js,ts}',
             'packages/eslint-plugin-nexus/__tests__/**/*.test.js',
+            'scripts/**/*.test.js',
             // Exclude component tests - they're now in stories
             '!packages/react/src/components/**/*.test.{ts,tsx}',
           ],


### PR DESCRIPTION
## Summary

- Encode the Nexus browser floor in root `package.json#browserslist`.
- Add `yarn audit:browser-support` with MWG feature policy checks for adopt/defer decisions.
- Wire the browser support audit into CI and document the workflow in README/RTK.

## GitHub Issue

Closes #387

## Test Plan

- [x] `yarn audit:browser-support`
- [x] `yarn test:unit scripts/audit-browser-support.test.js`
- [x] `yarn prettier --check .github/workflows/ci.yml README.md RTK.md package.json vitest.config.ts scripts/audit-browser-support.js scripts/audit-browser-support.test.js`
- [x] `yarn eslint scripts/audit-browser-support.js scripts/audit-browser-support.test.js vitest.config.ts`
- [x] `git diff --check`
