### PR TITLE
feat(console): brand the single-series hero charts (Phase 5b)

### DIFF
--- a/apps/console/src/modules/analytics/analytics-charts.tsx
+++ b/apps/console/src/modules/analytics/analytics-charts.tsx
@@ -24,8 +24,12 @@ import type { TrendPoint } from '../../lib/analytics-api';
 // dashboard chart is the same height regardless of its grid column's width.
 const CHART_BOX = 'nx:h-[260px] nx:w-full nx:min-w-0';
 
+// Single-series "hero" charts (Revenue, Sessions) colour their one series with
+// the brand/primary token, so flipping the brand re-colours them. Multi-series
+// charts (Audience) keep the categorical palette — distinct, brand-independent
+// hues so a series never reads as a status colour (tokens.md).
 const revenueConfig = {
-  revenue: { label: 'Revenue', color: 'var(--nx-color-chart-categorical-1)' },
+  revenue: { label: 'Revenue', color: 'var(--nx-color-primary-background)' },
 } satisfies ChartConfig;
 
 /** Revenue over the period — the hero metric. Single series, so no legend. */
@@ -102,7 +106,7 @@ export function AudienceChart({ data }: { data: TrendPoint[] }) {
 }
 
 const sessionsConfig = {
-  sessions: { label: 'Sessions', color: 'var(--nx-color-chart-categorical-4)' },
+  sessions: { label: 'Sessions', color: 'var(--nx-color-primary-background)' },
 } satisfies ChartConfig;
 
 /** Session volume trend. Single series, so no legend. */

--- a/apps/console/src/modules/analytics/analytics-charts.tsx
+++ b/apps/console/src/modules/analytics/analytics-charts.tsx
@@ -24,10 +24,7 @@ import type { TrendPoint } from '../../lib/analytics-api';
 // dashboard chart is the same height regardless of its grid column's width.
 const CHART_BOX = 'nx:h-[260px] nx:w-full nx:min-w-0';
 
-// Single-series "hero" charts (Revenue, Sessions) colour their one series with
-// the brand/primary token, so flipping the brand re-colours them. Multi-series
-// charts (Audience) keep the categorical palette — distinct, brand-independent
-// hues so a series never reads as a status colour (tokens.md).
+// Single-series hero charts use the brand token; multi-series keep categorical.
 const revenueConfig = {
   revenue: { label: 'Revenue', color: 'var(--nx-color-primary-background)' },
 } satisfies ChartConfig;


### PR DESCRIPTION
## Summary

Phase 5b. While verifying "charts re-theme," I found the categorical chart palette is a **deliberately fixed, brand-independent** set (`tokens.md` — distinct hues so a series never reads as a status colour), and charts already adapt to dark (the palette CSS has `html.dark`) + their chrome to base. So "re-theme the whole palette with brand" would *contradict* the token design.

The design-respecting win instead: **single-series "hero" charts adopt the brand**.

- `RevenueChart` (area) + `SessionsChart` (line) — single series — now colour with `var(--nx-color-primary-background)` instead of `chart-categorical-1`/`-4`. Flipping the brand re-colours them live, so the theme-proof demo (5a's palette → flip brand) now visibly reaches the charts.
- `AudienceChart` (new vs returning — two series) keeps the categorical palette: distinct, brand-independent hues are the point for multi-series.

The categorical token set is untouched and stays fixed.

## Test Plan

- [x] `typecheck` + `eslint` — clean
- [x] Browser (`:5180`): with brand=purple, Revenue area + Sessions line resolve to the primary token; Audience bars resolve to `chart-categorical-2`. **Flipping brand purple→blue via the 5a palette** re-coloured Revenue + Sessions to blue while Audience stayed categorical lime (verified by computed `fill`/`stroke` + screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)