### PR TITLE
feat(alert-dialog): audit component

### DIFF
--- a/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
+++ b/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
@@ -153,6 +153,7 @@ export const Centered: Story = {
     const dialog = await within(document.body).findByRole('alertdialog');
     await expect(dialog).toHaveAttribute('data-variant', 'center');
     await expect(dialog).toHaveAttribute('data-button-orientation', 'vertical');
+    await expect(dialog.className).toContain('nx:max-w-[320px]');
 
     const header = document.querySelector('[data-slot="alert-dialog-header"]');
     const footer = document.querySelector('[data-slot="alert-dialog-footer"]');

--- a/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
+++ b/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
 import { Button } from '../button';
 
@@ -170,6 +170,98 @@ export const EscapeCancels: Story = {
   },
 };
 
+export const CancelCloses: Story = {
+  render: (_args) => (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="outline">Show dialog</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Discard draft?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Cancel closes the dialog without confirming the action.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction>Continue</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole('button', { name: 'Show dialog' });
+    await userEvent.click(trigger);
+
+    const dialog = await within(document.body).findByRole('alertdialog');
+    const cancelButton = within(dialog).getByRole('button', { name: 'Cancel' });
+    await userEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="alert-dialog-content"]')
+      ).toBeNull();
+    });
+  },
+};
+
+export const OverlayDoesNotDismiss: Story = {
+  args: {
+    onOpenChange: fn(),
+  },
+  render: (args) => (
+    <AlertDialog {...args}>
+      <AlertDialogTrigger asChild>
+        <Button variant="outline">Show dialog</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Keep dialog open?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Clicking the overlay should not dismiss an alert dialog.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction>Continue</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const onOpenChange = args.onOpenChange;
+
+    const trigger = canvas.getByRole('button', { name: 'Show dialog' });
+    await userEvent.click(trigger);
+
+    const dialog = await within(document.body).findByRole('alertdialog');
+    await expect(onOpenChange).toHaveBeenCalledWith(true);
+
+    const overlay = document.querySelector(
+      '[data-slot="alert-dialog-overlay"]'
+    );
+    await expect(overlay).toBeInTheDocument();
+    if (!(overlay instanceof HTMLElement)) {
+      throw new Error('Expected alert dialog overlay to be rendered.');
+    }
+
+    await userEvent.click(overlay);
+    await expect(dialog).toBeInTheDocument();
+    await expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="alert-dialog-content"]')
+      ).toBeNull();
+    });
+  },
+};
+
 export const WithDataAttributes: Story = {
   render: (_args) => (
     <AlertDialog>
@@ -185,7 +277,7 @@ export const WithDataAttributes: Story = {
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction variant="destructive">Delete</AlertDialogAction>
+          <AlertDialogAction>Continue</AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
@@ -224,10 +316,14 @@ export const WithDataAttributes: Story = {
       ).toBeInTheDocument();
     });
 
-    // The action carries its data-slot and reflects the destructive variant.
+    // The cancel/action controls expose their effective default button variants.
+    const cancel = document.querySelector('[data-slot="alert-dialog-cancel"]');
+    await expect(cancel).toBeInTheDocument();
+    await expect(cancel).toHaveAttribute('data-variant', 'outline');
+
     const action = document.querySelector('[data-slot="alert-dialog-action"]');
     await expect(action).toBeInTheDocument();
-    await expect(action).toHaveAttribute('data-variant', 'destructive');
+    await expect(action).toHaveAttribute('data-variant', 'default');
 
     // Cleanup.
     await userEvent.keyboard('{Escape}');
@@ -247,7 +343,7 @@ export const AllVariants: Story = {
   render: (_args) => (
     <div className="nx:flex nx:flex-col nx:gap-8">
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Confirm (primary action)
         </h3>
         <AlertDialog>
@@ -270,7 +366,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Destructive action
         </h3>
         <AlertDialog>

--- a/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
+++ b/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
@@ -74,6 +74,133 @@ export const Destructive: Story = {
       </AlertDialogContent>
     </AlertDialog>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole('button', { name: 'Delete account' });
+    await userEvent.click(trigger);
+
+    const dialog = await within(document.body).findByRole('alertdialog');
+    const action = within(dialog).getByRole('button', { name: 'Delete' });
+    await expect(action).toHaveAttribute('data-variant', 'destructive');
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="alert-dialog-content"]')
+      ).toBeNull();
+    });
+  },
+};
+
+export const WithBodyContent: Story = {
+  render: (_args) => (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">Remove payment method</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent
+        title="Remove payment method?"
+        description="This payment method will be removed from the workspace."
+        body={
+          <>
+            <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
+              Future invoices will use the fallback payment method.
+            </div>
+            <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
+              Active subscriptions continue until the next billing cycle.
+            </div>
+          </>
+        }
+      >
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="destructive">
+            Remove method
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+};
+
+export const Centered: Story = {
+  render: (_args) => (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">Show centered dialog</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent
+        variant="center"
+        content={false}
+        title="Dialog Title"
+        description="Make changes to your profile here. Click save when you're done."
+      >
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="destructive">Action</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole('button', {
+      name: 'Show centered dialog',
+    });
+    await userEvent.click(trigger);
+
+    const dialog = await within(document.body).findByRole('alertdialog');
+    await expect(dialog).toHaveAttribute('data-variant', 'center');
+    await expect(dialog).toHaveAttribute('data-button-orientation', 'vertical');
+    await expect(dialog).toHaveAttribute('data-content', 'false');
+
+    const header = document.querySelector('[data-slot="alert-dialog-header"]');
+    const footer = document.querySelector('[data-slot="alert-dialog-footer"]');
+    await expect(header).toHaveAttribute('data-variant', 'center');
+    await expect(footer).toHaveAttribute('data-orientation', 'vertical');
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="alert-dialog-content"]')
+      ).toBeNull();
+    });
+  },
+};
+
+export const CenteredWithBodyContent: Story = {
+  render: (_args) => (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">Review centered content</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent
+        variant="center"
+        title="Dialog Title"
+        description="Make changes to your profile here. Click save when you're done."
+        body={
+          <>
+            <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
+              Slot
+            </div>
+            <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
+              Slot
+            </div>
+            <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
+              Slot
+            </div>
+          </>
+        }
+      >
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="destructive">Action</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
 };
 
 // ============================================
@@ -208,6 +335,54 @@ export const CancelCloses: Story = {
   },
 };
 
+export const FocusManagement: Story = {
+  render: (_args) => (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="outline">Show focus dialog</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Archive project?</AlertDialogTitle>
+          <AlertDialogDescription>
+            Archiving hides this project from the default workspace views.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction>Archive</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole('button', {
+      name: 'Show focus dialog',
+    });
+    await userEvent.click(trigger);
+
+    const dialog = await within(document.body).findByRole('alertdialog');
+    const cancelButton = within(dialog).getByRole('button', { name: 'Cancel' });
+
+    await waitFor(() => {
+      expect(cancelButton).toHaveFocus();
+    });
+
+    await userEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="alert-dialog-content"]')
+      ).toBeNull();
+    });
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+  },
+};
+
 export const OverlayDoesNotDismiss: Story = {
   args: {
     onOpenChange: fn(),
@@ -316,6 +491,22 @@ export const WithDataAttributes: Story = {
       ).toBeInTheDocument();
     });
 
+    const content = document.querySelector(
+      '[data-slot="alert-dialog-content"]'
+    );
+    await expect(content).toHaveAttribute('data-variant', 'default');
+    await expect(content).toHaveAttribute(
+      'data-button-orientation',
+      'horizontal'
+    );
+    await expect(content).toHaveAttribute('data-content', 'true');
+
+    const header = document.querySelector('[data-slot="alert-dialog-header"]');
+    await expect(header).toHaveAttribute('data-variant', 'default');
+
+    const footer = document.querySelector('[data-slot="alert-dialog-footer"]');
+    await expect(footer).toHaveAttribute('data-orientation', 'horizontal');
+
     // The cancel/action controls expose their effective default button variants.
     const cancel = document.querySelector('[data-slot="alert-dialog-cancel"]');
     await expect(cancel).toBeInTheDocument();
@@ -384,6 +575,30 @@ export const AllVariants: Story = {
               <AlertDialogCancel>Cancel</AlertDialogCancel>
               <AlertDialogAction variant="destructive">
                 Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+
+      <div>
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
+          Centered action stack
+        </h3>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button variant="destructive">Show centered dialog</Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent
+            variant="center"
+            content={false}
+            title="Dialog Title"
+            description="Make changes to your profile here. Click save when you're done."
+          >
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction variant="destructive">
+                Action
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
+++ b/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
@@ -132,7 +132,6 @@ export const Centered: Story = {
       </AlertDialogTrigger>
       <AlertDialogContent
         variant="center"
-        content={false}
         title="Dialog Title"
         description="Make changes to your profile here. Click save when you're done."
       >
@@ -154,7 +153,6 @@ export const Centered: Story = {
     const dialog = await within(document.body).findByRole('alertdialog');
     await expect(dialog).toHaveAttribute('data-variant', 'center');
     await expect(dialog).toHaveAttribute('data-button-orientation', 'vertical');
-    await expect(dialog).toHaveAttribute('data-content', 'false');
 
     const header = document.querySelector('[data-slot="alert-dialog-header"]');
     const footer = document.querySelector('[data-slot="alert-dialog-footer"]');
@@ -499,7 +497,6 @@ export const WithDataAttributes: Story = {
       'data-button-orientation',
       'horizontal'
     );
-    await expect(content).toHaveAttribute('data-content', 'true');
 
     const header = document.querySelector('[data-slot="alert-dialog-header"]');
     await expect(header).toHaveAttribute('data-variant', 'default');
@@ -591,7 +588,6 @@ export const AllVariants: Story = {
           </AlertDialogTrigger>
           <AlertDialogContent
             variant="center"
-            content={false}
             title="Dialog Title"
             description="Make changes to your profile here. Click save when you're done."
           >

--- a/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
+++ b/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
@@ -182,13 +182,13 @@ export const CenteredWithBodyContent: Story = {
         description="Make changes to your profile here. Click save when you're done."
         body={
           <>
-            <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
+            <div className="nx:rounded-md nx:border nx:border-dashed nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
               Slot
             </div>
-            <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
+            <div className="nx:rounded-md nx:border nx:border-dashed nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
               Slot
             </div>
-            <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
+            <div className="nx:rounded-md nx:border nx:border-dashed nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
               Slot
             </div>
           </>

--- a/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
+++ b/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
@@ -523,6 +523,62 @@ export const WithDataAttributes: Story = {
   },
 };
 
+export const ComposedHeaderWins: Story = {
+  render: (_args) => (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="outline">Show dialog</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent title="Prop title" description="Prop description">
+        {/*
+          A composed header is present (here grouped with the footer in a
+          Fragment), so the prop-driven title/description must be suppressed —
+          the gate has to detect the header *through* the Fragment.
+        */}
+        <>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Composed title</AlertDialogTitle>
+            <AlertDialogDescription>
+              The composed header takes precedence over the title and
+              description props.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction>Continue</AlertDialogAction>
+          </AlertDialogFooter>
+        </>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole('button', { name: 'Show dialog' });
+    await userEvent.click(trigger);
+
+    const dialog = await within(document.body).findByRole('alertdialog');
+
+    // Composed header wins: exactly one title (the composed one), so there is
+    // no duplicate Radix Title / ambiguous aria-labelledby.
+    const titles = document.querySelectorAll(
+      '[data-slot="alert-dialog-title"]'
+    );
+    await expect(titles).toHaveLength(1);
+    await expect(titles[0]).toHaveTextContent('Composed title');
+    await expect(
+      within(dialog).queryByText('Prop title')
+    ).not.toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="alert-dialog-content"]')
+      ).toBeNull();
+    });
+  },
+};
+
 // ============================================
 // ALL VARIANTS GRID
 // ============================================

--- a/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
+++ b/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
@@ -122,6 +122,29 @@ export const WithBodyContent: Story = {
       </AlertDialogContent>
     </AlertDialog>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const trigger = canvas.getByRole('button', {
+      name: 'Remove payment method',
+    });
+    await userEvent.click(trigger);
+
+    await within(document.body).findByRole('alertdialog');
+
+    const body = document.querySelector('[data-slot="alert-dialog-body"]');
+    await expect(body).toBeInTheDocument();
+    await expect(body).toHaveTextContent(
+      'Future invoices will use the fallback payment method.'
+    );
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-slot="alert-dialog-content"]')
+      ).toBeNull();
+    });
+  },
 };
 
 export const Centered: Story = {
@@ -152,8 +175,8 @@ export const Centered: Story = {
 
     const dialog = await within(document.body).findByRole('alertdialog');
     await expect(dialog).toHaveAttribute('data-variant', 'center');
-    await expect(dialog).toHaveAttribute('data-button-orientation', 'vertical');
-    await expect(dialog.className).toContain('nx:max-w-[320px]');
+    await expect(dialog).toHaveAttribute('data-orientation', 'vertical');
+    await expect(dialog.className).toContain('nx:max-w-xs');
 
     const header = document.querySelector('[data-slot="alert-dialog-header"]');
     const footer = document.querySelector('[data-slot="alert-dialog-footer"]');
@@ -494,10 +517,7 @@ export const WithDataAttributes: Story = {
       '[data-slot="alert-dialog-content"]'
     );
     await expect(content).toHaveAttribute('data-variant', 'default');
-    await expect(content).toHaveAttribute(
-      'data-button-orientation',
-      'horizontal'
-    );
+    await expect(content).toHaveAttribute('data-orientation', 'horizontal');
 
     const header = document.querySelector('[data-slot="alert-dialog-header"]');
     await expect(header).toHaveAttribute('data-variant', 'default');

--- a/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
+++ b/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
@@ -99,20 +99,21 @@ export const WithBodyContent: Story = {
       <AlertDialogTrigger asChild>
         <Button variant="destructive">Remove payment method</Button>
       </AlertDialogTrigger>
-      <AlertDialogContent
-        title="Remove payment method?"
-        description="This payment method will be removed from the workspace."
-        body={
-          <>
-            <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
-              Future invoices will use the fallback payment method.
-            </div>
-            <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
-              Active subscriptions continue until the next billing cycle.
-            </div>
-          </>
-        }
-      >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remove payment method?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This payment method will be removed from the workspace.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="nx:grid nx:gap-2">
+          <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
+            Future invoices will use the fallback payment method.
+          </div>
+          <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
+            Active subscriptions continue until the next billing cycle.
+          </div>
+        </div>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction variant="destructive">
@@ -130,11 +131,8 @@ export const WithBodyContent: Story = {
     });
     await userEvent.click(trigger);
 
-    await within(document.body).findByRole('alertdialog');
-
-    const body = document.querySelector('[data-slot="alert-dialog-body"]');
-    await expect(body).toBeInTheDocument();
-    await expect(body).toHaveTextContent(
+    const dialog = await within(document.body).findByRole('alertdialog');
+    await expect(dialog).toHaveTextContent(
       'Future invoices will use the fallback payment method.'
     );
 
@@ -153,11 +151,13 @@ export const Centered: Story = {
       <AlertDialogTrigger asChild>
         <Button variant="destructive">Show centered dialog</Button>
       </AlertDialogTrigger>
-      <AlertDialogContent
-        variant="center"
-        title="Dialog Title"
-        description="Make changes to your profile here. Click save when you're done."
-      >
+      <AlertDialogContent variant="center">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Dialog Title</AlertDialogTitle>
+          <AlertDialogDescription>
+            Make changes to your profile here. Click save when you are done.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction variant="destructive">Action</AlertDialogAction>
@@ -190,39 +190,6 @@ export const Centered: Story = {
       ).toBeNull();
     });
   },
-};
-
-export const CenteredWithBodyContent: Story = {
-  render: (_args) => (
-    <AlertDialog>
-      <AlertDialogTrigger asChild>
-        <Button variant="destructive">Review centered content</Button>
-      </AlertDialogTrigger>
-      <AlertDialogContent
-        variant="center"
-        title="Dialog Title"
-        description="Make changes to your profile here. Click save when you're done."
-        body={
-          <>
-            <div className="nx:rounded-md nx:border nx:border-dashed nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
-              Slot
-            </div>
-            <div className="nx:rounded-md nx:border nx:border-dashed nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
-              Slot
-            </div>
-            <div className="nx:rounded-md nx:border nx:border-dashed nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-small">
-              Slot
-            </div>
-          </>
-        }
-      >
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction variant="destructive">Action</AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  ),
 };
 
 // ============================================
@@ -544,62 +511,6 @@ export const WithDataAttributes: Story = {
   },
 };
 
-export const ComposedHeaderWins: Story = {
-  render: (_args) => (
-    <AlertDialog>
-      <AlertDialogTrigger asChild>
-        <Button variant="outline">Show dialog</Button>
-      </AlertDialogTrigger>
-      <AlertDialogContent title="Prop title" description="Prop description">
-        {/*
-          A composed header is present (here grouped with the footer in a
-          Fragment), so the prop-driven title/description must be suppressed —
-          the gate has to detect the header *through* the Fragment.
-        */}
-        <>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Composed title</AlertDialogTitle>
-            <AlertDialogDescription>
-              The composed header takes precedence over the title and
-              description props.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction>Continue</AlertDialogAction>
-          </AlertDialogFooter>
-        </>
-      </AlertDialogContent>
-    </AlertDialog>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    const trigger = canvas.getByRole('button', { name: 'Show dialog' });
-    await userEvent.click(trigger);
-
-    const dialog = await within(document.body).findByRole('alertdialog');
-
-    // Composed header wins: exactly one title (the composed one), so there is
-    // no duplicate Radix Title / ambiguous aria-labelledby.
-    const titles = document.querySelectorAll(
-      '[data-slot="alert-dialog-title"]'
-    );
-    await expect(titles).toHaveLength(1);
-    await expect(titles[0]).toHaveTextContent('Composed title');
-    await expect(
-      within(dialog).queryByText('Prop title')
-    ).not.toBeInTheDocument();
-
-    await userEvent.keyboard('{Escape}');
-    await waitFor(() => {
-      expect(
-        document.querySelector('[data-slot="alert-dialog-content"]')
-      ).toBeNull();
-    });
-  },
-};
-
 // ============================================
 // ALL VARIANTS GRID
 // ============================================
@@ -663,11 +574,13 @@ export const AllVariants: Story = {
           <AlertDialogTrigger asChild>
             <Button variant="destructive">Show centered dialog</Button>
           </AlertDialogTrigger>
-          <AlertDialogContent
-            variant="center"
-            title="Dialog Title"
-            description="Make changes to your profile here. Click save when you're done."
-          >
+          <AlertDialogContent variant="center">
+            <AlertDialogHeader>
+              <AlertDialogTitle>Dialog Title</AlertDialogTitle>
+              <AlertDialogDescription>
+                Make changes to your profile here. Click save when you are done.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
             <AlertDialogFooter>
               <AlertDialogCancel>Cancel</AlertDialogCancel>
               <AlertDialogAction variant="destructive">

--- a/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
+++ b/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
@@ -1,10 +1,88 @@
 import * as React from 'react';
 
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
-import type { VariantProps } from 'class-variance-authority';
+import { cva, type VariantProps } from 'class-variance-authority';
 
 import { buttonVariants } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+
+const alertDialogContentVariants = cva(
+  [
+    'nx:fixed nx:left-1/2 nx:top-1/2 nx:z-modal nx:grid nx:w-full nx:max-w-lg',
+    'nx:-translate-x-1/2 nx:-translate-y-1/2',
+    'nx:gap-4 nx:border nx:border-border-default nx:bg-container nx:p-6 nx:shadow-lg',
+    'nx:data-[state=open]:duration-300 nx:data-[state=closed]:duration-150',
+    'nx:data-[state=open]:ease-out nx:data-[state=closed]:ease-in',
+    'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
+    'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
+    'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',
+    'nx:motion-reduce:duration-0 nx:motion-reduce:data-[state=open]:animate-none nx:motion-reduce:data-[state=closed]:animate-none',
+    'nx:sm:rounded-lg',
+  ].join(' '),
+  {
+    variants: {
+      variant: {
+        default: '',
+        center: '',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+const alertDialogHeaderVariants = cva('nx:flex nx:flex-col nx:gap-1', {
+  variants: {
+    variant: {
+      default: 'nx:text-left',
+      center: 'nx:items-center nx:text-center',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+const alertDialogFooterVariants = cva('nx:flex nx:gap-2', {
+  variants: {
+    orientation: {
+      horizontal: 'nx:flex-row nx:items-center nx:justify-end',
+      vertical: 'nx:flex-col-reverse nx:items-stretch nx:[&>*]:w-full',
+    },
+  },
+  defaultVariants: {
+    orientation: 'horizontal',
+  },
+});
+
+type AlertDialogVariant = NonNullable<
+  VariantProps<typeof alertDialogContentVariants>['variant']
+>;
+type AlertDialogButtonOrientation = NonNullable<
+  VariantProps<typeof alertDialogFooterVariants>['orientation']
+>;
+
+type AlertDialogLayoutContextValue = {
+  variant: AlertDialogVariant;
+  buttonOrientation: AlertDialogButtonOrientation;
+};
+
+const defaultAlertDialogLayout: AlertDialogLayoutContextValue = {
+  variant: 'default',
+  buttonOrientation: 'horizontal',
+};
+
+const AlertDialogLayoutContext =
+  React.createContext<AlertDialogLayoutContextValue>(defaultAlertDialogLayout);
+
+function resolveButtonOrientation(
+  variant: AlertDialogVariant,
+  buttonOrientation?: AlertDialogButtonOrientation | null
+): AlertDialogButtonOrientation {
+  if (variant === 'center') return 'vertical';
+  return buttonOrientation ?? 'horizontal';
+}
 
 /**
  * AlertDialog
@@ -86,9 +164,54 @@ function AlertDialogOverlay({ className, ...props }: AlertDialogOverlayProps) {
  *
  * Props for the AlertDialogContent component.
  */
-interface AlertDialogContentProps extends React.ComponentProps<
-  typeof AlertDialogPrimitive.Content
-> {}
+interface AlertDialogContentProps
+  extends
+    Omit<
+      React.ComponentProps<typeof AlertDialogPrimitive.Content>,
+      'content' | 'title'
+    >,
+    VariantProps<typeof alertDialogContentVariants> {
+  /**
+   * Layout variant for the alert dialog content.
+   *
+   * `default` keeps the header left-aligned and footer actions horizontal.
+   * `center` centers the header and stacks full-width footer actions.
+   * @default "default"
+   */
+  variant?: AlertDialogVariant;
+
+  /**
+   * Optional title rendered before `children`.
+   * Use this for prop-driven alert dialogs; composed `AlertDialogHeader`
+   * children still work as before.
+   */
+  title?: React.ReactNode;
+
+  /**
+   * Optional description rendered before `children`.
+   * Use this for prop-driven alert dialogs; composed `AlertDialogDescription`
+   * children still work as before.
+   */
+  description?: React.ReactNode;
+
+  /**
+   * Optional body content rendered between the generated header and `children`.
+   */
+  body?: React.ReactNode;
+
+  /**
+   * Whether to render `body`.
+   * @default true
+   */
+  content?: boolean;
+
+  /**
+   * Footer button orientation inherited by `AlertDialogFooter`.
+   * Center variant always resolves to vertical.
+   * @default "horizontal"
+   */
+  buttonOrientation?: AlertDialogButtonOrientation;
+}
 
 /**
  * AlertDialogContent
@@ -110,27 +233,55 @@ interface AlertDialogContentProps extends React.ComponentProps<
  * </AlertDialogContent>
  * ```
  */
-function AlertDialogContent({ className, ...props }: AlertDialogContentProps) {
+function AlertDialogContent({
+  className,
+  children,
+  variant = 'default',
+  title,
+  description,
+  body,
+  content = true,
+  buttonOrientation,
+  ...props
+}: AlertDialogContentProps) {
+  const resolvedVariant = variant ?? 'default';
+  const resolvedButtonOrientation = resolveButtonOrientation(
+    resolvedVariant,
+    buttonOrientation
+  );
+  const hasGeneratedHeader = title != null || description != null;
+
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
-      <AlertDialogPrimitive.Content
-        data-slot="alert-dialog-content"
-        className={cn(
-          'nx:fixed nx:left-1/2 nx:top-1/2 nx:z-modal nx:grid nx:w-full nx:max-w-lg',
-          'nx:-translate-x-1/2 nx:-translate-y-1/2',
-          'nx:gap-4 nx:border nx:border-border-default nx:bg-container nx:p-6 nx:shadow-lg',
-          'nx:data-[state=open]:duration-300 nx:data-[state=closed]:duration-150',
-          'nx:data-[state=open]:ease-out nx:data-[state=closed]:ease-in',
-          'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
-          'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
-          'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',
-          'nx:motion-reduce:duration-0 nx:motion-reduce:data-[state=open]:animate-none nx:motion-reduce:data-[state=closed]:animate-none',
-          'nx:sm:rounded-lg',
-          className
-        )}
-        {...props}
-      />
+      <AlertDialogLayoutContext.Provider
+        value={{
+          variant: resolvedVariant,
+          buttonOrientation: resolvedButtonOrientation,
+        }}
+      >
+        <AlertDialogPrimitive.Content
+          data-slot="alert-dialog-content"
+          data-variant={resolvedVariant}
+          data-button-orientation={resolvedButtonOrientation}
+          data-content={content}
+          className={cn(
+            alertDialogContentVariants({ variant: resolvedVariant }),
+            className
+          )}
+          {...props}
+        >
+          {hasGeneratedHeader && (
+            <AlertDialogHeader title={title} description={description} />
+          )}
+          {content && body != null && (
+            <div data-slot="alert-dialog-body" className="nx:grid nx:gap-2">
+              {body}
+            </div>
+          )}
+          {children}
+        </AlertDialogPrimitive.Content>
+      </AlertDialogLayoutContext.Provider>
     </AlertDialogPortal>
   );
 }
@@ -140,7 +291,20 @@ function AlertDialogContent({ className, ...props }: AlertDialogContentProps) {
  *
  * Props for the AlertDialogHeader component.
  */
-interface AlertDialogHeaderProps extends React.ComponentProps<'div'> {}
+interface AlertDialogHeaderProps
+  extends
+    Omit<React.ComponentProps<'div'>, 'title'>,
+    VariantProps<typeof alertDialogHeaderVariants> {
+  /**
+   * Optional title text rendered when `children` are not supplied.
+   */
+  title?: React.ReactNode;
+
+  /**
+   * Optional description text rendered when `children` are not supplied.
+   */
+  description?: React.ReactNode;
+}
 
 /**
  * AlertDialogHeader
@@ -155,16 +319,39 @@ interface AlertDialogHeaderProps extends React.ComponentProps<'div'> {}
  * </AlertDialogHeader>
  * ```
  */
-function AlertDialogHeader({ className, ...props }: AlertDialogHeaderProps) {
+function AlertDialogHeader({
+  className,
+  children,
+  variant,
+  title,
+  description,
+  ...props
+}: AlertDialogHeaderProps) {
+  const layout = React.useContext(AlertDialogLayoutContext);
+  const resolvedVariant = variant ?? layout.variant;
+  const generatedChildren =
+    children ??
+    (title != null || description != null ? (
+      <>
+        {title != null && <AlertDialogTitle>{title}</AlertDialogTitle>}
+        {description != null && (
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        )}
+      </>
+    ) : null);
+
   return (
     <div
       data-slot="alert-dialog-header"
+      data-variant={resolvedVariant}
       className={cn(
-        'nx:flex nx:flex-col nx:gap-1.5 nx:text-center nx:sm:text-left',
+        alertDialogHeaderVariants({ variant: resolvedVariant }),
         className
       )}
       {...props}
-    />
+    >
+      {generatedChildren}
+    </div>
   );
 }
 
@@ -173,7 +360,10 @@ function AlertDialogHeader({ className, ...props }: AlertDialogHeaderProps) {
  *
  * Props for the AlertDialogFooter component.
  */
-interface AlertDialogFooterProps extends React.ComponentProps<'div'> {}
+interface AlertDialogFooterProps
+  extends
+    React.ComponentProps<'div'>,
+    VariantProps<typeof alertDialogFooterVariants> {}
 
 /**
  * AlertDialogFooter
@@ -188,12 +378,23 @@ interface AlertDialogFooterProps extends React.ComponentProps<'div'> {}
  * </AlertDialogFooter>
  * ```
  */
-function AlertDialogFooter({ className, ...props }: AlertDialogFooterProps) {
+function AlertDialogFooter({
+  className,
+  orientation,
+  ...props
+}: AlertDialogFooterProps) {
+  const layout = React.useContext(AlertDialogLayoutContext);
+  const resolvedOrientation =
+    layout.variant === 'center'
+      ? 'vertical'
+      : (orientation ?? layout.buttonOrientation);
+
   return (
     <div
       data-slot="alert-dialog-footer"
+      data-orientation={resolvedOrientation}
       className={cn(
-        'nx:flex nx:flex-col-reverse nx:sm:flex-row nx:sm:justify-end nx:sm:gap-2',
+        alertDialogFooterVariants({ orientation: resolvedOrientation }),
         className
       )}
       {...props}
@@ -351,6 +552,7 @@ export {
   AlertDialog,
   AlertDialogAction,
   type AlertDialogActionProps,
+  type AlertDialogButtonOrientation,
   AlertDialogCancel,
   type AlertDialogCancelProps,
   AlertDialogContent,
@@ -367,4 +569,5 @@ export {
   AlertDialogTitle,
   type AlertDialogTitleProps,
   AlertDialogTrigger,
+  type AlertDialogVariant,
 };

--- a/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
+++ b/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
@@ -119,14 +119,12 @@ function AlertDialogContent({ className, ...props }: AlertDialogContentProps) {
         className={cn(
           'nx:fixed nx:left-1/2 nx:top-1/2 nx:z-modal nx:grid nx:w-full nx:max-w-lg',
           'nx:-translate-x-1/2 nx:-translate-y-1/2',
-          'nx:gap-container nx:border nx:border-border-default nx:bg-container nx:p-container nx:shadow-lg',
+          'nx:gap-4 nx:border nx:border-border-default nx:bg-container nx:p-6 nx:shadow-lg',
           'nx:data-[state=open]:duration-300 nx:data-[state=closed]:duration-150',
           'nx:data-[state=open]:ease-out nx:data-[state=closed]:ease-in',
           'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
           'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
           'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',
-          'nx:data-[state=closed]:slide-out-to-left-1/2 nx:data-[state=closed]:slide-out-to-top-[48%]',
-          'nx:data-[state=open]:slide-in-from-left-1/2 nx:data-[state=open]:slide-in-from-top-[48%]',
           'nx:motion-reduce:duration-0 nx:motion-reduce:data-[state=open]:animate-none nx:motion-reduce:data-[state=closed]:animate-none',
           'nx:sm:rounded-lg',
           className
@@ -226,10 +224,7 @@ function AlertDialogTitle({ className, ...props }: AlertDialogTitleProps) {
   return (
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
-      className={cn(
-        'nx:text-lg nx:font-semibold nx:leading-none nx:tracking-tight',
-        className
-      )}
+      className={cn('nx:typography-heading-xsmall', className)}
       {...props}
     />
   );
@@ -263,7 +258,10 @@ function AlertDialogDescription({
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn('nx:text-sm nx:text-muted-foreground', className)}
+      className={cn(
+        'nx:typography-body-small nx:text-muted-foreground',
+        className
+      )}
       {...props}
     />
   );
@@ -295,7 +293,7 @@ interface AlertDialogActionProps
  */
 function AlertDialogAction({
   className,
-  variant,
+  variant = 'default',
   size,
   ...props
 }: AlertDialogActionProps) {
@@ -334,7 +332,7 @@ interface AlertDialogCancelProps
  */
 function AlertDialogCancel({
   className,
-  variant,
+  variant = 'outline',
   size,
   ...props
 }: AlertDialogCancelProps) {
@@ -343,10 +341,7 @@ function AlertDialogCancel({
       data-slot="alert-dialog-cancel"
       data-variant={variant}
       data-size={size}
-      className={cn(
-        buttonVariants({ variant: variant ?? 'outline', size }),
-        className
-      )}
+      className={cn(buttonVariants({ variant, size }), className)}
       {...props}
     />
   );

--- a/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
+++ b/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
@@ -37,8 +37,8 @@ const alertDialogFooterVariants = cva('nx:flex nx:gap-2', {
   variants: {
     orientation: {
       horizontal:
-        'nx:flex-col-reverse nx:sm:flex-row nx:sm:items-center nx:sm:justify-end',
-      vertical: 'nx:flex-col-reverse nx:items-stretch nx:[&>*]:w-full',
+        'nx:flex-col nx:sm:flex-row nx:sm:items-center nx:sm:justify-end',
+      vertical: 'nx:flex-col nx:items-stretch nx:[&>*]:w-full',
     },
   },
   defaultVariants: {

--- a/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
+++ b/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
@@ -241,6 +241,7 @@ function AlertDialogContent({
     variant,
     buttonOrientation
   );
+  const hasBody = body != null;
   const showGeneratedHeader =
     !containsComposedHeader(children) && (title != null || description != null);
 
@@ -254,13 +255,17 @@ function AlertDialogContent({
           data-slot="alert-dialog-content"
           data-variant={variant}
           data-button-orientation={resolvedButtonOrientation}
-          className={cn(alertDialogContentVariants(), className)}
+          className={cn(
+            alertDialogContentVariants(),
+            variant === 'center' && !hasBody && 'nx:max-w-[320px]',
+            className
+          )}
           {...props}
         >
           {showGeneratedHeader && (
             <AlertDialogHeader title={title} description={description} />
           )}
-          {body != null && (
+          {hasBody && (
             <div data-slot="alert-dialog-body" className="nx:grid nx:gap-2">
               {body}
             </div>

--- a/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
+++ b/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
@@ -18,24 +18,13 @@ const alertDialogContentVariants = cva(
     'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',
     'nx:motion-reduce:duration-0 nx:motion-reduce:data-[state=open]:animate-none nx:motion-reduce:data-[state=closed]:animate-none',
     'nx:sm:rounded-lg',
-  ].join(' '),
-  {
-    variants: {
-      variant: {
-        default: '',
-        center: '',
-      },
-    },
-    defaultVariants: {
-      variant: 'default',
-    },
-  }
+  ].join(' ')
 );
 
 const alertDialogHeaderVariants = cva('nx:flex nx:flex-col nx:gap-1', {
   variants: {
     variant: {
-      default: 'nx:text-left',
+      default: 'nx:text-center nx:sm:text-left',
       center: 'nx:items-center nx:text-center',
     },
   },
@@ -47,7 +36,8 @@ const alertDialogHeaderVariants = cva('nx:flex nx:flex-col nx:gap-1', {
 const alertDialogFooterVariants = cva('nx:flex nx:gap-2', {
   variants: {
     orientation: {
-      horizontal: 'nx:flex-row nx:items-center nx:justify-end',
+      horizontal:
+        'nx:flex-col-reverse nx:sm:flex-row nx:sm:items-center nx:sm:justify-end',
       vertical: 'nx:flex-col-reverse nx:items-stretch nx:[&>*]:w-full',
     },
   },
@@ -57,7 +47,7 @@ const alertDialogFooterVariants = cva('nx:flex nx:gap-2', {
 });
 
 type AlertDialogVariant = NonNullable<
-  VariantProps<typeof alertDialogContentVariants>['variant']
+  VariantProps<typeof alertDialogHeaderVariants>['variant']
 >;
 type AlertDialogButtonOrientation = NonNullable<
   VariantProps<typeof alertDialogFooterVariants>['orientation']
@@ -164,13 +154,10 @@ function AlertDialogOverlay({ className, ...props }: AlertDialogOverlayProps) {
  *
  * Props for the AlertDialogContent component.
  */
-interface AlertDialogContentProps
-  extends
-    Omit<
-      React.ComponentProps<typeof AlertDialogPrimitive.Content>,
-      'content' | 'title'
-    >,
-    VariantProps<typeof alertDialogContentVariants> {
+interface AlertDialogContentProps extends Omit<
+  React.ComponentProps<typeof AlertDialogPrimitive.Content>,
+  'title'
+> {
   /**
    * Layout variant for the alert dialog content.
    *
@@ -181,16 +168,15 @@ interface AlertDialogContentProps
   variant?: AlertDialogVariant;
 
   /**
-   * Optional title rendered before `children`.
-   * Use this for prop-driven alert dialogs; composed `AlertDialogHeader`
-   * children still work as before.
+   * Optional title for a prop-driven header, rendered before `children`.
+   * Ignored when a composed `AlertDialogHeader` child is present — composed
+   * children take precedence, so only one header (one Radix `Title`) renders.
    */
   title?: React.ReactNode;
 
   /**
-   * Optional description rendered before `children`.
-   * Use this for prop-driven alert dialogs; composed `AlertDialogDescription`
-   * children still work as before.
+   * Optional description for a prop-driven header, rendered before `children`.
+   * Ignored when a composed `AlertDialogHeader` child is present.
    */
   description?: React.ReactNode;
 
@@ -198,12 +184,6 @@ interface AlertDialogContentProps
    * Optional body content rendered between the generated header and `children`.
    */
   body?: React.ReactNode;
-
-  /**
-   * Whether to render `body`.
-   * @default true
-   */
-  content?: boolean;
 
   /**
    * Footer button orientation inherited by `AlertDialogFooter`.
@@ -240,41 +220,36 @@ function AlertDialogContent({
   title,
   description,
   body,
-  content = true,
   buttonOrientation,
   ...props
 }: AlertDialogContentProps) {
-  const resolvedVariant = variant ?? 'default';
   const resolvedButtonOrientation = resolveButtonOrientation(
-    resolvedVariant,
+    variant,
     buttonOrientation
   );
-  const hasGeneratedHeader = title != null || description != null;
+  const hasComposedHeader = React.Children.toArray(children).some(
+    (child) => React.isValidElement(child) && child.type === AlertDialogHeader
+  );
+  const showGeneratedHeader =
+    !hasComposedHeader && (title != null || description != null);
 
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
       <AlertDialogLayoutContext.Provider
-        value={{
-          variant: resolvedVariant,
-          buttonOrientation: resolvedButtonOrientation,
-        }}
+        value={{ variant, buttonOrientation: resolvedButtonOrientation }}
       >
         <AlertDialogPrimitive.Content
           data-slot="alert-dialog-content"
-          data-variant={resolvedVariant}
+          data-variant={variant}
           data-button-orientation={resolvedButtonOrientation}
-          data-content={content}
-          className={cn(
-            alertDialogContentVariants({ variant: resolvedVariant }),
-            className
-          )}
+          className={cn(alertDialogContentVariants(), className)}
           {...props}
         >
-          {hasGeneratedHeader && (
+          {showGeneratedHeader && (
             <AlertDialogHeader title={title} description={description} />
           )}
-          {content && body != null && (
+          {body != null && (
             <div data-slot="alert-dialog-body" className="nx:grid nx:gap-2">
               {body}
             </div>
@@ -360,10 +335,7 @@ function AlertDialogHeader({
  *
  * Props for the AlertDialogFooter component.
  */
-interface AlertDialogFooterProps
-  extends
-    React.ComponentProps<'div'>,
-    VariantProps<typeof alertDialogFooterVariants> {}
+interface AlertDialogFooterProps extends React.ComponentProps<'div'> {}
 
 /**
  * AlertDialogFooter
@@ -378,23 +350,15 @@ interface AlertDialogFooterProps
  * </AlertDialogFooter>
  * ```
  */
-function AlertDialogFooter({
-  className,
-  orientation,
-  ...props
-}: AlertDialogFooterProps) {
+function AlertDialogFooter({ className, ...props }: AlertDialogFooterProps) {
   const layout = React.useContext(AlertDialogLayoutContext);
-  const resolvedOrientation =
-    layout.variant === 'center'
-      ? 'vertical'
-      : (orientation ?? layout.buttonOrientation);
 
   return (
     <div
       data-slot="alert-dialog-footer"
-      data-orientation={resolvedOrientation}
+      data-orientation={layout.buttonOrientation}
       className={cn(
-        alertDialogFooterVariants({ orientation: resolvedOrientation }),
+        alertDialogFooterVariants({ orientation: layout.buttonOrientation }),
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
+++ b/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
@@ -66,14 +66,6 @@ const defaultAlertDialogLayout: AlertDialogLayoutContextValue = {
 const AlertDialogLayoutContext =
   React.createContext<AlertDialogLayoutContextValue>(defaultAlertDialogLayout);
 
-function resolveButtonOrientation(
-  variant: AlertDialogVariant,
-  buttonOrientation?: AlertDialogButtonOrientation | null
-): AlertDialogButtonOrientation {
-  if (variant === 'center') return 'vertical';
-  return buttonOrientation ?? 'horizontal';
-}
-
 function containsComposedHeader(children: React.ReactNode): boolean {
   return React.Children.toArray(children).some((child) => {
     if (!React.isValidElement(child)) return false;
@@ -185,6 +177,8 @@ interface AlertDialogContentProps extends Omit<
    * Optional title for a prop-driven header, rendered before `children`.
    * Ignored when a composed `AlertDialogHeader` child is present — composed
    * children take precedence, so only one header (one Radix `Title`) renders.
+   * Detection covers a direct child or a Fragment-wrapped header; a header
+   * nested inside another element is not detected.
    */
   title?: React.ReactNode;
 
@@ -198,13 +192,6 @@ interface AlertDialogContentProps extends Omit<
    * Optional body content rendered between the generated header and `children`.
    */
   body?: React.ReactNode;
-
-  /**
-   * Footer button orientation inherited by `AlertDialogFooter`.
-   * Center variant always resolves to vertical.
-   * @default "horizontal"
-   */
-  buttonOrientation?: AlertDialogButtonOrientation;
 }
 
 /**
@@ -234,13 +221,10 @@ function AlertDialogContent({
   title,
   description,
   body,
-  buttonOrientation,
   ...props
 }: AlertDialogContentProps) {
-  const resolvedButtonOrientation = resolveButtonOrientation(
-    variant,
-    buttonOrientation
-  );
+  const resolvedButtonOrientation =
+    variant === 'center' ? 'vertical' : 'horizontal';
   const hasBody = body != null;
   const showGeneratedHeader =
     !containsComposedHeader(children) && (title != null || description != null);
@@ -254,10 +238,10 @@ function AlertDialogContent({
         <AlertDialogPrimitive.Content
           data-slot="alert-dialog-content"
           data-variant={variant}
-          data-button-orientation={resolvedButtonOrientation}
+          data-orientation={resolvedButtonOrientation}
           className={cn(
             alertDialogContentVariants(),
-            variant === 'center' && !hasBody && 'nx:max-w-[320px]',
+            variant === 'center' && !hasBody && 'nx:max-w-xs',
             className
           )}
           {...props}
@@ -532,7 +516,6 @@ export {
   AlertDialog,
   AlertDialogAction,
   type AlertDialogActionProps,
-  type AlertDialogButtonOrientation,
   AlertDialogCancel,
   type AlertDialogCancelProps,
   AlertDialogContent,

--- a/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
+++ b/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
@@ -74,6 +74,20 @@ function resolveButtonOrientation(
   return buttonOrientation ?? 'horizontal';
 }
 
+function containsComposedHeader(children: React.ReactNode): boolean {
+  return React.Children.toArray(children).some((child) => {
+    if (!React.isValidElement(child)) return false;
+    if (child.type === AlertDialogHeader) return true;
+    if (child.type === React.Fragment) {
+      const fragment = child as React.ReactElement<{
+        children?: React.ReactNode;
+      }>;
+      return containsComposedHeader(fragment.props.children);
+    }
+    return false;
+  });
+}
+
 /**
  * AlertDialog
  *
@@ -227,11 +241,8 @@ function AlertDialogContent({
     variant,
     buttonOrientation
   );
-  const hasComposedHeader = React.Children.toArray(children).some(
-    (child) => React.isValidElement(child) && child.type === AlertDialogHeader
-  );
   const showGeneratedHeader =
-    !hasComposedHeader && (title != null || description != null);
+    !containsComposedHeader(children) && (title != null || description != null);
 
   return (
     <AlertDialogPortal>

--- a/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
+++ b/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
@@ -38,7 +38,7 @@ const alertDialogFooterVariants = cva('nx:flex nx:gap-2', {
     orientation: {
       horizontal:
         'nx:flex-col nx:sm:flex-row nx:sm:items-center nx:sm:justify-end',
-      vertical: 'nx:flex-col nx:items-stretch nx:[&>*]:w-full',
+      vertical: 'nx:flex-col nx:items-stretch nx:*:w-full',
     },
   },
   defaultVariants: {
@@ -65,20 +65,6 @@ const defaultAlertDialogLayout: AlertDialogLayoutContextValue = {
 
 const AlertDialogLayoutContext =
   React.createContext<AlertDialogLayoutContextValue>(defaultAlertDialogLayout);
-
-function containsComposedHeader(children: React.ReactNode): boolean {
-  return React.Children.toArray(children).some((child) => {
-    if (!React.isValidElement(child)) return false;
-    if (child.type === AlertDialogHeader) return true;
-    if (child.type === React.Fragment) {
-      const fragment = child as React.ReactElement<{
-        children?: React.ReactNode;
-      }>;
-      return containsComposedHeader(fragment.props.children);
-    }
-    return false;
-  });
-}
 
 /**
  * AlertDialog
@@ -160,9 +146,8 @@ function AlertDialogOverlay({ className, ...props }: AlertDialogOverlayProps) {
  *
  * Props for the AlertDialogContent component.
  */
-interface AlertDialogContentProps extends Omit<
-  React.ComponentProps<typeof AlertDialogPrimitive.Content>,
-  'title'
+interface AlertDialogContentProps extends React.ComponentProps<
+  typeof AlertDialogPrimitive.Content
 > {
   /**
    * Layout variant for the alert dialog content.
@@ -172,26 +157,6 @@ interface AlertDialogContentProps extends Omit<
    * @default "default"
    */
   variant?: AlertDialogVariant;
-
-  /**
-   * Optional title for a prop-driven header, rendered before `children`.
-   * Ignored when a composed `AlertDialogHeader` child is present — composed
-   * children take precedence, so only one header (one Radix `Title`) renders.
-   * Detection covers a direct child or a Fragment-wrapped header; a header
-   * nested inside another element is not detected.
-   */
-  title?: React.ReactNode;
-
-  /**
-   * Optional description for a prop-driven header, rendered before `children`.
-   * Ignored when a composed `AlertDialogHeader` child is present.
-   */
-  description?: React.ReactNode;
-
-  /**
-   * Optional body content rendered between the generated header and `children`.
-   */
-  body?: React.ReactNode;
 }
 
 /**
@@ -216,46 +181,26 @@ interface AlertDialogContentProps extends Omit<
  */
 function AlertDialogContent({
   className,
-  children,
   variant = 'default',
-  title,
-  description,
-  body,
   ...props
 }: AlertDialogContentProps) {
-  const resolvedButtonOrientation =
-    variant === 'center' ? 'vertical' : 'horizontal';
-  const hasBody = body != null;
-  const showGeneratedHeader =
-    !containsComposedHeader(children) && (title != null || description != null);
+  const buttonOrientation = variant === 'center' ? 'vertical' : 'horizontal';
 
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
-      <AlertDialogLayoutContext.Provider
-        value={{ variant, buttonOrientation: resolvedButtonOrientation }}
-      >
+      <AlertDialogLayoutContext.Provider value={{ variant, buttonOrientation }}>
         <AlertDialogPrimitive.Content
           data-slot="alert-dialog-content"
           data-variant={variant}
-          data-orientation={resolvedButtonOrientation}
+          data-orientation={buttonOrientation}
           className={cn(
             alertDialogContentVariants(),
-            variant === 'center' && !hasBody && 'nx:max-w-xs',
+            variant === 'center' && 'nx:max-w-xs',
             className
           )}
           {...props}
-        >
-          {showGeneratedHeader && (
-            <AlertDialogHeader title={title} description={description} />
-          )}
-          {hasBody && (
-            <div data-slot="alert-dialog-body" className="nx:grid nx:gap-2">
-              {body}
-            </div>
-          )}
-          {children}
-        </AlertDialogPrimitive.Content>
+        />
       </AlertDialogLayoutContext.Provider>
     </AlertDialogPortal>
   );
@@ -268,18 +213,8 @@ function AlertDialogContent({
  */
 interface AlertDialogHeaderProps
   extends
-    Omit<React.ComponentProps<'div'>, 'title'>,
-    VariantProps<typeof alertDialogHeaderVariants> {
-  /**
-   * Optional title text rendered when `children` are not supplied.
-   */
-  title?: React.ReactNode;
-
-  /**
-   * Optional description text rendered when `children` are not supplied.
-   */
-  description?: React.ReactNode;
-}
+    React.ComponentProps<'div'>,
+    VariantProps<typeof alertDialogHeaderVariants> {}
 
 /**
  * AlertDialogHeader
@@ -296,24 +231,11 @@ interface AlertDialogHeaderProps
  */
 function AlertDialogHeader({
   className,
-  children,
   variant,
-  title,
-  description,
   ...props
 }: AlertDialogHeaderProps) {
   const layout = React.useContext(AlertDialogLayoutContext);
   const resolvedVariant = variant ?? layout.variant;
-  const generatedChildren =
-    children ??
-    (title != null || description != null ? (
-      <>
-        {title != null && <AlertDialogTitle>{title}</AlertDialogTitle>}
-        {description != null && (
-          <AlertDialogDescription>{description}</AlertDialogDescription>
-        )}
-      </>
-    ) : null);
 
   return (
     <div
@@ -324,9 +246,7 @@ function AlertDialogHeader({
         className
       )}
       {...props}
-    >
-      {generatedChildren}
-    </div>
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

- Replace AlertDialog content role spacing with numeric `p-6` / `gap-4` while preserving default vega spacing.
- Tokenize AlertDialog title and description typography, and remove directional slide classes for centered fade/zoom motion.
- Expose effective default `data-variant` values and add Storybook coverage for cancel close, overlay non-dismiss, and default action/cancel data attributes.

## GitHub Issue

Closes #195

## Test Plan

- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component alert-dialog`
- [x] `pnpm typecheck`
- [x] `pnpm test:storybook` (exited 0; Vitest reported no Storybook test files found under the configured project)
- [x] `pnpm lint`
- [x] `pnpm format:check`