### PR TITLE
feat(console): theme quick-control in the topbar (Phase 5a)

### DIFF
--- a/apps/console/src/shell/theme-quick-control.tsx
+++ b/apps/console/src/shell/theme-quick-control.tsx
@@ -41,9 +41,8 @@ function SwatchRow<T extends string>({
               aria-label={`${label}: ${opt.label}`}
               aria-pressed={active}
               title={opt.label}
-              className="nx:hover:bg-background-hover nx:focus-visible:outline-focus-default nx:flex nx:size-9 nx:items-center nx:justify-center nx:rounded-full nx:transition-colors nx:focus-visible:outline-2 nx:focus-visible:outline-offset-2"
+              className="nx:hover:bg-background-hover nx:focus-visible:outline-focus-default nx:relative nx:flex nx:size-9 nx:items-center nx:justify-center nx:rounded-full nx:transition-colors nx:after:absolute nx:after:-inset-1 nx:focus-visible:outline-2 nx:focus-visible:outline-offset-(--focus-offset)"
             >
-              {/* Border stays 2px (color-only change) so selecting never shifts layout. */}
               <span
                 className={cn(
                   'nx:size-5 nx:rounded-full nx:border-2 nx:transition-colors',
@@ -83,7 +82,7 @@ export function ThemeQuickControl() {
           <IconPalette />
         </Button>
       </PopoverTrigger>
-      <PopoverContent align="end" className="nx:w-64 nx:space-y-3">
+      <PopoverContent align="end" className="nx:w-72 nx:space-y-3">
         <SwatchRow
           label="Base"
           value={theme.base}

--- a/apps/console/src/shell/theme-quick-control.tsx
+++ b/apps/console/src/shell/theme-quick-control.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+
+import {
+  Button,
+  cn,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Separator,
+} from '@nexus/react';
+import { IconPalette } from '@tabler/icons-react';
+import { useNavigate } from '@tanstack/react-router';
+
+import { useThemeContext } from '../app/theme-provider';
+import { BASES, BRANDS } from '../hooks/useTheme';
+
+function SwatchRow<T extends string>({
+  label,
+  value,
+  options,
+  onSelect,
+}: {
+  label: string;
+  value: T;
+  options: readonly { value: T; label: string; color: string }[];
+  onSelect: (value: T) => void;
+}) {
+  return (
+    <div className="nx:space-y-1.5">
+      <p className="nx:typography-label-small nx:text-muted-foreground">
+        {label}
+      </p>
+      <div className="nx:flex nx:flex-wrap nx:gap-1">
+        {options.map((opt) => {
+          const active = opt.value === value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => onSelect(opt.value)}
+              aria-label={`${label}: ${opt.label}`}
+              aria-pressed={active}
+              title={opt.label}
+              className="nx:hover:bg-background-hover nx:focus-visible:outline-focus-default nx:flex nx:size-9 nx:items-center nx:justify-center nx:rounded-full nx:transition-colors nx:focus-visible:outline-2 nx:focus-visible:outline-offset-2"
+            >
+              {/* Border stays 2px (color-only change) so selecting never shifts layout. */}
+              <span
+                className={cn(
+                  'nx:size-5 nx:rounded-full nx:border-2 nx:transition-colors',
+                  active ? 'nx:border-foreground' : 'nx:border-border-default'
+                )}
+                style={{ backgroundColor: opt.color }}
+              />
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Topbar theme quick-control — a Popover to flip the app's base + brand palette
+ * from anywhere, turning the live re-theme engine into an instant demo (every
+ * surface re-themes on click, the popover included). Dark mode stays a one-click
+ * topbar button; the full token axes live behind "Customize…" (Appearance).
+ */
+export function ThemeQuickControl() {
+  const { theme, setTheme } = useThemeContext();
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+
+  // Close the popover before navigating so it doesn't linger over Appearance.
+  const openAppearance = () => {
+    setOpen(false);
+    navigate({ to: '/design/appearance' });
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="sm" aria-label="Theme">
+          <IconPalette />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="nx:w-64 nx:space-y-3">
+        <SwatchRow
+          label="Base"
+          value={theme.base}
+          options={BASES}
+          onSelect={(base) => setTheme((t) => ({ ...t, base }))}
+        />
+        <SwatchRow
+          label="Brand"
+          value={theme.brand}
+          options={BRANDS}
+          onSelect={(brand) => setTheme((t) => ({ ...t, brand }))}
+        />
+        <Separator />
+        <Button
+          variant="ghost"
+          size="sm"
+          className="nx:w-full nx:justify-start"
+          onClick={openAppearance}
+        >
+          Customize…
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/console/src/shell/topbar.tsx
+++ b/apps/console/src/shell/topbar.tsx
@@ -4,6 +4,7 @@ import { IconMoon, IconSearch, IconSun } from '@tabler/icons-react';
 import { useThemeContext } from '../app/theme-provider';
 
 import { NotificationsMenu } from './notifications-menu';
+import { ThemeQuickControl } from './theme-quick-control';
 
 interface TopbarProps {
   /** Opens the ⌘K command palette — fired by the search button. */
@@ -38,6 +39,8 @@ export function Topbar({ onSearchClick }: TopbarProps) {
       <div className="nx:flex-1" />
 
       <NotificationsMenu />
+
+      <ThemeQuickControl />
 
       <Button
         variant="ghost"

--- a/apps/console/src/shell/topbar.tsx
+++ b/apps/console/src/shell/topbar.tsx
@@ -13,8 +13,8 @@ interface TopbarProps {
 
 /**
  * App-shell top bar: sidebar toggle, the ⌘K search button that opens the
- * command palette, the notifications bell, and a dark-mode quick-toggle wired
- * to the root theme.
+ * command palette, the notifications bell, the theme quick-control, and a
+ * dark-mode quick-toggle wired to the root theme.
  */
 export function Topbar({ onSearchClick }: TopbarProps) {
   const { theme, setTheme } = useThemeContext();


### PR DESCRIPTION
## Summary

First slice of **Phase 5 (polish + theme proof)**. The console's re-theme engine already flips all 8 axes live — but flipping base/brand meant digging into `/design/appearance`. This adds a **topbar palette button → Popover** to flip the app's base + brand from anywhere via clickable color swatches, turning the live engine into an instant demo: every surface re-themes on click and the choice persists.

- `shell/theme-quick-control.tsx` — `Popover` (palette icon) with a **Base** row (5 swatches) + **Brand** row (6 swatches); active swatch marked via `aria-pressed` + a foreground ring. A `Separator` then **"Customize…"** closes the popover and routes to `/design/appearance` for the full token axes.
- Dark mode stays the existing one-click topbar toggle (no redundancy in the popover).
- Dogfoods `@nexus/react` `Popover` / `Button` / `Separator`; reuses the `BASES` / `BRANDS` configs + `useThemeContext` from the theme engine — no new theming logic.

## Test Plan

- [x] `yarn workspace @nexus/console typecheck` + `eslint` — clean
- [x] Browser (`:5180`, 1280): palette opens; **clicking the Purple brand swatch re-themed the whole app live** (primary token blue→purple, the "New contact" button followed) and persisted to `nexus-console-theme`
- [x] Base (5) + Brand (6) swatches render; active swatch reflects current theme
- [x] "Customize…" navigates to `/design/appearance` **and** closes the popover
- [x] Semantic status badges (LEAD = information) correctly stay their own color, not the brand

🤖 Generated with [Claude Code](https://claude.com/claude-code)