### PR TITLE
feat(alert): audit component

### DIFF
--- a/packages/react/src/components/ui/alert/Alert.stories.tsx
+++ b/packages/react/src/components/ui/alert/Alert.stories.tsx
@@ -6,6 +6,7 @@ import {
   IconAlertTriangle,
   IconCircleCheck,
   IconInfoCircle,
+  IconX,
 } from '@tabler/icons-react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
@@ -267,6 +268,28 @@ export const WithTitle: Story = {
   ),
 };
 
+export const TitleAsHeading: Story = {
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
+      <AlertTitle asChild>
+        <h2>Semantic heading</h2>
+      </AlertTitle>
+      <AlertDescription>
+        Use this pattern when the alert title belongs in the page outline.
+      </AlertDescription>
+    </Alert>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const heading = canvas.getByRole('heading', {
+      name: 'Semantic heading',
+    });
+
+    await expect(heading).toBeInTheDocument();
+    await expect(heading).toHaveAttribute('data-slot', 'alert-title');
+  },
+};
+
 export const WithDescription: Story = {
   render: (args) => (
     <Alert {...args} className="nx:max-w-md">
@@ -490,6 +513,36 @@ export const DenseHelperBanner: Story = {
       </AlertActions>
     </Alert>
   ),
+};
+
+export const CustomCloseIconLabel: Story = {
+  args: {
+    layout: 'inline',
+    variant: 'information',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-xl">
+      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertContent>
+        <AlertTitle>Custom close icon</AlertTitle>
+        <AlertDescription>
+          Icon-only custom children keep a fallback accessible name.
+        </AlertDescription>
+      </AlertContent>
+      <AlertActions>
+        <AlertClose>
+          <IconX aria-hidden="true" />
+        </AlertClose>
+      </AlertActions>
+    </Alert>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const close = canvas.getByRole('button', { name: 'Dismiss alert' });
+
+    await expect(close).toBeInTheDocument();
+    await expect(close).toHaveAttribute('aria-label', 'Dismiss alert');
+  },
 };
 
 // ============================================
@@ -751,7 +804,7 @@ export const AllModes: Story = {
     docs: {
       description: {
         story:
-          'Alert stays on the document spacing scale (`nx:p-4`) rather than migrating to `p-container`. Alert still mode-couples through `--nx-spacing-4` (nova 14 / vega-cluster 16 / maia 18), so the visual height shifts between nova / vega-cluster / maia rows. The point is that Alert uses the document scale (callout rhythm) instead of the container scale (raised-surface rhythm).',
+          'Alert stays on the document spacing scale (`nx:p-4`) rather than migrating to `p-container`. Alert still mode-couples through `--nx-spacing-4` (nova 14 / vega-cluster 16 / maia 18), so the visual height shifts between nova / vega-cluster / maia rows. The point is that Alert uses numeric document padding even though its default visual surface uses `nx:bg-container`.',
       },
     },
   },

--- a/packages/react/src/components/ui/alert/Alert.stories.tsx
+++ b/packages/react/src/components/ui/alert/Alert.stories.tsx
@@ -35,10 +35,22 @@ const meta: Meta<typeof Alert> = {
   component: Alert,
   parameters: {
     layout: 'padded',
+    docs: {
+      description: {
+        component: `
+Alert is a composable callout for status, warning, error, success, or informational messages. The root controls status, presentation, and layout; icons, content, actions, and dismissal are composed with children.
+
+Action pattern rules:
+- Stack layout: valid with no actions, one or two button actions, or button action(s) plus AlertClose.
+- Stack layout: do not use AlertClose as the only action, because a lone close icon below the message is not an approved placement.
+- Inline layout: valid with close-only, one or two button actions, or button action(s) plus AlertClose.
+- Dismissal stays consumer-controlled. AlertClose only renders the control; it does not remove the alert by itself.
+        `,
+      },
+    },
   },
   args: {
     layout: 'stack',
-    density: 'comfortable',
     presentation: 'card',
     variant: 'default',
   },
@@ -47,27 +59,164 @@ const meta: Meta<typeof Alert> = {
       control: 'select',
       options: ['default', 'information', 'destructive', 'success', 'warning'],
       description: 'The visual style variant',
+      table: {
+        category: 'Controls',
+      },
     },
     presentation: {
       control: 'select',
       options: ['card', 'banner'],
       description: 'The alert presentation style',
+      table: {
+        category: 'Controls',
+      },
     },
     layout: {
       control: 'select',
       options: ['stack', 'inline'],
       description: 'The alert content/action arrangement',
-    },
-    density: {
-      control: 'select',
-      options: ['comfortable', 'compact'],
-      description: 'The alert spacing density',
+      table: {
+        category: 'Controls',
+      },
     },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Alert>;
+
+type PlaygroundIcon =
+  | 'none'
+  | 'information'
+  | 'warning'
+  | 'success'
+  | 'destructive';
+type PlaygroundActions =
+  | 'none'
+  | 'close'
+  | 'primary'
+  | 'primary + close'
+  | 'primary + secondary'
+  | 'primary + secondary + close';
+type PlaygroundStackActions = Exclude<PlaygroundActions, 'close'>;
+type PlaygroundButtonVariant = NonNullable<
+  React.ComponentProps<typeof Button>['variant']
+>;
+type PlaygroundStory = StoryObj<
+  React.ComponentProps<typeof Alert> & {
+    icon: PlaygroundIcon;
+    actionsInline: PlaygroundActions;
+    actionsStack: PlaygroundStackActions;
+    title: string;
+    description: string;
+    primaryActionLabel: string;
+    primaryActionVariant: PlaygroundButtonVariant;
+    secondaryActionLabel: string;
+    secondaryActionVariant: PlaygroundButtonVariant;
+  }
+>;
+
+function renderPlaygroundIcon(icon: PlaygroundIcon) {
+  if (icon === 'none') return null;
+  if (icon === 'destructive') {
+    return <IconAlertCircle aria-hidden="true" className="nx:size-4" />;
+  }
+  if (icon === 'success') {
+    return <IconCircleCheck aria-hidden="true" className="nx:size-4" />;
+  }
+  if (icon === 'warning') {
+    return <IconAlertTriangle aria-hidden="true" className="nx:size-4" />;
+  }
+
+  return <IconInfoCircle aria-hidden="true" className="nx:size-4" />;
+}
+
+function AlertPlaygroundExample({
+  actionsInline,
+  actionsStack,
+  description,
+  icon,
+  layout,
+  presentation,
+  primaryActionLabel,
+  primaryActionVariant,
+  secondaryActionLabel,
+  secondaryActionVariant,
+  title,
+  variant,
+}: React.ComponentProps<typeof Alert> & {
+  icon: PlaygroundIcon;
+  actionsInline: PlaygroundActions;
+  actionsStack: PlaygroundStackActions;
+  title: string;
+  description: string;
+  primaryActionLabel: string;
+  primaryActionVariant: PlaygroundButtonVariant;
+  secondaryActionLabel: string;
+  secondaryActionVariant: PlaygroundButtonVariant;
+}) {
+  const [visible, setVisible] = React.useState(true);
+  const actions = layout === 'inline' ? actionsInline : actionsStack;
+  const hasPrimaryAction = actions.includes('primary');
+  const hasSecondaryAction = actions.includes('secondary');
+  const hasCloseAction = actions.includes('close');
+  const hasActions = actions !== 'none';
+
+  React.useEffect(() => {
+    setVisible(true);
+  }, [
+    actionsInline,
+    actionsStack,
+    description,
+    icon,
+    layout,
+    presentation,
+    primaryActionLabel,
+    primaryActionVariant,
+    secondaryActionLabel,
+    secondaryActionVariant,
+    title,
+    variant,
+  ]);
+
+  if (!visible) {
+    return (
+      <Button variant="outline" onClick={() => setVisible(true)}>
+        Reset alert
+      </Button>
+    );
+  }
+
+  return (
+    <Alert
+      layout={layout}
+      presentation={presentation}
+      variant={variant}
+      className="nx:max-w-2xl"
+    >
+      {renderPlaygroundIcon(icon)}
+      <AlertContent>
+        <AlertTitle>{title}</AlertTitle>
+        <AlertDescription>{description}</AlertDescription>
+      </AlertContent>
+      {hasActions ? (
+        <AlertActions>
+          {hasPrimaryAction ? (
+            <Button variant={primaryActionVariant}>{primaryActionLabel}</Button>
+          ) : null}
+          {hasSecondaryAction ? (
+            <Button variant={secondaryActionVariant}>
+              {secondaryActionLabel}
+            </Button>
+          ) : null}
+          {hasCloseAction ? (
+            <AlertClose onClick={() => setVisible(false)} />
+          ) : null}
+        </AlertActions>
+      ) : null}
+    </Alert>
+  );
+}
 
 function DismissibleCloseButtonExample(
   props: React.ComponentProps<typeof Alert>
@@ -105,6 +254,164 @@ export const Default: Story = {
       </AlertDescription>
     </Alert>
   ),
+};
+
+export const Playground: PlaygroundStory = {
+  args: {
+    actionsInline: 'primary + close',
+    actionsStack: 'primary + close',
+    icon: 'information',
+    layout: 'inline',
+    presentation: 'card',
+    primaryActionLabel: 'Manage',
+    primaryActionVariant: 'outline',
+    secondaryActionLabel: 'View details',
+    secondaryActionVariant: 'ghost',
+    title: 'Storage almost full',
+    description: 'Uploads may fail soon.',
+    variant: 'information',
+  },
+  argTypes: {
+    actionsInline: {
+      name: 'actions (inline story only)',
+      control: 'select',
+      options: [
+        'none',
+        'close',
+        'primary',
+        'primary + close',
+        'primary + secondary',
+        'primary + secondary + close',
+      ],
+      description:
+        'Story-only inline action pattern. Inline permits close-only, one action, two actions, and close combinations.',
+      table: {
+        category: 'Controls',
+      },
+      if: {
+        arg: 'layout',
+        eq: 'inline',
+      },
+    },
+    actionsStack: {
+      name: 'actions (stack story only)',
+      control: 'select',
+      options: [
+        'none',
+        'primary',
+        'primary + close',
+        'primary + secondary',
+        'primary + secondary + close',
+      ],
+      description:
+        'Story-only stack action pattern. Close-only is intentionally omitted because the lone close icon should not sit below the message.',
+      table: {
+        category: 'Controls',
+      },
+      if: {
+        arg: 'layout',
+        eq: 'stack',
+      },
+    },
+    icon: {
+      name: 'icon (story only)',
+      control: 'select',
+      options: ['none', 'information', 'warning', 'success', 'destructive'],
+      description:
+        'Story-only control that renders an icon child before AlertContent.',
+      table: {
+        category: 'Controls',
+      },
+    },
+    title: {
+      control: 'text',
+      description: 'Story-only alert title text.',
+      table: {
+        category: 'Controls',
+      },
+    },
+    description: {
+      control: 'text',
+      description: 'Story-only alert description text.',
+      table: {
+        category: 'Controls',
+      },
+    },
+    primaryActionLabel: {
+      name: 'primary label (story only)',
+      control: 'text',
+      description: 'Story-only primary Button children.',
+      table: {
+        category: 'Controls',
+      },
+    },
+    primaryActionVariant: {
+      name: 'primary variant (story only)',
+      control: 'select',
+      options: ['default', 'destructive', 'outline', 'secondary', 'ghost'],
+      description: 'Story-only primary Button variant.',
+      table: {
+        category: 'Controls',
+      },
+    },
+    secondaryActionLabel: {
+      name: 'secondary label (story only)',
+      control: 'text',
+      description: 'Story-only secondary Button children.',
+      table: {
+        category: 'Controls',
+      },
+    },
+    secondaryActionVariant: {
+      name: 'secondary variant (story only)',
+      control: 'select',
+      options: ['default', 'destructive', 'outline', 'secondary', 'ghost'],
+      description: 'Story-only secondary Button variant.',
+      table: {
+        category: 'Controls',
+      },
+    },
+  },
+  parameters: {
+    controls: {
+      sort: 'alpha',
+    },
+    docs: {
+      description: {
+        story:
+          'Story-only controls render the recommended slot composition. They are not Alert props; production usage still composes icons, Button, AlertActions, and AlertClose as children. The visible action control changes by layout so stack omits the invalid close-only pattern while inline keeps it available.',
+      },
+      source: {
+        code: `<Alert variant="information" layout="inline">
+  <IconInfoCircle aria-hidden="true" />
+  <AlertContent>
+    <AlertTitle>Storage almost full</AlertTitle>
+    <AlertDescription>Uploads may fail soon.</AlertDescription>
+  </AlertContent>
+  <AlertActions>
+    <Button variant="outline">Manage</Button>
+    <AlertClose onClick={() => setVisible(false)} />
+  </AlertActions>
+</Alert>`,
+      },
+    },
+  },
+  render: (args) => <AlertPlaygroundExample {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = canvasElement.querySelector('[data-slot="alert"]');
+    const content = canvasElement.querySelector('[data-slot="alert-content"]');
+    const actions = canvasElement.querySelector('[data-slot="alert-actions"]');
+    const close = canvas.getByRole('button', { name: 'Dismiss alert' });
+    const primaryAction = canvas.getByRole('button', { name: 'Manage' });
+
+    await expect(alert).toBeInTheDocument();
+    await expect(alert).toHaveAttribute('data-layout', 'inline');
+    await expect(content).toBeInTheDocument();
+    await expect(actions).toBeInTheDocument();
+    await expect(close).toBeInTheDocument();
+    await expect(primaryAction).toBeInTheDocument();
+  },
 };
 
 export const Destructive: Story = {
@@ -494,10 +801,9 @@ export const BannerInlineActions: Story = {
   ),
 };
 
-export const CompactHelperBanner: Story = {
+export const HelperBanner: Story = {
   args: {
     layout: 'inline',
-    density: 'compact',
     presentation: 'banner',
     variant: 'information',
   },
@@ -525,7 +831,6 @@ export const CompactHelperBanner: Story = {
 
     await expect(alert).toBeInTheDocument();
     await expect(alert).toHaveAttribute('data-layout', 'inline');
-    await expect(alert).toHaveAttribute('data-density', 'compact');
   },
 };
 
@@ -612,7 +917,7 @@ export const WithDataAttributes: Story = {
     await expect(alert).toHaveAttribute('data-variant', 'destructive');
     await expect(alert).toHaveAttribute('data-presentation', 'card');
     await expect(alert).toHaveAttribute('data-layout', 'stack');
-    await expect(alert).toHaveAttribute('data-density', 'comfortable');
+    await expect(alert).not.toHaveAttribute('data-density');
     await expect(alert).not.toHaveAttribute('role');
     await expect(title).toBeInTheDocument();
     await expect(description).toBeInTheDocument();
@@ -661,7 +966,7 @@ export const DefaultDataAttributes: Story = {
     await expect(alert).toBeInTheDocument();
     await expect(alert).toHaveAttribute('data-variant', 'default');
     await expect(alert).toHaveAttribute('data-presentation', 'card');
-    await expect(alert).toHaveAttribute('data-density', 'comfortable');
+    await expect(alert).not.toHaveAttribute('data-density');
     await expect(alert).not.toHaveAttribute('role');
   },
 };

--- a/packages/react/src/components/ui/alert/Alert.stories.tsx
+++ b/packages/react/src/components/ui/alert/Alert.stories.tsx
@@ -105,19 +105,18 @@ type PlaygroundStackActions = Extract<
 type PlaygroundButtonVariant = NonNullable<
   React.ComponentProps<typeof Button>['variant']
 >;
-type PlaygroundStory = StoryObj<
-  React.ComponentProps<typeof Alert> & {
-    icon: PlaygroundIcon;
-    actionsInline: PlaygroundActions;
-    actionsStack: PlaygroundStackActions;
-    title: string;
-    description: string;
-    primaryActionLabel: string;
-    primaryActionVariant: PlaygroundButtonVariant;
-    secondaryActionLabel: string;
-    secondaryActionVariant: PlaygroundButtonVariant;
-  }
->;
+type PlaygroundArgs = React.ComponentProps<typeof Alert> & {
+  icon: PlaygroundIcon;
+  actionsInline: PlaygroundActions;
+  actionsStack: PlaygroundStackActions;
+  title: string;
+  description: string;
+  primaryActionLabel: string;
+  primaryActionVariant: PlaygroundButtonVariant;
+  secondaryActionLabel: string;
+  secondaryActionVariant: PlaygroundButtonVariant;
+};
+type PlaygroundStory = StoryObj<PlaygroundArgs>;
 
 function renderPlaygroundIcon(icon: PlaygroundIcon) {
   if (icon === 'none') return null;
@@ -134,16 +133,6 @@ function renderPlaygroundIcon(icon: PlaygroundIcon) {
   return <IconInfoCircle aria-hidden="true" className="nx:size-4" />;
 }
 
-function normalizeStackActions(
-  actions: PlaygroundActions
-): PlaygroundStackActions {
-  if (actions === 'close') return 'none';
-  if (actions === 'primary + close') return 'primary';
-  if (actions === 'primary + secondary + close') return 'primary + secondary';
-
-  return actions;
-}
-
 function AlertPlaygroundExample({
   actionsInline,
   actionsStack,
@@ -157,41 +146,13 @@ function AlertPlaygroundExample({
   secondaryActionVariant,
   title,
   variant,
-}: React.ComponentProps<typeof Alert> & {
-  icon: PlaygroundIcon;
-  actionsInline: PlaygroundActions;
-  actionsStack: PlaygroundStackActions;
-  title: string;
-  description: string;
-  primaryActionLabel: string;
-  primaryActionVariant: PlaygroundButtonVariant;
-  secondaryActionLabel: string;
-  secondaryActionVariant: PlaygroundButtonVariant;
-}) {
+}: PlaygroundArgs) {
   const [visible, setVisible] = React.useState(true);
-  const actions =
-    layout === 'inline' ? actionsInline : normalizeStackActions(actionsStack);
+  const actions = layout === 'inline' ? actionsInline : actionsStack;
   const hasPrimaryAction = actions.includes('primary');
   const hasSecondaryAction = actions.includes('secondary');
   const hasCloseAction = actions.includes('close');
   const hasActions = actions !== 'none';
-
-  React.useEffect(() => {
-    setVisible(true);
-  }, [
-    actionsInline,
-    actionsStack,
-    description,
-    icon,
-    layout,
-    presentation,
-    primaryActionLabel,
-    primaryActionVariant,
-    secondaryActionLabel,
-    secondaryActionVariant,
-    title,
-    variant,
-  ]);
 
   if (!visible) {
     return (
@@ -404,7 +365,9 @@ export const Playground: PlaygroundStory = {
       },
     },
   },
-  render: (args) => <AlertPlaygroundExample {...args} />,
+  render: (args) => (
+    <AlertPlaygroundExample key={JSON.stringify(args)} {...args} />
+  ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const alert = canvasElement.querySelector('[data-slot="alert"]');

--- a/packages/react/src/components/ui/alert/Alert.stories.tsx
+++ b/packages/react/src/components/ui/alert/Alert.stories.tsx
@@ -38,6 +38,7 @@ const meta: Meta<typeof Alert> = {
   },
   args: {
     layout: 'stack',
+    density: 'comfortable',
     presentation: 'card',
     variant: 'default',
   },
@@ -54,8 +55,13 @@ const meta: Meta<typeof Alert> = {
     },
     layout: {
       control: 'select',
-      options: ['stack', 'inline', 'dense'],
-      description: 'The alert content/action layout',
+      options: ['stack', 'inline'],
+      description: 'The alert content/action arrangement',
+    },
+    density: {
+      control: 'select',
+      options: ['comfortable', 'compact'],
+      description: 'The alert spacing density',
     },
   },
 };
@@ -488,9 +494,10 @@ export const BannerInlineActions: Story = {
   ),
 };
 
-export const DenseHelperBanner: Story = {
+export const CompactHelperBanner: Story = {
   args: {
-    layout: 'dense',
+    layout: 'inline',
+    density: 'compact',
     presentation: 'banner',
     variant: 'information',
   },
@@ -513,6 +520,13 @@ export const DenseHelperBanner: Story = {
       </AlertActions>
     </Alert>
   ),
+  play: async ({ canvasElement }) => {
+    const alert = canvasElement.querySelector('[data-slot="alert"]');
+
+    await expect(alert).toBeInTheDocument();
+    await expect(alert).toHaveAttribute('data-layout', 'inline');
+    await expect(alert).toHaveAttribute('data-density', 'compact');
+  },
 };
 
 export const CustomCloseIconLabel: Story = {
@@ -526,11 +540,11 @@ export const CustomCloseIconLabel: Story = {
       <AlertContent>
         <AlertTitle>Custom close icon</AlertTitle>
         <AlertDescription>
-          Icon-only custom children keep a fallback accessible name.
+          Icon-only custom children need an explicit accessible name.
         </AlertDescription>
       </AlertContent>
       <AlertActions>
-        <AlertClose>
+        <AlertClose aria-label="Dismiss alert">
           <IconX aria-hidden="true" />
         </AlertClose>
       </AlertActions>
@@ -542,6 +556,36 @@ export const CustomCloseIconLabel: Story = {
 
     await expect(close).toBeInTheDocument();
     await expect(close).toHaveAttribute('aria-label', 'Dismiss alert');
+  },
+};
+
+export const TextCloseLabel: Story = {
+  args: {
+    layout: 'inline',
+    variant: 'information',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-xl">
+      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertContent>
+        <AlertTitle>Text close control</AlertTitle>
+        <AlertDescription>
+          Text children self-label, so the button keeps its visible name.
+        </AlertDescription>
+      </AlertContent>
+      <AlertActions>
+        <AlertClose className="nx:size-auto nx:px-2 nx:typography-label-small">
+          Close
+        </AlertClose>
+      </AlertActions>
+    </Alert>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const close = canvas.getByRole('button', { name: 'Close' });
+
+    await expect(close).toBeInTheDocument();
+    await expect(close).not.toHaveAttribute('aria-label');
   },
 };
 
@@ -568,6 +612,7 @@ export const WithDataAttributes: Story = {
     await expect(alert).toHaveAttribute('data-variant', 'destructive');
     await expect(alert).toHaveAttribute('data-presentation', 'card');
     await expect(alert).toHaveAttribute('data-layout', 'stack');
+    await expect(alert).toHaveAttribute('data-density', 'comfortable');
     await expect(alert).not.toHaveAttribute('role');
     await expect(title).toBeInTheDocument();
     await expect(description).toBeInTheDocument();
@@ -616,6 +661,7 @@ export const DefaultDataAttributes: Story = {
     await expect(alert).toBeInTheDocument();
     await expect(alert).toHaveAttribute('data-variant', 'default');
     await expect(alert).toHaveAttribute('data-presentation', 'card');
+    await expect(alert).toHaveAttribute('data-density', 'comfortable');
     await expect(alert).not.toHaveAttribute('role');
   },
 };

--- a/packages/react/src/components/ui/alert/Alert.stories.tsx
+++ b/packages/react/src/components/ui/alert/Alert.stories.tsx
@@ -28,7 +28,7 @@ const meta: Meta<typeof Alert> = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['default', 'destructive', 'success', 'warning'],
+      options: ['default', 'information', 'destructive', 'success', 'warning'],
       description: 'The visual style variant',
     },
   },
@@ -58,6 +58,17 @@ export const Destructive: Story = {
       <AlertTitle>Error</AlertTitle>
       <AlertDescription>
         Your session has expired. Please log in again.
+      </AlertDescription>
+    </Alert>
+  ),
+};
+
+export const Information: Story = {
+  render: (_args) => (
+    <Alert variant="information" className="nx:max-w-md">
+      <AlertTitle>Information</AlertTitle>
+      <AlertDescription>
+        New workspace invitations are available for review.
       </AlertDescription>
     </Alert>
   ),
@@ -108,6 +119,18 @@ export const DestructiveWithIcon: Story = {
       <AlertTitle>Error</AlertTitle>
       <AlertDescription>
         Something went wrong. Please try again later.
+      </AlertDescription>
+    </Alert>
+  ),
+};
+
+export const InformationWithIcon: Story = {
+  render: (_args) => (
+    <Alert variant="information" className="nx:max-w-md">
+      <IconInfoCircle className="nx:size-4" />
+      <AlertTitle>Information</AlertTitle>
+      <AlertDescription>
+        New workspace invitations are available for review.
       </AlertDescription>
     </Alert>
   ),
@@ -215,8 +238,7 @@ export const DefaultDataAttributes: Story = {
     const alert = canvasElement.querySelector('[data-slot="alert"]');
 
     await expect(alert).toBeInTheDocument();
-    // Default variant should have data-variant undefined or 'default'
-    // CVA doesn't pass undefined variant to data-variant, so it will be 'default'
+    await expect(alert).toHaveAttribute('data-variant', 'default');
   },
 };
 
@@ -228,7 +250,7 @@ export const AllVariants: Story = {
   render: (_args) => (
     <div className="nx:flex nx:flex-col nx:gap-6">
       <div>
-        <div className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <div className="nx:mb-4 nx:typography-label-default nx:text-foreground">
           Default
         </div>
         <Alert className="nx:max-w-md">
@@ -241,7 +263,18 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <div className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <div className="nx:mb-4 nx:typography-label-default nx:text-foreground">
+          Information
+        </div>
+        <Alert variant="information" className="nx:max-w-md">
+          <IconInfoCircle className="nx:size-4" />
+          <AlertTitle>Information Alert</AlertTitle>
+          <AlertDescription>This is an informational alert.</AlertDescription>
+        </Alert>
+      </div>
+
+      <div>
+        <div className="nx:mb-4 nx:typography-label-default nx:text-foreground">
           Destructive
         </div>
         <Alert variant="destructive" className="nx:max-w-md">
@@ -254,7 +287,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <div className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <div className="nx:mb-4 nx:typography-label-default nx:text-foreground">
           Success
         </div>
         <Alert variant="success" className="nx:max-w-md">
@@ -265,7 +298,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <div className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <div className="nx:mb-4 nx:typography-label-default nx:text-foreground">
           Warning
         </div>
         <Alert variant="warning" className="nx:max-w-md">
@@ -282,7 +315,7 @@ export const AllVariants: Story = {
 };
 
 // ============================================
-// MODE BEHAVIOUR (density stability)
+// MODE BEHAVIOUR (callout rhythm)
 // ============================================
 
 export const AllModes: Story = {
@@ -291,7 +324,7 @@ export const AllModes: Story = {
     docs: {
       description: {
         story:
-          'Alert stays on the document spacing scale (`nx:p-4`) rather than migrating to `p-container`. Alert still mode-couples through `--nx-spacing-4` (nova 14 / vega-cluster 16 / maia 18), so the visual height shifts between nova / vega-cluster / maia rows. The point is that Alert uses the document scale (callout rhythm) instead of the container scale (raised-surface rhythm) — not that it is density-stable.',
+          'Alert stays on the document spacing scale (`nx:p-4`) rather than migrating to `p-container`. Alert still mode-couples through `--nx-spacing-4` (nova 14 / vega-cluster 16 / maia 18), so the visual height shifts between nova / vega-cluster / maia rows. The point is that Alert uses the document scale (callout rhythm) instead of the container scale (raised-surface rhythm).',
       },
     },
   },
@@ -302,7 +335,7 @@ export const AllModes: Story = {
           <Alert className="nx:w-[360px]">
             <AlertTitle>Heads up · {mode}</AlertTitle>
             <AlertDescription>
-              Padding does not move with mode.
+              Padding follows the spacing-4 mode value.
             </AlertDescription>
           </Alert>
         </AllModesRow>

--- a/packages/react/src/components/ui/alert/Alert.stories.tsx
+++ b/packages/react/src/components/ui/alert/Alert.stories.tsx
@@ -27,6 +27,7 @@ import {
   AlertClose,
   AlertContent,
   AlertDescription,
+  AlertIcon,
   AlertTitle,
 } from './alert';
 
@@ -121,16 +122,32 @@ type PlaygroundStory = StoryObj<PlaygroundArgs>;
 function renderPlaygroundIcon(icon: PlaygroundIcon) {
   if (icon === 'none') return null;
   if (icon === 'destructive') {
-    return <IconAlertCircle aria-hidden="true" className="nx:size-4" />;
+    return (
+      <AlertIcon>
+        <IconAlertCircle />
+      </AlertIcon>
+    );
   }
   if (icon === 'success') {
-    return <IconCircleCheck aria-hidden="true" className="nx:size-4" />;
+    return (
+      <AlertIcon>
+        <IconCircleCheck />
+      </AlertIcon>
+    );
   }
   if (icon === 'warning') {
-    return <IconAlertTriangle aria-hidden="true" className="nx:size-4" />;
+    return (
+      <AlertIcon>
+        <IconAlertTriangle />
+      </AlertIcon>
+    );
   }
 
-  return <IconInfoCircle aria-hidden="true" className="nx:size-4" />;
+  return (
+    <AlertIcon>
+      <IconInfoCircle />
+    </AlertIcon>
+  );
 }
 
 function AlertPlaygroundExample({
@@ -202,7 +219,9 @@ function DismissibleCloseButtonExample(
 
   return (
     <Alert {...props} className="nx:max-w-xl">
-      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconInfoCircle />
+      </AlertIcon>
       <AlertContent>
         <AlertTitle>Invite ready</AlertTitle>
         <AlertDescription>
@@ -352,7 +371,9 @@ export const Playground: PlaygroundStory = {
       },
       source: {
         code: `<Alert variant="information" layout="inline">
-  <IconInfoCircle aria-hidden="true" />
+  <AlertIcon>
+    <IconInfoCircle />
+  </AlertIcon>
   <AlertContent>
     <AlertTitle>Storage almost full</AlertTitle>
     <AlertDescription>Uploads may fail soon.</AlertDescription>
@@ -448,7 +469,9 @@ export const BannerPresentation: Story = {
   },
   render: (args) => (
     <Alert {...args} className="nx:max-w-md">
-      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconInfoCircle />
+      </AlertIcon>
       <AlertTitle>Information</AlertTitle>
       <AlertDescription>
         New workspace invitations are available for review.
@@ -471,7 +494,9 @@ export const BannerPresentation: Story = {
 export const WithIcon: Story = {
   render: (args) => (
     <Alert {...args} className="nx:max-w-md">
-      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconInfoCircle />
+      </AlertIcon>
       <AlertTitle>Information</AlertTitle>
       <AlertDescription>
         This is an informational alert with an icon.
@@ -486,7 +511,9 @@ export const DestructiveWithIcon: Story = {
   },
   render: (args) => (
     <Alert {...args} className="nx:max-w-md">
-      <IconAlertCircle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconAlertCircle />
+      </AlertIcon>
       <AlertTitle>Error</AlertTitle>
       <AlertDescription>
         Something went wrong. Please try again later.
@@ -501,7 +528,9 @@ export const InformationWithIcon: Story = {
   },
   render: (args) => (
     <Alert {...args} className="nx:max-w-md">
-      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconInfoCircle />
+      </AlertIcon>
       <AlertTitle>Information</AlertTitle>
       <AlertDescription>
         New workspace invitations are available for review.
@@ -516,7 +545,9 @@ export const SuccessWithIcon: Story = {
   },
   render: (args) => (
     <Alert {...args} className="nx:max-w-md">
-      <IconCircleCheck aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconCircleCheck />
+      </AlertIcon>
       <AlertTitle>Success</AlertTitle>
       <AlertDescription>
         Your payment was processed successfully.
@@ -531,7 +562,9 @@ export const WarningWithIcon: Story = {
   },
   render: (args) => (
     <Alert {...args} className="nx:max-w-md">
-      <IconAlertTriangle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconAlertTriangle />
+      </AlertIcon>
       <AlertTitle>Warning</AlertTitle>
       <AlertDescription>
         Your storage is almost full. Consider upgrading your plan.
@@ -635,7 +668,9 @@ export const TextDismissAction: Story = {
   },
   render: (args) => (
     <Alert {...args} className="nx:max-w-xl">
-      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconInfoCircle />
+      </AlertIcon>
       <AlertContent>
         <AlertTitle>Import completed</AlertTitle>
         <AlertDescription>
@@ -655,7 +690,9 @@ export const CriticalNoClose: Story = {
   },
   render: (args) => (
     <Alert {...args} className="nx:max-w-md">
-      <IconAlertCircle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconAlertCircle />
+      </AlertIcon>
       <AlertTitle>Payment failed</AlertTitle>
       <AlertDescription>
         Update the billing method before the workspace is paused.
@@ -671,7 +708,9 @@ export const InlineAction: Story = {
   },
   render: (args) => (
     <Alert {...args} className="nx:max-w-xl">
-      <IconAlertTriangle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconAlertTriangle />
+      </AlertIcon>
       <AlertContent>
         <AlertTitle>Storage almost full</AlertTitle>
         <AlertDescription>Uploads may fail soon.</AlertDescription>
@@ -689,7 +728,9 @@ export const DescriptionLinkAction: Story = {
   },
   render: (args) => (
     <Alert {...args} className="nx:max-w-md">
-      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconInfoCircle />
+      </AlertIcon>
       <AlertTitle>Sync is paused</AlertTitle>
       <AlertDescription>
         Reconnect the integration from{' '}
@@ -711,7 +752,9 @@ export const ActionsBelowDescription: Story = {
   },
   render: (args) => (
     <Alert {...args} className="nx:max-w-md">
-      <IconAlertTriangle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconAlertTriangle />
+      </AlertIcon>
       <AlertContent>
         <AlertTitle>Plan limit reached</AlertTitle>
         <AlertDescription>
@@ -734,7 +777,9 @@ export const InlineActionsWithClose: Story = {
   },
   render: (args) => (
     <Alert {...args} className="nx:max-w-2xl">
-      <IconCircleCheck aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconCircleCheck />
+      </AlertIcon>
       <AlertContent>
         <AlertTitle>Deployment complete</AlertTitle>
         <AlertDescription>
@@ -757,7 +802,9 @@ export const BannerInlineActions: Story = {
   },
   render: (args) => (
     <Alert {...args} className="nx:max-w-3xl">
-      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconInfoCircle />
+      </AlertIcon>
       <AlertContent>
         <AlertTitle>New policy available</AlertTitle>
         <AlertDescription>
@@ -780,7 +827,9 @@ export const HelperBanner: Story = {
   },
   render: (args) => (
     <Alert {...args} className="nx:max-w-3xl">
-      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconInfoCircle />
+      </AlertIcon>
       <AlertContent>
         <AlertDescription>
           Scheduled maintenance begins at 9 PM.{' '}
@@ -812,7 +861,9 @@ export const CustomCloseIconLabel: Story = {
   },
   render: (args) => (
     <Alert {...args} className="nx:max-w-xl">
-      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconInfoCircle />
+      </AlertIcon>
       <AlertContent>
         <AlertTitle>Custom close icon</AlertTitle>
         <AlertDescription>
@@ -842,7 +893,9 @@ export const TextCloseLabel: Story = {
   },
   render: (args) => (
     <Alert {...args} className="nx:max-w-xl">
-      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconInfoCircle />
+      </AlertIcon>
       <AlertContent>
         <AlertTitle>Text close control</AlertTitle>
         <AlertDescription>
@@ -898,7 +951,9 @@ export const WithDataAttributes: Story = {
 export const ActionSlotDataAttributes: Story = {
   render: (_args) => (
     <Alert variant="warning" layout="inline" className="nx:max-w-xl">
-      <IconAlertTriangle aria-hidden="true" className="nx:size-4" />
+      <AlertIcon>
+        <IconAlertTriangle />
+      </AlertIcon>
       <AlertContent>
         <AlertTitle>Storage almost full</AlertTitle>
         <AlertDescription>Uploads may fail soon.</AlertDescription>
@@ -980,7 +1035,9 @@ export const AllVariants: Story = {
           Default
         </div>
         <Alert className="nx:max-w-md">
-          <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+          <AlertIcon>
+            <IconInfoCircle />
+          </AlertIcon>
           <AlertTitle>Default Alert</AlertTitle>
           <AlertDescription>
             This is a default informational alert.
@@ -993,7 +1050,9 @@ export const AllVariants: Story = {
           Information
         </div>
         <Alert variant="information" className="nx:max-w-md">
-          <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+          <AlertIcon>
+            <IconInfoCircle />
+          </AlertIcon>
           <AlertTitle>Information Alert</AlertTitle>
           <AlertDescription>This is an informational alert.</AlertDescription>
         </Alert>
@@ -1004,7 +1063,9 @@ export const AllVariants: Story = {
           Destructive
         </div>
         <Alert variant="destructive" className="nx:max-w-md">
-          <IconAlertCircle aria-hidden="true" className="nx:size-4" />
+          <AlertIcon>
+            <IconAlertCircle />
+          </AlertIcon>
           <AlertTitle>Destructive Alert</AlertTitle>
           <AlertDescription>
             This is a destructive/error alert.
@@ -1017,7 +1078,9 @@ export const AllVariants: Story = {
           Success
         </div>
         <Alert variant="success" className="nx:max-w-md">
-          <IconCircleCheck aria-hidden="true" className="nx:size-4" />
+          <AlertIcon>
+            <IconCircleCheck />
+          </AlertIcon>
           <AlertTitle>Success Alert</AlertTitle>
           <AlertDescription>This is a success alert.</AlertDescription>
         </Alert>
@@ -1028,7 +1091,9 @@ export const AllVariants: Story = {
           Warning
         </div>
         <Alert variant="warning" className="nx:max-w-md">
-          <IconAlertTriangle aria-hidden="true" className="nx:size-4" />
+          <AlertIcon>
+            <IconAlertTriangle />
+          </AlertIcon>
           <AlertTitle>Warning Alert</AlertTitle>
           <AlertDescription>This is a warning alert.</AlertDescription>
         </Alert>
@@ -1048,7 +1113,9 @@ export const AllBannerVariants: Story = {
           Default Banner
         </div>
         <Alert presentation="banner" className="nx:max-w-md">
-          <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+          <AlertIcon>
+            <IconInfoCircle />
+          </AlertIcon>
           <AlertTitle>Default Alert</AlertTitle>
           <AlertDescription>
             This is a default informational alert.
@@ -1065,7 +1132,9 @@ export const AllBannerVariants: Story = {
           variant="information"
           className="nx:max-w-md"
         >
-          <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+          <AlertIcon>
+            <IconInfoCircle />
+          </AlertIcon>
           <AlertTitle>Information Alert</AlertTitle>
           <AlertDescription>This is an informational alert.</AlertDescription>
         </Alert>
@@ -1080,7 +1149,9 @@ export const AllBannerVariants: Story = {
           variant="destructive"
           className="nx:max-w-md"
         >
-          <IconAlertCircle aria-hidden="true" className="nx:size-4" />
+          <AlertIcon>
+            <IconAlertCircle />
+          </AlertIcon>
           <AlertTitle>Destructive Alert</AlertTitle>
           <AlertDescription>
             This is a destructive/error alert.
@@ -1093,7 +1164,9 @@ export const AllBannerVariants: Story = {
           Success Banner
         </div>
         <Alert presentation="banner" variant="success" className="nx:max-w-md">
-          <IconCircleCheck aria-hidden="true" className="nx:size-4" />
+          <AlertIcon>
+            <IconCircleCheck />
+          </AlertIcon>
           <AlertTitle>Success Alert</AlertTitle>
           <AlertDescription>This is a success alert.</AlertDescription>
         </Alert>
@@ -1104,7 +1177,9 @@ export const AllBannerVariants: Story = {
           Warning Banner
         </div>
         <Alert presentation="banner" variant="warning" className="nx:max-w-md">
-          <IconAlertTriangle aria-hidden="true" className="nx:size-4" />
+          <AlertIcon>
+            <IconAlertTriangle />
+          </AlertIcon>
           <AlertTitle>Warning Alert</AlertTitle>
           <AlertDescription>This is a warning alert.</AlertDescription>
         </Alert>

--- a/packages/react/src/components/ui/alert/Alert.stories.tsx
+++ b/packages/react/src/components/ui/alert/Alert.stories.tsx
@@ -41,8 +41,8 @@ const meta: Meta<typeof Alert> = {
 Alert is a composable callout for status, warning, error, success, or informational messages. The root controls status, presentation, and layout; icons, content, actions, and dismissal are composed with children.
 
 Action pattern rules:
-- Stack layout: valid with no actions, one or two button actions, or button action(s) plus AlertClose.
-- Stack layout: do not use AlertClose as the only action, because a lone close icon below the message is not an approved placement.
+- Stack layout: valid with no actions, one button action, or two button actions.
+- Stack layout: do not use AlertClose because the close icon is not an approved below-message placement.
 - Inline layout: valid with close-only, one or two button actions, or button action(s) plus AlertClose.
 - Dismissal stays consumer-controlled. AlertClose only renders the control; it does not remove the alert by itself.
         `,
@@ -98,7 +98,10 @@ type PlaygroundActions =
   | 'primary + close'
   | 'primary + secondary'
   | 'primary + secondary + close';
-type PlaygroundStackActions = Exclude<PlaygroundActions, 'close'>;
+type PlaygroundStackActions = Extract<
+  PlaygroundActions,
+  'none' | 'primary' | 'primary + secondary'
+>;
 type PlaygroundButtonVariant = NonNullable<
   React.ComponentProps<typeof Button>['variant']
 >;
@@ -131,6 +134,16 @@ function renderPlaygroundIcon(icon: PlaygroundIcon) {
   return <IconInfoCircle aria-hidden="true" className="nx:size-4" />;
 }
 
+function normalizeStackActions(
+  actions: PlaygroundActions
+): PlaygroundStackActions {
+  if (actions === 'close') return 'none';
+  if (actions === 'primary + close') return 'primary';
+  if (actions === 'primary + secondary + close') return 'primary + secondary';
+
+  return actions;
+}
+
 function AlertPlaygroundExample({
   actionsInline,
   actionsStack,
@@ -156,7 +169,8 @@ function AlertPlaygroundExample({
   secondaryActionVariant: PlaygroundButtonVariant;
 }) {
   const [visible, setVisible] = React.useState(true);
-  const actions = layout === 'inline' ? actionsInline : actionsStack;
+  const actions =
+    layout === 'inline' ? actionsInline : normalizeStackActions(actionsStack);
   const hasPrimaryAction = actions.includes('primary');
   const hasSecondaryAction = actions.includes('secondary');
   const hasCloseAction = actions.includes('close');
@@ -259,7 +273,7 @@ export const Default: Story = {
 export const Playground: PlaygroundStory = {
   args: {
     actionsInline: 'primary + close',
-    actionsStack: 'primary + close',
+    actionsStack: 'primary',
     icon: 'information',
     layout: 'inline',
     presentation: 'card',
@@ -296,15 +310,9 @@ export const Playground: PlaygroundStory = {
     actionsStack: {
       name: 'actions (stack story only)',
       control: 'select',
-      options: [
-        'none',
-        'primary',
-        'primary + close',
-        'primary + secondary',
-        'primary + secondary + close',
-      ],
+      options: ['none', 'primary', 'primary + secondary'],
       description:
-        'Story-only stack action pattern. Close-only is intentionally omitted because the lone close icon should not sit below the message.',
+        'Story-only stack action pattern. AlertClose is intentionally omitted because the close icon should not sit below the message.',
       table: {
         category: 'Controls',
       },
@@ -379,7 +387,7 @@ export const Playground: PlaygroundStory = {
     docs: {
       description: {
         story:
-          'Story-only controls render the recommended slot composition. They are not Alert props; production usage still composes icons, Button, AlertActions, and AlertClose as children. The visible action control changes by layout so stack omits the invalid close-only pattern while inline keeps it available.',
+          'Story-only controls render the recommended slot composition. They are not Alert props; production usage still composes icons, Button, AlertActions, and AlertClose as children. The visible action control changes by layout so stack omits AlertClose patterns while inline keeps them available.',
       },
       source: {
         code: `<Alert variant="information" layout="inline">

--- a/packages/react/src/components/ui/alert/Alert.stories.tsx
+++ b/packages/react/src/components/ui/alert/Alert.stories.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import type { Meta, StoryObj } from '@storybook/react';
 import {
   IconAlertCircle,
@@ -5,7 +7,7 @@ import {
   IconCircleCheck,
   IconInfoCircle,
 } from '@tabler/icons-react';
-import { expect, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import {
   AllModesGrid,
@@ -16,8 +18,16 @@ import {
   expectHeightPinned,
   expectModeCascadeWorks,
 } from '../../../stories/test-utils';
+import { Button } from '../button';
 
-import { Alert, AlertDescription, AlertTitle } from './alert';
+import {
+  Alert,
+  AlertActions,
+  AlertClose,
+  AlertContent,
+  AlertDescription,
+  AlertTitle,
+} from './alert';
 
 const meta: Meta<typeof Alert> = {
   title: 'Components/Alert',
@@ -25,11 +35,26 @@ const meta: Meta<typeof Alert> = {
   parameters: {
     layout: 'padded',
   },
+  args: {
+    layout: 'stack',
+    presentation: 'card',
+    variant: 'default',
+  },
   argTypes: {
     variant: {
       control: 'select',
       options: ['default', 'information', 'destructive', 'success', 'warning'],
       description: 'The visual style variant',
+    },
+    presentation: {
+      control: 'select',
+      options: ['card', 'banner'],
+      description: 'The alert presentation style',
+    },
+    layout: {
+      control: 'select',
+      options: ['stack', 'inline', 'dense'],
+      description: 'The alert content/action layout',
     },
   },
 };
@@ -37,13 +62,36 @@ const meta: Meta<typeof Alert> = {
 export default meta;
 type Story = StoryObj<typeof Alert>;
 
+function DismissibleCloseButtonExample(
+  props: React.ComponentProps<typeof Alert>
+) {
+  const [visible, setVisible] = React.useState(true);
+
+  if (!visible) return <div data-testid="dismissed-alert" />;
+
+  return (
+    <Alert {...props} className="nx:max-w-xl">
+      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertContent>
+        <AlertTitle>Invite ready</AlertTitle>
+        <AlertDescription>
+          The workspace invitation can now be sent.
+        </AlertDescription>
+      </AlertContent>
+      <AlertActions>
+        <AlertClose onClick={() => setVisible(false)} />
+      </AlertActions>
+    </Alert>
+  );
+}
+
 // ============================================
 // BASIC STORIES
 // ============================================
 
 export const Default: Story = {
-  render: (_args) => (
-    <Alert className="nx:max-w-md">
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
       <AlertTitle>Heads up!</AlertTitle>
       <AlertDescription>
         You can add components and dependencies to your app using the CLI.
@@ -53,8 +101,11 @@ export const Default: Story = {
 };
 
 export const Destructive: Story = {
-  render: (_args) => (
-    <Alert variant="destructive" className="nx:max-w-md">
+  args: {
+    variant: 'destructive',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
       <AlertTitle>Error</AlertTitle>
       <AlertDescription>
         Your session has expired. Please log in again.
@@ -64,8 +115,11 @@ export const Destructive: Story = {
 };
 
 export const Information: Story = {
-  render: (_args) => (
-    <Alert variant="information" className="nx:max-w-md">
+  args: {
+    variant: 'information',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
       <AlertTitle>Information</AlertTitle>
       <AlertDescription>
         New workspace invitations are available for review.
@@ -75,8 +129,11 @@ export const Information: Story = {
 };
 
 export const Success: Story = {
-  render: (_args) => (
-    <Alert variant="success" className="nx:max-w-md">
+  args: {
+    variant: 'success',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
       <AlertTitle>Success</AlertTitle>
       <AlertDescription>
         Your changes have been saved successfully.
@@ -86,8 +143,11 @@ export const Success: Story = {
 };
 
 export const Warning: Story = {
-  render: (_args) => (
-    <Alert variant="warning" className="nx:max-w-md">
+  args: {
+    variant: 'warning',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
       <AlertTitle>Warning</AlertTitle>
       <AlertDescription>
         Your account is about to expire. Please renew your subscription.
@@ -96,14 +156,37 @@ export const Warning: Story = {
   ),
 };
 
+export const BannerPresentation: Story = {
+  args: {
+    presentation: 'banner',
+    variant: 'information',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
+      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertTitle>Information</AlertTitle>
+      <AlertDescription>
+        New workspace invitations are available for review.
+      </AlertDescription>
+    </Alert>
+  ),
+  play: async ({ canvasElement }) => {
+    const alert = canvasElement.querySelector('[data-slot="alert"]');
+
+    await expect(alert).toBeInTheDocument();
+    await expect(alert).toHaveAttribute('data-variant', 'information');
+    await expect(alert).toHaveAttribute('data-presentation', 'banner');
+  },
+};
+
 // ============================================
 // WITH ICON STORIES
 // ============================================
 
 export const WithIcon: Story = {
-  render: (_args) => (
-    <Alert className="nx:max-w-md">
-      <IconInfoCircle className="nx:size-4" />
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
+      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
       <AlertTitle>Information</AlertTitle>
       <AlertDescription>
         This is an informational alert with an icon.
@@ -113,9 +196,12 @@ export const WithIcon: Story = {
 };
 
 export const DestructiveWithIcon: Story = {
-  render: (_args) => (
-    <Alert variant="destructive" className="nx:max-w-md">
-      <IconAlertCircle className="nx:size-4" />
+  args: {
+    variant: 'destructive',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
+      <IconAlertCircle aria-hidden="true" className="nx:size-4" />
       <AlertTitle>Error</AlertTitle>
       <AlertDescription>
         Something went wrong. Please try again later.
@@ -125,9 +211,12 @@ export const DestructiveWithIcon: Story = {
 };
 
 export const InformationWithIcon: Story = {
-  render: (_args) => (
-    <Alert variant="information" className="nx:max-w-md">
-      <IconInfoCircle className="nx:size-4" />
+  args: {
+    variant: 'information',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
+      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
       <AlertTitle>Information</AlertTitle>
       <AlertDescription>
         New workspace invitations are available for review.
@@ -137,9 +226,12 @@ export const InformationWithIcon: Story = {
 };
 
 export const SuccessWithIcon: Story = {
-  render: (_args) => (
-    <Alert variant="success" className="nx:max-w-md">
-      <IconCircleCheck className="nx:size-4" />
+  args: {
+    variant: 'success',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
+      <IconCircleCheck aria-hidden="true" className="nx:size-4" />
       <AlertTitle>Success</AlertTitle>
       <AlertDescription>
         Your payment was processed successfully.
@@ -149,9 +241,12 @@ export const SuccessWithIcon: Story = {
 };
 
 export const WarningWithIcon: Story = {
-  render: (_args) => (
-    <Alert variant="warning" className="nx:max-w-md">
-      <IconAlertTriangle className="nx:size-4" />
+  args: {
+    variant: 'warning',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
+      <IconAlertTriangle aria-hidden="true" className="nx:size-4" />
       <AlertTitle>Warning</AlertTitle>
       <AlertDescription>
         Your storage is almost full. Consider upgrading your plan.
@@ -165,16 +260,16 @@ export const WarningWithIcon: Story = {
 // ============================================
 
 export const WithTitle: Story = {
-  render: (_args) => (
-    <Alert className="nx:max-w-md">
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
       <AlertTitle>This is just a title</AlertTitle>
     </Alert>
   ),
 };
 
 export const WithDescription: Story = {
-  render: (_args) => (
-    <Alert className="nx:max-w-md">
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
       <AlertDescription>
         This alert has only a description without a title.
       </AlertDescription>
@@ -183,8 +278,8 @@ export const WithDescription: Story = {
 };
 
 export const LongContent: Story = {
-  render: (_args) => (
-    <Alert className="nx:max-w-md">
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
       <AlertTitle>Important Information</AlertTitle>
       <AlertDescription>
         <p>
@@ -196,6 +291,203 @@ export const LongContent: Story = {
           nisi ut aliquip ex ea commodo consequat.
         </p>
       </AlertDescription>
+    </Alert>
+  ),
+};
+
+// ============================================
+// ACTION PATTERNS
+// ============================================
+
+export const DismissibleCloseButton: Story = {
+  args: {
+    layout: 'inline',
+    variant: 'information',
+  },
+  render: (args) => <DismissibleCloseButtonExample {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = canvasElement.querySelector('[data-slot="alert"]');
+    const close = canvas.getByRole('button', { name: 'Dismiss alert' });
+
+    await expect(alert).toBeInTheDocument();
+    await expect(alert).toHaveAttribute('data-layout', 'inline');
+    await userEvent.click(close);
+    await waitFor(() => {
+      expect(
+        canvasElement.querySelector('[data-slot="alert"]')
+      ).not.toBeInTheDocument();
+    });
+  },
+};
+
+export const TextDismissAction: Story = {
+  args: {
+    layout: 'inline',
+    variant: 'information',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-xl">
+      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertContent>
+        <AlertTitle>Import completed</AlertTitle>
+        <AlertDescription>
+          Review the imported contacts before publishing them.
+        </AlertDescription>
+      </AlertContent>
+      <AlertActions>
+        <Button variant="ghost">Dismiss</Button>
+      </AlertActions>
+    </Alert>
+  ),
+};
+
+export const CriticalNoClose: Story = {
+  args: {
+    variant: 'destructive',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
+      <IconAlertCircle aria-hidden="true" className="nx:size-4" />
+      <AlertTitle>Payment failed</AlertTitle>
+      <AlertDescription>
+        Update the billing method before the workspace is paused.
+      </AlertDescription>
+    </Alert>
+  ),
+};
+
+export const InlineAction: Story = {
+  args: {
+    layout: 'inline',
+    variant: 'warning',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-xl">
+      <IconAlertTriangle aria-hidden="true" className="nx:size-4" />
+      <AlertContent>
+        <AlertTitle>Storage almost full</AlertTitle>
+        <AlertDescription>Uploads may fail soon.</AlertDescription>
+      </AlertContent>
+      <AlertActions>
+        <Button variant="outline">Manage</Button>
+      </AlertActions>
+    </Alert>
+  ),
+};
+
+export const DescriptionLinkAction: Story = {
+  args: {
+    variant: 'information',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
+      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertTitle>Sync is paused</AlertTitle>
+      <AlertDescription>
+        Reconnect the integration from{' '}
+        <a
+          className="nx:font-medium nx:text-primary-subtle-foreground nx:underline-offset-4 nx:hover:underline"
+          href="/settings"
+        >
+          workspace settings
+        </a>
+        .
+      </AlertDescription>
+    </Alert>
+  ),
+};
+
+export const ActionsBelowDescription: Story = {
+  args: {
+    variant: 'warning',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-md">
+      <IconAlertTriangle aria-hidden="true" className="nx:size-4" />
+      <AlertContent>
+        <AlertTitle>Plan limit reached</AlertTitle>
+        <AlertDescription>
+          Upgrade the workspace or remove unused seats before inviting more
+          members.
+        </AlertDescription>
+      </AlertContent>
+      <AlertActions>
+        <Button>Upgrade</Button>
+        <Button variant="outline">View usage</Button>
+      </AlertActions>
+    </Alert>
+  ),
+};
+
+export const InlineActionsWithClose: Story = {
+  args: {
+    layout: 'inline',
+    variant: 'success',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-2xl">
+      <IconCircleCheck aria-hidden="true" className="nx:size-4" />
+      <AlertContent>
+        <AlertTitle>Deployment complete</AlertTitle>
+        <AlertDescription>
+          Version 2.4.0 is live in the production environment.
+        </AlertDescription>
+      </AlertContent>
+      <AlertActions>
+        <Button variant="outline">View release</Button>
+        <AlertClose />
+      </AlertActions>
+    </Alert>
+  ),
+};
+
+export const BannerInlineActions: Story = {
+  args: {
+    layout: 'inline',
+    presentation: 'banner',
+    variant: 'information',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-3xl">
+      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertContent>
+        <AlertTitle>New policy available</AlertTitle>
+        <AlertDescription>
+          Review the updated workspace retention policy.
+        </AlertDescription>
+      </AlertContent>
+      <AlertActions>
+        <Button variant="outline">Review</Button>
+        <AlertClose />
+      </AlertActions>
+    </Alert>
+  ),
+};
+
+export const DenseHelperBanner: Story = {
+  args: {
+    layout: 'dense',
+    presentation: 'banner',
+    variant: 'information',
+  },
+  render: (args) => (
+    <Alert {...args} className="nx:max-w-3xl">
+      <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+      <AlertContent>
+        <AlertDescription>
+          Scheduled maintenance begins at 9 PM.{' '}
+          <a
+            className="nx:font-medium nx:text-primary-subtle-foreground nx:underline-offset-4 nx:hover:underline"
+            href="/status"
+          >
+            View status
+          </a>
+        </AlertDescription>
+      </AlertContent>
+      <AlertActions>
+        <AlertClose />
+      </AlertActions>
     </Alert>
   ),
 };
@@ -221,9 +513,40 @@ export const WithDataAttributes: Story = {
 
     await expect(alert).toBeInTheDocument();
     await expect(alert).toHaveAttribute('data-variant', 'destructive');
-    await expect(alert).toHaveAttribute('role', 'alert');
+    await expect(alert).toHaveAttribute('data-presentation', 'card');
+    await expect(alert).toHaveAttribute('data-layout', 'stack');
+    await expect(alert).not.toHaveAttribute('role');
     await expect(title).toBeInTheDocument();
     await expect(description).toBeInTheDocument();
+  },
+};
+
+export const ActionSlotDataAttributes: Story = {
+  render: (_args) => (
+    <Alert variant="warning" layout="inline" className="nx:max-w-xl">
+      <IconAlertTriangle aria-hidden="true" className="nx:size-4" />
+      <AlertContent>
+        <AlertTitle>Storage almost full</AlertTitle>
+        <AlertDescription>Uploads may fail soon.</AlertDescription>
+      </AlertContent>
+      <AlertActions>
+        <Button variant="outline">Manage</Button>
+        <AlertClose />
+      </AlertActions>
+    </Alert>
+  ),
+  play: async ({ canvasElement }) => {
+    const alert = canvasElement.querySelector('[data-slot="alert"]');
+    const content = canvasElement.querySelector('[data-slot="alert-content"]');
+    const actions = canvasElement.querySelector('[data-slot="alert-actions"]');
+    const close = canvasElement.querySelector('[data-slot="alert-close"]');
+
+    await expect(alert).toBeInTheDocument();
+    await expect(alert).toHaveAttribute('data-layout', 'inline');
+    await expect(content).toBeInTheDocument();
+    await expect(actions).toBeInTheDocument();
+    await expect(close).toBeInTheDocument();
+    await expect(close).toHaveAttribute('type', 'button');
   },
 };
 
@@ -239,6 +562,34 @@ export const DefaultDataAttributes: Story = {
 
     await expect(alert).toBeInTheDocument();
     await expect(alert).toHaveAttribute('data-variant', 'default');
+    await expect(alert).toHaveAttribute('data-presentation', 'card');
+    await expect(alert).not.toHaveAttribute('role');
+  },
+};
+
+export const RolePassThrough: Story = {
+  render: (_args) => (
+    <div className="nx:flex nx:flex-col nx:gap-4">
+      <Alert role="alert" variant="destructive" className="nx:max-w-md">
+        <AlertTitle>Session expired</AlertTitle>
+        <AlertDescription>
+          Sign in again before continuing this task.
+        </AlertDescription>
+      </Alert>
+      <Alert role="status" variant="information" className="nx:max-w-md">
+        <AlertTitle>Changes saved</AlertTitle>
+        <AlertDescription>
+          Your workspace settings were updated.
+        </AlertDescription>
+      </Alert>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const alert = canvasElement.querySelector('[role="alert"]');
+    const status = canvasElement.querySelector('[role="status"]');
+
+    await expect(alert).toBeInTheDocument();
+    await expect(status).toBeInTheDocument();
   },
 };
 
@@ -254,7 +605,7 @@ export const AllVariants: Story = {
           Default
         </div>
         <Alert className="nx:max-w-md">
-          <IconInfoCircle className="nx:size-4" />
+          <IconInfoCircle aria-hidden="true" className="nx:size-4" />
           <AlertTitle>Default Alert</AlertTitle>
           <AlertDescription>
             This is a default informational alert.
@@ -267,7 +618,7 @@ export const AllVariants: Story = {
           Information
         </div>
         <Alert variant="information" className="nx:max-w-md">
-          <IconInfoCircle className="nx:size-4" />
+          <IconInfoCircle aria-hidden="true" className="nx:size-4" />
           <AlertTitle>Information Alert</AlertTitle>
           <AlertDescription>This is an informational alert.</AlertDescription>
         </Alert>
@@ -278,7 +629,7 @@ export const AllVariants: Story = {
           Destructive
         </div>
         <Alert variant="destructive" className="nx:max-w-md">
-          <IconAlertCircle className="nx:size-4" />
+          <IconAlertCircle aria-hidden="true" className="nx:size-4" />
           <AlertTitle>Destructive Alert</AlertTitle>
           <AlertDescription>
             This is a destructive/error alert.
@@ -291,7 +642,7 @@ export const AllVariants: Story = {
           Success
         </div>
         <Alert variant="success" className="nx:max-w-md">
-          <IconCircleCheck className="nx:size-4" />
+          <IconCircleCheck aria-hidden="true" className="nx:size-4" />
           <AlertTitle>Success Alert</AlertTitle>
           <AlertDescription>This is a success alert.</AlertDescription>
         </Alert>
@@ -302,7 +653,83 @@ export const AllVariants: Story = {
           Warning
         </div>
         <Alert variant="warning" className="nx:max-w-md">
-          <IconAlertTriangle className="nx:size-4" />
+          <IconAlertTriangle aria-hidden="true" className="nx:size-4" />
+          <AlertTitle>Warning Alert</AlertTitle>
+          <AlertDescription>This is a warning alert.</AlertDescription>
+        </Alert>
+      </div>
+    </div>
+  ),
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export const AllBannerVariants: Story = {
+  render: (_args) => (
+    <div className="nx:flex nx:flex-col nx:gap-6">
+      <div>
+        <div className="nx:mb-4 nx:typography-label-default nx:text-foreground">
+          Default Banner
+        </div>
+        <Alert presentation="banner" className="nx:max-w-md">
+          <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+          <AlertTitle>Default Alert</AlertTitle>
+          <AlertDescription>
+            This is a default informational alert.
+          </AlertDescription>
+        </Alert>
+      </div>
+
+      <div>
+        <div className="nx:mb-4 nx:typography-label-default nx:text-foreground">
+          Information Banner
+        </div>
+        <Alert
+          presentation="banner"
+          variant="information"
+          className="nx:max-w-md"
+        >
+          <IconInfoCircle aria-hidden="true" className="nx:size-4" />
+          <AlertTitle>Information Alert</AlertTitle>
+          <AlertDescription>This is an informational alert.</AlertDescription>
+        </Alert>
+      </div>
+
+      <div>
+        <div className="nx:mb-4 nx:typography-label-default nx:text-foreground">
+          Destructive Banner
+        </div>
+        <Alert
+          presentation="banner"
+          variant="destructive"
+          className="nx:max-w-md"
+        >
+          <IconAlertCircle aria-hidden="true" className="nx:size-4" />
+          <AlertTitle>Destructive Alert</AlertTitle>
+          <AlertDescription>
+            This is a destructive/error alert.
+          </AlertDescription>
+        </Alert>
+      </div>
+
+      <div>
+        <div className="nx:mb-4 nx:typography-label-default nx:text-foreground">
+          Success Banner
+        </div>
+        <Alert presentation="banner" variant="success" className="nx:max-w-md">
+          <IconCircleCheck aria-hidden="true" className="nx:size-4" />
+          <AlertTitle>Success Alert</AlertTitle>
+          <AlertDescription>This is a success alert.</AlertDescription>
+        </Alert>
+      </div>
+
+      <div>
+        <div className="nx:mb-4 nx:typography-label-default nx:text-foreground">
+          Warning Banner
+        </div>
+        <Alert presentation="banner" variant="warning" className="nx:max-w-md">
+          <IconAlertTriangle aria-hidden="true" className="nx:size-4" />
           <AlertTitle>Warning Alert</AlertTitle>
           <AlertDescription>This is a warning alert.</AlertDescription>
         </Alert>

--- a/packages/react/src/components/ui/alert/alert.tsx
+++ b/packages/react/src/components/ui/alert/alert.tsx
@@ -35,7 +35,8 @@ const alertVariants = cva(
       },
       density: {
         comfortable: '',
-        compact: 'nx:py-3',
+        compact:
+          'nx:py-3 nx:[&>svg]:top-[calc(var(--nx-spacing-3)+(var(--nx-typography-line-height-sm)/2))]',
       },
     },
     compoundVariants: [

--- a/packages/react/src/components/ui/alert/alert.tsx
+++ b/packages/react/src/components/ui/alert/alert.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
 
+import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { IconX } from '@/lib/icons';
 import { cn } from '@/lib/utils';
 
+const alertStatusTextClassName =
+  'nx:group-data-[variant=destructive]/alert:text-error-subtle-foreground nx:group-data-[variant=success]/alert:text-success-subtle-foreground nx:group-data-[variant=information]/alert:text-information-subtle-foreground nx:group-data-[variant=warning]/alert:text-warning-subtle-foreground';
+
 const alertVariants = cva(
-  'nx:group/alert nx:relative nx:w-full nx:p-4 nx:[&>svg~*]:pl-6 nx:[&>svg]:absolute nx:[&>svg]:top-[calc(var(--nx-spacing-4)+10px)] nx:[&>svg]:left-4 nx:[&>svg]:translate-y-[-50%] nx:[&>svg]:text-foreground',
+  'nx:group/alert nx:relative nx:w-full nx:p-4 nx:[&>svg~*]:pl-6 nx:[&>svg]:absolute nx:[&>svg]:top-[calc(var(--nx-spacing-4)+(var(--nx-typography-line-height-sm)/2))] nx:[&>svg]:left-4 nx:[&>svg]:translate-y-[-50%] nx:[&>svg]:text-foreground',
   {
     variants: {
       variant: {
@@ -74,7 +78,7 @@ interface AlertProps
  * ```tsx
  * // With icon
  * <Alert variant="destructive">
- *   <IconAlertCircle className="nx:size-4" />
+ *   <IconAlertCircle aria-hidden="true" className="nx:size-4" />
  *   <AlertTitle>Error</AlertTitle>
  *   <AlertDescription>
  *     Your session has expired. Please log in again.
@@ -139,31 +143,53 @@ function AlertContent({ className, ...props }: AlertContentProps) {
  *
  * Props for the AlertTitle component.
  */
-interface AlertTitleProps extends React.ComponentProps<'div'> {}
+interface AlertTitleProps extends React.ComponentProps<'div'> {
+  /**
+   * Render the title styles on a child element. Use this when the alert title
+   * needs real heading semantics in the page outline.
+   *
+   * @default false
+   * @example
+   * ```tsx
+   * <AlertTitle asChild>
+   *   <h2>Important Notice</h2>
+   * </AlertTitle>
+   * ```
+   */
+  asChild?: boolean;
+}
 
 /**
  * AlertTitle
  *
- * The title of an alert. Renders as a div so consumers can choose heading
- * levels explicitly when the page outline needs one.
+ * The title of an alert. Renders as a div by default; use `asChild` to apply
+ * alert title styling to a semantic heading when the page outline needs one.
  *
  * @example
  * ```tsx
  * <AlertTitle>Important Notice</AlertTitle>
  * ```
  */
-function AlertTitle({ className, children, ...props }: AlertTitleProps) {
+function AlertTitle({
+  asChild = false,
+  className,
+  children,
+  ...props
+}: AlertTitleProps) {
+  const Comp = asChild ? Slot : 'div';
+
   return (
-    <div
+    <Comp
       data-slot="alert-title"
       className={cn(
-        'nx:mb-1 nx:typography-label-large nx:text-foreground nx:group-data-[variant=destructive]/alert:text-error-subtle-foreground nx:group-data-[variant=success]/alert:text-success-subtle-foreground nx:group-data-[variant=information]/alert:text-information-subtle-foreground nx:group-data-[variant=warning]/alert:text-warning-subtle-foreground',
+        'nx:mb-1 nx:typography-label-large nx:text-foreground',
+        alertStatusTextClassName,
         className
       )}
       {...props}
     >
       {children}
-    </div>
+    </Comp>
   );
 }
 
@@ -191,7 +217,8 @@ function AlertDescription({ className, ...props }: AlertDescriptionProps) {
     <div
       data-slot="alert-description"
       className={cn(
-        'nx:typography-body-small nx:text-muted-foreground nx:group-data-[variant=destructive]/alert:text-error-subtle-foreground nx:group-data-[variant=success]/alert:text-success-subtle-foreground nx:group-data-[variant=information]/alert:text-information-subtle-foreground nx:group-data-[variant=warning]/alert:text-warning-subtle-foreground nx:[&_p]:leading-relaxed',
+        'nx:typography-body-small nx:text-muted-foreground nx:[&_p]:leading-relaxed',
+        alertStatusTextClassName,
         className
       )}
       {...props}
@@ -245,7 +272,9 @@ interface AlertCloseProps extends React.ComponentProps<'button'> {}
  * AlertClose
  *
  * A styled close control for alerts. Dismissal is consumer-controlled: wire
- * `onClick` to app state when the alert should be removed.
+ * `onClick` to app state when the alert should be removed. Custom children get
+ * a fallback `aria-label="Dismiss alert"` unless you provide `aria-label` or
+ * `aria-labelledby`.
  *
  * @example
  * ```tsx
@@ -253,11 +282,19 @@ interface AlertCloseProps extends React.ComponentProps<'button'> {}
  * ```
  */
 function AlertClose({
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
   className,
   children,
   type = 'button',
   ...props
 }: AlertCloseProps) {
+  const hasCustomChildren = children !== undefined && children !== null;
+  const fallbackAriaLabel =
+    hasCustomChildren && !ariaLabel && !ariaLabelledBy
+      ? 'Dismiss alert'
+      : ariaLabel;
+
   return (
     <button
       data-slot="alert-close"
@@ -271,6 +308,8 @@ function AlertClose({
         className
       )}
       type={type}
+      aria-label={fallbackAriaLabel}
+      aria-labelledby={ariaLabelledBy}
       {...props}
     >
       {children ?? (

--- a/packages/react/src/components/ui/alert/alert.tsx
+++ b/packages/react/src/components/ui/alert/alert.tsx
@@ -2,26 +2,40 @@ import * as React from 'react';
 
 import { cva, type VariantProps } from 'class-variance-authority';
 
+import { IconX } from '@/lib/icons';
 import { cn } from '@/lib/utils';
 
 const alertVariants = cva(
-  'nx:relative nx:w-full nx:rounded-lg nx:border nx:p-4 nx:[&>svg~*]:pl-7 nx:[&>svg+div]:translate-y-[-3px] nx:[&>svg]:absolute nx:[&>svg]:left-4 nx:[&>svg]:top-4 nx:[&>svg]:text-foreground',
+  'nx:group/alert nx:relative nx:w-full nx:p-4 nx:[&>svg~*]:pl-6 nx:[&>svg]:absolute nx:[&>svg]:top-[calc(var(--nx-spacing-4)+10px)] nx:[&>svg]:left-4 nx:[&>svg]:translate-y-[-50%] nx:[&>svg]:text-foreground',
   {
     variants: {
       variant: {
-        default: 'nx:bg-background nx:text-foreground nx:border-border-default',
+        default: 'nx:border-border-default nx:bg-container',
         destructive:
-          'nx:border-border-error nx:text-error-subtle-foreground nx:bg-error-subtle nx:[&>svg]:text-error-subtle-foreground',
+          'nx:border-border-error nx:bg-error-subtle nx:[&>svg]:text-error-subtle-foreground',
         success:
-          'nx:border-border-success nx:text-success-subtle-foreground nx:bg-success-subtle nx:[&>svg]:text-success-subtle-foreground',
+          'nx:border-border-success nx:bg-success-subtle nx:[&>svg]:text-success-subtle-foreground',
         information:
-          'nx:border-border-information nx:text-information-subtle-foreground nx:bg-information-subtle nx:[&>svg]:text-information-subtle-foreground',
+          'nx:border-border-information nx:bg-information-subtle nx:[&>svg]:text-information-subtle-foreground',
         warning:
-          'nx:border-border-warning nx:text-warning-subtle-foreground nx:bg-warning-subtle nx:[&>svg]:text-warning-subtle-foreground',
+          'nx:border-border-warning nx:bg-warning-subtle nx:[&>svg]:text-warning-subtle-foreground',
+      },
+      presentation: {
+        card: 'nx:rounded-md nx:border',
+        banner: 'nx:rounded-none nx:border-b',
+      },
+      layout: {
+        stack: '',
+        inline:
+          'nx:grid nx:grid-cols-[minmax(0,1fr)_auto] nx:items-center nx:gap-x-4 nx:gap-y-1 nx:[&>[data-slot=alert-content]]:col-start-1 nx:[&>[data-slot=alert-title]]:col-start-1 nx:[&>[data-slot=alert-description]]:col-start-1 nx:[&>[data-slot=alert-actions]]:col-start-2 nx:[&>[data-slot=alert-actions]]:row-start-1 nx:[&>[data-slot=alert-actions]]:justify-self-end',
+        dense:
+          'nx:grid nx:grid-cols-[minmax(0,1fr)_auto] nx:items-center nx:gap-x-3 nx:gap-y-1 nx:py-3 nx:[&>svg]:top-1/2! nx:[&>[data-slot=alert-content]]:col-start-1 nx:[&>[data-slot=alert-title]]:col-start-1 nx:[&>[data-slot=alert-description]]:col-start-1 nx:[&>[data-slot=alert-actions]]:col-start-2 nx:[&>[data-slot=alert-actions]]:row-start-1 nx:[&>[data-slot=alert-actions]]:justify-self-end',
       },
     },
     defaultVariants: {
       variant: 'default',
+      presentation: 'card',
+      layout: 'stack',
     },
   }
 );
@@ -39,6 +53,12 @@ interface AlertProps
  *
  * Displays a callout for user attention with optional icon support.
  * Use for important messages, warnings, errors, or success confirmations.
+ * Use `presentation="banner"` for the edge-to-edge banner treatment from
+ * Figma's `isBanner=False` variants.
+ * Use `layout="inline"` or `layout="dense"` with `AlertContent` and
+ * `AlertActions` when the alert includes trailing controls.
+ * Alerts are passive by default; pass `role="alert"` for urgent dynamic
+ * messages or `role="status"` for polite status updates.
  *
  * @example
  * ```tsx
@@ -62,13 +82,53 @@ interface AlertProps
  * </Alert>
  * ```
  */
-function Alert({ className, variant, ...props }: AlertProps) {
+function Alert({
+  className,
+  variant,
+  presentation,
+  layout,
+  ...props
+}: AlertProps) {
   return (
     <div
       data-slot="alert"
       data-variant={variant ?? 'default'}
-      role="alert"
-      className={cn(alertVariants({ variant }), className)}
+      data-presentation={presentation ?? 'card'}
+      data-layout={layout ?? 'stack'}
+      className={cn(
+        alertVariants({ variant, presentation, layout }),
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * AlertContentProps
+ *
+ * Props for the AlertContent component.
+ */
+interface AlertContentProps extends React.ComponentProps<'div'> {}
+
+/**
+ * AlertContent
+ *
+ * Wraps alert title and description when the alert includes actions.
+ *
+ * @example
+ * ```tsx
+ * <AlertContent>
+ *   <AlertTitle>Storage almost full</AlertTitle>
+ *   <AlertDescription>Uploads may fail soon.</AlertDescription>
+ * </AlertContent>
+ * ```
+ */
+function AlertContent({ className, ...props }: AlertContentProps) {
+  return (
+    <div
+      data-slot="alert-content"
+      className={cn('nx:flex nx:min-w-0 nx:flex-1 nx:flex-col', className)}
       {...props}
     />
   );
@@ -79,12 +139,13 @@ function Alert({ className, variant, ...props }: AlertProps) {
  *
  * Props for the AlertTitle component.
  */
-interface AlertTitleProps extends React.ComponentProps<'h5'> {}
+interface AlertTitleProps extends React.ComponentProps<'div'> {}
 
 /**
  * AlertTitle
  *
- * The title of an alert. Renders as an h5 element.
+ * The title of an alert. Renders as a div so consumers can choose heading
+ * levels explicitly when the page outline needs one.
  *
  * @example
  * ```tsx
@@ -93,13 +154,16 @@ interface AlertTitleProps extends React.ComponentProps<'h5'> {}
  */
 function AlertTitle({ className, children, ...props }: AlertTitleProps) {
   return (
-    <h5
+    <div
       data-slot="alert-title"
-      className={cn('nx:mb-1 nx:typography-label-default', className)}
+      className={cn(
+        'nx:mb-1 nx:typography-label-large nx:text-foreground nx:group-data-[variant=destructive]/alert:text-error-subtle-foreground nx:group-data-[variant=success]/alert:text-success-subtle-foreground nx:group-data-[variant=information]/alert:text-information-subtle-foreground nx:group-data-[variant=warning]/alert:text-warning-subtle-foreground',
+        className
+      )}
       {...props}
     >
       {children}
-    </h5>
+    </div>
   );
 }
 
@@ -127,7 +191,7 @@ function AlertDescription({ className, ...props }: AlertDescriptionProps) {
     <div
       data-slot="alert-description"
       className={cn(
-        'nx:typography-body-small nx:[&_p]:leading-relaxed',
+        'nx:typography-body-small nx:text-muted-foreground nx:group-data-[variant=destructive]/alert:text-error-subtle-foreground nx:group-data-[variant=success]/alert:text-success-subtle-foreground nx:group-data-[variant=information]/alert:text-information-subtle-foreground nx:group-data-[variant=warning]/alert:text-warning-subtle-foreground nx:[&_p]:leading-relaxed',
         className
       )}
       {...props}
@@ -135,8 +199,98 @@ function AlertDescription({ className, ...props }: AlertDescriptionProps) {
   );
 }
 
+/**
+ * AlertActionsProps
+ *
+ * Props for the AlertActions component.
+ */
+interface AlertActionsProps extends React.ComponentProps<'div'> {}
+
+/**
+ * AlertActions
+ *
+ * Holds one or two alert CTAs. Use the existing Button component for actions.
+ *
+ * @example
+ * ```tsx
+ * <AlertActions>
+ *   <Button variant="outline">Manage</Button>
+ *   <AlertClose onClick={() => setShow(false)} />
+ * </AlertActions>
+ * ```
+ */
+function AlertActions({ className, ...props }: AlertActionsProps) {
+  return (
+    <div
+      data-slot="alert-actions"
+      className={cn(
+        'nx:mt-3 nx:flex nx:flex-wrap nx:items-center nx:gap-2',
+        'nx:group-data-[layout=inline]/alert:mt-0 nx:group-data-[layout=inline]/alert:self-center nx:group-data-[layout=inline]/alert:pl-0!',
+        'nx:group-data-[layout=dense]/alert:mt-0 nx:group-data-[layout=dense]/alert:self-center nx:group-data-[layout=dense]/alert:pl-0!',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * AlertCloseProps
+ *
+ * Props for the AlertClose component.
+ */
+interface AlertCloseProps extends React.ComponentProps<'button'> {}
+
+/**
+ * AlertClose
+ *
+ * A styled close control for alerts. Dismissal is consumer-controlled: wire
+ * `onClick` to app state when the alert should be removed.
+ *
+ * @example
+ * ```tsx
+ * <AlertClose onClick={() => setShow(false)} />
+ * ```
+ */
+function AlertClose({
+  className,
+  children,
+  type = 'button',
+  ...props
+}: AlertCloseProps) {
+  return (
+    <button
+      data-slot="alert-close"
+      className={cn(
+        'nx:inline-flex nx:size-8 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-sm nx:text-muted-foreground',
+        'nx:transition-colors nx:hover:bg-background-hover nx:hover:text-foreground',
+        'nx:focus-visible:bg-background-hover nx:focus-visible:text-foreground',
+        'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
+        'nx:disabled:pointer-events-none nx:disabled:opacity-50',
+        'nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+        className
+      )}
+      type={type}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <IconX aria-hidden="true" />
+          <span className="nx:sr-only">Dismiss alert</span>
+        </>
+      )}
+    </button>
+  );
+}
+
 export {
   Alert,
+  AlertActions,
+  type AlertActionsProps,
+  AlertClose,
+  type AlertCloseProps,
+  AlertContent,
+  type AlertContentProps,
   AlertDescription,
   type AlertDescriptionProps,
   type AlertProps,

--- a/packages/react/src/components/ui/alert/alert.tsx
+++ b/packages/react/src/components/ui/alert/alert.tsx
@@ -59,9 +59,9 @@ interface AlertProps
  * corners, bottom border only).
  * Use `layout="inline"` with `AlertContent` and `AlertActions` when the alert
  * has trailing controls.
- * In the default stack layout, use no actions, button actions, or button
- * actions with `AlertClose`; avoid rendering `AlertClose` as the only action.
- * Use `layout="inline"` for close-only dismissal.
+ * In the default stack layout, use no actions or button actions only; avoid
+ * rendering `AlertClose` below the message. Use `layout="inline"` for
+ * dismissal controls.
  * Alerts are passive by default; pass `role="alert"` for urgent dynamic
  * messages or `role="status"` for polite status updates.
  *
@@ -245,8 +245,8 @@ interface AlertActionsProps extends React.ComponentProps<'div'> {}
  * AlertActions
  *
  * Holds one or two alert CTAs. Use the existing Button component for actions.
- * In stack layout, `AlertClose` should accompany another action rather than sit
- * alone below the message. For close-only dismissal, use `layout="inline"`.
+ * In stack layout, use button actions only. For dismissal controls, use
+ * `layout="inline"` so `AlertClose` sits in the trailing action area.
  *
  * @example
  * ```tsx

--- a/packages/react/src/components/ui/alert/alert.tsx
+++ b/packages/react/src/components/ui/alert/alert.tsx
@@ -188,7 +188,7 @@ function AlertTitle({
     <Comp
       data-slot="alert-title"
       className={cn(
-        'nx:mb-1 nx:typography-label-large nx:text-foreground',
+        'nx:mb-1 nx:last:mb-0 nx:typography-label-large nx:text-foreground',
         alertStatusTextClassName,
         className
       )}

--- a/packages/react/src/components/ui/alert/alert.tsx
+++ b/packages/react/src/components/ui/alert/alert.tsx
@@ -14,6 +14,8 @@ const alertVariants = cva(
           'nx:border-border-error nx:text-error-subtle-foreground nx:bg-error-subtle nx:[&>svg]:text-error-subtle-foreground',
         success:
           'nx:border-border-success nx:text-success-subtle-foreground nx:bg-success-subtle nx:[&>svg]:text-success-subtle-foreground',
+        information:
+          'nx:border-border-information nx:text-information-subtle-foreground nx:bg-information-subtle nx:[&>svg]:text-information-subtle-foreground',
         warning:
           'nx:border-border-warning nx:text-warning-subtle-foreground nx:bg-warning-subtle nx:[&>svg]:text-warning-subtle-foreground',
       },
@@ -64,7 +66,7 @@ function Alert({ className, variant, ...props }: AlertProps) {
   return (
     <div
       data-slot="alert"
-      data-variant={variant}
+      data-variant={variant ?? 'default'}
       role="alert"
       className={cn(alertVariants({ variant }), className)}
       {...props}
@@ -93,10 +95,7 @@ function AlertTitle({ className, children, ...props }: AlertTitleProps) {
   return (
     <h5
       data-slot="alert-title"
-      className={cn(
-        'nx:mb-1 nx:font-medium nx:leading-none nx:tracking-tight',
-        className
-      )}
+      className={cn('nx:mb-1 nx:typography-label-default', className)}
       {...props}
     >
       {children}
@@ -127,7 +126,10 @@ function AlertDescription({ className, ...props }: AlertDescriptionProps) {
   return (
     <div
       data-slot="alert-description"
-      className={cn('nx:text-sm nx:[&_p]:leading-relaxed', className)}
+      className={cn(
+        'nx:typography-body-small nx:[&_p]:leading-relaxed',
+        className
+      )}
       {...props}
     />
   );

--- a/packages/react/src/components/ui/alert/alert.tsx
+++ b/packages/react/src/components/ui/alert/alert.tsx
@@ -189,7 +189,6 @@ function AlertTitle({
       data-slot="alert-title"
       className={cn(
         'nx:mb-1 nx:typography-label-large nx:text-foreground',
-        'nx:group-data-[layout=inline]/alert:col-start-1',
         alertStatusTextClassName,
         className
       )}
@@ -225,7 +224,6 @@ function AlertDescription({ className, ...props }: AlertDescriptionProps) {
       data-slot="alert-description"
       className={cn(
         'nx:typography-body-small nx:text-muted-foreground nx:[&_p]:leading-relaxed',
-        'nx:group-data-[layout=inline]/alert:col-start-1',
         alertStatusTextClassName,
         className
       )}

--- a/packages/react/src/components/ui/alert/alert.tsx
+++ b/packages/react/src/components/ui/alert/alert.tsx
@@ -31,26 +31,13 @@ const alertVariants = cva(
       layout: {
         stack: '',
         inline:
-          'nx:grid nx:grid-cols-[minmax(0,1fr)_auto] nx:items-center nx:gap-x-4 nx:gap-y-1 nx:[&>[data-slot=alert-content]]:col-start-1 nx:[&>[data-slot=alert-actions]]:col-start-2 nx:[&>[data-slot=alert-actions]]:row-start-1 nx:[&>[data-slot=alert-actions]]:justify-self-end',
-      },
-      density: {
-        comfortable: '',
-        compact:
-          'nx:py-3 nx:[&>svg]:top-[calc(var(--nx-spacing-3)+(var(--nx-typography-line-height-sm)/2))]',
+          'nx:grid nx:grid-cols-[minmax(0,1fr)_auto] nx:items-center nx:gap-x-4 nx:gap-y-1',
       },
     },
-    compoundVariants: [
-      {
-        layout: 'inline',
-        density: 'compact',
-        className: 'nx:gap-x-3 nx:[&>svg]:top-1/2!',
-      },
-    ],
     defaultVariants: {
       variant: 'default',
       presentation: 'card',
       layout: 'stack',
-      density: 'comfortable',
     },
   }
 );
@@ -71,7 +58,10 @@ interface AlertProps
  * Use `presentation="banner"` for the edge-to-edge banner treatment (squared
  * corners, bottom border only).
  * Use `layout="inline"` with `AlertContent` and `AlertActions` when the alert
- * has trailing controls; add `density="compact"` for a tighter banner row.
+ * has trailing controls.
+ * In the default stack layout, use no actions, button actions, or button
+ * actions with `AlertClose`; avoid rendering `AlertClose` as the only action.
+ * Use `layout="inline"` for close-only dismissal.
  * Alerts are passive by default; pass `role="alert"` for urgent dynamic
  * messages or `role="status"` for polite status updates.
  *
@@ -102,7 +92,6 @@ function Alert({
   variant,
   presentation,
   layout,
-  density,
   ...props
 }: AlertProps) {
   return (
@@ -111,9 +100,8 @@ function Alert({
       data-variant={variant ?? 'default'}
       data-presentation={presentation ?? 'card'}
       data-layout={layout ?? 'stack'}
-      data-density={density ?? 'comfortable'}
       className={cn(
-        alertVariants({ variant, presentation, layout, density }),
+        alertVariants({ variant, presentation, layout }),
         className
       )}
       {...props}
@@ -146,7 +134,11 @@ function AlertContent({ className, ...props }: AlertContentProps) {
   return (
     <div
       data-slot="alert-content"
-      className={cn('nx:flex nx:min-w-0 nx:flex-col', className)}
+      className={cn(
+        'nx:flex nx:min-w-0 nx:flex-col',
+        'nx:group-data-[layout=inline]/alert:col-start-1',
+        className
+      )}
       {...props}
     />
   );
@@ -197,6 +189,7 @@ function AlertTitle({
       data-slot="alert-title"
       className={cn(
         'nx:mb-1 nx:typography-label-large nx:text-foreground',
+        'nx:group-data-[layout=inline]/alert:col-start-1',
         alertStatusTextClassName,
         className
       )}
@@ -232,6 +225,7 @@ function AlertDescription({ className, ...props }: AlertDescriptionProps) {
       data-slot="alert-description"
       className={cn(
         'nx:typography-body-small nx:text-muted-foreground nx:[&_p]:leading-relaxed',
+        'nx:group-data-[layout=inline]/alert:col-start-1',
         alertStatusTextClassName,
         className
       )}
@@ -251,6 +245,8 @@ interface AlertActionsProps extends React.ComponentProps<'div'> {}
  * AlertActions
  *
  * Holds one or two alert CTAs. Use the existing Button component for actions.
+ * In stack layout, `AlertClose` should accompany another action rather than sit
+ * alone below the message. For close-only dismissal, use `layout="inline"`.
  *
  * @example
  * ```tsx
@@ -266,7 +262,7 @@ function AlertActions({ className, ...props }: AlertActionsProps) {
       data-slot="alert-actions"
       className={cn(
         'nx:mt-3 nx:flex nx:flex-wrap nx:items-center nx:gap-2',
-        'nx:group-data-[layout=inline]/alert:mt-0 nx:group-data-[layout=inline]/alert:self-center nx:group-data-[layout=inline]/alert:pl-0!',
+        'nx:group-data-[layout=inline]/alert:col-start-2 nx:group-data-[layout=inline]/alert:row-start-1 nx:group-data-[layout=inline]/alert:mt-0 nx:group-data-[layout=inline]/alert:self-center nx:group-data-[layout=inline]/alert:justify-self-end nx:group-data-[layout=inline]/alert:pl-0!',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/alert/alert.tsx
+++ b/packages/react/src/components/ui/alert/alert.tsx
@@ -6,41 +6,36 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { IconX } from '@/lib/icons';
 import { cn } from '@/lib/utils';
 
-const alertStatusTextClassName =
-  'nx:group-data-[variant=destructive]/alert:text-error-subtle-foreground nx:group-data-[variant=success]/alert:text-success-subtle-foreground nx:group-data-[variant=information]/alert:text-information-subtle-foreground nx:group-data-[variant=warning]/alert:text-warning-subtle-foreground';
-
-const alertVariants = cva(
-  'nx:group/alert nx:relative nx:w-full nx:p-4 nx:[&>svg~*]:pl-6 nx:[&>svg]:absolute nx:[&>svg]:top-[calc(var(--nx-spacing-4)+(var(--nx-typography-line-height-sm)/2))] nx:[&>svg]:left-4 nx:[&>svg]:translate-y-[-50%] nx:[&>svg]:text-foreground',
-  {
-    variants: {
-      variant: {
-        default: 'nx:border-border-default nx:bg-container',
-        destructive:
-          'nx:border-border-error nx:bg-error-subtle nx:[&>svg]:text-error-subtle-foreground',
-        success:
-          'nx:border-border-success nx:bg-success-subtle nx:[&>svg]:text-success-subtle-foreground',
-        information:
-          'nx:border-border-information nx:bg-information-subtle nx:[&>svg]:text-information-subtle-foreground',
-        warning:
-          'nx:border-border-warning nx:bg-warning-subtle nx:[&>svg]:text-warning-subtle-foreground',
-      },
-      presentation: {
-        card: 'nx:rounded-md nx:border',
-        banner: 'nx:rounded-none nx:border-b',
-      },
-      layout: {
-        stack: '',
-        inline:
-          'nx:grid nx:grid-cols-[minmax(0,1fr)_auto] nx:items-center nx:gap-x-4 nx:gap-y-1',
-      },
+const alertVariants = cva('nx:group/alert nx:grid nx:w-full nx:p-4', {
+  variants: {
+    variant: {
+      default: 'nx:border-border-default nx:bg-container nx:text-foreground',
+      destructive:
+        'nx:border-border-error nx:bg-error-subtle nx:text-error-subtle-foreground',
+      success:
+        'nx:border-border-success nx:bg-success-subtle nx:text-success-subtle-foreground',
+      information:
+        'nx:border-border-information nx:bg-information-subtle nx:text-information-subtle-foreground',
+      warning:
+        'nx:border-border-warning nx:bg-warning-subtle nx:text-warning-subtle-foreground',
     },
-    defaultVariants: {
-      variant: 'default',
-      presentation: 'card',
-      layout: 'stack',
+    presentation: {
+      card: 'nx:rounded-md nx:border',
+      banner: 'nx:rounded-none nx:border-b',
     },
-  }
-);
+    layout: {
+      stack:
+        'nx:grid-cols-[auto_minmax(0,1fr)] nx:items-start nx:has-[>[data-slot=alert-icon]]:gap-x-2 nx:*:data-[slot=alert-title]:col-start-2 nx:*:data-[slot=alert-description]:col-start-2 nx:*:data-[slot=alert-content]:col-start-2 nx:*:data-[slot=alert-actions]:col-start-2',
+      inline:
+        'nx:grid-cols-[minmax(0,1fr)_auto] nx:items-center nx:gap-x-4 nx:gap-y-1 nx:has-[>[data-slot=alert-icon]]:grid-cols-[auto_minmax(0,1fr)_auto]',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    presentation: 'card',
+    layout: 'stack',
+  },
+});
 
 /**
  * AlertProps
@@ -79,7 +74,9 @@ interface AlertProps
  * ```tsx
  * // With icon
  * <Alert variant="destructive">
- *   <IconAlertCircle aria-hidden="true" className="nx:size-4" />
+ *   <AlertIcon>
+ *     <IconAlertCircle />
+ *   </AlertIcon>
  *   <AlertTitle>Error</AlertTitle>
  *   <AlertDescription>
  *     Your session has expired. Please log in again.
@@ -102,6 +99,45 @@ function Alert({
       data-layout={layout ?? 'stack'}
       className={cn(
         alertVariants({ variant, presentation, layout }),
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * AlertIconProps
+ *
+ * Props for the AlertIcon component.
+ */
+interface AlertIconProps extends React.ComponentProps<'span'> {}
+
+/**
+ * AlertIcon
+ *
+ * The leading status icon. Owns the icon's size, its status color (matched to
+ * the Alert `variant`, mirroring the title), and the decorative `aria-hidden`.
+ * Place it as the first child of `Alert` and pass any icon as its child.
+ *
+ * @example
+ * ```tsx
+ * <Alert variant="success">
+ *   <AlertIcon>
+ *     <IconCircleCheck />
+ *   </AlertIcon>
+ *   <AlertTitle>Saved</AlertTitle>
+ * </Alert>
+ * ```
+ */
+function AlertIcon({ className, ...props }: AlertIconProps) {
+  return (
+    <span
+      data-slot="alert-icon"
+      aria-hidden="true"
+      className={cn(
+        'nx:flex nx:[&>svg]:size-4',
+        'nx:group-data-[layout=stack]/alert:translate-y-0.5',
         className
       )}
       {...props}
@@ -134,11 +170,7 @@ function AlertContent({ className, ...props }: AlertContentProps) {
   return (
     <div
       data-slot="alert-content"
-      className={cn(
-        'nx:flex nx:min-w-0 nx:flex-col',
-        'nx:group-data-[layout=inline]/alert:col-start-1',
-        className
-      )}
+      className={cn('nx:flex nx:min-w-0 nx:flex-col', className)}
       {...props}
     />
   );
@@ -188,8 +220,7 @@ function AlertTitle({
     <Comp
       data-slot="alert-title"
       className={cn(
-        'nx:mb-1 nx:last:mb-0 nx:typography-label-large nx:text-foreground',
-        alertStatusTextClassName,
+        'nx:mb-1 nx:last:mb-0 nx:typography-label-large',
         className
       )}
       {...props}
@@ -223,8 +254,7 @@ function AlertDescription({ className, ...props }: AlertDescriptionProps) {
     <div
       data-slot="alert-description"
       className={cn(
-        'nx:typography-body-small nx:text-muted-foreground nx:[&_p]:leading-relaxed',
-        alertStatusTextClassName,
+        'nx:typography-body-small nx:group-data-[variant=default]/alert:text-muted-foreground',
         className
       )}
       {...props}
@@ -260,7 +290,7 @@ function AlertActions({ className, ...props }: AlertActionsProps) {
       data-slot="alert-actions"
       className={cn(
         'nx:mt-3 nx:flex nx:flex-wrap nx:items-center nx:gap-2',
-        'nx:group-data-[layout=inline]/alert:col-start-2 nx:group-data-[layout=inline]/alert:row-start-1 nx:group-data-[layout=inline]/alert:mt-0 nx:group-data-[layout=inline]/alert:self-center nx:group-data-[layout=inline]/alert:justify-self-end nx:group-data-[layout=inline]/alert:pl-0!',
+        'nx:group-data-[layout=inline]/alert:mt-0 nx:group-data-[layout=inline]/alert:self-center',
         className
       )}
       {...props}
@@ -330,6 +360,8 @@ export {
   type AlertContentProps,
   AlertDescription,
   type AlertDescriptionProps,
+  AlertIcon,
+  type AlertIconProps,
   type AlertProps,
   AlertTitle,
   type AlertTitleProps,

--- a/packages/react/src/components/ui/alert/alert.tsx
+++ b/packages/react/src/components/ui/alert/alert.tsx
@@ -31,15 +31,25 @@ const alertVariants = cva(
       layout: {
         stack: '',
         inline:
-          'nx:grid nx:grid-cols-[minmax(0,1fr)_auto] nx:items-center nx:gap-x-4 nx:gap-y-1 nx:[&>[data-slot=alert-content]]:col-start-1 nx:[&>[data-slot=alert-title]]:col-start-1 nx:[&>[data-slot=alert-description]]:col-start-1 nx:[&>[data-slot=alert-actions]]:col-start-2 nx:[&>[data-slot=alert-actions]]:row-start-1 nx:[&>[data-slot=alert-actions]]:justify-self-end',
-        dense:
-          'nx:grid nx:grid-cols-[minmax(0,1fr)_auto] nx:items-center nx:gap-x-3 nx:gap-y-1 nx:py-3 nx:[&>svg]:top-1/2! nx:[&>[data-slot=alert-content]]:col-start-1 nx:[&>[data-slot=alert-title]]:col-start-1 nx:[&>[data-slot=alert-description]]:col-start-1 nx:[&>[data-slot=alert-actions]]:col-start-2 nx:[&>[data-slot=alert-actions]]:row-start-1 nx:[&>[data-slot=alert-actions]]:justify-self-end',
+          'nx:grid nx:grid-cols-[minmax(0,1fr)_auto] nx:items-center nx:gap-x-4 nx:gap-y-1 nx:[&>[data-slot=alert-content]]:col-start-1 nx:[&>[data-slot=alert-actions]]:col-start-2 nx:[&>[data-slot=alert-actions]]:row-start-1 nx:[&>[data-slot=alert-actions]]:justify-self-end',
+      },
+      density: {
+        comfortable: '',
+        compact: 'nx:py-3',
       },
     },
+    compoundVariants: [
+      {
+        layout: 'inline',
+        density: 'compact',
+        className: 'nx:gap-x-3 nx:[&>svg]:top-1/2!',
+      },
+    ],
     defaultVariants: {
       variant: 'default',
       presentation: 'card',
       layout: 'stack',
+      density: 'comfortable',
     },
   }
 );
@@ -57,10 +67,10 @@ interface AlertProps
  *
  * Displays a callout for user attention with optional icon support.
  * Use for important messages, warnings, errors, or success confirmations.
- * Use `presentation="banner"` for the edge-to-edge banner treatment from
- * Figma's `isBanner=False` variants.
- * Use `layout="inline"` or `layout="dense"` with `AlertContent` and
- * `AlertActions` when the alert includes trailing controls.
+ * Use `presentation="banner"` for the edge-to-edge banner treatment (squared
+ * corners, bottom border only).
+ * Use `layout="inline"` with `AlertContent` and `AlertActions` when the alert
+ * has trailing controls; add `density="compact"` for a tighter banner row.
  * Alerts are passive by default; pass `role="alert"` for urgent dynamic
  * messages or `role="status"` for polite status updates.
  *
@@ -91,6 +101,7 @@ function Alert({
   variant,
   presentation,
   layout,
+  density,
   ...props
 }: AlertProps) {
   return (
@@ -99,8 +110,9 @@ function Alert({
       data-variant={variant ?? 'default'}
       data-presentation={presentation ?? 'card'}
       data-layout={layout ?? 'stack'}
+      data-density={density ?? 'comfortable'}
       className={cn(
-        alertVariants({ variant, presentation, layout }),
+        alertVariants({ variant, presentation, layout, density }),
         className
       )}
       {...props}
@@ -118,7 +130,8 @@ interface AlertContentProps extends React.ComponentProps<'div'> {}
 /**
  * AlertContent
  *
- * Wraps alert title and description when the alert includes actions.
+ * Wraps alert title and description. Required in `layout="inline"` so the
+ * content fills the first grid column beside `AlertActions`.
  *
  * @example
  * ```tsx
@@ -132,7 +145,7 @@ function AlertContent({ className, ...props }: AlertContentProps) {
   return (
     <div
       data-slot="alert-content"
-      className={cn('nx:flex nx:min-w-0 nx:flex-1 nx:flex-col', className)}
+      className={cn('nx:flex nx:min-w-0 nx:flex-col', className)}
       {...props}
     />
   );
@@ -253,7 +266,6 @@ function AlertActions({ className, ...props }: AlertActionsProps) {
       className={cn(
         'nx:mt-3 nx:flex nx:flex-wrap nx:items-center nx:gap-2',
         'nx:group-data-[layout=inline]/alert:mt-0 nx:group-data-[layout=inline]/alert:self-center nx:group-data-[layout=inline]/alert:pl-0!',
-        'nx:group-data-[layout=dense]/alert:mt-0 nx:group-data-[layout=dense]/alert:self-center nx:group-data-[layout=dense]/alert:pl-0!',
         className
       )}
       {...props}
@@ -272,9 +284,10 @@ interface AlertCloseProps extends React.ComponentProps<'button'> {}
  * AlertClose
  *
  * A styled close control for alerts. Dismissal is consumer-controlled: wire
- * `onClick` to app state when the alert should be removed. Custom children get
- * a fallback `aria-label="Dismiss alert"` unless you provide `aria-label` or
- * `aria-labelledby`.
+ * `onClick` to app state when the alert should be removed. The default renders a
+ * close icon with a visually-hidden "Dismiss alert" label. If you pass custom
+ * children, give them their own accessible name — visible text self-labels;
+ * supply `aria-label` for an icon-only child.
  *
  * @example
  * ```tsx
@@ -282,19 +295,11 @@ interface AlertCloseProps extends React.ComponentProps<'button'> {}
  * ```
  */
 function AlertClose({
-  'aria-label': ariaLabel,
-  'aria-labelledby': ariaLabelledBy,
   className,
   children,
   type = 'button',
   ...props
 }: AlertCloseProps) {
-  const hasCustomChildren = children !== undefined && children !== null;
-  const fallbackAriaLabel =
-    hasCustomChildren && !ariaLabel && !ariaLabelledBy
-      ? 'Dismiss alert'
-      : ariaLabel;
-
   return (
     <button
       data-slot="alert-close"
@@ -308,8 +313,6 @@ function AlertClose({
         className
       )}
       type={type}
-      aria-label={fallbackAriaLabel}
-      aria-labelledby={ariaLabelledBy}
       {...props}
     >
       {children ?? (


### PR DESCRIPTION
## Summary

Completes the initial Alert component audit. Beyond the cosmetic updates, this PR expands the Alert API:

**New API surface**

- `variant="information"` added (default / information / destructive / success / warning).
- `presentation` axis — `card` (default; rounded, full border) | `banner` (squared, bottom border only).
- `layout` axis — `stack` (default; block) | `inline` (content + trailing actions in a grid).
- New subcomponents: `AlertContent`, `AlertActions`, `AlertClose` (consumer-controlled dismissal).
- Title/description typography moved to `nx:typography-*` composites; default surface is `bg-container` on the numeric `p-4` document scale.

**Behavior / contract changes (consumers should note)**

- **Default `role="alert"` removed.** Alert is now a passive callout — the implicit assertive live region is gone (a page-load callout is not a live region). **Dynamic messages must opt in:** pass `role="alert"` for urgent/error alerts (e.g. form `rootError`) or `role="status"` for polite updates. First-party `apps/console` error alerts are unaffected at runtime today (they consume the published `dist`), but should adopt `role="alert"` when they next upgrade `@nexus/react`.
- **`AlertTitle` renders a `<div>` (was `<h5>`).** Use `<AlertTitle asChild><h2>…</h2></AlertTitle>` when the title belongs in the page outline.
- **`AlertClose` accessible name.** The default icon control self-labels ("Dismiss alert"); custom children own their name — visible text self-labels, icon-only children pass `aria-label`.

## Test Plan

- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component alert` — 0 missing, 0 drift
- [x] `pnpm --filter @nexus/react typecheck`
- [x] `pnpm --filter @nexus/react lint`
- [x] `pnpm exec prettier --check` (alert files)
- [ ] `pnpm test:storybook` (runs in CI)

## Notes

- Figma parity audit follow-up is tracked in #201 and not included here.

