### PR TITLE
feat(console): add sidebar collapse toggle to the Settings scene

### DIFF
--- a/apps/console/src/modules/design-system/settings/AppearanceSettings.tsx
+++ b/apps/console/src/modules/design-system/settings/AppearanceSettings.tsx
@@ -16,6 +16,7 @@ import {
   Switch,
 } from '@nexus/react';
 
+import { type SidebarMode, useSidebarStore } from '../../../app/sidebar-store';
 import {
   BASES,
   BRANDS,
@@ -30,6 +31,11 @@ type AppearanceSettingsProps = {
   theme: ThemeConfig;
   setTheme: React.Dispatch<React.SetStateAction<ThemeConfig>>;
 };
+
+const SIDEBAR_MODE_OPTIONS: { value: SidebarMode; label: string }[] = [
+  { value: 'icon', label: 'Icon rail' },
+  { value: 'offcanvas', label: 'Full collapse' },
+];
 
 /** Turn a list of lowercase mode keys into title-cased Select options. */
 function modeOptions<T extends string>(
@@ -83,6 +89,9 @@ export function AppearanceSettings({
   theme,
   setTheme,
 }: AppearanceSettingsProps) {
+  const sidebarMode = useSidebarStore((s) => s.mode);
+  const setSidebarMode = useSidebarStore((s) => s.setMode);
+
   return (
     <div className="nx:space-y-6">
       <Card>
@@ -170,6 +179,23 @@ export function AppearanceSettings({
             onValueChange={(borderWidth) =>
               setTheme((t) => ({ ...t, borderWidth }))
             }
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Sidebar</CardTitle>
+          <CardDescription>
+            How the navigation sidebar collapses.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <AxisSelect
+            label="Collapse style"
+            value={sidebarMode}
+            options={SIDEBAR_MODE_OPTIONS}
+            onValueChange={setSidebarMode}
           />
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary

Mirrors the Appearance-panel sidebar toggle (#417) into the composed Settings scene (`/design/scenes` → Appearance tab), so **both** live appearance surfaces can switch the sidebar's collapse mode.

- Adds a "Sidebar" card with a "Collapse style" select (Icon rail / Full collapse) in `AppearanceSettings.tsx`, built from the same `AxisSelect` + Nexus `Select` pattern as the theme axes.
- Wired to the shared `useSidebarStore` (`mode` / `setMode`) — the same store the `/design/appearance` toggle and the live sidebar read — so all stay in sync and persist.

## GitHub Issue

None — UX parity follow-up to #417.

## Test Plan

Verified at runtime (Vite + Playwright):

- [x] Settings scene → Appearance tab renders the "Sidebar" card; the select reflects the current mode
- [x] Changing it writes the shared store → mode flips and persists across reload
- [x] The `/design/appearance` toggle reflects the change (both surfaces in sync)
- [x] `yarn workspace @nexus/console typecheck` + `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)