### PR TITLE
docs(react): scope ButtonGroup to button-shaped swap-ins, cross-link InputGroup

### DIFF
--- a/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
+++ b/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
@@ -175,13 +175,14 @@ export const WithSelectTrigger: Story = {
   },
 };
 
-// A split button: a primary action joined to a DropdownMenu trigger. The
-// trigger renders as a button via asChild, so it joins the seam like any
-// other button-shaped control.
+// A split button: a primary action and a DropdownMenu trigger, divided by a
+// separator. On the filled primary surface the default border-colored rule
+// would vanish, so the divider is tinted from the button foreground.
 export const SplitButton: Story = {
   render: () => (
     <ButtonGroup>
       <Button>Deploy</Button>
+      <ButtonGroupSeparator className="nx:bg-primary-foreground/30" />
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button size="icon" aria-label="Deployment options">
@@ -196,14 +197,16 @@ export const SplitButton: Story = {
     </ButtonGroup>
   ),
   play: async ({ canvasElement }) => {
-    // The DropdownMenu trigger composes onto a Button via asChild, so it lands
-    // in the group as a button-shaped control (data-slot=button) that opens a
-    // menu.
+    // The DropdownMenu trigger composes onto a Button via asChild (data-slot=
+    // button) and opens a menu; a separator divides it from the primary action.
     const trigger = canvasElement.querySelector(
       '[data-slot="button-group"] [aria-haspopup="menu"]'
     );
     await expect(trigger).toBeInTheDocument();
     await expect(trigger).toHaveAttribute('data-slot', 'button');
+    await expect(
+      canvasElement.querySelector('[data-slot="button-group-separator"]')
+    ).toBeInTheDocument();
   },
 };
 

--- a/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
+++ b/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
@@ -175,14 +175,13 @@ export const WithSelectTrigger: Story = {
   },
 };
 
-// A split button: a primary action and a DropdownMenu trigger, divided by a
-// separator. On the filled primary surface the default border-colored rule
-// would vanish, so the divider is tinted from the button foreground.
+// A split button: a primary action joined to a DropdownMenu trigger. The
+// trigger renders as a button via asChild, so it joins the seam like any
+// other button-shaped control.
 export const SplitButton: Story = {
   render: () => (
     <ButtonGroup>
       <Button>Deploy</Button>
-      <ButtonGroupSeparator className="nx:bg-primary-foreground/30" />
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button size="icon" aria-label="Deployment options">
@@ -197,16 +196,14 @@ export const SplitButton: Story = {
     </ButtonGroup>
   ),
   play: async ({ canvasElement }) => {
-    // The DropdownMenu trigger composes onto a Button via asChild (data-slot=
-    // button) and opens a menu; a separator divides it from the primary action.
+    // The DropdownMenu trigger composes onto a Button via asChild, so it lands
+    // in the group as a button-shaped control (data-slot=button) that opens a
+    // menu.
     const trigger = canvasElement.querySelector(
       '[data-slot="button-group"] [aria-haspopup="menu"]'
     );
     await expect(trigger).toBeInTheDocument();
     await expect(trigger).toHaveAttribute('data-slot', 'button');
-    await expect(
-      canvasElement.querySelector('[data-slot="button-group-separator"]')
-    ).toBeInTheDocument();
   },
 };
 

--- a/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
+++ b/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
@@ -1,5 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { IconChevronDown } from '@tabler/icons-react';
+import {
+  IconBold,
+  IconChevronDown,
+  IconItalic,
+  IconLink,
+  IconUnderline,
+} from '@tabler/icons-react';
 import { expect, within } from 'storybook/test';
 
 import { Button } from '../button';
@@ -72,14 +78,25 @@ export const WithText: Story = {
   },
 };
 
-// A separator divides two sub-clusters.
+// A separator divides sub-groups in a toolbar of borderless (ghost) controls —
+// the rule is the only division, so it reads clearly. In a row of bordered
+// (outline) buttons the per-button borders sit in the same color and hide it.
 export const WithSeparator: Story = {
   render: () => (
     <ButtonGroup>
-      <Button variant="outline">Undo</Button>
-      <Button variant="outline">Redo</Button>
+      <Button variant="ghost" size="icon" aria-label="Bold">
+        <IconBold />
+      </Button>
+      <Button variant="ghost" size="icon" aria-label="Italic">
+        <IconItalic />
+      </Button>
+      <Button variant="ghost" size="icon" aria-label="Underline">
+        <IconUnderline />
+      </Button>
       <ButtonGroupSeparator />
-      <Button variant="outline">Save</Button>
+      <Button variant="ghost" size="icon" aria-label="Add link">
+        <IconLink />
+      </Button>
     </ButtonGroup>
   ),
   play: async ({ canvasElement }) => {
@@ -207,7 +224,6 @@ export const AllVariants: Story = {
       <ButtonGroup>
         <ButtonGroupText>https://</ButtonGroupText>
         <Button variant="outline">nexus.dev</Button>
-        <ButtonGroupSeparator />
         <Button variant="outline">Go</Button>
       </ButtonGroup>
       <ButtonGroup orientation="vertical">

--- a/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
+++ b/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
@@ -1,7 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { IconChevronDown } from '@tabler/icons-react';
 import { expect, within } from 'storybook/test';
 
 import { Button } from '../button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '../dropdown-menu';
 import {
   Select,
   SelectContent,
@@ -148,6 +155,38 @@ export const WithSelectTrigger: Story = {
     // The trigger joins the seam like a button: its left border is removed so
     // it doesn't double up against the previous control.
     await expect(getComputedStyle(trigger).borderLeftWidth).toBe('0px');
+  },
+};
+
+// A split button: a primary action joined to a DropdownMenu trigger. The
+// trigger renders as a button via asChild, so it joins the seam like any
+// other button-shaped control.
+export const SplitButton: Story = {
+  render: () => (
+    <ButtonGroup>
+      <Button>Deploy</Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button size="icon" aria-label="Deployment options">
+            <IconChevronDown />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem>Deploy to staging</DropdownMenuItem>
+          <DropdownMenuItem>Deploy to production</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </ButtonGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    // The DropdownMenu trigger composes onto a Button via asChild, so it lands
+    // in the group as a button-shaped control (data-slot=button) that opens a
+    // menu.
+    const trigger = canvasElement.querySelector(
+      '[data-slot="button-group"] [aria-haspopup="menu"]'
+    );
+    await expect(trigger).toBeInTheDocument();
+    await expect(trigger).toHaveAttribute('data-slot', 'button');
   },
 };
 

--- a/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
+++ b/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
@@ -175,15 +175,13 @@ export const WithSelectTrigger: Story = {
   },
 };
 
-// A split button: a primary action and a DropdownMenu trigger, divided by a
-// rule tinted with the button's own foreground token (primary-foreground) —
-// the default border color is invisible on a filled surface. Works in both
-// themes (the primary fill + foreground pair is theme-stable).
+// A split button: a primary action joined to a DropdownMenu trigger. The
+// trigger renders as a button via asChild, so it joins the seam like any
+// other button-shaped control.
 export const SplitButton: Story = {
   render: () => (
     <ButtonGroup>
       <Button>Deploy</Button>
-      <ButtonGroupSeparator className="nx:bg-primary-foreground" />
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button size="icon" aria-label="Deployment options">
@@ -198,16 +196,14 @@ export const SplitButton: Story = {
     </ButtonGroup>
   ),
   play: async ({ canvasElement }) => {
-    // The DropdownMenu trigger composes onto a Button via asChild (data-slot=
-    // button) and opens a menu; a separator divides it from the primary action.
+    // The DropdownMenu trigger composes onto a Button via asChild, so it lands
+    // in the group as a button-shaped control (data-slot=button) that opens a
+    // menu.
     const trigger = canvasElement.querySelector(
       '[data-slot="button-group"] [aria-haspopup="menu"]'
     );
     await expect(trigger).toBeInTheDocument();
     await expect(trigger).toHaveAttribute('data-slot', 'button');
-    await expect(
-      canvasElement.querySelector('[data-slot="button-group-separator"]')
-    ).toBeInTheDocument();
   },
 };
 

--- a/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
+++ b/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
@@ -175,13 +175,15 @@ export const WithSelectTrigger: Story = {
   },
 };
 
-// A split button: a primary action joined to a DropdownMenu trigger. The
-// trigger renders as a button via asChild, so it joins the seam like any
-// other button-shaped control.
+// A split button: a primary action and a DropdownMenu trigger, divided by a
+// rule tinted with the button's own foreground token (primary-foreground) —
+// the default border color is invisible on a filled surface. Works in both
+// themes (the primary fill + foreground pair is theme-stable).
 export const SplitButton: Story = {
   render: () => (
     <ButtonGroup>
       <Button>Deploy</Button>
+      <ButtonGroupSeparator className="nx:bg-primary-foreground" />
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button size="icon" aria-label="Deployment options">
@@ -196,14 +198,16 @@ export const SplitButton: Story = {
     </ButtonGroup>
   ),
   play: async ({ canvasElement }) => {
-    // The DropdownMenu trigger composes onto a Button via asChild, so it lands
-    // in the group as a button-shaped control (data-slot=button) that opens a
-    // menu.
+    // The DropdownMenu trigger composes onto a Button via asChild (data-slot=
+    // button) and opens a menu; a separator divides it from the primary action.
     const trigger = canvasElement.querySelector(
       '[data-slot="button-group"] [aria-haspopup="menu"]'
     );
     await expect(trigger).toBeInTheDocument();
     await expect(trigger).toHaveAttribute('data-slot', 'button');
+    await expect(
+      canvasElement.querySelector('[data-slot="button-group-separator"]')
+    ).toBeInTheDocument();
   },
 };
 

--- a/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
+++ b/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
@@ -2,6 +2,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { expect, within } from 'storybook/test';
 
 import { Button } from '../button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../select';
 
 import {
   ButtonGroup,
@@ -111,6 +118,36 @@ export const AsChild: Story = {
     const link = within(canvasElement).getByRole('link', { name: 'Docs' });
     await expect(link.tagName).toBe('A');
     await expect(link).toHaveAttribute('data-slot', 'button-group-text');
+  },
+};
+
+// A Select trigger joins the group as a button-shaped control, sharing the
+// seam with the adjacent button.
+export const WithSelectTrigger: Story = {
+  render: () => (
+    <ButtonGroup>
+      <Button variant="outline">Filter</Button>
+      <Select defaultValue="all">
+        <SelectTrigger aria-label="Status">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All</SelectItem>
+          <SelectItem value="open">Open</SelectItem>
+          <SelectItem value="closed">Closed</SelectItem>
+        </SelectContent>
+      </Select>
+    </ButtonGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const trigger = canvasElement.querySelector<HTMLElement>(
+      '[data-slot="select-trigger"]'
+    );
+    await expect(trigger).toBeInTheDocument();
+    if (!trigger) return;
+    // The trigger joins the seam like a button: its left border is removed so
+    // it doesn't double up against the previous control.
+    await expect(getComputedStyle(trigger).borderLeftWidth).toBe('0px');
   },
 };
 

--- a/packages/react/src/components/ui/button-group/button-group.tsx
+++ b/packages/react/src/components/ui/button-group/button-group.tsx
@@ -36,10 +36,16 @@ interface ButtonGroupProps
 /**
  * ButtonGroup
  *
- * A visually-joined cluster of buttons (or inputs / selects) sharing borders
- * and outer rounding — adjacent children lose their touching corners and the
+ * A visually-joined cluster of button-shaped controls — Buttons, a
+ * `DropdownMenu` or `Select` trigger, a link via `<ButtonGroupText asChild>`,
+ * plus `ButtonGroupText` and `ButtonGroupSeparator` addons — sharing borders
+ * and outer rounding so adjacent children lose their touching corners and the
  * seam between them. Lay out horizontally (default) or vertically with
  * `orientation`.
+ *
+ * For an input or textarea with leading/trailing addons in one shared-focus
+ * field, reach for `InputGroup` instead — composing inputs is its job, not
+ * this one's.
  *
  * @example
  * ```tsx

--- a/packages/react/src/components/ui/button-group/button-group.tsx
+++ b/packages/react/src/components/ui/button-group/button-group.tsx
@@ -7,7 +7,7 @@ import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
 
 const buttonGroupVariants = cva(
-  "nx:flex nx:w-fit nx:items-stretch nx:has-[>[data-slot=button-group]]:gap-2 nx:*:focus-visible:relative nx:*:focus-visible:z-10 nx:has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md nx:[&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit nx:[&>input]:flex-1",
+  "nx:flex nx:w-fit nx:items-stretch nx:has-[>[data-slot=button-group]]:gap-2 nx:*:focus-visible:relative nx:*:focus-visible:z-10 nx:has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md nx:[&>input]:flex-1",
   {
     variants: {
       orientation: {

--- a/packages/react/src/components/ui/button-group/button-group.tsx
+++ b/packages/react/src/components/ui/button-group/button-group.tsx
@@ -7,7 +7,7 @@ import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
 
 const buttonGroupVariants = cva(
-  "nx:flex nx:w-fit nx:items-stretch nx:has-[>[data-slot=button-group]]:gap-2 nx:*:focus-visible:relative nx:*:focus-visible:z-10 nx:has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md",
+  'nx:flex nx:w-fit nx:items-stretch nx:has-[>[data-slot=button-group]]:gap-2 nx:*:focus-visible:relative nx:*:focus-visible:z-10 nx:has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md',
   {
     variants: {
       orientation: {

--- a/packages/react/src/components/ui/button-group/button-group.tsx
+++ b/packages/react/src/components/ui/button-group/button-group.tsx
@@ -7,7 +7,7 @@ import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
 
 const buttonGroupVariants = cva(
-  "nx:flex nx:w-fit nx:items-stretch nx:has-[>[data-slot=button-group]]:gap-2 nx:*:focus-visible:relative nx:*:focus-visible:z-10 nx:has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md nx:[&>input]:flex-1",
+  "nx:flex nx:w-fit nx:items-stretch nx:has-[>[data-slot=button-group]]:gap-2 nx:*:focus-visible:relative nx:*:focus-visible:z-10 nx:has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md",
   {
     variants: {
       orientation: {


### PR DESCRIPTION
## Summary

- **Docs reframe.** `ButtonGroup` is for joined **button-shaped** controls — Button, a `DropdownMenu` / `Select` *trigger*, a link via `<ButtonGroupText asChild>`, plus `ButtonGroupText` / `ButtonGroupSeparator`. Its JSDoc previously read *"cluster of buttons (or inputs / selects)"*, which invited input compositions that belong in the existing **`InputGroup`** (shared focus ring, invalid-state propagation, addon alignment). Reframed the JSDoc and cross-linked the two.
- **Swap-in showcases (verified live on Storybook :6006 + Playwright).** `WithSelectTrigger` — a Select trigger joins the seam (`border-left-width: 0`, fits its content, flush) — and `SplitButton` — a DropdownMenu trigger composed onto a Button via `asChild`.
- **Cleanup.** Removed a dead select-trigger `w-fit` CVA rule. It never matched (Nexus `SelectTrigger` ships `w-full`, so the `:not([class*='w-'])` guard always excludes it); the trigger fits via the flex + `w-fit`-group context regardless (65px before and after — measured).

## GitHub Issue

N/A — ButtonGroup component audit. Stacked on the `data-orientation` audit (base branch `aish/component-buttongroup-audit`); retarget to `prasad/components-cleanup` once that merges.

## Test Plan

- [x] Verified live on Storybook :6006 + Playwright — Select trigger and DropdownMenu trigger join cleanly (flush seam, fit content, no double border); dead-rule removal had zero rendered effect.
- [x] `pnpm --filter @nexus/react lint` + `typecheck` clean.
- [ ] **CI caveat:** the vitest storybook project collects **0 files** on this branch line (the `#429` path-doubling bug → `passWithNoTests` silently green), so the play functions are **not** gate-verified until #429 lands. Verified manually instead.

> Aside (separate from this PR): this Storybook build renders all corners square — `--nx-radius-md` resolves to `0px` globally, which looks like a missing radius-mode default in the preview, not a ButtonGroup issue. Worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)