### PR TITLE
fix(carousel): improve controls accessibility

### DIFF
--- a/packages/react/src/components/ui/carousel/Carousel.stories.tsx
+++ b/packages/react/src/components/ui/carousel/Carousel.stories.tsx
@@ -3,6 +3,7 @@ import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import {
   Carousel,
+  type CarouselApi,
   CarouselContent,
   CarouselItem,
   CarouselNext,
@@ -80,10 +81,19 @@ export const ClickInteraction: Story = {
   },
 };
 
-// ArrowRight inside the carousel region advances it (onKeyDownCapture).
+// Captures the Embla API so the play fn can read the carousel's position.
+const keyboardApiRef: { current: CarouselApi } = { current: undefined };
+
+// ArrowRight advances a horizontal carousel; ArrowDown is ignored (vertical-only).
 export const KeyboardInteraction: Story = {
   render: () => (
-    <Carousel className="nx:w-full" aria-label="Keyboard demo carousel">
+    <Carousel
+      className="nx:w-full"
+      aria-label="Keyboard demo carousel"
+      setApi={(api) => {
+        keyboardApiRef.current = api;
+      }}
+    >
       <CarouselContent>{slideItems}</CarouselContent>
       <CarouselPrevious />
       <CarouselNext />
@@ -95,8 +105,9 @@ export const KeyboardInteraction: Story = {
     const next = canvas.getByRole('button', { name: 'Next slide' });
     await waitFor(() => expect(next).toBeEnabled());
     next.focus();
+    // Horizontal carousel ignores ArrowDown — it must stay on the first slide.
     await userEvent.keyboard('{ArrowDown}');
-    await expect(prev).toBeDisabled();
+    expect(keyboardApiRef.current?.selectedScrollSnap()).toBe(0);
     await userEvent.keyboard('{ArrowRight}');
     await waitFor(() => expect(prev).toBeEnabled());
   },
@@ -120,6 +131,11 @@ export const VerticalKeyboardInteraction: Story = {
     const prev = canvas.getByRole('button', { name: 'Previous slide' });
     const next = canvas.getByRole('button', { name: 'Next slide' });
     await waitFor(() => expect(next).toBeEnabled());
+
+    await expect(
+      canvasElement.querySelector('[data-slot="carousel"]')
+    ).toHaveAttribute('data-orientation', 'vertical');
+
     next.focus();
     await userEvent.keyboard('{ArrowDown}');
     await waitFor(() => expect(prev).toBeEnabled());

--- a/packages/react/src/components/ui/carousel/Carousel.stories.tsx
+++ b/packages/react/src/components/ui/carousel/Carousel.stories.tsx
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof Carousel>;
 
 // Five numbered slides reused across stories.
 const slideItems = [1, 2, 3, 4, 5].map((n) => (
-  <CarouselItem key={n}>
+  <CarouselItem key={n} aria-label={`Slide ${n} of 5`}>
     <div className="nx:flex nx:aspect-square nx:items-center nx:justify-center nx:rounded-md nx:border nx:border-border-default">
       <span className="nx:text-4xl nx:font-semibold">{n}</span>
     </div>
@@ -95,7 +95,33 @@ export const KeyboardInteraction: Story = {
     const next = canvas.getByRole('button', { name: 'Next slide' });
     await waitFor(() => expect(next).toBeEnabled());
     next.focus();
+    await userEvent.keyboard('{ArrowDown}');
+    await expect(prev).toBeDisabled();
     await userEvent.keyboard('{ArrowRight}');
+    await waitFor(() => expect(prev).toBeEnabled());
+  },
+};
+
+// Vertical carousels use ArrowDown / ArrowUp instead of horizontal arrows.
+export const VerticalKeyboardInteraction: Story = {
+  render: () => (
+    <Carousel
+      orientation="vertical"
+      className="nx:w-full"
+      aria-label="Vertical keyboard demo carousel"
+    >
+      <CarouselContent className="nx:h-[260px]">{slideItems}</CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const prev = canvas.getByRole('button', { name: 'Previous slide' });
+    const next = canvas.getByRole('button', { name: 'Next slide' });
+    await waitFor(() => expect(next).toBeEnabled());
+    next.focus();
+    await userEvent.keyboard('{ArrowDown}');
     await waitFor(() => expect(prev).toBeEnabled());
   },
 };
@@ -121,6 +147,10 @@ export const WithDataAttributes: Story = {
         canvasElement.querySelector(`[data-slot="${slot}"]`)
       ).toBeInTheDocument();
     }
+
+    await expect(
+      canvasElement.querySelector('[data-slot="carousel"]')
+    ).toHaveAttribute('data-orientation', 'horizontal');
   },
 };
 

--- a/packages/react/src/components/ui/carousel/Carousel.stories.tsx
+++ b/packages/react/src/components/ui/carousel/Carousel.stories.tsx
@@ -53,7 +53,7 @@ export const Vertical: Story = {
       className="nx:w-full"
       aria-label="Vertical carousel"
     >
-      <CarouselContent className="nx:h-[260px]">{slideItems}</CarouselContent>
+      <CarouselContent className="nx:h-[350px]">{slideItems}</CarouselContent>
       <CarouselPrevious />
       <CarouselNext />
     </Carousel>
@@ -121,7 +121,7 @@ export const VerticalKeyboardInteraction: Story = {
       className="nx:w-full"
       aria-label="Vertical keyboard demo carousel"
     >
-      <CarouselContent className="nx:h-[260px]">{slideItems}</CarouselContent>
+      <CarouselContent className="nx:h-[350px]">{slideItems}</CarouselContent>
       <CarouselPrevious />
       <CarouselNext />
     </Carousel>

--- a/packages/react/src/components/ui/carousel/carousel.tsx
+++ b/packages/react/src/components/ui/carousel/carousel.tsx
@@ -75,20 +75,23 @@ function useCarousel() {
  *
  * @example
  * ```tsx
- * <Carousel className="nx:w-full nx:max-w-xs" aria-label="Featured products">
- *   <CarouselContent>
- *     {items.map((item, index) => (
- *       <CarouselItem
- *         key={item.id}
- *         aria-label={`Slide ${index + 1} of ${items.length}`}
- *       >
- *         {item.title}
- *       </CarouselItem>
- *     ))}
- *   </CarouselContent>
- *   <CarouselPrevious />
- *   <CarouselNext />
- * </Carousel>
+ * // px-12 matches the controls' -left-12 / -right-12 offset so they don't clip.
+ * <div className="nx:px-12">
+ *   <Carousel className="nx:w-full" aria-label="Featured products">
+ *     <CarouselContent>
+ *       {items.map((item, index) => (
+ *         <CarouselItem
+ *           key={item.id}
+ *           aria-label={`Slide ${index + 1} of ${items.length}`}
+ *         >
+ *           {item.title}
+ *         </CarouselItem>
+ *       ))}
+ *     </CarouselContent>
+ *     <CarouselPrevious />
+ *     <CarouselNext />
+ *   </Carousel>
+ * </div>
  * ```
  */
 function Carousel({

--- a/packages/react/src/components/ui/carousel/carousel.tsx
+++ b/packages/react/src/components/ui/carousel/carousel.tsx
@@ -36,7 +36,6 @@ type CarouselProps = {
 
 type CarouselContextProps = {
   carouselRef: ReturnType<typeof useEmblaCarousel>[0];
-  api: CarouselApi;
   orientation: NonNullable<CarouselProps['orientation']>;
   scrollPrev: () => void;
   scrollNext: () => void;
@@ -123,9 +122,11 @@ function Carousel({
   const scrollNext = () => api?.scrollNext();
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    const prevKey = orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp';
-    const nextKey = orientation === 'horizontal' ? 'ArrowRight' : 'ArrowDown';
-    if (event.key !== prevKey && event.key !== nextKey) return;
+    const isPrev =
+      event.key === (orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp');
+    const isNext =
+      event.key === (orientation === 'horizontal' ? 'ArrowRight' : 'ArrowDown');
+    if (!isPrev && !isNext) return;
     // Don't hijack arrow keys from a focused control that uses them itself.
     if (
       (event.target as HTMLElement).closest(
@@ -135,11 +136,11 @@ function Carousel({
       return;
     }
 
-    if (event.key === prevKey && !canScrollPrev) return;
-    if (event.key === nextKey && !canScrollNext) return;
+    if (isPrev && !canScrollPrev) return;
+    if (isNext && !canScrollNext) return;
 
     event.preventDefault();
-    if (event.key === prevKey) scrollPrev();
+    if (isPrev) scrollPrev();
     else scrollNext();
   };
 
@@ -166,7 +167,6 @@ function Carousel({
     <CarouselContext.Provider
       value={{
         carouselRef,
-        api,
         orientation,
         scrollPrev,
         scrollNext,

--- a/packages/react/src/components/ui/carousel/carousel.tsx
+++ b/packages/react/src/components/ui/carousel/carousel.tsx
@@ -69,6 +69,10 @@ function useCarousel() {
  * Keyboard: a horizontal carousel scrolls with Left/Right arrows, a vertical
  * one with Up/Down (arrows for the other axis are ignored).
  *
+ * Layout: the Previous / Next controls render just outside the content frame,
+ * so give the carousel horizontal room (a `max-w-*` with auto margins, or
+ * container padding) — otherwise they clip off-canvas at narrow / mobile widths.
+ *
  * @example
  * ```tsx
  * <Carousel className="nx:w-full nx:max-w-xs" aria-label="Featured products">

--- a/packages/react/src/components/ui/carousel/carousel.tsx
+++ b/packages/react/src/components/ui/carousel/carousel.tsx
@@ -34,9 +34,6 @@ type CarouselProps = {
   setApi?: (api: CarouselApi) => void;
 };
 
-const carouselControlClasses =
-  'nx:absolute nx:rounded-full nx:after:absolute nx:after:-inset-2';
-
 type CarouselContextProps = {
   carouselRef: ReturnType<typeof useEmblaCarousel>[0];
   api: CarouselApi;
@@ -46,6 +43,9 @@ type CarouselContextProps = {
   canScrollPrev: boolean;
   canScrollNext: boolean;
 };
+
+const carouselControlClasses =
+  'nx:absolute nx:rounded-full nx:after:absolute nx:after:-inset-2';
 
 const CarouselContext = React.createContext<CarouselContextProps | null>(null);
 
@@ -65,6 +65,9 @@ function useCarousel() {
  * Slideshow / horizontal (or vertical) scroller built on Embla. Compose with
  * `CarouselContent` + `CarouselItem`, and `CarouselPrevious` / `CarouselNext`
  * for the controls.
+ *
+ * Keyboard: a horizontal carousel scrolls with Left/Right arrows, a vertical
+ * one with Up/Down (arrows for the other axis are ignored).
  *
  * @example
  * ```tsx

--- a/packages/react/src/components/ui/carousel/carousel.tsx
+++ b/packages/react/src/components/ui/carousel/carousel.tsx
@@ -34,6 +34,9 @@ type CarouselProps = {
   setApi?: (api: CarouselApi) => void;
 };
 
+const carouselControlClasses =
+  'nx:absolute nx:rounded-full nx:after:absolute nx:after:-inset-2';
+
 type CarouselContextProps = {
   carouselRef: ReturnType<typeof useEmblaCarousel>[0];
   api: CarouselApi;
@@ -67,8 +70,13 @@ function useCarousel() {
  * ```tsx
  * <Carousel className="nx:w-full nx:max-w-xs" aria-label="Featured products">
  *   <CarouselContent>
- *     {items.map((item) => (
- *       <CarouselItem key={item.id}>{item.title}</CarouselItem>
+ *     {items.map((item, index) => (
+ *       <CarouselItem
+ *         key={item.id}
+ *         aria-label={`Slide ${index + 1} of ${items.length}`}
+ *       >
+ *         {item.title}
+ *       </CarouselItem>
  *     ))}
  *   </CarouselContent>
  *   <CarouselPrevious />
@@ -105,7 +113,9 @@ function Carousel({
   const scrollNext = () => api?.scrollNext();
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+    const prevKey = orientation === 'horizontal' ? 'ArrowLeft' : 'ArrowUp';
+    const nextKey = orientation === 'horizontal' ? 'ArrowRight' : 'ArrowDown';
+    if (event.key !== prevKey && event.key !== nextKey) return;
     // Don't hijack arrow keys from a focused control that uses them itself.
     if (
       (event.target as HTMLElement).closest(
@@ -114,8 +124,12 @@ function Carousel({
     ) {
       return;
     }
+
+    if (event.key === prevKey && !canScrollPrev) return;
+    if (event.key === nextKey && !canScrollNext) return;
+
     event.preventDefault();
-    if (event.key === 'ArrowLeft') scrollPrev();
+    if (event.key === prevKey) scrollPrev();
     else scrollNext();
   };
 
@@ -156,6 +170,7 @@ function Carousel({
         role="region"
         aria-roledescription="carousel"
         data-slot="carousel"
+        data-orientation={orientation}
         {...props}
       >
         {children}
@@ -217,7 +232,7 @@ function CarouselPrevious({
       variant={variant}
       size={size}
       className={cn(
-        'nx:absolute nx:rounded-full',
+        carouselControlClasses,
         orientation === 'horizontal'
           ? 'nx:top-1/2 nx:-left-12 nx:-translate-y-1/2'
           : 'nx:-top-12 nx:left-1/2 nx:-translate-x-1/2 nx:rotate-90',
@@ -247,7 +262,7 @@ function CarouselNext({
       variant={variant}
       size={size}
       className={cn(
-        'nx:absolute nx:rounded-full',
+        carouselControlClasses,
         orientation === 'horizontal'
           ? 'nx:top-1/2 nx:-right-12 nx:-translate-y-1/2'
           : 'nx:-bottom-12 nx:left-1/2 nx:-translate-x-1/2 nx:rotate-90',
@@ -270,4 +285,5 @@ export {
   CarouselItem,
   CarouselNext,
   CarouselPrevious,
+  type CarouselProps,
 };


### PR DESCRIPTION
## Summary

- Improve Carousel control accessibility without changing the visible layout.
- Add orientation-aware keyboard handling so horizontal carousels use Left/Right and vertical carousels use Up/Down.
- Add root `data-orientation`, export `CarouselProps`, and expand Carousel story coverage for the fixed behavior.

## GitHub Issue

N/A

## Test Plan

- [x] `corepack pnpm --filter @nexus/react build`
- [x] `corepack pnpm --filter @nexus/react audit:storybook-coverage --component carousel`
- [x] `corepack pnpm test:storybook` exited 0; Vitest reported no Storybook test files found in this environment
- [x] Direct Playwright temp harness confirmed horizontal ignores ArrowDown / advances ArrowRight, vertical ignores ArrowRight / advances ArrowDown
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm format:check`
