### PR TITLE
feat(console): persisted, configurable sidebar collapse (icon-rail / offcanvas)

### DIFF
--- a/apps/console/src/app/root-layout.tsx
+++ b/apps/console/src/app/root-layout.tsx
@@ -5,8 +5,9 @@ import { Outlet } from '@tanstack/react-router';
 
 import { AppSidebar } from '../shell/app-sidebar';
 import { CommandPalette } from '../shell/command-palette';
-import { useSidebarStore } from '../shell/sidebar-store';
 import { Topbar } from '../shell/topbar';
+
+import { useSidebarStore } from './sidebar-store';
 
 /**
  * The authenticated app shell, rendered by the `_app` pathless layout route

--- a/apps/console/src/app/root-layout.tsx
+++ b/apps/console/src/app/root-layout.tsx
@@ -5,6 +5,7 @@ import { Outlet } from '@tanstack/react-router';
 
 import { AppSidebar } from '../shell/app-sidebar';
 import { CommandPalette } from '../shell/command-palette';
+import { useSidebarStore } from '../shell/sidebar-store';
 import { Topbar } from '../shell/topbar';
 
 /**
@@ -15,6 +16,8 @@ import { Topbar } from '../shell/topbar';
  */
 export function RootLayout() {
   const [commandOpen, setCommandOpen] = useState(false);
+  const sidebarOpen = useSidebarStore((s) => s.open);
+  const setSidebarOpen = useSidebarStore((s) => s.setOpen);
 
   // ⌘K / Ctrl+K toggles the command palette from anywhere — a global keyboard
   // subscription, which is exactly what an effect is for.
@@ -30,7 +33,7 @@ export function RootLayout() {
   }, []);
 
   return (
-    <SidebarProvider>
+    <SidebarProvider open={sidebarOpen} onOpenChange={setSidebarOpen}>
       <AppSidebar />
       <SidebarInset>
         <Topbar onSearchClick={() => setCommandOpen(true)} />

--- a/apps/console/src/app/sidebar-store.ts
+++ b/apps/console/src/app/sidebar-store.ts
@@ -1,21 +1,29 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
+/** Icon rail (collapses to icons) vs offcanvas (collapses to fully hidden). */
+export type SidebarMode = 'icon' | 'offcanvas';
+
 type SidebarState = {
   open: boolean;
   setOpen: (open: boolean) => void;
+  mode: SidebarMode;
+  setMode: (mode: SidebarMode) => void;
 };
 
 /**
- * Persists the app-shell sidebar's expanded/collapsed state across reloads.
- * Wired into `SidebarProvider` as its controlled `open` / `onOpenChange`, so the
- * rail toggle and the `Cmd/Ctrl+B` shortcut flow through here too.
+ * Persists the app-shell sidebar's open state and collapse mode (icon rail vs
+ * full offcanvas) across reloads. Controls `SidebarProvider`'s `open` /
+ * `onOpenChange` and the `Sidebar` `collapsible` prop; the Appearance panel sets
+ * the mode, and the rail toggle and `Cmd/Ctrl+B` shortcut flow through here.
  */
 export const useSidebarStore = create<SidebarState>()(
   persist(
     (set) => ({
       open: true,
       setOpen: (open) => set({ open }),
+      mode: 'icon',
+      setMode: (mode) => set({ mode }),
     }),
     { name: 'nexus-console-sidebar' }
   )

--- a/apps/console/src/app/sidebar-store.ts
+++ b/apps/console/src/app/sidebar-store.ts
@@ -10,12 +10,6 @@ type SidebarState = {
  * Persists the app-shell sidebar's expanded/collapsed state across reloads.
  * Wired into `SidebarProvider` as its controlled `open` / `onOpenChange`, so the
  * rail toggle and the `Cmd/Ctrl+B` shortcut flow through here too.
- *
- * The Nexus `Sidebar` only writes its open state to a `sidebar_state` cookie for
- * server-side restore and never reads it back — a client-only SPA like the
- * console has no server to do that, so we own the state here instead. `persist`
- * uses localStorage (synchronous), so it hydrates before first paint — the
- * sidebar opens in its saved state, with no expanded→collapsed flash.
  */
 export const useSidebarStore = create<SidebarState>()(
   persist(

--- a/apps/console/src/modules/design-system/ThemeSwitcher.tsx
+++ b/apps/console/src/modules/design-system/ThemeSwitcher.tsx
@@ -1,3 +1,4 @@
+import { useSidebarStore } from '../../app/sidebar-store';
 import {
   BASES,
   BRANDS,
@@ -171,10 +172,13 @@ function ToggleSwitch({
 export function ThemeSwitcher({ theme, setTheme }: ThemeSwitcherProps) {
   const iconLibrary = useIconStore((s) => s.library);
   const setIconLibrary = useIconStore((s) => s.setLibrary);
+  const sidebarMode = useSidebarStore((s) => s.mode);
+  const setSidebarMode = useSidebarStore((s) => s.setMode);
 
   const handleReset = () => {
     setTheme(DEFAULT_THEME);
     setIconLibrary('tabler');
+    setSidebarMode('icon');
   };
 
   return (
@@ -198,6 +202,16 @@ export function ThemeSwitcher({ theme, setTheme }: ThemeSwitcherProps) {
             onChange={(dark) => setTheme((t) => ({ ...t, dark }))}
             labelLeft="Light"
             labelRight="Dark"
+          />
+        </Section>
+
+        {/* Sidebar */}
+        <Section title="Sidebar">
+          <ToggleSwitch
+            checked={sidebarMode === 'offcanvas'}
+            onChange={(full) => setSidebarMode(full ? 'offcanvas' : 'icon')}
+            labelLeft="Icon rail"
+            labelRight="Full collapse"
           />
         </Section>
 

--- a/apps/console/src/shell/app-sidebar.tsx
+++ b/apps/console/src/shell/app-sidebar.tsx
@@ -16,6 +16,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
+  SidebarSeparator,
 } from '@nexus/react';
 import {
   IconComponents,
@@ -33,6 +34,7 @@ import {
 } from '@tanstack/react-router';
 
 import { useSession } from '../app/session';
+import { useSidebarStore } from '../app/sidebar-store';
 
 import { MODULE_ITEMS } from './modules';
 
@@ -56,6 +58,8 @@ export function AppSidebar() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const user = useSession((s) => s.user);
   const signOut = useSession((s) => s.signOut);
+  const sidebarMode = useSidebarStore((s) => s.mode);
+  const showSectionLabels = sidebarMode === 'offcanvas';
 
   const handleSignOut = () => {
     signOut();
@@ -63,7 +67,7 @@ export function AppSidebar() {
   };
 
   return (
-    <Sidebar collapsible="icon">
+    <Sidebar collapsible={sidebarMode}>
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>
@@ -83,7 +87,9 @@ export function AppSidebar() {
 
       <SidebarContent>
         <SidebarGroup>
-          <SidebarGroupLabel>Design System</SidebarGroupLabel>
+          {showSectionLabels && (
+            <SidebarGroupLabel>Design System</SidebarGroupLabel>
+          )}
           <SidebarGroupContent>
             <SidebarMenu>
               {DESIGN_ITEMS.map(({ label, to, icon: Icon }) => (
@@ -104,8 +110,12 @@ export function AppSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
 
+        {!showSectionLabels && <SidebarSeparator />}
+
         <SidebarGroup>
-          <SidebarGroupLabel>Workspace</SidebarGroupLabel>
+          {showSectionLabels && (
+            <SidebarGroupLabel>Workspace</SidebarGroupLabel>
+          )}
           <SidebarGroupContent>
             <SidebarMenu>
               {MODULE_ITEMS.map((item) => {

--- a/apps/console/src/shell/app-sidebar.tsx
+++ b/apps/console/src/shell/app-sidebar.tsx
@@ -86,14 +86,15 @@ export function AppSidebar() {
       </SidebarHeader>
 
       <SidebarContent>
-        <SidebarGroup>
+        <SidebarGroup
+          role={showSectionLabels ? undefined : 'group'}
+          aria-label={showSectionLabels ? undefined : 'Design System'}
+        >
           {showSectionLabels && (
             <SidebarGroupLabel>Design System</SidebarGroupLabel>
           )}
           <SidebarGroupContent>
-            <SidebarMenu
-              aria-label={showSectionLabels ? undefined : 'Design System'}
-            >
+            <SidebarMenu>
               {DESIGN_ITEMS.map(({ label, to, icon: Icon }) => (
                 <SidebarMenuItem key={to}>
                   <SidebarMenuButton
@@ -114,14 +115,15 @@ export function AppSidebar() {
 
         {!showSectionLabels && <SidebarSeparator />}
 
-        <SidebarGroup>
+        <SidebarGroup
+          role={showSectionLabels ? undefined : 'group'}
+          aria-label={showSectionLabels ? undefined : 'Workspace'}
+        >
           {showSectionLabels && (
             <SidebarGroupLabel>Workspace</SidebarGroupLabel>
           )}
           <SidebarGroupContent>
-            <SidebarMenu
-              aria-label={showSectionLabels ? undefined : 'Workspace'}
-            >
+            <SidebarMenu>
               {MODULE_ITEMS.map((item) => {
                 const Icon = item.icon;
                 const isActive =

--- a/apps/console/src/shell/app-sidebar.tsx
+++ b/apps/console/src/shell/app-sidebar.tsx
@@ -63,7 +63,7 @@ export function AppSidebar() {
   };
 
   return (
-    <Sidebar>
+    <Sidebar collapsible="icon">
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>

--- a/apps/console/src/shell/app-sidebar.tsx
+++ b/apps/console/src/shell/app-sidebar.tsx
@@ -91,7 +91,9 @@ export function AppSidebar() {
             <SidebarGroupLabel>Design System</SidebarGroupLabel>
           )}
           <SidebarGroupContent>
-            <SidebarMenu>
+            <SidebarMenu
+              aria-label={showSectionLabels ? undefined : 'Design System'}
+            >
               {DESIGN_ITEMS.map(({ label, to, icon: Icon }) => (
                 <SidebarMenuItem key={to}>
                   <SidebarMenuButton
@@ -117,7 +119,9 @@ export function AppSidebar() {
             <SidebarGroupLabel>Workspace</SidebarGroupLabel>
           )}
           <SidebarGroupContent>
-            <SidebarMenu>
+            <SidebarMenu
+              aria-label={showSectionLabels ? undefined : 'Workspace'}
+            >
               {MODULE_ITEMS.map((item) => {
                 const Icon = item.icon;
                 const isActive =

--- a/apps/console/src/shell/sidebar-store.ts
+++ b/apps/console/src/shell/sidebar-store.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type SidebarState = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+};
+
+/**
+ * Persists the app-shell sidebar's expanded/collapsed state across reloads.
+ * Wired into `SidebarProvider` as its controlled `open` / `onOpenChange`, so the
+ * rail toggle and the `Cmd/Ctrl+B` shortcut flow through here too.
+ *
+ * The Nexus `Sidebar` only writes its open state to a `sidebar_state` cookie for
+ * server-side restore and never reads it back — a client-only SPA like the
+ * console has no server to do that, so we own the state here instead. `persist`
+ * uses localStorage (synchronous), so it hydrates before first paint — the
+ * sidebar opens in its saved state, with no expanded→collapsed flash.
+ */
+export const useSidebarStore = create<SidebarState>()(
+  persist(
+    (set) => ({
+      open: true,
+      setOpen: (open) => set({ open }),
+    }),
+    { name: 'nexus-console-sidebar' }
+  )
+);


### PR DESCRIPTION
## Summary

The Atlas console sidebar's collapse behaviour is now **persisted and user-configurable**.

- **Persist** — collapse/expand state reset on every reload: the Nexus `SidebarProvider` writes a `sidebar_state` cookie only for _server-side_ restore and never reads it back, and the console is a client-only SPA. A Zustand `persist` store (`apps/console/src/app/sidebar-store.ts`, localStorage key `nexus-console-sidebar`) now drives the provider's controlled `open`/`onOpenChange`; the rail toggle and `Cmd/Ctrl+B` both route through it (synchronous hydration → no first-paint flash).
- **Configurable mode** — a "Sidebar" toggle in the Appearance panel (`/design/appearance`) chooses how the sidebar collapses, persisted as `mode` in the same store:
  - **Icon rail** (`collapsible="icon"`) — collapses to icons. Section labels are dropped (their `-mt-8`/`opacity-0` collapse fade reflows the rail) and a `SidebarSeparator` keeps the two groups distinct.
  - **Full collapse** (`collapsible="offcanvas"`) — hides entirely; keeps the "Design System" / "Workspace" section headers.
- **Review fixes** — store relocated `shell/` → `app/` (alongside `session.ts`); JSDoc rationale trimmed per `code-comments.md`.

## GitHub Issue

No tracked issue — fixes the seeded demo-backlog item in `apps/console/src/mocks/projects-fixtures.ts` (_"Sidebar collapse state not persisted"_) and extends it into a user preference.

## Test Plan

Verified at runtime (Vite dev + Playwright):

- [x] Persistence: collapse/expand → reload → state survives (both `open` and `mode`); the toggle reflects the saved mode
- [x] Mode × open 2×2 — icon+expanded (separator, no headers) · icon+collapsed (rail + separator) · offcanvas+expanded (headers, no separator) · offcanvas+collapsed (fully hidden, width 0)
- [x] Switching mode **while collapsed** (icon ↔ offcanvas) transitions cleanly — no stale-prop glitch
- [x] `yarn workspace @nexus/console typecheck` + `eslint` clean

## Notes / open decisions

- **Desktop-only:** mobile renders the Sheet drawer regardless of `mode`, so the toggle has no effect on narrow viewports.
- **Appearance-surface parity:** the toggle lives on `/design/appearance` (ThemeSwitcher). The polished `SettingsScene` appearance panel (`/design/scenes`) does **not** yet mirror it — can add for parity if wanted.
- **A11y (optional):** dropping `SidebarGroupLabel` in icon mode also drops the groups' accessible names; an `aria-label` on `SidebarGroup` (icon mode only) would keep the grouping announced while staying visually headerless.
- **Reviews predate the feature:** the two posted reviews were on the persist-only diff; the configurable-mode feature is currently unreviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
