### PR TITLE
fix(react): improve ScrollArea forced-colors affordances

### DIFF
--- a/packages/react/src/components/ui/ScrollArea.stories.tsx
+++ b/packages/react/src/components/ui/ScrollArea.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect } from 'storybook/test';
+import { expect, waitFor } from 'storybook/test';
 
 import { Card, CardContent, CardHeader, CardTitle } from './card';
 import { ScrollArea, ScrollBar } from './scroll-area';
@@ -41,6 +41,15 @@ const artworks = [
   { title: 'Quartz', artist: 'Liang Wu' },
   { title: 'Meadow', artist: 'Sofia Russo' },
 ];
+
+// Dense operational data that overflows in both directions.
+const jobRuns = Array.from({ length: 28 }, (_, i) => ({
+  id: `run-${4820 - i}`,
+  branch: ['main', 'release/vega', 'codex/ui-polish', 'docs/mwg'][i % 4],
+  owner: ['Mira', 'Omar', 'Jules', 'Nia'][i % 4],
+  duration: `${3 + (i % 9)}m ${10 + ((i * 7) % 50)}s`,
+  status: ['Passed', 'Queued', 'Reviewing', 'Blocked'][i % 4],
+}));
 
 // ============================================
 // BASIC STORIES
@@ -133,6 +142,94 @@ export const Both: Story = {
       <ScrollBar orientation="horizontal" />
     </ScrollArea>
   ),
+};
+
+// Dense panels should not rely on hover to reveal that more content exists.
+export const VisibleAffordance: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`type="always"` pins the custom scrollbar chrome for dense panels where scrollability needs to be visible without hover. The Radix custom scrollbar remains the default; native `scrollbar-color`, `scrollbar-width`, and scroll-state queries are progressive-only relative to the Nexus browser floor.',
+      },
+    },
+  },
+  render: () => (
+    <ScrollArea
+      type="always"
+      className="nx:h-64 nx:w-80 nx:rounded-md nx:border nx:border-border-default"
+    >
+      <div className="nx:w-max nx:p-4">
+        <div className="nx:grid nx:grid-cols-[112px_160px_96px_96px_96px] nx:gap-x-4 nx:border-b nx:border-border-default nx:pb-2 nx:text-xs nx:font-medium nx:text-muted-foreground">
+          <span>Run</span>
+          <span>Branch</span>
+          <span>Owner</span>
+          <span>Duration</span>
+          <span>Status</span>
+        </div>
+        <div className="nx:flex nx:flex-col">
+          {jobRuns.map((run) => (
+            <div
+              key={run.id}
+              className="nx:grid nx:grid-cols-[112px_160px_96px_96px_96px] nx:gap-x-4 nx:border-b nx:border-border-default nx:py-2 nx:text-sm nx:text-foreground nx:last:border-b-0"
+            >
+              <span className="nx:font-mono nx:text-xs">{run.id}</span>
+              <span>{run.branch}</span>
+              <span>{run.owner}</span>
+              <span>{run.duration}</span>
+              <span>{run.status}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <ScrollBar orientation="horizontal" />
+    </ScrollArea>
+  ),
+  play: async ({ canvasElement }) => {
+    const viewport = canvasElement.querySelector(
+      '[data-slot="scroll-area-viewport"]'
+    );
+    const verticalScrollbar = canvasElement.querySelector(
+      '[data-slot="scroll-bar"][data-orientation="vertical"]'
+    );
+    const horizontalScrollbar = canvasElement.querySelector(
+      '[data-slot="scroll-bar"][data-orientation="horizontal"]'
+    );
+    const corner = canvasElement.querySelector(
+      '[data-slot="scroll-area-corner"]'
+    );
+
+    await expect(viewport).toHaveAttribute('tabindex', '0');
+    await expect(verticalScrollbar).toBeInTheDocument();
+    await expect(horizontalScrollbar).toBeInTheDocument();
+    await expect(verticalScrollbar).toHaveClass(
+      'nx:forced-colors:bg-[Canvas]',
+      'nx:forced-colors:border-l-[ButtonBorder]'
+    );
+    await expect(horizontalScrollbar).toHaveClass(
+      'nx:forced-colors:bg-[Canvas]',
+      'nx:forced-colors:border-t-[ButtonBorder]'
+    );
+
+    if (corner) {
+      await expect(corner).toHaveClass(
+        'nx:forced-colors:bg-[Canvas]',
+        'nx:forced-colors:border-[ButtonBorder]'
+      );
+    }
+
+    await waitFor(() => {
+      expect(
+        canvasElement.querySelectorAll('[data-slot="scroll-bar-thumb"]').length
+      ).toBeGreaterThan(1);
+    });
+
+    for (const thumb of canvasElement.querySelectorAll(
+      '[data-slot="scroll-bar-thumb"]'
+    )) {
+      await expect(thumb).toHaveClass('nx:forced-colors:bg-[CanvasText]');
+    }
+  },
 };
 
 // Inside a Card — a bounded scroll region keeps a long list from stretching the

--- a/packages/react/src/components/ui/scroll-area.tsx
+++ b/packages/react/src/components/ui/scroll-area.tsx
@@ -20,10 +20,16 @@ interface ScrollAreaProps extends React.ComponentProps<
  * ScrollArea
  *
  * A viewport with cross-browser custom scrollbars, so a scrollable region reads
- * the same on every platform instead of inheriting the OS scrollbar. Wraps its
- * children in a measured viewport and renders a vertical scrollbar for you. For
- * horizontal (or both-axis) scrolling, add a `<ScrollBar orientation="horizontal" />`
- * as a child, after the content.
+ * the same on every platform instead of inheriting the OS scrollbar. This is an
+ * intentional divergence from native scrollbar styling guidance: Radix keeps
+ * scrolling native, while Nexus owns the visible track and thumb. In
+ * `forced-colors` environments, the scrollbar chrome switches to system colors
+ * as a progressive enhancement and leaves user content under the browser's
+ * normal forced-color adjustment.
+ *
+ * Wraps its children in a measured viewport and renders a vertical scrollbar
+ * for you. For horizontal (or both-axis) scrolling, add a
+ * `<ScrollBar orientation="horizontal" />` as a child, after the content.
  *
  * @example
  * ```tsx
@@ -62,7 +68,10 @@ function ScrollArea({ className, children, ...props }: ScrollAreaProps) {
         {children}
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />
-      <ScrollAreaPrimitive.Corner data-slot="scroll-area-corner" />
+      <ScrollAreaPrimitive.Corner
+        data-slot="scroll-area-corner"
+        className="nx:forced-colors:border nx:forced-colors:border-[ButtonBorder] nx:forced-colors:bg-[Canvas]"
+      />
     </ScrollAreaPrimitive.Root>
   );
 }
@@ -98,20 +107,21 @@ function ScrollBar({
   return (
     <ScrollAreaPrimitive.ScrollAreaScrollbar
       data-slot="scroll-bar"
+      data-orientation={orientation}
       orientation={orientation}
       className={cn(
-        'nx:flex nx:touch-none nx:select-none nx:p-px nx:transition-colors',
+        'nx:flex nx:touch-none nx:select-none nx:p-px nx:transition-colors nx:forced-colors:bg-[Canvas]',
         orientation === 'vertical' &&
-          'nx:h-full nx:w-2.5 nx:border-l nx:border-l-transparent',
+          'nx:h-full nx:w-2.5 nx:border-l nx:border-l-transparent nx:forced-colors:border-l-[ButtonBorder]',
         orientation === 'horizontal' &&
-          'nx:h-2.5 nx:flex-col nx:border-t nx:border-t-transparent',
+          'nx:h-2.5 nx:flex-col nx:border-t nx:border-t-transparent nx:forced-colors:border-t-[ButtonBorder]',
         className
       )}
       {...props}
     >
       <ScrollAreaPrimitive.ScrollAreaThumb
         data-slot="scroll-bar-thumb"
-        className="nx:relative nx:flex-1 nx:rounded-full nx:bg-border-default"
+        className="nx:relative nx:flex-1 nx:rounded-full nx:bg-border-default nx:forced-colors:bg-[CanvasText]"
       />
     </ScrollAreaPrimitive.ScrollAreaScrollbar>
   );


### PR DESCRIPTION
## Summary

- Document the intentional Radix ScrollArea divergence from native scrollbar styling.
- Add forced-colors system-color styling for custom scrollbar track, thumb, and corner chrome.
- Add a dense type=always ScrollArea story that shows visible scroll affordance for both axes and verifies stable scrollbar wiring.

## GitHub Issue

Closes #395

## Test Plan

- [x] yarn workspace @nexus/react audit:storybook-coverage --component scroll-area
- [x] yarn test:storybook packages/react/src/components/ui/ScrollArea.stories.tsx
- [x] yarn test:storybook
- [x] yarn typecheck
- [x] yarn lint
- [x] yarn audit:browser-support
- [x] CSS spot check confirmed emitted @media (forced-colors: active) rules