### PR TITLE
feat(breadcrumb): audit component

### DIFF
--- a/COMPONENT-REVIEW.md
+++ b/COMPONENT-REVIEW.md
@@ -73,9 +73,9 @@ small screens), so the ~44px touch-target floor does not apply — segments and
 icon triggers keep their compact sizing and the touch-only hit-area overlays were
 removed (responsive.md: the touch case sets the floor).
 
-Resolved: `BreadcrumbList` uses `overflow-x-auto` with a keyboard-focusable scroll
-region, so an overflowing trail — including the current page — scrolls into reach
-instead of being silently clipped.
+Resolved: `BreadcrumbList` is a keyboard-focusable horizontal scroll region
+(`overflow-x-auto` + `tabIndex`), so an overflowing trail — including the
+non-focusable current page — can be scrolled into reach instead of being clipped.
 
 Note: segment corners use `rounded-[4px]` to match Figma; the Nexus radius scale
 is currently `0px` (sharp), so no token maps to 4px — kept as a deliberate

--- a/COMPONENT-REVIEW.md
+++ b/COMPONENT-REVIEW.md
@@ -59,15 +59,27 @@ Numeric spacing notes: chip rhythm on `gap-1` and chip `px`/`py`.
 
 ## breadcrumb
 
-Resolved: `size-9` sets the ellipsis footprint; the ellipsis is non-interactive,
-so the touch-target floor does not apply.
+Resolved: `BreadcrumbPage` drops raw `nx:font-normal` (the list's
+`typography-body-small` already sets normal weight) and no longer advertises
+`role="link"`/`aria-disabled`; the current page is announced via
+`aria-current="page"` only.
 
-Resolved: breadcrumb links keep their visual text footprint but use a
-vertical-only hit-area overlay for the ~44px touch floor. The ellipsis remains
-decorative and unchanged.
+Resolved: `BreadcrumbEllipsis` and `BreadcrumbMenuTrigger` are interactive
+`<button>` triggers composed with `DropdownMenuTrigger asChild` — no longer a
+presentational span.
 
-Resolved: `BreadcrumbPage` no longer adds raw `nx:font-normal`; the list's
-`typography-body-small` already sets normal weight.
+Decision: breadcrumb is a desktop / pointer-fine control (not used on touch or
+small screens), so the ~44px touch-target floor does not apply — segments and
+icon triggers keep their compact sizing and the touch-only hit-area overlays were
+removed (responsive.md: the touch case sets the floor).
+
+Resolved: `BreadcrumbList` uses `overflow-x-auto` with a keyboard-focusable scroll
+region, so an overflowing trail — including the current page — scrolls into reach
+instead of being silently clipped.
+
+Note: segment corners use `rounded-[4px]` to match Figma; the Nexus radius scale
+is currently `0px` (sharp), so no token maps to 4px — kept as a deliberate
+arbitrary value.
 
 ## button
 

--- a/COMPONENT-REVIEW.md
+++ b/COMPONENT-REVIEW.md
@@ -59,11 +59,15 @@ Numeric spacing notes: chip rhythm on `gap-1` and chip `px`/`py`.
 
 ## breadcrumb
 
-Numeric spacing note: `size-9` sets the ellipsis hit-slot footprint.
+Resolved: `size-9` sets the ellipsis footprint; the ellipsis is non-interactive,
+so the touch-target floor does not apply.
 
-Touch targets (mobile, discuss): breadcrumb links are bare inline text (~20px); ellipsis is `size-9` (36px). Both under the ~44px floor.
+Resolved: breadcrumb links keep their visual text footprint but use a
+vertical-only hit-area overlay for the ~44px touch floor. The ellipsis remains
+decorative and unchanged.
 
-Trivial: `BreadcrumbPage` adds raw `nx:font-normal` (list already sets `typography-body-small`).
+Resolved: `BreadcrumbPage` no longer adds raw `nx:font-normal`; the list's
+`typography-body-small` already sets normal weight.
 
 ## button
 

--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -24,7 +24,11 @@
     { "name": "AspectRatio", "showcase": "AllVariants" },
     { "name": "Avatar", "showcase": "AllSizes" },
     { "name": "Badge", "showcase": "AllVariants" },
-    { "name": "Breadcrumb", "showcase": "AllVariants" },
+    {
+      "name": "Breadcrumb",
+      "showcase": "AllVariants",
+      "interactions": ["KeyboardInteraction"]
+    },
     { "name": "Button", "showcase": "AllVariants" },
     { "name": "ButtonGroup", "showcase": "AllVariants" },
     {

--- a/packages/react/src/components/ui/breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/react/src/components/ui/breadcrumb/Breadcrumb.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { IconFolder } from '@tabler/icons-react';
+import { IconFolder, IconHome, IconSettings } from '@tabler/icons-react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import {
@@ -28,12 +28,249 @@ const meta: Meta<typeof Breadcrumb> = {
 export default meta;
 type Story = StoryObj<typeof Breadcrumb>;
 
+type PlaygroundArgs = {
+  itemCount: number;
+  showIcons: boolean;
+  iconOnly: boolean;
+  showMenus: boolean;
+  collapseMiddle: boolean;
+  constrainedWidth: boolean;
+};
+
+const playgroundCrumbs = [
+  {
+    label: 'Home',
+    href: '/home',
+    icon: IconHome,
+    menuItems: ['Dashboard', 'Activity', 'Reports'],
+  },
+  {
+    label: 'Workspace',
+    href: '/workspaces/team',
+    icon: IconFolder,
+    menuItems: ['Personal', 'Team', 'Archived'],
+  },
+  {
+    label: 'Projects',
+    href: '/projects',
+    icon: IconFolder,
+    menuItems: ['Components', 'Patterns', 'Tokens'],
+  },
+  {
+    label: 'Breadcrumb settings with a long page name',
+    href: '/components/breadcrumb',
+    icon: IconSettings,
+    menuItems: ['API', 'Stories', 'Changelog'],
+  },
+];
+
+function renderCrumbContent({
+  crumb,
+  iconOnly,
+  isCurrent,
+  showIcons,
+}: {
+  crumb: (typeof playgroundCrumbs)[number];
+  iconOnly: boolean;
+  isCurrent: boolean;
+  showIcons: boolean;
+}) {
+  const CrumbIcon = crumb.icon;
+  const showVisualIcon = showIcons || iconOnly;
+
+  if (iconOnly) {
+    return (
+      <>
+        <CrumbIcon aria-hidden />
+        {isCurrent ? <span className="nx:sr-only">{crumb.label}</span> : null}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {showVisualIcon ? <CrumbIcon aria-hidden /> : null}
+      <span>{crumb.label}</span>
+    </>
+  );
+}
+
+function renderMenuContent(crumb: (typeof playgroundCrumbs)[number]) {
+  return (
+    <DropdownMenuContent align="start">
+      {crumb.menuItems.map((label) => (
+        <DropdownMenuItem key={label} asChild>
+          <a href={`${crumb.href}/${label.toLowerCase()}`}>{label}</a>
+        </DropdownMenuItem>
+      ))}
+    </DropdownMenuContent>
+  );
+}
+
+function renderPlaygroundItem({
+  crumb,
+  iconOnly,
+  isCurrent,
+  showIcons,
+  showMenus,
+}: {
+  crumb: (typeof playgroundCrumbs)[number];
+  iconOnly: boolean;
+  isCurrent: boolean;
+  showIcons: boolean;
+  showMenus: boolean;
+}) {
+  return (
+    <BreadcrumbItem key={crumb.label}>
+      {isCurrent ? (
+        <BreadcrumbPage>
+          {renderCrumbContent({ crumb, iconOnly, isCurrent, showIcons })}
+        </BreadcrumbPage>
+      ) : (
+        <BreadcrumbLink
+          href={crumb.href}
+          aria-label={iconOnly ? crumb.label : undefined}
+        >
+          {renderCrumbContent({ crumb, iconOnly, isCurrent, showIcons })}
+        </BreadcrumbLink>
+      )}
+      {showMenus ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <BreadcrumbMenuTrigger
+              aria-label={
+                isCurrent
+                  ? `Show related pages for ${crumb.label}`
+                  : `Show alternate paths for ${crumb.label}`
+              }
+            />
+          </DropdownMenuTrigger>
+          {renderMenuContent(crumb)}
+        </DropdownMenu>
+      ) : null}
+    </BreadcrumbItem>
+  );
+}
+
+function renderSeparator(key: string) {
+  return <BreadcrumbSeparator key={key} />;
+}
+
+// Compound playground for trying the breadcrumb anatomy without adding runtime
+// props to the component itself.
+export const Playground: StoryObj<PlaygroundArgs> = {
+  args: {
+    itemCount: 4,
+    showIcons: true,
+    iconOnly: false,
+    showMenus: true,
+    collapseMiddle: false,
+    constrainedWidth: false,
+  },
+  argTypes: {
+    itemCount: {
+      control: 'select',
+      options: [2, 3, 4],
+      description: 'Number of breadcrumb items to render',
+    },
+    showIcons: {
+      control: 'boolean',
+      description: 'Show leading icons in each breadcrumb segment',
+    },
+    iconOnly: {
+      control: 'boolean',
+      description:
+        'Render items as icons only while preserving accessible names',
+    },
+    showMenus: {
+      control: 'boolean',
+      description: 'Show dropdown menu triggers next to breadcrumb segments',
+    },
+    collapseMiddle: {
+      control: 'boolean',
+      description: 'Collapse middle items into the ellipsis dropdown',
+    },
+    constrainedWidth: {
+      control: 'boolean',
+      description: 'Render inside a narrow container to preview truncation',
+    },
+  },
+  render: ({
+    collapseMiddle,
+    constrainedWidth,
+    iconOnly,
+    itemCount,
+    showIcons,
+    showMenus,
+  }) => {
+    const selectedCrumbs = playgroundCrumbs.slice(0, itemCount);
+    const shouldCollapse = collapseMiddle && selectedCrumbs.length > 3;
+    const visibleTrail = shouldCollapse
+      ? [
+          renderPlaygroundItem({
+            crumb: selectedCrumbs[0]!,
+            iconOnly,
+            isCurrent: false,
+            showIcons,
+            showMenus,
+          }),
+          renderSeparator('separator-ellipsis'),
+          <BreadcrumbItem key="ellipsis">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <BreadcrumbEllipsis />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                {selectedCrumbs.slice(1, -1).map((crumb) => (
+                  <DropdownMenuItem key={crumb.label} asChild>
+                    <a href={crumb.href}>{crumb.label}</a>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </BreadcrumbItem>,
+          renderSeparator('separator-current'),
+          renderPlaygroundItem({
+            crumb: selectedCrumbs[selectedCrumbs.length - 1]!,
+            iconOnly,
+            isCurrent: true,
+            showIcons,
+            showMenus,
+          }),
+        ]
+      : selectedCrumbs.flatMap((crumb, index) => {
+          const isCurrent = index === selectedCrumbs.length - 1;
+          const item = renderPlaygroundItem({
+            crumb,
+            iconOnly,
+            isCurrent,
+            showIcons,
+            showMenus,
+          });
+
+          return index === 0
+            ? [item]
+            : [renderSeparator(`separator-${crumb.label}`), item];
+        });
+    const breadcrumb = (
+      <Breadcrumb>
+        <BreadcrumbList>{visibleTrail}</BreadcrumbList>
+      </Breadcrumb>
+    );
+
+    return constrainedWidth ? (
+      <div className="nx:w-[240px]">{breadcrumb}</div>
+    ) : (
+      breadcrumb
+    );
+  },
+};
+
 // A three-level trail ending on the current page.
 export const Default: Story = {
   render: () => (
     <Breadcrumb>
       <BreadcrumbList>
-        <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbLink href="#">Home</BreadcrumbLink>
         </BreadcrumbItem>
@@ -55,7 +292,6 @@ export const WithEllipsis: Story = {
   render: () => (
     <Breadcrumb>
       <BreadcrumbList>
-        <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbLink href="#">Home</BreadcrumbLink>
         </BreadcrumbItem>
@@ -109,7 +345,6 @@ export const WithIcons: Story = {
   render: () => (
     <Breadcrumb>
       <BreadcrumbList>
-        <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbLink href="#">
             <IconFolder aria-hidden />
@@ -195,6 +430,48 @@ export const WithIcons: Story = {
   },
 };
 
+// Breadcrumb items can be icon-only visually. Links still need an accessible
+// name, and the current page carries screen-reader text because it is not a
+// named interactive control.
+export const IconOnly: Story = {
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/home" aria-label="Home">
+            <IconHome aria-hidden />
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/projects" aria-label="Projects">
+            <IconFolder aria-hidden />
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>
+            <IconSettings aria-hidden />
+            <span className="nx:sr-only">Settings</span>
+          </BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole('link', { name: 'Home' })).toHaveAttribute(
+      'data-slot',
+      'breadcrumb-link'
+    );
+    await expect(
+      canvas.getByRole('link', { name: 'Projects' })
+    ).toHaveAttribute('data-slot', 'breadcrumb-link');
+    await expect(canvas.getByText('Settings')).toHaveClass('nx:sr-only');
+  },
+};
+
 // Breadcrumb labels cap at 150px, then shrink below that when the available
 // breadcrumb width is tighter.
 export const LongContent: Story = {
@@ -202,7 +479,6 @@ export const LongContent: Story = {
     <div className="nx:w-[240px]">
       <Breadcrumb>
         <BreadcrumbList>
-          <BreadcrumbSeparator />
           <BreadcrumbItem>
             <BreadcrumbLink href="#">
               Quarterly reporting workspace with an unusually long name
@@ -226,7 +502,6 @@ export const AsChild: Story = {
   render: () => (
     <Breadcrumb>
       <BreadcrumbList>
-        <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbLink asChild>
             <a href="/contacts" data-testid="router-link">
@@ -255,7 +530,6 @@ export const KeyboardInteraction: Story = {
   render: () => (
     <Breadcrumb>
       <BreadcrumbList>
-        <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbLink href="#">Home</BreadcrumbLink>
           <DropdownMenu>
@@ -306,7 +580,6 @@ export const WithDataAttributes: Story = {
   render: () => (
     <Breadcrumb>
       <BreadcrumbList>
-        <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbLink href="#">Home</BreadcrumbLink>
           <DropdownMenu>
@@ -373,7 +646,6 @@ export const AllVariants: Story = {
   render: () => (
     <Breadcrumb>
       <BreadcrumbList>
-        <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbLink href="#">Home</BreadcrumbLink>
         </BreadcrumbItem>

--- a/packages/react/src/components/ui/breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/react/src/components/ui/breadcrumb/Breadcrumb.stories.tsx
@@ -524,8 +524,8 @@ export const AsChild: Story = {
   },
 };
 
-// Breadcrumb links follow the native anchor focus contract; the current page is
-// a non-interactive span and stays out of the tab order.
+// The list is a focusable scroll region (first tab stop); the links then follow
+// the native anchor focus contract, and the current page stays out of the order.
 export const KeyboardInteraction: Story = {
   render: () => (
     <Breadcrumb>
@@ -555,12 +555,17 @@ export const KeyboardInteraction: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const list = canvas.getByRole('list');
     const link = canvas.getByRole('link', { name: 'Home' });
     const trigger = canvas.getByRole('button', {
       name: 'Show alternate paths for Home',
     });
     const page = canvas.getByText('Contacts');
 
+    // The list is a keyboard-focusable scroll region, so it is the first tab
+    // stop; the link and trigger follow, and the current page is never focused.
+    await userEvent.tab();
+    await expect(list).toHaveFocus();
     await userEvent.tab();
     await expect(link).toHaveFocus();
     await expect(link).toHaveAttribute('data-slot', 'breadcrumb-link');

--- a/packages/react/src/components/ui/breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/react/src/components/ui/breadcrumb/Breadcrumb.stories.tsx
@@ -1,5 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, userEvent, within } from 'storybook/test';
+import { IconFolder } from '@tabler/icons-react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../dropdown-menu';
 
 import {
   Breadcrumb,
@@ -7,6 +15,7 @@ import {
   BreadcrumbItem,
   BreadcrumbLink,
   BreadcrumbList,
+  BreadcrumbMenuTrigger,
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from './breadcrumb';
@@ -24,6 +33,7 @@ export const Default: Story = {
   render: () => (
     <Breadcrumb>
       <BreadcrumbList>
+        <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbLink href="#">Home</BreadcrumbLink>
         </BreadcrumbItem>
@@ -45,12 +55,28 @@ export const WithEllipsis: Story = {
   render: () => (
     <Breadcrumb>
       <BreadcrumbList>
+        <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbLink href="#">Home</BreadcrumbLink>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
-          <BreadcrumbEllipsis />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <BreadcrumbEllipsis />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem asChild>
+                <a href="/projects">Projects</a>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <a href="/projects/design-system">Design System</a>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <a href="/projects/design-system/components">Components</a>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
@@ -58,6 +84,139 @@ export const WithEllipsis: Story = {
         </BreadcrumbItem>
       </BreadcrumbList>
     </Breadcrumb>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Show hidden breadcrumbs' })
+    );
+
+    await waitFor(async () => {
+      await expect(
+        within(document.body).getByRole('menuitem', {
+          name: 'Design System',
+        })
+      ).toBeVisible();
+    });
+  },
+};
+
+// Figma supports optional item icons and trailing dropdown affordances. The
+// chevron is a real menu trigger next to the link, not an interactive control
+// nested inside the anchor.
+export const WithIcons: Story = {
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">
+            <IconFolder aria-hidden />
+            <span>Workspace</span>
+          </BreadcrumbLink>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <BreadcrumbMenuTrigger aria-label="Show alternate paths for Workspace" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem asChild>
+                <a href="/workspaces/personal">Personal</a>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <a href="/workspaces/team">Team</a>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <a href="/workspaces/archived">Archived</a>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">
+            <IconFolder aria-hidden />
+            <span>Projects</span>
+          </BreadcrumbLink>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <BreadcrumbMenuTrigger aria-label="Show alternate paths for Projects" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem asChild>
+                <a href="/projects/components">Components</a>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <a href="/projects/patterns">Patterns</a>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <a href="/projects/tokens">Tokens</a>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>
+            <IconFolder aria-hidden />
+            <span>Breadcrumb</span>
+          </BreadcrumbPage>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <BreadcrumbMenuTrigger aria-label="Show related pages for Breadcrumb" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem asChild>
+                <a href="/components/breadcrumb/api">Breadcrumb API</a>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <a href="/components/breadcrumb/stories">Breadcrumb Stories</a>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      canvas.getByRole('button', {
+        name: 'Show alternate paths for Workspace',
+      })
+    );
+
+    await waitFor(async () => {
+      await expect(
+        within(document.body).getByRole('menuitem', { name: 'Team' })
+      ).toBeVisible();
+    });
+  },
+};
+
+// Breadcrumb labels cap at 150px, then shrink below that when the available
+// breadcrumb width is tighter.
+export const LongContent: Story = {
+  render: () => (
+    <div className="nx:w-[240px]">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink href="#">
+              Quarterly reporting workspace with an unusually long name
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>
+              Budget assumptions and approval workflow details
+            </BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+    </div>
   ),
 };
 
@@ -67,6 +226,7 @@ export const AsChild: Story = {
   render: () => (
     <Breadcrumb>
       <BreadcrumbList>
+        <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbLink asChild>
             <a href="/contacts" data-testid="router-link">
@@ -95,8 +255,22 @@ export const KeyboardInteraction: Story = {
   render: () => (
     <Breadcrumb>
       <BreadcrumbList>
+        <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbLink href="#">Home</BreadcrumbLink>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <BreadcrumbMenuTrigger aria-label="Show alternate paths for Home" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem asChild>
+                <a href="/accounts">Accounts</a>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <a href="/companies">Companies</a>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
@@ -108,11 +282,20 @@ export const KeyboardInteraction: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const link = canvas.getByRole('link', { name: 'Home' });
+    const trigger = canvas.getByRole('button', {
+      name: 'Show alternate paths for Home',
+    });
     const page = canvas.getByText('Contacts');
 
     await userEvent.tab();
     await expect(link).toHaveFocus();
     await expect(link).toHaveAttribute('data-slot', 'breadcrumb-link');
+    await userEvent.tab();
+    await expect(trigger).toHaveFocus();
+    await expect(trigger).toHaveAttribute(
+      'data-slot',
+      'breadcrumb-menu-trigger'
+    );
     await expect(page).not.toHaveFocus();
   },
 };
@@ -123,12 +306,32 @@ export const WithDataAttributes: Story = {
   render: () => (
     <Breadcrumb>
       <BreadcrumbList>
+        <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbLink href="#">Home</BreadcrumbLink>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <BreadcrumbMenuTrigger aria-label="Show alternate paths for Home" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem asChild>
+                <a href="/companies">Companies</a>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
-          <BreadcrumbEllipsis />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <BreadcrumbEllipsis />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem asChild>
+                <a href="/companies">Companies</a>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
@@ -143,6 +346,7 @@ export const WithDataAttributes: Story = {
       'breadcrumb-list',
       'breadcrumb-item',
       'breadcrumb-link',
+      'breadcrumb-menu-trigger',
       'breadcrumb-separator',
       'breadcrumb-ellipsis',
       'breadcrumb-page',
@@ -163,18 +367,28 @@ export const WithDataAttributes: Story = {
 // ALL VARIANTS GRID
 // ============================================
 
-// The full anatomy: links, chevron separators, a collapsed ellipsis, and the
+// The full anatomy: links, slash separators, a collapsed ellipsis, and the
 // current page. Reused by the per-base variant generator.
 export const AllVariants: Story = {
   render: () => (
     <Breadcrumb>
       <BreadcrumbList>
+        <BreadcrumbSeparator />
         <BreadcrumbItem>
           <BreadcrumbLink href="#">Home</BreadcrumbLink>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
-          <BreadcrumbEllipsis />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <BreadcrumbEllipsis />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start">
+              <DropdownMenuItem asChild>
+                <a href="/projects/design-system">Design System</a>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>

--- a/packages/react/src/components/ui/breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/react/src/components/ui/breadcrumb/Breadcrumb.stories.tsx
@@ -481,13 +481,15 @@ export const LongContent: Story = {
         <BreadcrumbList>
           <BreadcrumbItem>
             <BreadcrumbLink href="#">
-              Quarterly reporting workspace with an unusually long name
+              <span>
+                Quarterly reporting workspace with an unusually long name
+              </span>
             </BreadcrumbLink>
           </BreadcrumbItem>
           <BreadcrumbSeparator />
           <BreadcrumbItem>
             <BreadcrumbPage>
-              Budget assumptions and approval workflow details
+              <span>Budget assumptions and approval workflow details</span>
             </BreadcrumbPage>
           </BreadcrumbItem>
         </BreadcrumbList>

--- a/packages/react/src/components/ui/breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/react/src/components/ui/breadcrumb/Breadcrumb.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, within } from 'storybook/test';
+import { expect, userEvent, within } from 'storybook/test';
 
 import {
   Breadcrumb,
@@ -89,14 +89,46 @@ export const AsChild: Story = {
   },
 };
 
+// Breadcrumb links follow the native anchor focus contract; the current page is
+// a non-interactive span and stays out of the tab order.
+export const KeyboardInteraction: Story = {
+  render: () => (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Contacts</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: 'Home' });
+    const page = canvas.getByText('Contacts');
+
+    await userEvent.tab();
+    await expect(link).toHaveFocus();
+    await expect(link).toHaveAttribute('data-slot', 'breadcrumb-link');
+    await expect(page).not.toHaveFocus();
+  },
+};
+
 // Every structural part carries a data-slot hook; the current page advertises
-// aria-current.
+// aria-current without pretending to be a disabled link.
 export const WithDataAttributes: Story = {
   render: () => (
     <Breadcrumb>
       <BreadcrumbList>
         <BreadcrumbItem>
           <BreadcrumbLink href="#">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbEllipsis />
         </BreadcrumbItem>
         <BreadcrumbSeparator />
         <BreadcrumbItem>
@@ -112,6 +144,7 @@ export const WithDataAttributes: Story = {
       'breadcrumb-item',
       'breadcrumb-link',
       'breadcrumb-separator',
+      'breadcrumb-ellipsis',
       'breadcrumb-page',
     ]) {
       await expect(
@@ -121,6 +154,8 @@ export const WithDataAttributes: Story = {
 
     const page = canvasElement.querySelector('[data-slot="breadcrumb-page"]');
     await expect(page).toHaveAttribute('aria-current', 'page');
+    await expect(page).not.toHaveAttribute('role');
+    await expect(page).not.toHaveAttribute('aria-disabled');
   },
 };
 

--- a/packages/react/src/components/ui/breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/react/src/components/ui/breadcrumb/Breadcrumb.stories.tsx
@@ -524,8 +524,7 @@ export const AsChild: Story = {
   },
 };
 
-// The list is a focusable scroll region (first tab stop); the links then follow
-// the native anchor focus contract, and the current page stays out of the order.
+// Breadcrumb links are native anchors; the current page is a non-interactive span.
 export const KeyboardInteraction: Story = {
   render: () => (
     <Breadcrumb>

--- a/packages/react/src/components/ui/breadcrumb/breadcrumb.tsx
+++ b/packages/react/src/components/ui/breadcrumb/breadcrumb.tsx
@@ -73,15 +73,19 @@ interface BreadcrumbListProps extends React.ComponentProps<'ol'> {}
  * BreadcrumbList
  *
  * The `<ol>` that lays the trail out in one horizontal row. When the trail is
- * wider than its container it scrolls horizontally instead of clipping; the links
- * scroll into view on focus, so the current page is never silently cut off.
+ * wider than its container it becomes a keyboard-focusable horizontal scroll
+ * region, so the current page can be scrolled into view instead of being clipped.
  */
 function BreadcrumbList({ className, ...props }: BreadcrumbListProps) {
   return (
     <ol
       data-slot="breadcrumb-list"
+      // The current page is a non-focusable <span>, so the list itself must be
+      // keyboard-focusable to scroll an overflowing trail into view (WCAG 2.1.1).
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+      tabIndex={0}
       className={cn(
-        'nx:flex nx:min-w-0 nx:max-w-full nx:flex-nowrap nx:items-center nx:gap-0.5 nx:overflow-x-auto nx:px-1.5 nx:py-1.5 nx:typography-body-small nx:text-muted-foreground',
+        'nx:flex nx:min-w-0 nx:max-w-full nx:flex-nowrap nx:items-center nx:gap-0.5 nx:overflow-x-auto nx:px-1.5 nx:py-1.5 nx:typography-body-small nx:text-muted-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/breadcrumb/breadcrumb.tsx
+++ b/packages/react/src/components/ui/breadcrumb/breadcrumb.tsx
@@ -72,14 +72,16 @@ interface BreadcrumbListProps extends React.ComponentProps<'ol'> {}
 /**
  * BreadcrumbList
  *
- * The `<ol>` that lays the trail out in one horizontal, truncating row.
+ * The `<ol>` that lays the trail out in one horizontal row. When the trail is
+ * wider than its container it scrolls horizontally instead of clipping; the links
+ * scroll into view on focus, so the current page is never silently cut off.
  */
 function BreadcrumbList({ className, ...props }: BreadcrumbListProps) {
   return (
     <ol
       data-slot="breadcrumb-list"
       className={cn(
-        'nx:flex nx:min-w-0 nx:max-w-full nx:flex-nowrap nx:items-center nx:gap-0.5 nx:overflow-hidden nx:typography-body-small nx:text-muted-foreground',
+        'nx:flex nx:min-w-0 nx:max-w-full nx:flex-nowrap nx:items-center nx:gap-0.5 nx:overflow-x-auto nx:px-1.5 nx:py-1.5 nx:typography-body-small nx:text-muted-foreground',
         className
       )}
       {...props}
@@ -129,10 +131,10 @@ interface BreadcrumbLinkProps extends React.ComponentProps<'a'> {
 /**
  * BreadcrumbLink
  *
- * A link to an ancestor page. It follows the compact Figma item rhythm while
- * keeping the canonical focus ring since it is reachable by keyboard. Its
- * vertical hit area is expanded for touch without overlapping neighboring
- * breadcrumbs.
+ * A link to an ancestor page. It follows the compact Figma item rhythm and keeps
+ * the canonical focus ring since it is reachable by keyboard. Bare text children
+ * are wrapped so long labels truncate; when composing an icon with text, wrap the
+ * text in a `<span>` so it truncates.
  */
 function BreadcrumbLink({
   asChild,
@@ -146,7 +148,7 @@ function BreadcrumbLink({
     <Comp
       data-slot="breadcrumb-link"
       className={cn(
-        "nx:relative nx:inline-flex nx:min-w-0 nx:max-w-[150px] nx:items-center nx:gap-1 nx:rounded-[4px] nx:px-1.5 nx:typography-label-default nx:transition-colors nx:after:absolute nx:after:inset-x-0 nx:after:-inset-y-3 nx:after:content-[''] nx:hover:bg-background-hover nx:active:bg-background-active nx:data-[state=active]:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&>span]:min-w-0 nx:[&>span]:truncate nx:[&_svg]:size-4 nx:[&_svg]:shrink-0",
+        'nx:inline-flex nx:min-w-0 nx:max-w-[150px] nx:items-center nx:gap-1 nx:rounded-[4px] nx:px-1.5 nx:typography-label-default nx:transition-colors nx:hover:bg-background-hover nx:active:bg-background-active nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&>span]:min-w-0 nx:[&>span]:truncate nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
         className
       )}
       {...props}
@@ -204,19 +206,14 @@ interface BreadcrumbMenuTriggerProps extends React.ComponentProps<'button'> {}
  * segment. Compose it with `DropdownMenuTrigger asChild`; do not nest it inside
  * a `BreadcrumbLink`.
  */
-const BreadcrumbMenuTrigger = React.forwardRef<
-  HTMLButtonElement,
-  BreadcrumbMenuTriggerProps
->(function BreadcrumbMenuTrigger(
-  {
-    children,
-    className,
-    type = 'button',
-    'aria-label': ariaLabel = 'Show alternate paths',
-    ...props
-  },
-  ref
-) {
+function BreadcrumbMenuTrigger({
+  children,
+  className,
+  ref,
+  type = 'button',
+  'aria-label': ariaLabel = 'Show alternate paths',
+  ...props
+}: BreadcrumbMenuTriggerProps) {
   return (
     <button
       ref={ref}
@@ -224,7 +221,7 @@ const BreadcrumbMenuTrigger = React.forwardRef<
       type={type}
       aria-label={ariaLabel}
       className={cn(
-        "nx:relative nx:inline-flex nx:size-5 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-[4px] nx:transition-colors nx:after:absolute nx:after:inset-x-0 nx:after:-inset-y-3 nx:after:content-[''] nx:hover:bg-background-hover nx:active:bg-background-active nx:data-[state=open]:bg-background-active nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&_svg]:size-4 nx:[&_svg]:shrink-0",
+        'nx:inline-flex nx:size-5 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-[4px] nx:transition-colors nx:hover:bg-background-hover nx:active:bg-background-active nx:data-[state=open]:bg-background-active nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
         className
       )}
       {...props}
@@ -232,7 +229,7 @@ const BreadcrumbMenuTrigger = React.forwardRef<
       {children ?? <IconChevronDown aria-hidden="true" />}
     </button>
   );
-});
+}
 
 /**
  * BreadcrumbSeparatorProps
@@ -281,18 +278,13 @@ interface BreadcrumbEllipsisProps extends React.ComponentProps<'button'> {}
  * Overflow trigger for a collapsed run of middle items. Compose it with
  * `DropdownMenuTrigger asChild` and put the hidden paths in the menu content.
  */
-const BreadcrumbEllipsis = React.forwardRef<
-  HTMLButtonElement,
-  BreadcrumbEllipsisProps
->(function BreadcrumbEllipsis(
-  {
-    className,
-    type = 'button',
-    'aria-label': ariaLabel = 'Show hidden breadcrumbs',
-    ...props
-  },
-  ref
-) {
+function BreadcrumbEllipsis({
+  className,
+  ref,
+  type = 'button',
+  'aria-label': ariaLabel = 'Show hidden breadcrumbs',
+  ...props
+}: BreadcrumbEllipsisProps) {
   return (
     <button
       ref={ref}
@@ -300,7 +292,7 @@ const BreadcrumbEllipsis = React.forwardRef<
       type={type}
       aria-label={ariaLabel}
       className={cn(
-        "nx:relative nx:inline-flex nx:shrink-0 nx:items-center nx:justify-center nx:rounded-[4px] nx:px-1.5 nx:typography-body-small nx:transition-colors nx:after:absolute nx:after:inset-x-0 nx:after:-inset-y-3 nx:after:content-[''] nx:hover:bg-background-hover nx:active:bg-background-active nx:data-[state=open]:bg-background-active nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)",
+        'nx:inline-flex nx:shrink-0 nx:items-center nx:justify-center nx:rounded-[4px] nx:px-1.5 nx:typography-body-small nx:transition-colors nx:hover:bg-background-hover nx:active:bg-background-active nx:data-[state=open]:bg-background-active nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
         className
       )}
       {...props}
@@ -308,7 +300,7 @@ const BreadcrumbEllipsis = React.forwardRef<
       ...
     </button>
   );
-});
+}
 
 export {
   Breadcrumb,

--- a/packages/react/src/components/ui/breadcrumb/breadcrumb.tsx
+++ b/packages/react/src/components/ui/breadcrumb/breadcrumb.tsx
@@ -47,7 +47,6 @@ interface BreadcrumbProps extends React.ComponentProps<'nav'> {}
  * ```tsx
  * <Breadcrumb>
  *   <BreadcrumbList>
- *     <BreadcrumbSeparator />
  *     <BreadcrumbItem>
  *       <BreadcrumbLink href="/">Home</BreadcrumbLink>
  *     </BreadcrumbItem>
@@ -245,8 +244,8 @@ interface BreadcrumbSeparatorProps extends React.ComponentProps<'li'> {}
 /**
  * BreadcrumbSeparator
  *
- * The divider before or between items — a slash by default; pass `children` to
- * use a different glyph.
+ * The divider between items — a slash by default; pass `children` to use a
+ * different glyph.
  */
 function BreadcrumbSeparator({
   children,

--- a/packages/react/src/components/ui/breadcrumb/breadcrumb.tsx
+++ b/packages/react/src/components/ui/breadcrumb/breadcrumb.tsx
@@ -105,7 +105,8 @@ interface BreadcrumbLinkProps extends React.ComponentProps<'a'> {
  * BreadcrumbLink
  *
  * A link to an ancestor page. Muted by default, darkening on hover; carries the
- * canonical focus ring since it is reachable by keyboard.
+ * canonical focus ring since it is reachable by keyboard. Its vertical hit
+ * area is expanded for touch without overlapping neighboring breadcrumbs.
  */
 function BreadcrumbLink({ asChild, className, ...props }: BreadcrumbLinkProps) {
   const Comp = asChild ? Slot : 'a';
@@ -114,7 +115,7 @@ function BreadcrumbLink({ asChild, className, ...props }: BreadcrumbLinkProps) {
     <Comp
       data-slot="breadcrumb-link"
       className={cn(
-        'nx:rounded-sm nx:transition-colors nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
+        "nx:relative nx:rounded-sm nx:transition-colors nx:after:absolute nx:after:inset-x-0 nx:after:-inset-y-3 nx:after:content-[''] nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)",
         className
       )}
       {...props}
@@ -138,10 +139,8 @@ function BreadcrumbPage({ className, ...props }: BreadcrumbPageProps) {
   return (
     <span
       data-slot="breadcrumb-page"
-      role="link"
-      aria-disabled="true"
       aria-current="page"
-      className={cn('nx:font-normal nx:text-foreground', className)}
+      className={cn('nx:text-foreground', className)}
       {...props}
     />
   );
@@ -188,8 +187,8 @@ interface BreadcrumbEllipsisProps extends React.ComponentProps<'span'> {}
 /**
  * BreadcrumbEllipsis
  *
- * Stands in for a collapsed run of middle items; pair with a menu to reveal
- * them.
+ * Decorative overflow marker for a collapsed run of middle items. If it is
+ * wrapped in a real trigger, that trigger must provide its own accessible label.
  */
 function BreadcrumbEllipsis({ className, ...props }: BreadcrumbEllipsisProps) {
   return (
@@ -204,7 +203,6 @@ function BreadcrumbEllipsis({ className, ...props }: BreadcrumbEllipsisProps) {
       {...props}
     >
       <IconDots className="nx:size-4" />
-      <span className="nx:sr-only">More</span>
     </span>
   );
 }

--- a/packages/react/src/components/ui/breadcrumb/breadcrumb.tsx
+++ b/packages/react/src/components/ui/breadcrumb/breadcrumb.tsx
@@ -5,28 +5,6 @@ import { Slot } from '@radix-ui/react-slot';
 import { IconChevronDown } from '@/lib/icons';
 import { cn } from '@/lib/utils';
 
-function renderBreadcrumbText(children: React.ReactNode) {
-  return React.Children.map(children, (child) => {
-    if (typeof child === 'string' || typeof child === 'number') {
-      return <span>{child}</span>;
-    }
-
-    return child;
-  });
-}
-
-function renderSlottedBreadcrumbText(children: React.ReactNode) {
-  const child = React.Children.only(children);
-
-  if (!React.isValidElement<{ children?: React.ReactNode }>(child)) {
-    return child;
-  }
-
-  return React.cloneElement(child, {
-    children: renderBreadcrumbText(child.props.children),
-  });
-}
-
 /**
  * BreadcrumbProps
  *
@@ -136,31 +114,22 @@ interface BreadcrumbLinkProps extends React.ComponentProps<'a'> {
  * BreadcrumbLink
  *
  * A link to an ancestor page. It follows the compact Figma item rhythm and keeps
- * the canonical focus ring since it is reachable by keyboard. Bare text children
- * are wrapped so long labels truncate; when composing an icon with text, wrap the
- * text in a `<span>` so it truncates.
+ * the canonical focus ring since it is reachable by keyboard. Wrap the label in a
+ * `<span>` so it truncates at the 150px cap — both for plain text and when
+ * composing an icon with text.
  */
-function BreadcrumbLink({
-  asChild,
-  children,
-  className,
-  ...props
-}: BreadcrumbLinkProps) {
+function BreadcrumbLink({ asChild, className, ...props }: BreadcrumbLinkProps) {
   const Comp = asChild ? Slot : 'a';
 
   return (
     <Comp
       data-slot="breadcrumb-link"
       className={cn(
-        'nx:inline-flex nx:min-w-0 nx:max-w-[150px] nx:items-center nx:gap-1 nx:rounded-[4px] nx:px-1.5 nx:typography-label-default nx:transition-colors nx:hover:bg-background-hover nx:active:bg-background-active nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&>span]:min-w-0 nx:[&>span]:truncate nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+        'nx:inline-flex nx:min-w-0 nx:max-w-[150px] nx:items-center nx:gap-1 nx:rounded-md nx:px-1.5 nx:typography-label-default nx:transition-colors nx:hover:bg-background-hover nx:active:bg-background-active nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&>span]:min-w-0 nx:[&>span]:truncate nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
         className
       )}
       {...props}
-    >
-      {asChild
-        ? renderSlottedBreadcrumbText(children)
-        : renderBreadcrumbText(children)}
-    </Comp>
+    />
   );
 }
 
@@ -174,25 +143,20 @@ interface BreadcrumbPageProps extends React.ComponentProps<'span'> {}
 /**
  * BreadcrumbPage
  *
- * The current page — non-interactive, announced via `aria-current="page"`.
+ * The current page — non-interactive, announced via `aria-current="page"`. Wrap
+ * the label in a `<span>` so it truncates at the 150px cap.
  */
-function BreadcrumbPage({
-  children,
-  className,
-  ...props
-}: BreadcrumbPageProps) {
+function BreadcrumbPage({ className, ...props }: BreadcrumbPageProps) {
   return (
     <span
       data-slot="breadcrumb-page"
       aria-current="page"
       className={cn(
-        'nx:inline-flex nx:min-w-0 nx:max-w-[150px] nx:items-center nx:gap-1 nx:rounded-[4px] nx:px-1.5 nx:typography-label-default nx:text-foreground nx:[&>span]:min-w-0 nx:[&>span]:truncate nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+        'nx:inline-flex nx:min-w-0 nx:max-w-[150px] nx:items-center nx:gap-1 nx:rounded-md nx:px-1.5 nx:typography-label-default nx:text-foreground nx:[&>span]:min-w-0 nx:[&>span]:truncate nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
         className
       )}
       {...props}
-    >
-      {renderBreadcrumbText(children)}
-    </span>
+    />
   );
 }
 
@@ -225,7 +189,7 @@ function BreadcrumbMenuTrigger({
       type={type}
       aria-label={ariaLabel}
       className={cn(
-        'nx:inline-flex nx:size-5 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-[4px] nx:transition-colors nx:hover:bg-background-hover nx:active:bg-background-active nx:data-[state=open]:bg-background-active nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+        'nx:inline-flex nx:size-5 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-md nx:transition-colors nx:hover:bg-background-hover nx:active:bg-background-active nx:data-[state=open]:bg-background-active nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
         className
       )}
       {...props}
@@ -296,7 +260,7 @@ function BreadcrumbEllipsis({
       type={type}
       aria-label={ariaLabel}
       className={cn(
-        'nx:inline-flex nx:shrink-0 nx:items-center nx:justify-center nx:rounded-[4px] nx:px-1.5 nx:typography-body-small nx:transition-colors nx:hover:bg-background-hover nx:active:bg-background-active nx:data-[state=open]:bg-background-active nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
+        'nx:inline-flex nx:shrink-0 nx:items-center nx:justify-center nx:rounded-md nx:px-1.5 nx:typography-body-small nx:transition-colors nx:hover:bg-background-hover nx:active:bg-background-active nx:data-[state=open]:bg-background-active nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/breadcrumb/breadcrumb.tsx
+++ b/packages/react/src/components/ui/breadcrumb/breadcrumb.tsx
@@ -2,8 +2,30 @@ import * as React from 'react';
 
 import { Slot } from '@radix-ui/react-slot';
 
-import { IconChevronRight, IconDots } from '@/lib/icons';
+import { IconChevronDown } from '@/lib/icons';
 import { cn } from '@/lib/utils';
+
+function renderBreadcrumbText(children: React.ReactNode) {
+  return React.Children.map(children, (child) => {
+    if (typeof child === 'string' || typeof child === 'number') {
+      return <span>{child}</span>;
+    }
+
+    return child;
+  });
+}
+
+function renderSlottedBreadcrumbText(children: React.ReactNode) {
+  const child = React.Children.only(children);
+
+  if (!React.isValidElement<{ children?: React.ReactNode }>(child)) {
+    return child;
+  }
+
+  return React.cloneElement(child, {
+    children: renderBreadcrumbText(child.props.children),
+  });
+}
 
 /**
  * BreadcrumbProps
@@ -18,13 +40,14 @@ interface BreadcrumbProps extends React.ComponentProps<'nav'> {}
  * A hierarchical navigation trail wrapped in the `navigation` landmark. Compose
  * with the sub-components: `BreadcrumbList` lays out a row of `BreadcrumbItem`s,
  * each holding a `BreadcrumbLink` (an ancestor) or `BreadcrumbPage` (the current
- * page); `BreadcrumbSeparator` divides them and `BreadcrumbEllipsis` stands in
- * for a collapsed middle.
+ * page); `BreadcrumbSeparator` divides them and `BreadcrumbEllipsis` reveals a
+ * collapsed middle when composed with a menu.
  *
  * @example
  * ```tsx
  * <Breadcrumb>
  *   <BreadcrumbList>
+ *     <BreadcrumbSeparator />
  *     <BreadcrumbItem>
  *       <BreadcrumbLink href="/">Home</BreadcrumbLink>
  *     </BreadcrumbItem>
@@ -50,14 +73,14 @@ interface BreadcrumbListProps extends React.ComponentProps<'ol'> {}
 /**
  * BreadcrumbList
  *
- * The `<ol>` that lays the trail out in a horizontal, wrapping row.
+ * The `<ol>` that lays the trail out in one horizontal, truncating row.
  */
 function BreadcrumbList({ className, ...props }: BreadcrumbListProps) {
   return (
     <ol
       data-slot="breadcrumb-list"
       className={cn(
-        'nx:flex nx:flex-wrap nx:items-center nx:gap-1.5 nx:wrap-break-word nx:typography-body-small nx:text-muted-foreground',
+        'nx:flex nx:min-w-0 nx:max-w-full nx:flex-nowrap nx:items-center nx:gap-0.5 nx:overflow-hidden nx:typography-body-small nx:text-muted-foreground',
         className
       )}
       {...props}
@@ -81,7 +104,10 @@ function BreadcrumbItem({ className, ...props }: BreadcrumbItemProps) {
   return (
     <li
       data-slot="breadcrumb-item"
-      className={cn('nx:inline-flex nx:items-center nx:gap-1.5', className)}
+      className={cn(
+        'nx:inline-flex nx:min-w-0 nx:items-center nx:gap-0',
+        className
+      )}
       {...props}
     />
   );
@@ -104,22 +130,32 @@ interface BreadcrumbLinkProps extends React.ComponentProps<'a'> {
 /**
  * BreadcrumbLink
  *
- * A link to an ancestor page. Muted by default, darkening on hover; carries the
- * canonical focus ring since it is reachable by keyboard. Its vertical hit
- * area is expanded for touch without overlapping neighboring breadcrumbs.
+ * A link to an ancestor page. It follows the compact Figma item rhythm while
+ * keeping the canonical focus ring since it is reachable by keyboard. Its
+ * vertical hit area is expanded for touch without overlapping neighboring
+ * breadcrumbs.
  */
-function BreadcrumbLink({ asChild, className, ...props }: BreadcrumbLinkProps) {
+function BreadcrumbLink({
+  asChild,
+  children,
+  className,
+  ...props
+}: BreadcrumbLinkProps) {
   const Comp = asChild ? Slot : 'a';
 
   return (
     <Comp
       data-slot="breadcrumb-link"
       className={cn(
-        "nx:relative nx:rounded-sm nx:transition-colors nx:after:absolute nx:after:inset-x-0 nx:after:-inset-y-3 nx:after:content-[''] nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)",
+        "nx:relative nx:inline-flex nx:min-w-0 nx:max-w-[150px] nx:items-center nx:gap-1 nx:rounded-[4px] nx:px-1.5 nx:typography-label-default nx:transition-colors nx:after:absolute nx:after:inset-x-0 nx:after:-inset-y-3 nx:after:content-[''] nx:hover:bg-background-hover nx:active:bg-background-active nx:data-[state=active]:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&>span]:min-w-0 nx:[&>span]:truncate nx:[&_svg]:size-4 nx:[&_svg]:shrink-0",
         className
       )}
       {...props}
-    />
+    >
+      {asChild
+        ? renderSlottedBreadcrumbText(children)
+        : renderBreadcrumbText(children)}
+    </Comp>
   );
 }
 
@@ -135,16 +171,69 @@ interface BreadcrumbPageProps extends React.ComponentProps<'span'> {}
  *
  * The current page — non-interactive, announced via `aria-current="page"`.
  */
-function BreadcrumbPage({ className, ...props }: BreadcrumbPageProps) {
+function BreadcrumbPage({
+  children,
+  className,
+  ...props
+}: BreadcrumbPageProps) {
   return (
     <span
       data-slot="breadcrumb-page"
       aria-current="page"
-      className={cn('nx:text-foreground', className)}
+      className={cn(
+        'nx:inline-flex nx:min-w-0 nx:max-w-[150px] nx:items-center nx:gap-1 nx:rounded-[4px] nx:px-1.5 nx:typography-label-default nx:text-foreground nx:[&>span]:min-w-0 nx:[&>span]:truncate nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+        className
+      )}
       {...props}
-    />
+    >
+      {renderBreadcrumbText(children)}
+    </span>
   );
 }
+
+/**
+ * BreadcrumbMenuTriggerProps
+ *
+ * Props for the BreadcrumbMenuTrigger component.
+ */
+interface BreadcrumbMenuTriggerProps extends React.ComponentProps<'button'> {}
+
+/**
+ * BreadcrumbMenuTrigger
+ *
+ * An icon button for revealing alternate paths for the adjacent breadcrumb
+ * segment. Compose it with `DropdownMenuTrigger asChild`; do not nest it inside
+ * a `BreadcrumbLink`.
+ */
+const BreadcrumbMenuTrigger = React.forwardRef<
+  HTMLButtonElement,
+  BreadcrumbMenuTriggerProps
+>(function BreadcrumbMenuTrigger(
+  {
+    children,
+    className,
+    type = 'button',
+    'aria-label': ariaLabel = 'Show alternate paths',
+    ...props
+  },
+  ref
+) {
+  return (
+    <button
+      ref={ref}
+      data-slot="breadcrumb-menu-trigger"
+      type={type}
+      aria-label={ariaLabel}
+      className={cn(
+        "nx:relative nx:inline-flex nx:size-5 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-[4px] nx:transition-colors nx:after:absolute nx:after:inset-x-0 nx:after:-inset-y-3 nx:after:content-[''] nx:hover:bg-background-hover nx:active:bg-background-active nx:data-[state=open]:bg-background-active nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&_svg]:size-4 nx:[&_svg]:shrink-0",
+        className
+      )}
+      {...props}
+    >
+      {children ?? <IconChevronDown aria-hidden="true" />}
+    </button>
+  );
+});
 
 /**
  * BreadcrumbSeparatorProps
@@ -156,7 +245,7 @@ interface BreadcrumbSeparatorProps extends React.ComponentProps<'li'> {}
 /**
  * BreadcrumbSeparator
  *
- * The divider between items — a right chevron by default; pass `children` to
+ * The divider before or between items — a slash by default; pass `children` to
  * use a different glyph.
  */
 function BreadcrumbSeparator({
@@ -169,10 +258,13 @@ function BreadcrumbSeparator({
       data-slot="breadcrumb-separator"
       role="presentation"
       aria-hidden="true"
-      className={cn('nx:[&>svg]:size-3.5', className)}
+      className={cn(
+        'nx:inline-flex nx:shrink-0 nx:items-center nx:typography-body-small nx:text-muted-foreground nx:[&>svg]:size-3.5',
+        className
+      )}
       {...props}
     >
-      {children ?? <IconChevronRight />}
+      {children ?? '/'}
     </li>
   );
 }
@@ -182,30 +274,42 @@ function BreadcrumbSeparator({
  *
  * Props for the BreadcrumbEllipsis component.
  */
-interface BreadcrumbEllipsisProps extends React.ComponentProps<'span'> {}
+interface BreadcrumbEllipsisProps extends React.ComponentProps<'button'> {}
 
 /**
  * BreadcrumbEllipsis
  *
- * Decorative overflow marker for a collapsed run of middle items. If it is
- * wrapped in a real trigger, that trigger must provide its own accessible label.
+ * Overflow trigger for a collapsed run of middle items. Compose it with
+ * `DropdownMenuTrigger asChild` and put the hidden paths in the menu content.
  */
-function BreadcrumbEllipsis({ className, ...props }: BreadcrumbEllipsisProps) {
+const BreadcrumbEllipsis = React.forwardRef<
+  HTMLButtonElement,
+  BreadcrumbEllipsisProps
+>(function BreadcrumbEllipsis(
+  {
+    className,
+    type = 'button',
+    'aria-label': ariaLabel = 'Show hidden breadcrumbs',
+    ...props
+  },
+  ref
+) {
   return (
-    <span
+    <button
+      ref={ref}
       data-slot="breadcrumb-ellipsis"
-      role="presentation"
-      aria-hidden="true"
+      type={type}
+      aria-label={ariaLabel}
       className={cn(
-        'nx:flex nx:size-9 nx:items-center nx:justify-center',
+        "nx:relative nx:inline-flex nx:shrink-0 nx:items-center nx:justify-center nx:rounded-[4px] nx:px-1.5 nx:typography-body-small nx:transition-colors nx:after:absolute nx:after:inset-x-0 nx:after:-inset-y-3 nx:after:content-[''] nx:hover:bg-background-hover nx:active:bg-background-active nx:data-[state=open]:bg-background-active nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)",
         className
       )}
       {...props}
     >
-      <IconDots className="nx:size-4" />
-    </span>
+      ...
+    </button>
   );
-}
+});
 
 export {
   Breadcrumb,
@@ -217,6 +321,8 @@ export {
   type BreadcrumbLinkProps,
   BreadcrumbList,
   type BreadcrumbListProps,
+  BreadcrumbMenuTrigger,
+  type BreadcrumbMenuTriggerProps,
   BreadcrumbPage,
   type BreadcrumbPageProps,
   type BreadcrumbProps,


### PR DESCRIPTION
## Summary

- Align Breadcrumb with the Figma audit direction while preserving the semantic `nav > ol > li` structure, native anchors, `aria-current="page"`, and Nexus focus styling.
- Update breadcrumb item styling for slash separators, compact Figma-like link/page segments, icon composition, hover/active background states, and long-label truncation.
- Add real dropdown composition for alternate paths: `BreadcrumbMenuTrigger` and `BreadcrumbEllipsis` are button triggers intended for `DropdownMenuTrigger asChild`, not plain divs or controls nested inside links.
- Expand Storybook coverage with ellipsis dropdown, icon/menu composition, icon-only items, long-content truncation, data-slot assertions, keyboard coverage, and a controlled Playground story for authoring exploration.
- Update breadcrumb review/config metadata for the completed audit work.

## Validation

- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component breadcrumb`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] Storybook browser checks for default, icon-only, and playground stories

## Target

Base branch: `prasad/components-cleanup`