### PR TITLE
feat(console): mobile card layout for data tables + overflow fixes (Phase 4)

### DIFF
--- a/apps/console/src/app/root-layout.tsx
+++ b/apps/console/src/app/root-layout.tsx
@@ -32,7 +32,10 @@ export function RootLayout() {
   return (
     <SidebarProvider>
       <AppSidebar />
-      <SidebarInset>
+      {/* min-w-0 lets the inset shrink below a wide child's intrinsic width
+          (e.g. an 8-column table) so that child scrolls inside its own
+          container instead of pushing the whole page wider than the viewport. */}
+      <SidebarInset className="nx:min-w-0">
         <Topbar onSearchClick={() => setCommandOpen(true)} />
         {/* nx:text-foreground re-establishes the adaptive base text color for
             module content — without it, reused content that relies on inherited

--- a/apps/console/src/app/root-layout.tsx
+++ b/apps/console/src/app/root-layout.tsx
@@ -32,10 +32,7 @@ export function RootLayout() {
   return (
     <SidebarProvider>
       <AppSidebar />
-      {/* min-w-0 lets the inset shrink below a wide child's intrinsic width
-          (e.g. an 8-column table) so that child scrolls inside its own
-          container instead of pushing the whole page wider than the viewport. */}
-      <SidebarInset className="nx:min-w-0">
+      <SidebarInset>
         <Topbar onSearchClick={() => setCommandOpen(true)} />
         {/* nx:text-foreground re-establishes the adaptive base text color for
             module content — without it, reused content that relies on inherited

--- a/apps/console/src/components/data-pager.tsx
+++ b/apps/console/src/components/data-pager.tsx
@@ -1,0 +1,54 @@
+import { Button } from '@nexus/react';
+import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+
+interface DataPagerProps {
+  /** 0-based page index. */
+  page: number;
+  pageCount: number;
+  /** Total filtered row count, summarised on the left. */
+  total: number;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+/**
+ * The prev/next pager for the mobile card lists — mirrors the pager built into
+ * {@link DataTable} (row count, "Page X of Y", bounded chevrons) so the table
+ * (≥lg) and card (<lg) views read consistently.
+ */
+export function DataPager({
+  page,
+  pageCount,
+  total,
+  onPrev,
+  onNext,
+}: DataPagerProps) {
+  return (
+    <div className="nx:flex nx:items-center nx:justify-between nx:gap-4">
+      <p className="nx:text-muted-foreground nx:text-sm">{total} row(s)</p>
+      <div className="nx:flex nx:items-center nx:gap-3">
+        <span className="nx:text-muted-foreground nx:text-sm">
+          Page {page + 1} of {pageCount}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onPrev}
+          disabled={page === 0}
+          aria-label="Previous page"
+        >
+          <IconChevronLeft />
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onNext}
+          disabled={page >= pageCount - 1}
+          aria-label="Next page"
+        >
+          <IconChevronRight />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/console/src/components/filter-input.tsx
+++ b/apps/console/src/components/filter-input.tsx
@@ -1,0 +1,33 @@
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@nexus/react';
+import { IconSearch } from '@tabler/icons-react';
+
+interface FilterInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+/**
+ * The search box that filters the mobile card lists — mirrors the filter box
+ * built into {@link DataTable} so the table (≥lg) and card (<lg) views share one
+ * look. Controlled: the parent owns the query string.
+ */
+export function FilterInput({
+  value,
+  onChange,
+  placeholder = 'Filter…',
+}: FilterInputProps) {
+  return (
+    <InputGroup className="nx:max-w-xs">
+      <InputGroupAddon>
+        <IconSearch />
+      </InputGroupAddon>
+      <InputGroupInput
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label={placeholder}
+      />
+    </InputGroup>
+  );
+}

--- a/apps/console/src/components/record-card.tsx
+++ b/apps/console/src/components/record-card.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from 'react';
+
+interface RecordCardProps {
+  /** The card heading — typically a Link to the record's detail page. */
+  title: ReactNode;
+  /** Optional status badge, pinned to the top-right corner. */
+  badge?: ReactNode;
+  /** Secondary fields, stacked under the heading as muted lines. */
+  children: ReactNode;
+}
+
+/**
+ * The mobile record card — one per data-table row below `lg`, where the full
+ * table can't fit. A titled, bordered tile with an optional status badge in the
+ * corner and a stack of secondary fields below. Modules compose it with their
+ * own curated title / badge / field lines (reading raw row data, never the
+ * table's `<td>` cell renderers).
+ *
+ * Renders an `<li>` — always lives inside a card list's `<ul>`.
+ */
+export function RecordCard({ title, badge, children }: RecordCardProps) {
+  return (
+    <li className="nx:border-border-default nx:bg-container nx:rounded-lg nx:border nx:p-4">
+      <div className="nx:flex nx:items-start nx:justify-between nx:gap-3">
+        <div className="nx:min-w-0 nx:flex-1">{title}</div>
+        {badge ? <div className="nx:shrink-0">{badge}</div> : null}
+      </div>
+      <div className="nx:text-muted-foreground nx:mt-2 nx:space-y-1 nx:text-sm">
+        {children}
+      </div>
+    </li>
+  );
+}

--- a/apps/console/src/hooks/use-filter-paginate.ts
+++ b/apps/console/src/hooks/use-filter-paginate.ts
@@ -1,0 +1,49 @@
+import { useMemo, useState } from 'react';
+
+interface FilterPaginateOptions<T> {
+  /** Maps an item to the text the filter box matches against. */
+  search: (item: T) => string;
+  /** Items per page (default 10, matching the desktop DataTable). */
+  pageSize?: number;
+}
+
+/**
+ * Filter + pagination for the mobile card lists — the plain-array equivalent of
+ * the desktop {@link DataTable}'s TanStack state, for the `<lg` card view where
+ * the table (and its sort / selection machinery) doesn't render. Filtering
+ * resets to the first page, and the page index is clamped so a shrinking result
+ * set never strands the view past the end.
+ */
+export function useFilterPaginate<T>(
+  items: T[],
+  { search, pageSize = 10 }: FilterPaginateOptions<T>
+) {
+  const [query, setQueryState] = useState('');
+  const [page, setPage] = useState(0);
+
+  const setQuery = (next: string) => {
+    setQueryState(next);
+    setPage(0);
+  };
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((item) => search(item).toLowerCase().includes(q));
+  }, [items, query, search]);
+
+  const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize));
+  const safePage = Math.min(page, pageCount - 1);
+  const start = safePage * pageSize;
+
+  return {
+    query,
+    setQuery,
+    pageItems: filtered.slice(start, start + pageSize),
+    total: filtered.length,
+    page: safePage,
+    pageCount,
+    prev: () => setPage((p) => Math.max(0, p - 1)),
+    next: () => setPage((p) => Math.min(pageCount - 1, p + 1)),
+  };
+}

--- a/apps/console/src/modules/analytics/analytics-charts.tsx
+++ b/apps/console/src/modules/analytics/analytics-charts.tsx
@@ -22,7 +22,7 @@ import type { TrendPoint } from '../../lib/analytics-api';
 
 // Fixed height overrides ChartContainer's default `aspect-video` so every
 // dashboard chart is the same height regardless of its grid column's width.
-const CHART_BOX = 'nx:h-[260px] nx:w-full';
+const CHART_BOX = 'nx:h-[260px] nx:w-full nx:min-w-0';
 
 const revenueConfig = {
   revenue: { label: 'Revenue', color: 'var(--nx-color-chart-categorical-1)' },

--- a/apps/console/src/modules/analytics/analytics-route.tsx
+++ b/apps/console/src/modules/analytics/analytics-route.tsx
@@ -157,7 +157,7 @@ function ChartCard({
   children: React.ReactNode;
 }) {
   return (
-    <Card>
+    <Card className="nx:min-w-0">
       <CardHeader>
         <CardTitle>{title}</CardTitle>
       </CardHeader>

--- a/apps/console/src/modules/crm/contact-card.tsx
+++ b/apps/console/src/modules/crm/contact-card.tsx
@@ -1,0 +1,33 @@
+import { Link } from '@tanstack/react-router';
+
+import { RecordCard } from '../../components/record-card';
+import type { Contact } from '../../lib/crm-api';
+import { formatCurrency, formatDate } from '../../lib/format';
+
+import { ContactStatusBadge } from './contact-ui';
+
+/** Mobile card for one contact — the `<lg` stand-in for a Contacts table row. */
+export function ContactCard({ contact }: { contact: Contact }) {
+  return (
+    <RecordCard
+      title={
+        <Link
+          to="/m/crm/$id"
+          params={{ id: contact.id }}
+          className="nx:text-foreground nx:font-medium nx:hover:underline"
+        >
+          {contact.name}
+        </Link>
+      }
+      badge={<ContactStatusBadge status={contact.status} />}
+    >
+      <p className="nx:truncate">
+        {contact.company} · {contact.owner}
+      </p>
+      <p className="nx:tabular-nums">
+        {formatCurrency(contact.value)} · Last:{' '}
+        {formatDate(contact.lastContacted)}
+      </p>
+    </RecordCard>
+  );
+}

--- a/apps/console/src/modules/crm/contacts-card-list.tsx
+++ b/apps/console/src/modules/crm/contacts-card-list.tsx
@@ -1,0 +1,46 @@
+import { DataPager } from '../../components/data-pager';
+import { FilterInput } from '../../components/filter-input';
+import { useFilterPaginate } from '../../hooks/use-filter-paginate';
+import type { Contact } from '../../lib/crm-api';
+
+import { ContactCard } from './contact-card';
+
+const searchContact = (contact: Contact) => contact.name;
+
+/**
+ * The Contacts table's `<lg` counterpart: one card per contact, with the same
+ * name filter + pagination as the desktop table (sort and bulk-select are
+ * desktop-only affordances). Receives the already status-filtered list.
+ */
+export function ContactCardList({ contacts }: { contacts: Contact[] }) {
+  const { query, setQuery, pageItems, total, page, pageCount, prev, next } =
+    useFilterPaginate(contacts, { search: searchContact });
+
+  return (
+    <div className="nx:space-y-4">
+      <FilterInput
+        value={query}
+        onChange={setQuery}
+        placeholder="Filter by name…"
+      />
+      {pageItems.length === 0 ? (
+        <p className="nx:text-muted-foreground nx:py-8 nx:text-center nx:text-sm">
+          No results.
+        </p>
+      ) : (
+        <ul className="nx:space-y-3">
+          {pageItems.map((contact) => (
+            <ContactCard key={contact.id} contact={contact} />
+          ))}
+        </ul>
+      )}
+      <DataPager
+        page={page}
+        pageCount={pageCount}
+        total={total}
+        onPrev={prev}
+        onNext={next}
+      />
+    </div>
+  );
+}

--- a/apps/console/src/modules/crm/contacts-route.tsx
+++ b/apps/console/src/modules/crm/contacts-route.tsx
@@ -15,10 +15,12 @@ import { getRouteApi } from '@tanstack/react-router';
 
 import { DataTable } from '../../components/data-table';
 import { ErrorState } from '../../components/error-state';
+import { useMediaQuery } from '../../hooks/use-media-query';
 import { crmKeys, fetchContacts } from '../../lib/crm-api';
 
 import { ContactFormSheet } from './contact-form-sheet';
 import { ContactsBoard } from './contacts-board';
+import { ContactCardList } from './contacts-card-list';
 import { contactColumns } from './contacts-columns';
 import type { ContactsView } from './contacts-search';
 import { ContactsToolbar } from './contacts-toolbar';
@@ -34,6 +36,15 @@ export function ContactsRoute() {
   const { view, status } = crmRoute.useSearch();
   const navigate = crmRoute.useNavigate();
   const [createOpen, setCreateOpen] = useState(false);
+  const isDesktop = useMediaQuery('(min-width: 64rem)');
+
+  // The status facet applies to the table / card list (board is organised by
+  // status, so it ignores the facet).
+  const tableData = contacts
+    ? status.length > 0
+      ? contacts.filter((c) => status.includes(c.status))
+      : contacts
+    : [];
 
   const setSearch = (patch: Partial<ContactsView>) =>
     navigate({
@@ -78,17 +89,15 @@ export function ContactsRoute() {
           <ContactsEmpty />
         ) : view === 'board' ? (
           <ContactsBoard contacts={contacts} />
-        ) : (
+        ) : isDesktop ? (
           <DataTable
             columns={contactColumns}
-            data={
-              status.length > 0
-                ? contacts.filter((c) => status.includes(c.status))
-                : contacts
-            }
+            data={tableData}
             filterColumn="name"
             filterPlaceholder="Filter by name…"
           />
+        ) : (
+          <ContactCardList contacts={tableData} />
         ))}
 
       <ContactFormSheet open={createOpen} onOpenChange={setCreateOpen} />

--- a/apps/console/src/modules/people/member-card.tsx
+++ b/apps/console/src/modules/people/member-card.tsx
@@ -1,0 +1,32 @@
+import { Link } from '@tanstack/react-router';
+
+import { RecordCard } from '../../components/record-card';
+import { formatDate } from '../../lib/format';
+import { type Member, ROLE_LABELS } from '../../lib/people-api';
+
+import { MemberStatusBadge } from './people-ui';
+
+/** Mobile card for one member — the `<lg` stand-in for a People table row. */
+export function MemberCard({ member }: { member: Member }) {
+  return (
+    <RecordCard
+      title={
+        <Link
+          to="/m/people/$id"
+          params={{ id: member.id }}
+          className="nx:text-foreground nx:font-medium nx:hover:underline"
+        >
+          {member.name}
+        </Link>
+      }
+      badge={<MemberStatusBadge status={member.status} />}
+    >
+      <p className="nx:truncate">
+        {member.title} · {member.department}
+      </p>
+      <p>
+        {ROLE_LABELS[member.role]} · Joined {formatDate(member.joinedAt)}
+      </p>
+    </RecordCard>
+  );
+}

--- a/apps/console/src/modules/people/people-card-list.tsx
+++ b/apps/console/src/modules/people/people-card-list.tsx
@@ -1,0 +1,46 @@
+import { DataPager } from '../../components/data-pager';
+import { FilterInput } from '../../components/filter-input';
+import { useFilterPaginate } from '../../hooks/use-filter-paginate';
+import type { Member } from '../../lib/people-api';
+
+import { MemberCard } from './member-card';
+
+const searchMember = (member: Member) => member.name;
+
+/**
+ * The People table's `<lg` counterpart: one card per member, with the same name
+ * filter + pagination as the desktop table (sort and bulk-select are
+ * desktop-only affordances). Receives the already facet-filtered list.
+ */
+export function MemberCardList({ members }: { members: Member[] }) {
+  const { query, setQuery, pageItems, total, page, pageCount, prev, next } =
+    useFilterPaginate(members, { search: searchMember });
+
+  return (
+    <div className="nx:space-y-4">
+      <FilterInput
+        value={query}
+        onChange={setQuery}
+        placeholder="Filter by name…"
+      />
+      {pageItems.length === 0 ? (
+        <p className="nx:text-muted-foreground nx:py-8 nx:text-center nx:text-sm">
+          No results.
+        </p>
+      ) : (
+        <ul className="nx:space-y-3">
+          {pageItems.map((member) => (
+            <MemberCard key={member.id} member={member} />
+          ))}
+        </ul>
+      )}
+      <DataPager
+        page={page}
+        pageCount={pageCount}
+        total={total}
+        onPrev={prev}
+        onNext={next}
+      />
+    </div>
+  );
+}

--- a/apps/console/src/modules/people/people-route.tsx
+++ b/apps/console/src/modules/people/people-route.tsx
@@ -15,9 +15,11 @@ import { getRouteApi } from '@tanstack/react-router';
 
 import { DataTable } from '../../components/data-table';
 import { ErrorState } from '../../components/error-state';
+import { useMediaQuery } from '../../hooks/use-media-query';
 import { fetchMembers, peopleKeys } from '../../lib/people-api';
 
 import { MemberFormSheet } from './member-form-sheet';
+import { MemberCardList } from './people-card-list';
 import { memberColumns } from './people-columns';
 import type { PeopleView } from './people-search';
 import { PeopleToolbar } from './people-toolbar';
@@ -33,6 +35,16 @@ export function PeopleRoute() {
   const { role, department, status } = peopleRoute.useSearch();
   const navigate = peopleRoute.useNavigate();
   const [inviteOpen, setInviteOpen] = useState(false);
+  const isDesktop = useMediaQuery('(min-width: 64rem)');
+
+  const tableData = members
+    ? members.filter(
+        (m) =>
+          (role.length === 0 || role.includes(m.role)) &&
+          (department.length === 0 || department.includes(m.department)) &&
+          (status.length === 0 || status.includes(m.status))
+      )
+    : [];
 
   const setSearch = (patch: Partial<PeopleView>) =>
     navigate({ search: (prev) => ({ ...prev, ...patch }) });
@@ -72,19 +84,15 @@ export function PeopleRoute() {
       {members &&
         (members.length === 0 ? (
           <PeopleEmpty />
-        ) : (
+        ) : isDesktop ? (
           <DataTable
             columns={memberColumns}
-            data={members.filter(
-              (m) =>
-                (role.length === 0 || role.includes(m.role)) &&
-                (department.length === 0 ||
-                  department.includes(m.department)) &&
-                (status.length === 0 || status.includes(m.status))
-            )}
+            data={tableData}
             filterColumn="name"
             filterPlaceholder="Filter by name…"
           />
+        ) : (
+          <MemberCardList members={tableData} />
         ))}
 
       <MemberFormSheet open={inviteOpen} onOpenChange={setInviteOpen} />

--- a/apps/console/src/modules/projects/issue-card.tsx
+++ b/apps/console/src/modules/projects/issue-card.tsx
@@ -1,0 +1,36 @@
+import { Link } from '@tanstack/react-router';
+
+import { RecordCard } from '../../components/record-card';
+import { formatDate } from '../../lib/format';
+import type { Issue } from '../../lib/projects-api';
+
+import { IssuePriorityBadge, IssueStatusBadge } from './issue-ui';
+
+/** Mobile card for one issue — the `<lg` stand-in for an Issues table row. */
+export function IssueCard({ issue }: { issue: Issue }) {
+  return (
+    <RecordCard
+      title={
+        <Link
+          to="/m/projects/$id"
+          params={{ id: issue.id }}
+          className="nx:hover:underline"
+        >
+          <span className="nx:text-muted-foreground nx:text-sm nx:tabular-nums">
+            {issue.key}
+          </span>{' '}
+          <span className="nx:text-foreground nx:font-medium">
+            {issue.title}
+          </span>
+        </Link>
+      }
+      badge={<IssueStatusBadge status={issue.status} />}
+    >
+      <div className="nx:flex nx:items-center nx:gap-2">
+        <IssuePriorityBadge priority={issue.priority} />
+        <span>{issue.assignee}</span>
+      </div>
+      <p>Updated {formatDate(issue.updatedAt)}</p>
+    </RecordCard>
+  );
+}

--- a/apps/console/src/modules/projects/issues-card-list.tsx
+++ b/apps/console/src/modules/projects/issues-card-list.tsx
@@ -1,0 +1,46 @@
+import { DataPager } from '../../components/data-pager';
+import { FilterInput } from '../../components/filter-input';
+import { useFilterPaginate } from '../../hooks/use-filter-paginate';
+import type { Issue } from '../../lib/projects-api';
+
+import { IssueCard } from './issue-card';
+
+const searchIssue = (issue: Issue) => `${issue.key} ${issue.title}`;
+
+/**
+ * The Issues table's `<lg` counterpart: one card per issue, filterable by key or
+ * title and paginated like the desktop table (sort and bulk-select are
+ * desktop-only affordances).
+ */
+export function IssueCardList({ issues }: { issues: Issue[] }) {
+  const { query, setQuery, pageItems, total, page, pageCount, prev, next } =
+    useFilterPaginate(issues, { search: searchIssue });
+
+  return (
+    <div className="nx:space-y-4">
+      <FilterInput
+        value={query}
+        onChange={setQuery}
+        placeholder="Filter by title…"
+      />
+      {pageItems.length === 0 ? (
+        <p className="nx:text-muted-foreground nx:py-8 nx:text-center nx:text-sm">
+          No results.
+        </p>
+      ) : (
+        <ul className="nx:space-y-3">
+          {pageItems.map((issue) => (
+            <IssueCard key={issue.id} issue={issue} />
+          ))}
+        </ul>
+      )}
+      <DataPager
+        page={page}
+        pageCount={pageCount}
+        total={total}
+        onPrev={prev}
+        onNext={next}
+      />
+    </div>
+  );
+}

--- a/apps/console/src/modules/projects/issues-card-list.tsx
+++ b/apps/console/src/modules/projects/issues-card-list.tsx
@@ -5,7 +5,9 @@ import type { Issue } from '../../lib/projects-api';
 
 import { IssueCard } from './issue-card';
 
-const searchIssue = (issue: Issue) => `${issue.key} ${issue.title}`;
+// Title-only, matching the desktop table's `filterColumn="title"` + the
+// "Filter by title…" placeholder — so the two views filter identically.
+const searchIssue = (issue: Issue) => issue.title;
 
 /**
  * The Issues table's `<lg` counterpart: one card per issue, filterable by key or

--- a/apps/console/src/modules/projects/issues-route.tsx
+++ b/apps/console/src/modules/projects/issues-route.tsx
@@ -14,9 +14,11 @@ import { useQuery } from '@tanstack/react-query';
 
 import { DataTable } from '../../components/data-table';
 import { ErrorState } from '../../components/error-state';
+import { useMediaQuery } from '../../hooks/use-media-query';
 import { fetchIssues, projectKeys } from '../../lib/projects-api';
 
 import { IssueFormSheet } from './issue-form-sheet';
+import { IssueCardList } from './issues-card-list';
 import { issueColumns } from './issues-columns';
 
 export function IssuesRoute() {
@@ -26,6 +28,7 @@ export function IssuesRoute() {
   });
   const issues = data?.issues;
   const [createOpen, setCreateOpen] = useState(false);
+  const isDesktop = useMediaQuery('(min-width: 64rem)');
 
   return (
     <div className="nx:space-y-6 nx:p-6">
@@ -56,13 +59,15 @@ export function IssuesRoute() {
       {issues &&
         (issues.length === 0 ? (
           <IssuesEmpty />
-        ) : (
+        ) : isDesktop ? (
           <DataTable
             columns={issueColumns}
             data={issues}
             filterColumn="title"
             filterPlaceholder="Filter by title…"
           />
+        ) : (
+          <IssueCardList issues={issues} />
         ))}
 
       <IssueFormSheet open={createOpen} onOpenChange={setCreateOpen} />

--- a/packages/react/src/components/ui/sidebar.tsx
+++ b/packages/react/src/components/ui/sidebar.tsx
@@ -449,14 +449,16 @@ interface SidebarInsetProps extends React.ComponentProps<'main'> {}
  * SidebarInset
  *
  * The main content region beside the sidebar. With `variant="inset"` it floats
- * as a rounded card; otherwise it fills the remaining width.
+ * as a rounded card; otherwise it fills the remaining width. `min-w-0` lets a
+ * wide child (e.g. a data table) scroll inside its own container instead of
+ * forcing the inset — and the page — wider than the viewport.
  */
 function SidebarInset({ className, ...props }: SidebarInsetProps) {
   return (
     <main
       data-slot="sidebar-inset"
       className={cn(
-        'nx:relative nx:flex nx:w-full nx:flex-1 nx:flex-col nx:bg-background',
+        'nx:relative nx:flex nx:w-full nx:min-w-0 nx:flex-1 nx:flex-col nx:bg-background',
         'nx:lg:peer-data-[variant=inset]:m-2 nx:lg:peer-data-[variant=inset]:ml-0 nx:lg:peer-data-[variant=inset]:rounded-xl nx:lg:peer-data-[variant=inset]:shadow-sm nx:lg:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
         className
       )}


### PR DESCRIPTION
## Summary

Phase 4 responsive sweep for the Atlas console. An empirical **390 / 768 / 1280** survey found the app shell (sidebar → drawer below `lg`), detail routes, the Inbox split, and form Sheets already responsive; the real gaps were the data tables and two horizontal overflows.

- **Mobile card layout (CRM, Projects, People).** Below `lg`, each data-table row renders as a stacked card (`useMediaQuery('(min-width: 64rem)')`); the desktop table is unchanged at `≥lg`. Cards read **raw row data** — not the table's `<td>` cell renderers (which would look wrong / nest interactives) — and keep a name/title filter + pagination; sort and bulk-select stay desktop-only. New shared atoms: `useFilterPaginate`, `DataPager`, `FilterInput`, `RecordCard`, plus one `{Type}Card` + `{Type}CardList` per module.
- **Analytics chart overflow.** `min-w-0` on the chart `Card` (grid item) **and** the `ChartContainer` (its recharts flex child) — the two `min-width:auto` layers that kept the chart from shrinking (536px → 390px at a 390px viewport).
- **Shell `SidebarInset` overflow (pre-existing).** `min-w-0` so a wide table (Projects' 8 columns) scrolls inside its own `table-container` instead of pushing the page ~30px past the viewport at desktop widths.

Part of the Atlas roadmap — `docs/plans/atlas-company-os.md` (Phase 4, cross-cutting).

## Test Plan

- [x] `yarn workspace @nexus/console typecheck` — clean
- [x] `eslint` + `prettier` on all touched files — clean
- [x] **390px:** CRM / Projects / People render cards, no page overflow; filter narrows + pager pages (Next → page 2; `"wei"` → 1 result, resets to page 1); analytics no longer overflows
- [x] **1280px:** all three render the table, no overflow; Projects' wide table now scrolls inside its container
- [x] Detail routes + an open "New contact" Sheet remain overflow-free at 390px

🤖 Generated with [Claude Code](https://claude.com/claude-code)