### PR TITLE
fix(react): align form error announcements

### DIFF
--- a/packages/react/src/components/ui/Field.stories.tsx
+++ b/packages/react/src/components/ui/Field.stories.tsx
@@ -89,11 +89,36 @@ export const WithError: Story = {
     <div className="nx:w-80">
       <Field data-invalid="true">
         <FieldLabel htmlFor="field-err">Password</FieldLabel>
-        <Input id="field-err" type="password" aria-invalid />
-        <FieldError errors={[{ message: 'Must be at least 8 characters.' }]} />
+        <Input
+          id="field-err"
+          type="password"
+          aria-describedby="field-err-help"
+          aria-errormessage="field-err-message"
+          aria-invalid
+        />
+        <FieldDescription id="field-err-help">
+          Use a memorable passphrase.
+        </FieldDescription>
+        <FieldError
+          id="field-err-message"
+          errors={[{ message: 'Must be at least 8 characters.' }]}
+        />
       </Field>
     </div>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Password');
+    const error = canvas.getByText('Must be at least 8 characters.');
+
+    await expect(input).toHaveAttribute('aria-invalid', 'true');
+    await expect(input).toHaveAttribute('aria-describedby', 'field-err-help');
+    await expect(input).toHaveAttribute(
+      'aria-errormessage',
+      error.getAttribute('id')
+    );
+    await expect(error).toHaveAttribute('role', 'alert');
+  },
 };
 
 // A divider between groups of fields, with centered content.

--- a/packages/react/src/components/ui/Form.stories.tsx
+++ b/packages/react/src/components/ui/Form.stories.tsx
@@ -81,7 +81,7 @@ function SignUpForm({
 /**
  * A single-field form with no resolver — the simplest possible composition.
  */
-function UsernameForm() {
+function UsernameForm({ extraDescriptionId }: { extraDescriptionId?: string }) {
   const form = useForm<{ username: string }>({
     defaultValues: { username: '' },
   });
@@ -95,7 +95,7 @@ function UsernameForm() {
           render={({ field }) => (
             <FormItem>
               <FormLabel>Username</FormLabel>
-              <FormControl>
+              <FormControl aria-describedby={extraDescriptionId}>
                 <Input placeholder="janedoe" {...field} />
               </FormControl>
               <FormDescription>Your public display name.</FormDescription>
@@ -234,6 +234,13 @@ export const ShowErrors: Story = {
   render: (args) => <SignUpForm onSubmit={args.onSubmit} />,
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
+    const username = canvas.getByLabelText('Username');
+    const usernameDescription = canvas.getByText('Your public display name.');
+
+    await expect(
+      canvas.queryByText('Username must be at least 2 characters')
+    ).not.toBeInTheDocument();
+    await expect(username).not.toHaveAttribute('aria-errormessage');
 
     // Submit with empty fields — the resolver should surface messages.
     await userEvent.click(
@@ -246,9 +253,41 @@ export const ShowErrors: Story = {
       ).toBeInTheDocument()
     );
 
-    const username = canvas.getByLabelText('Username');
+    const usernameMessage = canvas.getByText(
+      'Username must be at least 2 characters'
+    );
     await expect(username).toHaveAttribute('aria-invalid', 'true');
+    await expect(username).toHaveAttribute(
+      'aria-describedby',
+      usernameDescription.getAttribute('id')
+    );
+    await expect(username).toHaveAttribute(
+      'aria-errormessage',
+      usernameMessage.getAttribute('id')
+    );
+    await expect(usernameMessage).toHaveAttribute('role', 'alert');
     await expect(args.onSubmit).not.toHaveBeenCalled();
+  },
+};
+
+export const WithMergedDescription: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-[360px] nx:flex-col nx:gap-2">
+      <p id="username-extra-description" className="nx:text-sm">
+        Use letters, numbers, and underscores.
+      </p>
+      <UsernameForm extraDescriptionId="username-extra-description" />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Username');
+    const description = canvas.getByText('Your public display name.');
+
+    await expect(input).toHaveAttribute(
+      'aria-describedby',
+      `${description.getAttribute('id')} username-extra-description`
+    );
   },
 };
 
@@ -263,13 +302,14 @@ export const WithDataAttributes: Story = {
     const description = canvas.getByText('Your public display name.');
     await expect(description).toHaveAttribute('data-slot', 'form-description');
 
-    // FormControl wires the control's id + aria-describedby to the FormItem.
+    // FormControl wires the control's id + helper description to the FormItem.
     const input = canvas.getByLabelText('Username');
     await expect(input).toHaveAttribute('id', label.getAttribute('for'));
     await expect(input).toHaveAttribute(
       'aria-describedby',
       description.getAttribute('id')
     );
+    await expect(input).not.toHaveAttribute('aria-errormessage');
 
     await expect(
       canvasElement.querySelector('[data-slot="form-item"]')

--- a/packages/react/src/components/ui/Form.stories.tsx
+++ b/packages/react/src/components/ui/Form.stories.tsx
@@ -108,6 +108,39 @@ function UsernameForm({ extraDescriptionId }: { extraDescriptionId?: string }) {
   );
 }
 
+function MessageLessErrorForm() {
+  const form = useForm<{ code: string }>({
+    defaultValues: { code: '' },
+  });
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(() => undefined)}
+        className="nx:w-[360px]"
+      >
+        <FormField
+          control={form.control}
+          name="code"
+          rules={{ required: true }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Invite code</FormLabel>
+              <FormControl>
+                <Input placeholder="NX-123" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="nx:mt-4">
+          Redeem code
+        </Button>
+      </form>
+    </Form>
+  );
+}
+
 /**
  * Showcase of the field anatomy across its resting configurations: a full
  * field, a label-plus-control field, and a disabled control. Every field keeps
@@ -288,6 +321,22 @@ export const WithMergedDescription: Story = {
       'aria-describedby',
       `${description.getAttribute('id')} username-extra-description`
     );
+  },
+};
+
+export const WithoutErrorMessage: Story = {
+  render: () => <MessageLessErrorForm />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByLabelText('Invite code');
+
+    await userEvent.click(canvas.getByRole('button', { name: /redeem code/i }));
+
+    await waitFor(() => expect(input).toHaveAttribute('aria-invalid', 'true'));
+    await expect(input).not.toHaveAttribute('aria-errormessage');
+    await expect(
+      canvasElement.querySelector('[data-slot="form-message"]')
+    ).toHaveAttribute('role', 'alert');
   },
 };
 

--- a/packages/react/src/components/ui/field.tsx
+++ b/packages/react/src/components/ui/field.tsx
@@ -320,6 +320,7 @@ function FieldError({
   return (
     <div
       role="alert"
+      aria-atomic="true"
       data-slot="field-error"
       className={cn(
         'nx:text-sm nx:font-normal nx:text-error-subtle-foreground',

--- a/packages/react/src/components/ui/form.tsx
+++ b/packages/react/src/components/ui/form.tsx
@@ -212,6 +212,7 @@ function FormControl({
     hasDescription,
     hasMessage,
   } = useFormField();
+  const hasErrorMessage = Boolean(error?.message);
   const describedBy =
     [hasDescription ? formDescriptionId : undefined, ariaDescribedBy]
       .filter(Boolean)
@@ -224,7 +225,9 @@ function FormControl({
       id={formItemId}
       aria-describedby={describedBy}
       aria-invalid={!!error}
-      aria-errormessage={error && hasMessage ? formMessageId : undefined}
+      aria-errormessage={
+        hasErrorMessage && hasMessage ? formMessageId : undefined
+      }
     />
   );
 }

--- a/packages/react/src/components/ui/form.tsx
+++ b/packages/react/src/components/ui/form.tsx
@@ -62,6 +62,8 @@ const FormFieldContext = React.createContext<FormFieldContextValue | null>(
 
 type FormItemContextValue = {
   id: string;
+  hasDescription: boolean;
+  hasMessage: boolean;
 };
 
 const FormItemContext = React.createContext<FormItemContextValue | null>(null);
@@ -94,7 +96,10 @@ function useFormField() {
   const fieldContext = React.useContext(FormFieldContext);
   const itemContext = React.useContext(FormItemContext);
   const formContext = useFormContext();
-  const formState = useFormState({ name: fieldContext?.name });
+  const formState = useFormState({
+    name: fieldContext?.name,
+    exact: true,
+  });
 
   if (!fieldContext) {
     throw new Error('useFormField should be used within <FormField>');
@@ -108,7 +113,7 @@ function useFormField() {
   const fieldState = getFieldState(fieldContext.name, formState);
 
   return {
-    id,
+    ...itemContext,
     name: fieldContext.name,
     formItemId: `${id}-form-item`,
     formDescriptionId: `${id}-form-item-description`,
@@ -130,11 +135,12 @@ interface FormItemProps extends React.ComponentProps<'div'> {}
  * Groups one field's label, control, description, and message, and generates
  * the shared `id` that wires them together.
  */
-function FormItem({ className, ...props }: FormItemProps) {
+function FormItem({ className, children, ...props }: FormItemProps) {
   const id = React.useId();
+  const { hasDescription, hasMessage } = getFormItemParts(children);
 
   return (
-    <FormItemContext.Provider value={{ id }}>
+    <FormItemContext.Provider value={{ id, hasDescription, hasMessage }}>
       <div
         data-slot="form-item"
         className={cn(
@@ -143,7 +149,9 @@ function FormItem({ className, ...props }: FormItemProps) {
           className
         )}
         {...props}
-      />
+      >
+        {children}
+      </div>
     </FormItemContext.Provider>
   );
 }
@@ -189,22 +197,34 @@ interface FormControlProps extends React.ComponentProps<typeof Slot> {}
  * FormControl
  *
  * Slot that wires the field's control to the surrounding `FormItem` — setting
- * its `id`, `aria-invalid`, and `aria-describedby` (pointing at the description
- * and, when invalid, the message).
+ * its `id`, `aria-invalid`, `aria-describedby` (helper text only), and
+ * `aria-errormessage` when invalid.
  */
-function FormControl(props: FormControlProps) {
-  const { error, formItemId, formDescriptionId, formMessageId } =
-    useFormField();
+function FormControl({
+  'aria-describedby': ariaDescribedBy,
+  ...props
+}: FormControlProps) {
+  const {
+    error,
+    formItemId,
+    formDescriptionId,
+    formMessageId,
+    hasDescription,
+    hasMessage,
+  } = useFormField();
+  const describedBy =
+    [hasDescription ? formDescriptionId : undefined, ariaDescribedBy]
+      .filter(Boolean)
+      .join(' ') || undefined;
 
   return (
     <Slot
+      {...props}
       data-slot="form-control"
       id={formItemId}
-      aria-describedby={
-        error ? `${formDescriptionId} ${formMessageId}` : formDescriptionId
-      }
+      aria-describedby={describedBy}
       aria-invalid={!!error}
-      {...props}
+      aria-errormessage={error && hasMessage ? formMessageId : undefined}
     />
   );
 }
@@ -226,10 +246,10 @@ function FormDescription({ className, ...props }: FormDescriptionProps) {
 
   return (
     <p
+      {...props}
       data-slot="form-description"
       id={formDescriptionId}
       className={cn('nx:text-sm nx:text-muted-foreground', className)}
-      {...props}
     />
   );
 }
@@ -244,27 +264,60 @@ interface FormMessageProps extends React.ComponentProps<'p'> {}
 /**
  * FormMessage
  *
- * Validation message for the field. Renders the field's error message, falling
- * back to its `children`, and renders nothing when there is neither.
+ * Validation message for the field. Renders a stable alert region so new
+ * validation text is announced when the field becomes invalid.
  */
-function FormMessage({ className, children, ...props }: FormMessageProps) {
+function FormMessage({
+  className,
+  children,
+  role,
+  ...props
+}: FormMessageProps) {
   const { error, formMessageId } = useFormField();
   const body = error ? String(error.message ?? '') : children;
 
-  if (!body) {
-    return null;
-  }
-
   return (
     <p
+      {...props}
+      role={role ?? 'alert'}
+      aria-atomic="true"
       data-slot="form-message"
       id={formMessageId}
       className={cn('nx:text-sm nx:text-error-subtle-foreground', className)}
-      {...props}
     >
       {body}
     </p>
   );
+}
+
+function getFormItemParts(children: React.ReactNode) {
+  let hasDescription = false;
+  let hasMessage = false;
+
+  React.Children.forEach(children, (child) => {
+    if (!React.isValidElement(child)) {
+      return;
+    }
+
+    if (child.type === React.Fragment) {
+      const fragment = child as React.ReactElement<{
+        children?: React.ReactNode;
+      }>;
+      const parts = getFormItemParts(fragment.props.children);
+      hasDescription ||= parts.hasDescription;
+      hasMessage ||= parts.hasMessage;
+      return;
+    }
+
+    if (child.type === FormDescription) {
+      hasDescription = true;
+    }
+    if (child.type === FormMessage) {
+      hasMessage = true;
+    }
+  });
+
+  return { hasDescription, hasMessage };
 }
 
 export {


### PR DESCRIPTION
## Summary

- Split RHF form helper text and validation errors across `aria-describedby` and `aria-errormessage`.
- Render `FormMessage` as a stable alert region and align `FieldError` with explicit atomic alert behavior.
- Add Storybook coverage for invalid wiring, merged helper descriptions, standalone field errors, and message-less RHF errors.

## GitHub Issue

Closes #390

## Test Plan

- [x] `yarn workspace @nexus/react audit:storybook-coverage --component form`
- [x] `yarn workspace @nexus/react audit:storybook-coverage --component field`
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test:storybook`
