### PR TITLE
fix(auth): add browser semantics to auth forms

### DIFF
--- a/apps/console/src/modules/auth/forgot-route.tsx
+++ b/apps/console/src/modules/auth/forgot-route.tsx
@@ -80,7 +80,10 @@ export function ForgotRoute() {
                   <FormControl>
                     <Input
                       type="email"
+                      autoComplete="username"
+                      enterKeyHint="send"
                       placeholder="you@example.com"
+                      required
                       {...field}
                     />
                   </FormControl>

--- a/apps/console/src/modules/auth/login-route.tsx
+++ b/apps/console/src/modules/auth/login-route.tsx
@@ -75,7 +75,10 @@ export function LoginRoute() {
                   <FormControl>
                     <Input
                       type="email"
+                      autoComplete="username"
+                      enterKeyHint="next"
                       placeholder="you@example.com"
+                      required
                       {...field}
                     />
                   </FormControl>
@@ -98,7 +101,14 @@ export function LoginRoute() {
                     </Link>
                   </div>
                   <FormControl>
-                    <Input type="password" placeholder="••••••••" {...field} />
+                    <Input
+                      type="password"
+                      autoComplete="current-password"
+                      enterKeyHint="go"
+                      placeholder="••••••••"
+                      required
+                      {...field}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/apps/console/src/modules/auth/signup-route.tsx
+++ b/apps/console/src/modules/auth/signup-route.tsx
@@ -74,7 +74,14 @@ export function SignupRoute() {
                 <FormItem>
                   <FormLabel>Name</FormLabel>
                   <FormControl>
-                    <Input placeholder="Ada Lovelace" {...field} />
+                    <Input
+                      type="text"
+                      autoComplete="name"
+                      enterKeyHint="next"
+                      placeholder="Ada Lovelace"
+                      required
+                      {...field}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -89,7 +96,10 @@ export function SignupRoute() {
                   <FormControl>
                     <Input
                       type="email"
+                      autoComplete="username"
+                      enterKeyHint="next"
                       placeholder="you@example.com"
+                      required
                       {...field}
                     />
                   </FormControl>
@@ -104,7 +114,14 @@ export function SignupRoute() {
                 <FormItem>
                   <FormLabel>Password</FormLabel>
                   <FormControl>
-                    <Input type="password" placeholder="••••••••" {...field} />
+                    <Input
+                      type="password"
+                      autoComplete="new-password"
+                      enterKeyHint="go"
+                      placeholder="••••••••"
+                      required
+                      {...field}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>


### PR DESCRIPTION
## Summary
- add autofill tokens to login, signup, and forgot password auth fields
- add required semantics and mobile enter key hints while keeping RHF/Zod validation with noValidate
- keep the OTP-oriented login submit copy as Continue

## GitHub Issue
Closes #389

## Test Plan
- [x] yarn workspace @nexus/react build
- [x] yarn workspace @nexus/console typecheck
- [x] yarn lint
- [x] yarn audit:browser-support
- [x] Browser DOM inspection for /login, /signup, and /forgot confirmed expected name, type, autocomplete, required, and enterkeyhint attributes