### PR TITLE
fix(docs): harden theme bootstrap for CSP

### DIFF
--- a/apps/docs/app/_components/LiveThemeSwapper.tsx
+++ b/apps/docs/app/_components/LiveThemeSwapper.tsx
@@ -1,5 +1,11 @@
 'use client';
 
+import {
+  getThemeStylesheetHref,
+  sanitizeMode,
+  THEME_MODE_OPTIONS,
+  type ThemeStylesheetMode,
+} from '../_lib/theme-modes';
 import { useThemeStore } from '../_stores/use-theme-store';
 
 import { Button } from './nexus';
@@ -11,15 +17,17 @@ import { Button } from './nexus';
  * stays in sync with the picker.
  */
 
-const BASES = ['slate', 'stone', 'neutral', 'gray', 'zinc'] as const;
-const BRANDS = ['blue', 'purple', 'pink', 'teal', 'orange', 'black'] as const;
-const PREFIX = { base: 'base-', brand: 'brands-' } as const;
+type LiveThemeMode = Extract<ThemeStylesheetMode, 'base' | 'brand'>;
 
-function applyTheme(mode: 'base' | 'brand', value: string) {
+const BASES = THEME_MODE_OPTIONS.base.map((option) => option.value);
+const BRANDS = THEME_MODE_OPTIONS.brand.map((option) => option.value);
+
+function applyTheme(mode: LiveThemeMode, value: string) {
+  const safeValue = sanitizeMode(mode, value);
   const link = document.querySelector<HTMLLinkElement>(
     `link[data-theme="${mode}"]`
   );
-  if (link) link.href = `/themes/${PREFIX[mode]}${value}.css`;
+  if (link) link.href = getThemeStylesheetHref(mode, safeValue);
 }
 
 export function LiveThemeSwapper() {
@@ -27,9 +35,10 @@ export function LiveThemeSwapper() {
   const brand = useThemeStore((s) => s.brand);
   const update = useThemeStore((s) => s.update);
 
-  const pick = (mode: 'base' | 'brand', value: string) => {
-    update(mode, value);
-    applyTheme(mode, value);
+  const pick = (mode: LiveThemeMode, value: string) => {
+    const safeValue = sanitizeMode(mode, value);
+    update(mode, safeValue);
+    applyTheme(mode, safeValue);
   };
 
   return (

--- a/apps/docs/app/_components/ThemeBootstrap.tsx
+++ b/apps/docs/app/_components/ThemeBootstrap.tsx
@@ -1,87 +1,10 @@
-/**
- * Emits an inline script that runs before React hydration to apply
- * stored theme prefs (base / brand / typography / shadow / radius /
- * borderwidth / spacing / dark-mode). Without this, the page would
- * flash with default tokens before the picker hydrated.
- *
- * Reads the same storage shape Zustand's persist middleware writes:
- *   localStorage['nexus-docs-tokens'] = { state: {...}, version: 0 }
- *
- * Dark mode is stored separately (single boolean key) so the bootstrap
- * can apply the class with no JSON parsing risk.
- */
+import { DOCS_THEME_BOOTSTRAP_SCRIPT } from '../_lib/theme-bootstrap-script';
+
 export function ThemeBootstrap() {
-  const script = `(function () {
-    try {
-      var ls = window.localStorage;
-      var PATH = '/themes/';
-      var PREFIX = {
-        base: 'base-',
-        brand: 'brands-',
-        typography: 'typography-',
-        shadow: 'shadow-',
-        radius: 'radius-',
-        borderwidth: 'borderwidth-',
-      };
-      var DEFAULTS = {
-        base: 'stone',
-        brand: 'blue',
-        spacing: 'vega',
-        typography: 'vega',
-        shadow: 'vega',
-        radius: 'sharp',
-        borderwidth: 'vega',
-      };
-      var VALID_MODES = {
-        base: ['slate', 'stone', 'neutral', 'gray', 'zinc'],
-        brand: ['blue', 'purple', 'pink', 'teal', 'orange', 'black'],
-        spacing: ['vega', 'lyra', 'maia', 'mira', 'nova', 'luma', 'sera'],
-        typography: ['vega', 'nova', 'maia'],
-        shadow: ['vega', 'lyra', 'maia', 'mira', 'nova'],
-        radius: ['sharp', 'subtle', 'smooth', 'mellow', 'blunt'],
-        borderwidth: ['vega', 'lyra', 'maia', 'mira', 'nova'],
-      };
-      var prefs = Object.assign({}, DEFAULTS);
-      var stored = ls.getItem('nexus-docs-tokens');
-      if (stored) {
-        try {
-          var parsed = JSON.parse(stored);
-          if (parsed && parsed.state) {
-            Object.keys(DEFAULTS).forEach(function (key) {
-              if (typeof parsed.state[key] === 'string') {
-                prefs[key] = parsed.state[key];
-              }
-            });
-          }
-        } catch (e) {}
-      }
-      Object.keys(VALID_MODES).forEach(function (key) {
-        if (VALID_MODES[key].indexOf(prefs[key]) === -1) {
-          prefs[key] = DEFAULTS[key];
-        }
-      });
-      // focus is single-variant today
-      var focusLink = document.createElement('link');
-      focusLink.rel = 'stylesheet';
-      focusLink.href = PATH + 'focus-default.css';
-      document.head.appendChild(focusLink);
-      // per-mode dynamic links
-      Object.keys(PREFIX).forEach(function (key) {
-        var link = document.createElement('link');
-        link.rel = 'stylesheet';
-        link.dataset.theme = key;
-        link.href = PATH + PREFIX[key] + prefs[key] + '.css';
-        document.head.appendChild(link);
-      });
-      // spacing density via data-style attribute
-      document.documentElement.setAttribute('data-style', prefs.spacing);
-      // dark mode
-      var darkPref = ls.getItem('nexus-docs-theme');
-      if (darkPref === 'dark' ||
-          (darkPref === null && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-        document.documentElement.classList.add('dark');
-      }
-    } catch (e) {}
-  })();`;
-  return <script dangerouslySetInnerHTML={{ __html: script }} />;
+  return (
+    <script
+      data-nexus-theme-bootstrap=""
+      dangerouslySetInnerHTML={{ __html: DOCS_THEME_BOOTSTRAP_SCRIPT }}
+    />
+  );
 }

--- a/apps/docs/app/_components/ThemePicker.tsx
+++ b/apps/docs/app/_components/ThemePicker.tsx
@@ -4,6 +4,12 @@ import { useState } from 'react';
 
 import { usePathname } from 'next/navigation';
 
+import {
+  getThemeModeOptions,
+  getThemeStylesheetHref,
+  sanitizeMode,
+  type ThemeMode,
+} from '../_lib/theme-modes';
 import { useThemeStore } from '../_stores/use-theme-store';
 
 import {
@@ -15,86 +21,18 @@ import {
   SelectValue,
 } from './nexus';
 
-type ModeKey =
-  | 'base'
-  | 'brand'
-  | 'spacing'
-  | 'typography'
-  | 'shadow'
-  | 'radius'
-  | 'borderwidth';
+function applyMode(mode: ThemeMode, value: string) {
+  const safeValue = sanitizeMode(mode, value);
 
-const PREFIX: Record<Exclude<ModeKey, 'spacing'>, string> = {
-  base: 'base-',
-  brand: 'brands-',
-  typography: 'typography-',
-  shadow: 'shadow-',
-  radius: 'radius-',
-  borderwidth: 'borderwidth-',
-};
-
-const OPTIONS: Record<ModeKey, { value: string; label: string }[]> = {
-  base: [
-    { value: 'slate', label: 'Slate' },
-    { value: 'stone', label: 'Stone' },
-    { value: 'neutral', label: 'Neutral' },
-    { value: 'gray', label: 'Gray' },
-    { value: 'zinc', label: 'Zinc' },
-  ],
-  brand: [
-    { value: 'blue', label: 'Blue' },
-    { value: 'purple', label: 'Purple' },
-    { value: 'pink', label: 'Pink' },
-    { value: 'teal', label: 'Teal' },
-    { value: 'orange', label: 'Orange' },
-    { value: 'black', label: 'Black' },
-  ],
-  spacing: [
-    { value: 'vega', label: 'Vega' },
-    { value: 'lyra', label: 'Lyra' },
-    { value: 'maia', label: 'Maia' },
-    { value: 'mira', label: 'Mira (≈ Vega)' },
-    { value: 'nova', label: 'Nova' },
-    { value: 'luma', label: 'Luma' },
-    { value: 'sera', label: 'Sera' },
-  ],
-  typography: [
-    { value: 'vega', label: 'Vega' },
-    { value: 'nova', label: 'Nova' },
-    { value: 'maia', label: 'Maia' },
-  ],
-  shadow: [
-    { value: 'vega', label: 'Vega' },
-    { value: 'lyra', label: 'Lyra' },
-    { value: 'maia', label: 'Maia' },
-    { value: 'mira', label: 'Mira' },
-    { value: 'nova', label: 'Nova' },
-  ],
-  radius: [
-    { value: 'sharp', label: 'Sharp' },
-    { value: 'subtle', label: 'Subtle' },
-    { value: 'smooth', label: 'Smooth' },
-    { value: 'mellow', label: 'Mellow' },
-    { value: 'blunt', label: 'Blunt' },
-  ],
-  borderwidth: [
-    { value: 'vega', label: 'Vega' },
-    { value: 'lyra', label: 'Lyra (≈ Vega)' },
-    { value: 'maia', label: 'Maia' },
-    { value: 'mira', label: 'Mira (≈ Vega)' },
-    { value: 'nova', label: 'Nova' },
-  ],
-};
-
-function applyMode(mode: ModeKey, value: string) {
   if (mode === 'spacing') {
-    document.documentElement.setAttribute('data-style', value);
+    document.documentElement.setAttribute('data-style', safeValue);
     return;
   }
+
   const link = document.querySelector<HTMLLinkElement>(
     `link[data-theme="${mode}"]`
   );
-  if (link) link.href = '/themes/' + PREFIX[mode] + value + '.css';
+  if (link) link.href = getThemeStylesheetHref(mode, safeValue);
 }
 
 export function ThemePicker() {
@@ -113,9 +51,10 @@ export function ThemePicker() {
   // picker would overlap it and duplicate its controls, so hide it there.
   if (pathname === '/') return null;
 
-  const onChange = (mode: ModeKey) => (value: string) => {
-    update(mode, value);
-    applyMode(mode, value);
+  const onChange = (mode: ThemeMode) => (value: string) => {
+    const safeValue = sanitizeMode(mode, value);
+    update(mode, safeValue);
+    applyMode(mode, safeValue);
   };
 
   return (
@@ -235,7 +174,7 @@ function ModeSelect({
   value,
   onChange,
 }: {
-  mode: ModeKey;
+  mode: ThemeMode;
   value: string;
   onChange: (v: string) => void;
 }) {
@@ -245,7 +184,7 @@ function ModeSelect({
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
-        {OPTIONS[mode].map((o) => (
+        {getThemeModeOptions(mode).map((o) => (
           <SelectItem key={o.value} value={o.value}>
             {o.label}
           </SelectItem>

--- a/apps/docs/app/_lib/theme-bootstrap-script.ts
+++ b/apps/docs/app/_lib/theme-bootstrap-script.ts
@@ -1,0 +1,77 @@
+import {
+  DEFAULT_THEME_STATE,
+  DOCS_DARK_MODE_STORAGE_KEY,
+  DOCS_THEME_STORAGE_KEY,
+  THEME_MODE_KEYS,
+  THEME_MODE_VALUES,
+  THEME_STYLESHEET_HREFS,
+  THEME_STYLESHEET_MODE_KEYS,
+} from './theme-modes';
+
+const DEFAULTS = JSON.stringify(DEFAULT_THEME_STATE);
+const DARK_MODE_STORAGE_KEY = JSON.stringify(DOCS_DARK_MODE_STORAGE_KEY);
+const MODE_KEYS = JSON.stringify(THEME_MODE_KEYS);
+const STORAGE_KEY = JSON.stringify(DOCS_THEME_STORAGE_KEY);
+const STYLESHEET_HREFS = JSON.stringify(THEME_STYLESHEET_HREFS);
+const STYLESHEET_MODE_KEYS = JSON.stringify(THEME_STYLESHEET_MODE_KEYS);
+const VALID_MODES = JSON.stringify(THEME_MODE_VALUES);
+
+/**
+ * The docs app intentionally keeps one inline script so token stylesheets and
+ * dark mode are selected before first paint. CSP code hashes this exact string.
+ */
+export const DOCS_THEME_BOOTSTRAP_SCRIPT = `(function () {
+    try {
+      var ls = window.localStorage;
+      var DEFAULTS = ${DEFAULTS};
+      var MODE_KEYS = ${MODE_KEYS};
+      var STYLESHEET_HREFS = ${STYLESHEET_HREFS};
+      var STYLESHEET_MODE_KEYS = ${STYLESHEET_MODE_KEYS};
+      var VALID_MODES = ${VALID_MODES};
+      var prefs = Object.assign({}, DEFAULTS);
+      var stored = ls.getItem(${STORAGE_KEY});
+      if (stored) {
+        try {
+          var parsed = JSON.parse(stored);
+          var state =
+            parsed && typeof parsed === 'object' && parsed.state
+              ? parsed.state
+              : null;
+          if (state && typeof state === 'object') {
+            MODE_KEYS.forEach(function (key) {
+              var value = state[key];
+              if (
+                typeof value === 'string' &&
+                VALID_MODES[key].indexOf(value) !== -1
+              ) {
+                prefs[key] = value;
+              }
+            });
+          }
+        } catch (e) {}
+      }
+      var focusLink = document.createElement('link');
+      focusLink.rel = 'stylesheet';
+      focusLink.href = '/themes/focus-default.css';
+      document.head.appendChild(focusLink);
+      STYLESHEET_MODE_KEYS.forEach(function (key) {
+        var link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.dataset.theme = key;
+        link.href = STYLESHEET_HREFS[key][prefs[key]];
+        document.head.appendChild(link);
+      });
+      document.documentElement.setAttribute('data-style', prefs.spacing);
+      var darkPref = ls.getItem(${DARK_MODE_STORAGE_KEY});
+      if (darkPref !== 'dark' && darkPref !== 'light') {
+        darkPref = null;
+      }
+      if (
+        darkPref === 'dark' ||
+        (darkPref === null &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches)
+      ) {
+        document.documentElement.classList.add('dark');
+      }
+    } catch (e) {}
+  })();`;

--- a/apps/docs/app/_lib/theme-modes.test.ts
+++ b/apps/docs/app/_lib/theme-modes.test.ts
@@ -3,13 +3,17 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
+import { DOCS_THEME_BOOTSTRAP_SCRIPT } from './theme-bootstrap-script';
 import {
   DEFAULT_THEME_STATE,
+  DOCS_DARK_MODE_STORAGE_KEY,
+  DOCS_THEME_STORAGE_KEY,
   getThemeStylesheetHref,
   sanitizeMode,
   sanitizeStoredColorScheme,
   sanitizeThemeState,
   THEME_MODE_VALUES,
+  THEME_STYLESHEET_HREFS,
   THEME_STYLESHEET_MODE_KEYS,
 } from './theme-modes';
 
@@ -82,5 +86,55 @@ describe('docs theme modes', () => {
     expect(sanitizeStoredColorScheme('dark')).toBe('dark');
     expect(sanitizeStoredColorScheme('light')).toBe('light');
     expect(sanitizeStoredColorScheme('auto')).toBeNull();
+  });
+
+  it('executes the bootstrap script with sanitized persisted theme values', () => {
+    localStorage.clear();
+    document.head.replaceChildren();
+    document.documentElement.removeAttribute('data-style');
+    document.documentElement.classList.remove('dark');
+
+    localStorage.setItem(
+      DOCS_THEME_STORAGE_KEY,
+      JSON.stringify({
+        state: {
+          base: '../base-slate',
+          brand: '/themes/brands-pink.css',
+          spacing: 'sera);document.body.innerHTML=""',
+          typography: 'nova',
+          shadow: 'javascript:alert(1)',
+          radius: 'smooth',
+          borderwidth: 'mira',
+        },
+      })
+    );
+    localStorage.setItem(DOCS_DARK_MODE_STORAGE_KEY, 'javascript:alert(1)');
+
+    window.eval(DOCS_THEME_BOOTSTRAP_SCRIPT);
+
+    expect(
+      document.head
+        .querySelector<HTMLLinkElement>('link:not([data-theme])')
+        ?.getAttribute('href')
+    ).toBe('/themes/focus-default.css');
+    expect(document.documentElement.getAttribute('data-style')).toBe(
+      DEFAULT_THEME_STATE.spacing
+    );
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+
+    const themeLinks = Array.from(
+      document.head.querySelectorAll<HTMLLinkElement>('link[data-theme]')
+    );
+
+    expect(
+      themeLinks.map((link) => [link.dataset.theme, link.getAttribute('href')])
+    ).toEqual([
+      ['base', THEME_STYLESHEET_HREFS.base[DEFAULT_THEME_STATE.base]],
+      ['brand', THEME_STYLESHEET_HREFS.brand[DEFAULT_THEME_STATE.brand]],
+      ['typography', THEME_STYLESHEET_HREFS.typography.nova],
+      ['shadow', THEME_STYLESHEET_HREFS.shadow[DEFAULT_THEME_STATE.shadow]],
+      ['radius', THEME_STYLESHEET_HREFS.radius.smooth],
+      ['borderwidth', THEME_STYLESHEET_HREFS.borderwidth.mira],
+    ]);
   });
 });

--- a/apps/docs/app/_lib/theme-modes.test.ts
+++ b/apps/docs/app/_lib/theme-modes.test.ts
@@ -1,0 +1,86 @@
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_THEME_STATE,
+  getThemeStylesheetHref,
+  sanitizeMode,
+  sanitizeStoredColorScheme,
+  sanitizeThemeState,
+  THEME_MODE_VALUES,
+  THEME_STYLESHEET_MODE_KEYS,
+} from './theme-modes';
+
+const docsRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+describe('docs theme modes', () => {
+  it('keeps valid theme state values', () => {
+    const state = sanitizeThemeState({
+      base: 'slate',
+      brand: 'teal',
+      spacing: 'sera',
+      typography: 'nova',
+      shadow: 'mira',
+      radius: 'smooth',
+      borderwidth: 'maia',
+    });
+
+    expect(state).toMatchObject({
+      base: 'slate',
+      brand: 'teal',
+      spacing: 'sera',
+      typography: 'nova',
+      shadow: 'mira',
+      radius: 'smooth',
+      borderwidth: 'maia',
+    });
+  });
+
+  it('falls back safely for invalid or legacy values', () => {
+    const state = sanitizeThemeState({
+      base: '../base-slate',
+      brand: 'blue.css',
+      spacing: 'compact',
+      typography: null,
+      shadow: 'nova',
+      radius: 'smooth',
+      borderwidth: 'mira',
+    });
+
+    expect(state).toMatchObject({
+      ...DEFAULT_THEME_STATE,
+      shadow: 'nova',
+      radius: 'smooth',
+      borderwidth: 'mira',
+    });
+  });
+
+  it('sanitizes interactive updates before building stylesheet hrefs', () => {
+    expect(sanitizeMode('brand', 'pink')).toBe('pink');
+    expect(sanitizeMode('brand', '/themes/brands-pink.css')).toBe(
+      DEFAULT_THEME_STATE.brand
+    );
+    expect(getThemeStylesheetHref('brand', '/themes/brands-pink.css')).toBe(
+      '/themes/brands-blue.css'
+    );
+  });
+
+  it('maps every allowlisted stylesheet mode to an existing file', () => {
+    for (const mode of THEME_STYLESHEET_MODE_KEYS) {
+      for (const value of THEME_MODE_VALUES[mode]) {
+        const href = getThemeStylesheetHref(mode, value);
+        const filePath = join(docsRoot, 'public', href.slice(1));
+
+        expect(existsSync(filePath), `${mode}:${value} -> ${href}`).toBe(true);
+      }
+    }
+  });
+
+  it('keeps stored dark mode values narrow', () => {
+    expect(sanitizeStoredColorScheme('dark')).toBe('dark');
+    expect(sanitizeStoredColorScheme('light')).toBe('light');
+    expect(sanitizeStoredColorScheme('auto')).toBeNull();
+  });
+});

--- a/apps/docs/app/_lib/theme-modes.ts
+++ b/apps/docs/app/_lib/theme-modes.ts
@@ -1,0 +1,221 @@
+export const DOCS_THEME_STORAGE_KEY = 'nexus-docs-tokens';
+export const DOCS_DARK_MODE_STORAGE_KEY = 'nexus-docs-theme';
+
+export const THEME_MODE_KEYS = [
+  'base',
+  'brand',
+  'spacing',
+  'typography',
+  'shadow',
+  'radius',
+  'borderwidth',
+] as const;
+
+export type ThemeMode = (typeof THEME_MODE_KEYS)[number];
+export type ThemeStylesheetMode = Exclude<ThemeMode, 'spacing'>;
+export type StoredColorScheme = 'light' | 'dark';
+
+export const THEME_STYLESHEET_MODE_KEYS = [
+  'base',
+  'brand',
+  'typography',
+  'shadow',
+  'radius',
+  'borderwidth',
+] as const satisfies readonly ThemeStylesheetMode[];
+
+export const THEME_MODE_VALUES = {
+  base: ['slate', 'stone', 'neutral', 'gray', 'zinc'],
+  brand: ['blue', 'purple', 'pink', 'teal', 'orange', 'black'],
+  spacing: ['vega', 'lyra', 'maia', 'mira', 'nova', 'luma', 'sera'],
+  typography: ['vega', 'nova', 'maia'],
+  shadow: ['vega', 'lyra', 'maia', 'mira', 'nova'],
+  radius: ['sharp', 'subtle', 'smooth', 'mellow', 'blunt'],
+  borderwidth: ['vega', 'lyra', 'maia', 'mira', 'nova'],
+} as const;
+
+type ThemeModeValues = typeof THEME_MODE_VALUES;
+
+export type ThemeState = {
+  [K in ThemeMode]: ThemeModeValues[K][number];
+};
+
+export type ThemeModeOption<K extends ThemeMode = ThemeMode> = {
+  value: ThemeState[K];
+  label: string;
+};
+
+export const DEFAULT_THEME_STATE = {
+  base: 'stone',
+  brand: 'blue',
+  spacing: 'vega',
+  typography: 'vega',
+  shadow: 'vega',
+  radius: 'sharp',
+  borderwidth: 'vega',
+} as const satisfies ThemeState;
+
+export const THEME_MODE_OPTIONS = {
+  base: [
+    { value: 'slate', label: 'Slate' },
+    { value: 'stone', label: 'Stone' },
+    { value: 'neutral', label: 'Neutral' },
+    { value: 'gray', label: 'Gray' },
+    { value: 'zinc', label: 'Zinc' },
+  ],
+  brand: [
+    { value: 'blue', label: 'Blue' },
+    { value: 'purple', label: 'Purple' },
+    { value: 'pink', label: 'Pink' },
+    { value: 'teal', label: 'Teal' },
+    { value: 'orange', label: 'Orange' },
+    { value: 'black', label: 'Black' },
+  ],
+  spacing: [
+    { value: 'vega', label: 'Vega' },
+    { value: 'lyra', label: 'Lyra' },
+    { value: 'maia', label: 'Maia' },
+    { value: 'mira', label: 'Mira (≈ Vega)' },
+    { value: 'nova', label: 'Nova' },
+    { value: 'luma', label: 'Luma' },
+    { value: 'sera', label: 'Sera' },
+  ],
+  typography: [
+    { value: 'vega', label: 'Vega' },
+    { value: 'nova', label: 'Nova' },
+    { value: 'maia', label: 'Maia' },
+  ],
+  shadow: [
+    { value: 'vega', label: 'Vega' },
+    { value: 'lyra', label: 'Lyra' },
+    { value: 'maia', label: 'Maia' },
+    { value: 'mira', label: 'Mira' },
+    { value: 'nova', label: 'Nova' },
+  ],
+  radius: [
+    { value: 'sharp', label: 'Sharp' },
+    { value: 'subtle', label: 'Subtle' },
+    { value: 'smooth', label: 'Smooth' },
+    { value: 'mellow', label: 'Mellow' },
+    { value: 'blunt', label: 'Blunt' },
+  ],
+  borderwidth: [
+    { value: 'vega', label: 'Vega' },
+    { value: 'lyra', label: 'Lyra (≈ Vega)' },
+    { value: 'maia', label: 'Maia' },
+    { value: 'mira', label: 'Mira (≈ Vega)' },
+    { value: 'nova', label: 'Nova' },
+  ],
+} as const satisfies {
+  [K in ThemeMode]: readonly ThemeModeOption<K>[];
+};
+
+export const THEME_STYLESHEET_HREFS = {
+  base: {
+    slate: '/themes/base-slate.css',
+    stone: '/themes/base-stone.css',
+    neutral: '/themes/base-neutral.css',
+    gray: '/themes/base-gray.css',
+    zinc: '/themes/base-zinc.css',
+  },
+  brand: {
+    blue: '/themes/brands-blue.css',
+    purple: '/themes/brands-purple.css',
+    pink: '/themes/brands-pink.css',
+    teal: '/themes/brands-teal.css',
+    orange: '/themes/brands-orange.css',
+    black: '/themes/brands-black.css',
+  },
+  typography: {
+    vega: '/themes/typography-vega.css',
+    nova: '/themes/typography-nova.css',
+    maia: '/themes/typography-maia.css',
+  },
+  shadow: {
+    vega: '/themes/shadow-vega.css',
+    lyra: '/themes/shadow-lyra.css',
+    maia: '/themes/shadow-maia.css',
+    mira: '/themes/shadow-mira.css',
+    nova: '/themes/shadow-nova.css',
+  },
+  radius: {
+    sharp: '/themes/radius-sharp.css',
+    subtle: '/themes/radius-subtle.css',
+    smooth: '/themes/radius-smooth.css',
+    mellow: '/themes/radius-mellow.css',
+    blunt: '/themes/radius-blunt.css',
+  },
+  borderwidth: {
+    vega: '/themes/borderwidth-vega.css',
+    lyra: '/themes/borderwidth-lyra.css',
+    maia: '/themes/borderwidth-maia.css',
+    mira: '/themes/borderwidth-mira.css',
+    nova: '/themes/borderwidth-nova.css',
+  },
+} as const satisfies {
+  [K in ThemeStylesheetMode]: Record<ThemeState[K], `/themes/${string}.css`>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function getThemeModeOptions(
+  mode: ThemeMode
+): readonly ThemeModeOption[] {
+  return THEME_MODE_OPTIONS[mode];
+}
+
+export function sanitizeMode<K extends ThemeMode>(
+  mode: K,
+  value: unknown
+): ThemeState[K] {
+  return typeof value === 'string' &&
+    (THEME_MODE_VALUES[mode] as readonly string[]).includes(value)
+    ? (value as ThemeState[K])
+    : DEFAULT_THEME_STATE[mode];
+}
+
+export function sanitizeThemeState(raw: unknown): ThemeState {
+  const state = isRecord(raw) ? raw : {};
+
+  return {
+    base: sanitizeMode('base', state.base),
+    brand: sanitizeMode('brand', state.brand),
+    spacing: sanitizeMode('spacing', state.spacing),
+    typography: sanitizeMode('typography', state.typography),
+    shadow: sanitizeMode('shadow', state.shadow),
+    radius: sanitizeMode('radius', state.radius),
+    borderwidth: sanitizeMode('borderwidth', state.borderwidth),
+  };
+}
+
+export function getThemeStylesheetHref(
+  mode: ThemeStylesheetMode,
+  value: unknown
+): `/themes/${string}.css` {
+  switch (mode) {
+    case 'base':
+      return THEME_STYLESHEET_HREFS.base[sanitizeMode('base', value)];
+    case 'brand':
+      return THEME_STYLESHEET_HREFS.brand[sanitizeMode('brand', value)];
+    case 'typography':
+      return THEME_STYLESHEET_HREFS.typography[
+        sanitizeMode('typography', value)
+      ];
+    case 'shadow':
+      return THEME_STYLESHEET_HREFS.shadow[sanitizeMode('shadow', value)];
+    case 'radius':
+      return THEME_STYLESHEET_HREFS.radius[sanitizeMode('radius', value)];
+    case 'borderwidth':
+      return THEME_STYLESHEET_HREFS.borderwidth[
+        sanitizeMode('borderwidth', value)
+      ];
+  }
+}
+
+export function sanitizeStoredColorScheme(
+  value: unknown
+): StoredColorScheme | null {
+  return value === 'light' || value === 'dark' ? value : null;
+}

--- a/apps/docs/app/_stores/use-theme-store.ts
+++ b/apps/docs/app/_stores/use-theme-store.ts
@@ -3,6 +3,15 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
+import {
+  DEFAULT_THEME_STATE,
+  DOCS_THEME_STORAGE_KEY,
+  sanitizeMode,
+  sanitizeThemeState,
+  type ThemeMode,
+  type ThemeState,
+} from '../_lib/theme-modes';
+
 /**
  * Theme picker state.
  *
@@ -18,73 +27,25 @@ import { createJSONStorage, persist } from 'zustand/middleware';
  * after rehydration commits.
  */
 
-export const STORAGE_KEY = 'nexus-docs-tokens';
-
-export type ThemeState = {
-  base: string;
-  brand: string;
-  spacing: string;
-  typography: string;
-  shadow: string;
-  radius: string;
-  borderwidth: string;
+export {
+  DEFAULT_THEME_STATE as DEFAULTS,
+  DOCS_THEME_STORAGE_KEY as STORAGE_KEY,
 };
-
-const THEME_MODE_VALUES = {
-  base: ['slate', 'stone', 'neutral', 'gray', 'zinc'],
-  brand: ['blue', 'purple', 'pink', 'teal', 'orange', 'black'],
-  spacing: ['vega', 'lyra', 'maia', 'mira', 'nova', 'luma', 'sera'],
-  typography: ['vega', 'nova', 'maia'],
-  shadow: ['vega', 'lyra', 'maia', 'mira', 'nova'],
-  radius: ['sharp', 'subtle', 'smooth', 'mellow', 'blunt'],
-  borderwidth: ['vega', 'lyra', 'maia', 'mira', 'nova'],
-} as const satisfies Record<keyof ThemeState, readonly string[]>;
-
-export const DEFAULTS: ThemeState = {
-  base: 'stone',
-  brand: 'blue',
-  spacing: 'vega',
-  typography: 'vega',
-  shadow: 'vega',
-  radius: 'sharp',
-  borderwidth: 'vega',
-};
+export type { ThemeState };
 
 type ThemeStore = ThemeState & {
-  update: <K extends keyof ThemeState>(key: K, value: ThemeState[K]) => void;
+  update: <K extends ThemeMode>(key: K, value: unknown) => void;
 };
-
-function sanitizeMode<K extends keyof ThemeState>(
-  key: K,
-  value: unknown
-): ThemeState[K] {
-  return typeof value === 'string' &&
-    (THEME_MODE_VALUES[key] as readonly string[]).includes(value)
-    ? value
-    : DEFAULTS[key];
-}
-
-function sanitizeThemeState(raw: unknown): ThemeState {
-  const state = (raw ?? {}) as Partial<Record<keyof ThemeState, unknown>>;
-  return {
-    base: sanitizeMode('base', state.base),
-    brand: sanitizeMode('brand', state.brand),
-    spacing: sanitizeMode('spacing', state.spacing),
-    typography: sanitizeMode('typography', state.typography),
-    shadow: sanitizeMode('shadow', state.shadow),
-    radius: sanitizeMode('radius', state.radius),
-    borderwidth: sanitizeMode('borderwidth', state.borderwidth),
-  };
-}
 
 export const useThemeStore = create<ThemeStore>()(
   persist(
     (set) => ({
-      ...DEFAULTS,
-      update: (key, value) => set({ [key]: value } as Partial<ThemeStore>),
+      ...DEFAULT_THEME_STATE,
+      update: (key, value) =>
+        set({ [key]: sanitizeMode(key, value) } as Partial<ThemeStore>),
     }),
     {
-      name: STORAGE_KEY,
+      name: DOCS_THEME_STORAGE_KEY,
       storage: createJSONStorage(() => localStorage),
       skipHydration: true,
       version: 1,

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -3,6 +3,36 @@ import type { NextConfig } from 'next';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { DOCS_THEME_BOOTSTRAP_CSP_HASH } from './theme-csp';
+
+const SCRIPT_SRC = [
+  "'self'",
+  DOCS_THEME_BOOTSTRAP_CSP_HASH,
+  process.env.NODE_ENV === 'development' ? "'unsafe-eval'" : null,
+]
+  .filter(Boolean)
+  .join(' ');
+
+const CONNECT_SRC = [
+  "'self'",
+  process.env.NODE_ENV === 'development' ? 'ws:' : null,
+]
+  .filter(Boolean)
+  .join(' ');
+
+const CONTENT_SECURITY_POLICY_REPORT_ONLY = [
+  "default-src 'self'",
+  `script-src ${SCRIPT_SRC}`,
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "font-src 'self'",
+  `connect-src ${CONNECT_SRC}`,
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+].join('; ');
+
 const nextConfig: NextConfig = {
   transpilePackages: ['@nexus/react'],
   // let .md/.mdx resolve as modules (for content imported by the dynamic route)
@@ -11,6 +41,19 @@ const nextConfig: NextConfig = {
   // a nested .claude/worktrees/* checkout and pick the parent repo's lockfile.
   turbopack: {
     root: path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..'),
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Content-Security-Policy-Report-Only',
+            value: CONTENT_SECURITY_POLICY_REPORT_ONLY,
+          },
+        ],
+      },
+    ];
   },
 };
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,6 +9,7 @@
     "build": "next build",
     "start": "next start",
     "gen:themes": "cd ../.. && yarn tokens:tailwind && yarn tokens:modular",
+    "audit:csp": "node scripts/audit-csp-inventory.mjs",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf .next dist"
   },

--- a/apps/docs/scripts/audit-csp-inventory.mjs
+++ b/apps/docs/scripts/audit-csp-inventory.mjs
@@ -1,0 +1,69 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const docsRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..'
+);
+const appOutputDir = path.join(docsRoot, '.next', 'server', 'app');
+const inlineScriptPattern =
+  /<script\b(?![^>]*\bsrc=)([^>]*)>([\s\S]*?)<\/script>/gi;
+
+function walk(dir) {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = path.join(dir, entry.name);
+    return entry.isDirectory() ? walk(entryPath) : entryPath;
+  });
+}
+
+if (!existsSync(appOutputDir)) {
+  console.error('Missing .next/server/app. Run `yarn build` first.');
+  process.exit(1);
+}
+
+const htmlFiles = walk(appOutputDir).filter((file) => file.endsWith('.html'));
+
+if (htmlFiles.length === 0) {
+  console.error('No prerendered app HTML files found under .next/server/app.');
+  process.exit(1);
+}
+
+let bootstrapScripts = 0;
+let inlineScripts = 0;
+let inlineStyleAttributes = 0;
+let serializedBootstrapReferences = 0;
+
+for (const file of htmlFiles) {
+  const html = readFileSync(file, 'utf8');
+  const scripts = [...html.matchAll(inlineScriptPattern)];
+
+  inlineScripts += scripts.length;
+  inlineStyleAttributes += html.match(/\sstyle="/g)?.length ?? 0;
+  bootstrapScripts += scripts.filter(([, attrs]) =>
+    attrs.includes('data-nexus-theme-bootstrap')
+  ).length;
+  serializedBootstrapReferences += scripts.filter(([, , body]) =>
+    body.includes('nexus-docs-tokens')
+  ).length;
+}
+
+console.log(
+  JSON.stringify(
+    {
+      htmlFiles: htmlFiles.length,
+      inlineScripts,
+      bootstrapScripts,
+      nextInlineScripts: inlineScripts - bootstrapScripts,
+      serializedBootstrapReferences,
+      inlineStyleAttributes,
+    },
+    null,
+    2
+  )
+);
+
+if (bootstrapScripts === 0) {
+  console.error('Expected the docs theme bootstrap script in prerendered HTML.');
+  process.exit(1);
+}

--- a/apps/docs/theme-csp.ts
+++ b/apps/docs/theme-csp.ts
@@ -1,0 +1,11 @@
+import { createHash } from 'node:crypto';
+
+import { DOCS_THEME_BOOTSTRAP_SCRIPT } from './app/_lib/theme-bootstrap-script';
+
+export function getSha256CspHash(source: string) {
+  return `'sha256-${createHash('sha256').update(source).digest('base64')}'`;
+}
+
+export const DOCS_THEME_BOOTSTRAP_CSP_HASH = getSha256CspHash(
+  DOCS_THEME_BOOTSTRAP_SCRIPT
+);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,6 +29,8 @@ export default defineConfig({
           environment: 'jsdom',
           globals: true,
           include: [
+            'apps/**/app/**/*.test.{ts,tsx}',
+            'apps/**/src/**/*.test.{ts,tsx}',
             'packages/**/src/**/*.test.{ts,tsx}',
             'packages/**/scripts/**/*.test.{js,ts}',
             'packages/eslint-plugin-nexus/__tests__/**/*.test.js',


### PR DESCRIPTION
## Summary

- Centralize docs theme mode defaults, allowlists, labels, and stylesheet href mapping behind shared sanitizers.
- Generate the pre-hydration theme bootstrap from the shared contract and expose a SHA-256 CSP hash for the exact inline script.
- Add a docs CSP inventory command and serve a report-only CSP header so Next inline runtime scripts can be audited before enforcement.

## GitHub Issue

Closes #393

## Test Plan

- [x] `yarn test:unit apps/docs/app/_lib/theme-modes.test.ts`
- [x] `yarn workspace @nexus/docs typecheck`
- [x] `yarn workspace @nexus/docs build`
- [x] `yarn workspace @nexus/docs audit:csp`
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `curl -I http://localhost:3023/foundations/color` verified `Content-Security-Policy-Report-Only`
- [x] Browser smoke for missing, valid, and malicious `localStorage` theme values
