### PR TITLE
fix(console): app-level a11y sweep (Phase 5d)

### DIFF
--- a/apps/console/src/app/root-layout.tsx
+++ b/apps/console/src/app/root-layout.tsx
@@ -34,12 +34,14 @@ export function RootLayout() {
       <AppSidebar />
       <SidebarInset>
         <Topbar onSearchClick={() => setCommandOpen(true)} />
-        {/* nx:text-foreground re-establishes the adaptive base text color for
+        {/* SidebarInset already provides the <main> landmark, so this is a
+            plain <div> (a second <main> trips axe landmark rules).
+            nx:text-foreground re-establishes the adaptive base text color for
             module content — without it, reused content that relies on inherited
             foreground (e.g. the typography showcase) renders black in dark mode. */}
-        <main className="nx:text-foreground nx:min-w-0 nx:flex-1">
+        <div className="nx:text-foreground nx:min-w-0 nx:flex-1">
           <Outlet />
-        </main>
+        </div>
       </SidebarInset>
       <CommandPalette open={commandOpen} onOpenChange={setCommandOpen} />
     </SidebarProvider>

--- a/apps/console/src/modules/coming-soon.tsx
+++ b/apps/console/src/modules/coming-soon.tsx
@@ -24,6 +24,8 @@ export function ComingSoon() {
 
   return (
     <EmptyState className="nx:min-h-[60svh]">
+      {/* The page's h1 — the visible title is EmptyStateTitle, not a heading. */}
+      <h1 className="nx:sr-only">{label}</h1>
       <EmptyStateHeader>
         {Icon && (
           <EmptyStateMedia variant="icon">

--- a/apps/console/src/modules/crm/contacts-columns.tsx
+++ b/apps/console/src/modules/crm/contacts-columns.tsx
@@ -136,6 +136,7 @@ export const contactColumns: ColumnDef<Contact>[] = [
   },
   {
     id: 'actions',
+    header: () => <span className="nx:sr-only">Actions</span>,
     cell: ({ row }) => <RowActions contact={row.original} />,
     enableSorting: false,
   },

--- a/apps/console/src/modules/people/people-columns.tsx
+++ b/apps/console/src/modules/people/people-columns.tsx
@@ -130,6 +130,7 @@ export const memberColumns: ColumnDef<Member>[] = [
   },
   {
     id: 'actions',
+    header: () => <span className="nx:sr-only">Actions</span>,
     cell: ({ row }) => <RowActions member={row.original} />,
     enableSorting: false,
   },

--- a/apps/console/src/modules/projects/issues-columns.tsx
+++ b/apps/console/src/modules/projects/issues-columns.tsx
@@ -135,6 +135,7 @@ export const issueColumns: ColumnDef<Issue>[] = [
   },
   {
     id: 'actions',
+    header: () => <span className="nx:sr-only">Actions</span>,
     cell: ({ row }) => <RowActions issue={row.original} />,
     enableSorting: false,
   },


### PR DESCRIPTION
## Summary

Phase 5d (finale). Ran an **axe-core sweep across every console route** — the first app-level a11y pass (components are axe-checked in Storybook, but the assembled app wasn't). Fixed every console-level finding:

| Finding | Fix |
| --- | --- |
| `landmark-no-duplicate-main` / `-main-is-top-level` / `landmark-unique` (every route) | `root-layout`'s content wrapper is now a `<div>` — `SidebarInset` already renders the `<main>` landmark, so there were two. |
| `empty-table-header` (CRM/Projects/People) | The Actions column gets a `sr-only` "Actions" header. |
| `page-has-heading-one` (unbuilt modules) | `ComingSoon` gets a `sr-only <h1>` (its visible title is an `EmptyStateTitle`, not a heading). |

Verified cleared by re-running axe after each fix.

## Not fixed — by policy

`color-contrast` (serious) flags e.g. the success badge (white-on-green, WCAG 3.35). **Nexus gates contrast via APCA, not WCAG ratios** — Storybook disables this same axe rule for exactly this reason (`testing-react.md`), and the token pairs pass `@nexus/core`'s `audit:contrast`. Excluded, not "fixed."

## Tracked separately

- **#412** — two `@nexus/react` component gaps surfaced by the sweep: `Sidebar` isn't a `nav` landmark (`region`, every route) and `CardTitle` is a fixed `<h3>` (`heading-order`). DS-level, not console-fixable.
- **#409** — the brand-as-chart-mark APCA gate (from 5b) needs a brand×base combinatorial addition to `audit-contrast.js`; verified safe by reasoning + visual, tracked for a focused core change.

## Test Plan

- [x] `typecheck` + `eslint` — clean
- [x] axe-core swept across crm/projects/analytics/billing/inbox/people/settings before & after; landmark / empty-table-header / page-has-heading-one all cleared; only the two DS-component findings (#412) remain (color-contrast excluded per APCA policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)