### PR TITLE
fix(react): give Sidebar a navigation landmark

### DIFF
--- a/packages/react/src/components/ui/Sidebar.stories.tsx
+++ b/packages/react/src/components/ui/Sidebar.stories.tsx
@@ -12,7 +12,7 @@ import {
   IconSettings,
   IconUser,
 } from '@tabler/icons-react';
-import { expect, userEvent } from 'storybook/test';
+import { expect, userEvent, within } from 'storybook/test';
 
 import {
   Sidebar,
@@ -291,6 +291,11 @@ export const WithDataAttributes: Story = {
       '[data-slot="sidebar-menu-button"][data-active="true"]'
     );
     await expect(activeButton).toBeInTheDocument();
+
+    // The content region is a labelled navigation landmark (issue #418).
+    await expect(
+      within(canvasElement).getByRole('navigation', { name: 'Sidebar' })
+    ).toBeInTheDocument();
   },
 };
 

--- a/packages/react/src/components/ui/sidebar.tsx
+++ b/packages/react/src/components/ui/sidebar.tsx
@@ -577,12 +577,16 @@ interface SidebarContentProps extends React.ComponentProps<'nav'> {}
 function SidebarContent({
   className,
   'aria-label': ariaLabel = 'Sidebar',
+  'aria-labelledby': ariaLabelledby,
   ...props
 }: SidebarContentProps) {
   return (
     <nav
       data-slot="sidebar-content"
-      aria-label={ariaLabel}
+      // A labelledby reference, when given, names the landmark — so suppress the
+      // default string label rather than emitting both on the <nav> (issue #418).
+      aria-label={ariaLabelledby ? undefined : ariaLabel}
+      aria-labelledby={ariaLabelledby}
       className={cn(
         // nexus-allow-numeric: sidebar nav-chrome rhythm
         'nx:flex nx:min-h-0 nx:flex-1 nx:flex-col nx:gap-2 nx:overflow-auto nx:group-data-[collapsible=icon]:overflow-hidden',

--- a/packages/react/src/components/ui/sidebar.tsx
+++ b/packages/react/src/components/ui/sidebar.tsx
@@ -564,18 +564,25 @@ function SidebarSeparator({ className, ...props }: SidebarSeparatorProps) {
  *
  * Props for the SidebarContent component.
  */
-interface SidebarContentProps extends React.ComponentProps<'div'> {}
+interface SidebarContentProps extends React.ComponentProps<'nav'> {}
 
 /**
  * SidebarContent
  *
- * Scrollable middle region holding the sidebar's groups and menus. Hides
- * overflow when collapsed to the icon rail.
+ * The sidebar's scrollable nav region holding its groups and menus. Renders as a
+ * `<nav>` landmark, named via `aria-label` (default "Sidebar"), so assistive tech
+ * can jump to it — pass a distinct `aria-label` when a page has more than one
+ * navigation. Hides overflow when collapsed to the icon rail.
  */
-function SidebarContent({ className, ...props }: SidebarContentProps) {
+function SidebarContent({
+  className,
+  'aria-label': ariaLabel = 'Sidebar',
+  ...props
+}: SidebarContentProps) {
   return (
-    <div
+    <nav
       data-slot="sidebar-content"
+      aria-label={ariaLabel}
       className={cn(
         // nexus-allow-numeric: sidebar nav-chrome rhythm
         'nx:flex nx:min-h-0 nx:flex-1 nx:flex-col nx:gap-2 nx:overflow-auto nx:group-data-[collapsible=icon]:overflow-hidden',


### PR DESCRIPTION
## Summary

- `SidebarContent` now renders as `<nav aria-label="Sidebar">` instead of a plain `<div>`, giving the Nexus `Sidebar` a proper navigation landmark. Assistive tech can jump straight to the sidebar's navigation via the landmarks rotor.
- The label defaults to `"Sidebar"` and is overridable through `aria-label` for pages that carry more than one navigation landmark (keeps axe's `landmark-unique` satisfied).
- `WithDataAttributes` story gains a runtime assertion that the content region resolves as a labelled `navigation` landmark.

## Why `SidebarContent`, not the whole `Sidebar`?

The landmark sits on the scrollable content region rather than the `Sidebar` root for two reasons:

- **Branch-agnostic.** `Sidebar` has three render branches — a `collapsible="none"` div, a mobile `Sheet` (a Radix Dialog), and the desktop docked panel. The mobile branch is a `role="dialog"`; making the root a `<nav>` would fight that role or force per-branch landmark logic. `SidebarContent` renders identically across all three, so one `<nav>` covers every branch.
- **Tight nav scope.** `SidebarHeader` / `SidebarFooter` are chrome (brand mark, account menu, collapse trigger), not navigation. Scoping the landmark to the content region keeps the nav to the actual menu groups, so the landmark announces only what it contains.

## GitHub Issue

Closes #418

## Test Plan

- [x] `yarn workspace @nexus/react typecheck` — clean
- [x] `eslint` + `prettier --check` on changed files — clean
- [x] Runtime-verified in Storybook (from this branch's `src`): `WithDataAttributes` renders exactly one `<nav data-slot="sidebar-content" aria-label="Sidebar">` — implicit `navigation` role, `landmark-unique` satisfied (one nav, uniquely named).
- [x] Probed the icon-collapsed rail (`Collapsed` story): the landmark **survives collapse** — still present, still named, in the a11y tree (`display: flex`), `overflow: hidden` applied.
- [ ] `yarn test:storybook` runs in CI (the new `getByRole('navigation', { name: 'Sidebar' })` assertion lives in `WithDataAttributes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)