### PR TITLE
feat(command): audit component

### DIFF
--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -41,6 +41,11 @@
     { "name": "Checkbox", "showcase": "AllVariants" },
     { "name": "Collapsible", "showcase": "AllVariants" },
     {
+      "name": "Command",
+      "showcase": "AllVariants",
+      "interactions": ["Disabled", "ClickInteraction", "KeyboardInteraction"]
+    },
+    {
       "name": "ContextMenu",
       "showcase": "AllVariants",
       "interactions": ["Disabled", "ClickInteraction", "KeyboardInteraction"],

--- a/packages/react/src/components/ui/command/Command.stories.tsx
+++ b/packages/react/src/components/ui/command/Command.stories.tsx
@@ -1,9 +1,19 @@
 import * as React from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react';
+import {
+  IconBook,
+  IconCreditCard,
+  IconFile,
+  IconSettings,
+  IconUser,
+  IconUsers,
+} from '@tabler/icons-react';
+import { useCommandState } from 'cmdk';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { Button } from '../button';
+import { Spinner } from '../spinner';
 
 import {
   Command,
@@ -13,6 +23,7 @@ import {
   CommandInput,
   CommandItem,
   CommandList,
+  CommandLoading,
   CommandSeparator,
   CommandShortcut,
 } from './command';
@@ -31,7 +42,89 @@ type Story = StoryObj<typeof Command>;
 // Presentational chrome for the inline (non-dialog) palette stories — a fixed
 // width with a bordered, elevated surface so the palette reads as a card.
 const paletteClass =
-  'nx:w-[420px] nx:rounded-lg nx:border nx:border-border-default nx:shadow-md';
+  'nx:w-[480px] nx:rounded-lg nx:border nx:border-border-default nx:shadow-md';
+
+// Design-reference chrome for the Figma CommandContent node. Kept separate
+// from the default story chrome so production Command remains unframed.
+const figmaPaletteClass =
+  'nx:w-[450px] nx:max-h-[360px] nx:rounded-lg nx:border nx:border-border-default nx:shadow-base';
+
+const projectCommands = [
+  {
+    label: 'Open project plan',
+    description: 'View roadmap, milestones, and project notes',
+    value: 'open-project-plan',
+    keywords: ['roadmap', 'milestones', 'docs'],
+    icon: IconFile,
+    shortcut: '⌘P',
+  },
+  {
+    label: 'Search documentation',
+    description: 'Find API references and implementation guides',
+    value: 'search-documentation',
+    keywords: ['docs', 'api', 'guide'],
+    icon: IconBook,
+    shortcut: '⌘D',
+  },
+  {
+    label: 'Project settings',
+    description: 'Update members, billing, and notifications',
+    value: 'project-settings',
+    keywords: ['preferences', 'configuration', 'admin'],
+    icon: IconSettings,
+    trailing: 'Admin',
+  },
+  {
+    label: 'Invite teammate',
+    description: 'Add a member to this workspace',
+    value: 'invite-teammate',
+    keywords: ['members', 'users', 'people'],
+    icon: IconUsers,
+  },
+];
+
+function QueryAwareEmptyMessage() {
+  const search = useCommandState((state) => state.search);
+
+  return (
+    <CommandEmpty>
+      {search ? `No results found for "${search}".` : 'No results found.'}
+    </CommandEmpty>
+  );
+}
+
+function CommandRichItem({
+  command,
+}: {
+  command: (typeof projectCommands)[number];
+}) {
+  const Icon = command.icon;
+
+  return (
+    <CommandItem
+      value={command.value}
+      keywords={command.keywords}
+      className="nx:items-start"
+    >
+      <Icon aria-hidden="true" className="nx:mt-0.5 nx:text-muted-foreground" />
+      <span className="nx:flex nx:min-w-0 nx:flex-1 nx:flex-col nx:gap-0.5">
+        <span className="nx:truncate">{command.label}</span>
+        <span className="nx:truncate nx:typography-body-small nx:text-muted-foreground">
+          {command.description}
+        </span>
+      </span>
+      {command.shortcut ? (
+        <CommandShortcut className="nx:mt-0.5">
+          {command.shortcut}
+        </CommandShortcut>
+      ) : command.trailing ? (
+        <span className="nx:mt-0.5 nx:ml-auto nx:shrink-0 nx:typography-label-small nx:text-muted-foreground">
+          {command.trailing}
+        </span>
+      ) : null}
+    </CommandItem>
+  );
+}
 
 // ============================================
 // BASIC STORIES
@@ -109,6 +202,208 @@ export const Empty: Story = {
     await expect(
       canvasElement.querySelector('[data-slot="command-empty"]')
     ).toBeInTheDocument();
+  },
+};
+
+export const QueryAwareEmpty: Story = {
+  render: () => (
+    <Command label="Command menu" className={paletteClass}>
+      <CommandInput placeholder="Search commands..." />
+      <CommandList>
+        <QueryAwareEmptyMessage />
+        <CommandGroup heading="Suggestions">
+          <CommandItem>Calendar</CommandItem>
+          <CommandItem>Calculator</CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  ),
+  parameters: {
+    a11y: {
+      config: { rules: [{ id: 'aria-required-children', enabled: false }] },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox');
+
+    await userEvent.type(input, 'roadmap');
+    await expect(
+      canvas.getByText('No results found for "roadmap".')
+    ).toBeInTheDocument();
+  },
+};
+
+export const AsyncLoading: Story = {
+  render: function AsyncLoadingStory() {
+    const [loading, setLoading] = React.useState(true);
+    const [items, setItems] = React.useState([
+      'Recent project',
+      'Team dashboard',
+    ]);
+
+    React.useEffect(() => {
+      const timeout = window.setTimeout(() => {
+        setItems([
+          'Recent project',
+          'Team dashboard',
+          'Design review',
+          'Release notes',
+        ]);
+        setLoading(false);
+      }, 600);
+
+      return () => window.clearTimeout(timeout);
+    }, []);
+
+    return (
+      <Command label="Async command menu" className={paletteClass}>
+        <CommandInput placeholder="Search commands..." />
+        <CommandList>
+          {loading ? (
+            <CommandLoading progress={60} label="Loading command results">
+              <Spinner
+                aria-hidden="true"
+                role="presentation"
+                className="nx:size-3.5"
+              />
+              Loading commands...
+            </CommandLoading>
+          ) : (
+            <CommandEmpty>No results found.</CommandEmpty>
+          )}
+          <CommandGroup heading={loading ? 'Recent' : 'Results'}>
+            {items.map((item) => (
+              <CommandItem key={item} value={item}>
+                {item}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </CommandList>
+      </Command>
+    );
+  },
+};
+
+export const RichItems: Story = {
+  render: () => (
+    <Command label="Project command menu" className={paletteClass}>
+      <CommandInput placeholder="Search project commands..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Project">
+          {projectCommands.map((command) => (
+            <CommandRichItem key={command.value} command={command} />
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  ),
+};
+
+export const AdvancedFiltering: Story = {
+  render: function AdvancedFilteringStory() {
+    const [search, setSearch] = React.useState('');
+    const actionCommands = [
+      {
+        label: 'Invite teammate',
+        value: 'invite-teammate',
+        keywords: ['members', 'users', 'people'],
+        icon: IconUsers,
+      },
+      {
+        label: 'Open billing',
+        value: 'open-billing',
+        keywords: ['invoice', 'payment', 'card'],
+        icon: IconCreditCard,
+      },
+    ];
+    const destinationCommands = [
+      {
+        label: 'Profile',
+        value: 'profile',
+        keywords: ['account', 'user'],
+        icon: IconUser,
+      },
+      {
+        label: 'Settings',
+        value: 'settings',
+        keywords: ['preferences', 'configuration'],
+        icon: IconSettings,
+      },
+    ];
+    const matchesSearch = (command: { label: string; keywords: string[] }) => {
+      const query = search.trim().toLowerCase();
+
+      if (!query) return true;
+
+      return [command.label, ...command.keywords].some((value) =>
+        value.toLowerCase().includes(query)
+      );
+    };
+    const visibleActions = actionCommands.filter(matchesSearch);
+    const visibleDestinations = destinationCommands.filter(matchesSearch);
+
+    return (
+      <Command
+        label="Advanced command menu"
+        className={paletteClass}
+        loop
+        shouldFilter={false}
+      >
+        <CommandInput
+          value={search}
+          onValueChange={setSearch}
+          placeholder="Try members, invoice, or preferences..."
+        />
+        <CommandList>
+          <CommandEmpty>No matching command.</CommandEmpty>
+          {visibleActions.length > 0 ? (
+            <CommandGroup heading="Actions">
+              {visibleActions.map((command) => {
+                const Icon = command.icon;
+
+                return (
+                  <CommandItem key={command.value} value={command.value}>
+                    <Icon aria-hidden="true" />
+                    {command.label}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          ) : null}
+          {visibleActions.length > 0 && visibleDestinations.length > 0 ? (
+            <CommandSeparator alwaysRender />
+          ) : null}
+          {visibleDestinations.length > 0 ? (
+            <CommandGroup heading="Destinations">
+              {visibleDestinations.map((command) => {
+                const Icon = command.icon;
+
+                return (
+                  <CommandItem key={command.value} value={command.value}>
+                    <Icon aria-hidden="true" />
+                    {command.label}
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          ) : null}
+        </CommandList>
+      </Command>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox');
+
+    await userEvent.type(input, 'members');
+    await expect(
+      canvas.getByRole('option', { name: 'Invite teammate' })
+    ).toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('option', { name: 'Open billing' })
+    ).not.toBeInTheDocument();
   },
 };
 
@@ -335,6 +630,87 @@ export const WithDataAttributes: Story = {
       canvasElement.querySelector('[data-slot="command-shortcut"]')
     ).toBeInTheDocument();
   },
+};
+
+// ============================================
+// FIGMA COMPOSITION REFERENCE
+// ============================================
+
+export const FigmaComposition: Story = {
+  render: () => (
+    <Command
+      label="Figma command content reference"
+      className={figmaPaletteClass}
+    >
+      <CommandInput placeholder="Type a command or search..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        <CommandGroup heading="Heading">
+          {['Item', 'Item 2', 'Item 3', 'Item 4', 'Item 5'].map((item) => (
+            <CommandItem key={item} value={`primary-${item}`}>
+              <span
+                aria-hidden="true"
+                className="nx:size-4 nx:shrink-0 nx:rounded-sm nx:border nx:border-dashed nx:border-border-default"
+              />
+              {item}
+              <span
+                aria-hidden="true"
+                className="nx:ml-auto nx:size-5 nx:shrink-0 nx:rounded-sm nx:border nx:border-dashed nx:border-border-default"
+              />
+            </CommandItem>
+          ))}
+        </CommandGroup>
+        <CommandSeparator />
+        <CommandGroup heading="Heading">
+          {[
+            'Open palette',
+            'Search docs',
+            'Toggle theme',
+            'Go to settings',
+          ].map((item, index) => (
+            <CommandItem key={item} value={`secondary-${item}`}>
+              <span
+                aria-hidden="true"
+                className="nx:size-4 nx:shrink-0 nx:rounded-sm nx:border nx:border-dashed nx:border-border-default"
+              />
+              {item}
+              {index === 0 ? (
+                <CommandShortcut>⌘K</CommandShortcut>
+              ) : (
+                <span
+                  aria-hidden="true"
+                  className="nx:ml-auto nx:size-5 nx:shrink-0 nx:rounded-sm nx:border nx:border-dashed nx:border-border-default"
+                />
+              )}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+        <CommandSeparator />
+        <CommandGroup heading="Heading">
+          {[
+            'Create project',
+            'Invite teammate',
+            'View shortcuts',
+            'Open billing',
+            'Archive item',
+            'Export report',
+          ].map((item) => (
+            <CommandItem key={item} value={`tertiary-${item}`}>
+              <span
+                aria-hidden="true"
+                className="nx:size-4 nx:shrink-0 nx:rounded-sm nx:border nx:border-dashed nx:border-border-default"
+              />
+              {item}
+              <span
+                aria-hidden="true"
+                className="nx:ml-auto nx:size-5 nx:shrink-0 nx:rounded-sm nx:border nx:border-dashed nx:border-border-default"
+              />
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  ),
 };
 
 // ============================================

--- a/packages/react/src/components/ui/command/Command.stories.tsx
+++ b/packages/react/src/components/ui/command/Command.stories.tsx
@@ -44,11 +44,6 @@ type Story = StoryObj<typeof Command>;
 const paletteClass =
   'nx:w-[480px] nx:rounded-lg nx:border nx:border-border-default nx:shadow-md';
 
-// Design-reference chrome for the Figma CommandContent node. Kept separate
-// from the default story chrome so production Command remains unframed.
-const figmaPaletteClass =
-  'nx:w-[450px] nx:max-h-[360px] nx:rounded-lg nx:border nx:border-border-default nx:shadow-base';
-
 const projectCommands = [
   {
     label: 'Open project plan',
@@ -630,87 +625,6 @@ export const WithDataAttributes: Story = {
       canvasElement.querySelector('[data-slot="command-shortcut"]')
     ).toBeInTheDocument();
   },
-};
-
-// ============================================
-// FIGMA COMPOSITION REFERENCE
-// ============================================
-
-export const FigmaComposition: Story = {
-  render: () => (
-    <Command
-      label="Figma command content reference"
-      className={figmaPaletteClass}
-    >
-      <CommandInput placeholder="Type a command or search..." />
-      <CommandList>
-        <CommandEmpty>No results found.</CommandEmpty>
-        <CommandGroup heading="Heading">
-          {['Item', 'Item 2', 'Item 3', 'Item 4', 'Item 5'].map((item) => (
-            <CommandItem key={item} value={`primary-${item}`}>
-              <span
-                aria-hidden="true"
-                className="nx:size-4 nx:shrink-0 nx:rounded-sm nx:border nx:border-dashed nx:border-border-default"
-              />
-              {item}
-              <span
-                aria-hidden="true"
-                className="nx:ml-auto nx:size-5 nx:shrink-0 nx:rounded-sm nx:border nx:border-dashed nx:border-border-default"
-              />
-            </CommandItem>
-          ))}
-        </CommandGroup>
-        <CommandSeparator />
-        <CommandGroup heading="Heading">
-          {[
-            'Open palette',
-            'Search docs',
-            'Toggle theme',
-            'Go to settings',
-          ].map((item, index) => (
-            <CommandItem key={item} value={`secondary-${item}`}>
-              <span
-                aria-hidden="true"
-                className="nx:size-4 nx:shrink-0 nx:rounded-sm nx:border nx:border-dashed nx:border-border-default"
-              />
-              {item}
-              {index === 0 ? (
-                <CommandShortcut>⌘K</CommandShortcut>
-              ) : (
-                <span
-                  aria-hidden="true"
-                  className="nx:ml-auto nx:size-5 nx:shrink-0 nx:rounded-sm nx:border nx:border-dashed nx:border-border-default"
-                />
-              )}
-            </CommandItem>
-          ))}
-        </CommandGroup>
-        <CommandSeparator />
-        <CommandGroup heading="Heading">
-          {[
-            'Create project',
-            'Invite teammate',
-            'View shortcuts',
-            'Open billing',
-            'Archive item',
-            'Export report',
-          ].map((item) => (
-            <CommandItem key={item} value={`tertiary-${item}`}>
-              <span
-                aria-hidden="true"
-                className="nx:size-4 nx:shrink-0 nx:rounded-sm nx:border nx:border-dashed nx:border-border-default"
-              />
-              {item}
-              <span
-                aria-hidden="true"
-                className="nx:ml-auto nx:size-5 nx:shrink-0 nx:rounded-sm nx:border nx:border-dashed nx:border-border-default"
-              />
-            </CommandItem>
-          ))}
-        </CommandGroup>
-      </CommandList>
-    </Command>
-  ),
 };
 
 // ============================================

--- a/packages/react/src/components/ui/command/Command.stories.tsx
+++ b/packages/react/src/components/ui/command/Command.stories.tsx
@@ -106,6 +106,9 @@ export const Empty: Story = {
     // Typing a query that matches nothing surfaces the empty state.
     await userEvent.type(input, 'zzzzzz');
     await expect(canvas.getByText('No results found.')).toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-slot="command-empty"]')
+    ).toBeInTheDocument();
   },
 };
 
@@ -133,7 +136,7 @@ export const WithDialog: Story = {
         <Button variant="outline" onClick={() => setOpen(true)}>
           Open Command Palette
         </Button>
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-small nx:text-muted-foreground">
           Press <kbd className="nx:font-mono">⌘K</kbd> to toggle
         </p>
         <CommandDialog open={open} onOpenChange={setOpen}>
@@ -296,7 +299,10 @@ export const WithDataAttributes: Story = {
         </CommandGroup>
         <CommandSeparator />
         <CommandGroup heading="Settings">
-          <CommandItem>Profile</CommandItem>
+          <CommandItem>
+            Profile
+            <CommandShortcut>⌘P</CommandShortcut>
+          </CommandItem>
         </CommandGroup>
       </CommandList>
     </Command>
@@ -307,6 +313,9 @@ export const WithDataAttributes: Story = {
     const input = canvas.getByRole('combobox');
     await expect(input).toHaveAttribute('data-slot', 'command-input');
 
+    await expect(
+      canvasElement.querySelector('[data-slot="command-input-wrapper"]')
+    ).toBeInTheDocument();
     await expect(
       canvasElement.querySelector('[data-slot="command"]')
     ).toBeInTheDocument();
@@ -322,6 +331,9 @@ export const WithDataAttributes: Story = {
     await expect(
       canvasElement.querySelector('[data-slot="command-separator"]')
     ).toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-slot="command-shortcut"]')
+    ).toBeInTheDocument();
   },
 };
 
@@ -333,7 +345,7 @@ export const AllVariants: Story = {
   render: () => (
     <div className="nx:flex nx:flex-col nx:gap-8">
       <div>
-        <h3 className="nx:mb-4 nx:text-sm nx:font-medium nx:text-foreground">
+        <h3 className="nx:mb-4 nx:typography-label-default nx:text-foreground">
           Basic
         </h3>
         <Command label="Basic command menu" className={paletteClass}>
@@ -350,7 +362,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:mb-4 nx:text-sm nx:font-medium nx:text-foreground">
+        <h3 className="nx:mb-4 nx:typography-label-default nx:text-foreground">
           Grouped with shortcuts
         </h3>
         <Command label="Grouped command menu" className={paletteClass}>

--- a/packages/react/src/components/ui/command/command.tsx
+++ b/packages/react/src/components/ui/command/command.tsx
@@ -245,7 +245,7 @@ function CommandLoading({ className, ...props }: CommandLoadingProps) {
       className={cn(
         'nx:px-3 nx:py-2.5',
         // cmdk nests Loading's children in an inner aria-hidden div — target it to lay the spinner + label out as a row.
-        'nx:[&>[aria-hidden=true]]:flex nx:[&>[aria-hidden=true]]:items-center nx:[&>[aria-hidden=true]]:gap-3',
+        'nx:*:aria-hidden:flex nx:*:aria-hidden:items-center nx:*:aria-hidden:gap-3',
         'nx:typography-body-small nx:text-muted-foreground',
         className
       )}

--- a/packages/react/src/components/ui/command/command.tsx
+++ b/packages/react/src/components/ui/command/command.tsx
@@ -151,8 +151,7 @@ function CommandInput({ className, ...props }: CommandInputProps) {
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          'nx:flex nx:w-full nx:bg-transparent nx:py-2 nx:typography-body-small',
-          'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
+          'nx:flex nx:w-full nx:bg-transparent nx:py-2 nx:typography-body-small nx:outline-none',
           'nx:placeholder:text-muted-foreground',
           'nx:disabled:cursor-not-allowed nx:disabled:opacity-50',
           className
@@ -182,7 +181,7 @@ function CommandList({ className, ...props }: CommandListProps) {
     <CommandPrimitive.List
       data-slot="command-list"
       className={cn(
-        'nx:max-h-[300px] nx:overflow-y-auto nx:overflow-x-hidden',
+        'nx:max-h-[300px] nx:overflow-y-auto nx:overflow-x-hidden nx:scroll-py-2',
         className
       )}
       {...props}
@@ -218,6 +217,43 @@ function CommandEmpty({ className, ...props }: CommandEmptyProps) {
 }
 
 /**
+ * CommandLoadingProps
+ *
+ * Props for the CommandLoading component.
+ */
+interface CommandLoadingProps extends React.ComponentProps<
+  typeof CommandPrimitive.Loading
+> {}
+
+/**
+ * CommandLoading
+ *
+ * Rendered while asynchronous command results are loading. Pass `progress` and
+ * `label` when you can estimate loading state for assistive technology.
+ *
+ * @example
+ * ```tsx
+ * <CommandLoading label="Loading command results">
+ *   Loading commands...
+ * </CommandLoading>
+ * ```
+ */
+function CommandLoading({ className, ...props }: CommandLoadingProps) {
+  return (
+    <CommandPrimitive.Loading
+      data-slot="command-loading"
+      className={cn(
+        'nx:px-3 nx:py-2.5',
+        'nx:[&>[aria-hidden=true]]:flex nx:[&>[aria-hidden=true]]:items-center nx:[&>[aria-hidden=true]]:gap-3',
+        'nx:typography-body-small nx:text-muted-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
  * CommandGroupProps
  *
  * Props for the CommandGroup component.
@@ -245,7 +281,7 @@ function CommandGroup({ className, ...props }: CommandGroupProps) {
       data-slot="command-group"
       className={cn(
         'nx:overflow-hidden nx:text-popover-foreground',
-        'nx:p-1',
+        'nx:p-2',
         'nx:**:[[cmdk-group-heading]]:px-2 nx:**:[[cmdk-group-heading]]:py-1.5',
         'nx:**:[[cmdk-group-heading]]:typography-label-small nx:**:[[cmdk-group-heading]]:text-muted-foreground',
         className
@@ -311,7 +347,7 @@ function CommandItem({ className, ...props }: CommandItemProps) {
       data-slot="command-item"
       className={cn(
         'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:rounded-sm nx:typography-body-small nx:outline-none',
-        'nx:gap-2 nx:px-2 nx:py-1.5',
+        'nx:gap-3 nx:px-3 nx:py-2.5',
         'nx:data-[selected=true]:bg-popover-hover nx:data-[selected=true]:text-popover-foreground',
         'nx:data-[disabled=true]:pointer-events-none nx:data-[disabled=true]:opacity-50',
         'nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
@@ -368,6 +404,8 @@ export {
   type CommandItemProps,
   CommandList,
   type CommandListProps,
+  CommandLoading,
+  type CommandLoadingProps,
   type CommandProps,
   CommandSeparator,
   type CommandSeparatorProps,

--- a/packages/react/src/components/ui/command/command.tsx
+++ b/packages/react/src/components/ui/command/command.tsx
@@ -244,6 +244,7 @@ function CommandLoading({ className, ...props }: CommandLoadingProps) {
       data-slot="command-loading"
       className={cn(
         'nx:px-3 nx:py-2.5',
+        // cmdk nests Loading's children in an inner aria-hidden div — target it to lay the spinner + label out as a row.
         'nx:[&>[aria-hidden=true]]:flex nx:[&>[aria-hidden=true]]:items-center nx:[&>[aria-hidden=true]]:gap-3',
         'nx:typography-body-small nx:text-muted-foreground',
         className

--- a/packages/react/src/components/ui/command/command.tsx
+++ b/packages/react/src/components/ui/command/command.tsx
@@ -151,7 +151,8 @@ function CommandInput({ className, ...props }: CommandInputProps) {
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          'nx:flex nx:w-full nx:bg-transparent nx:py-control-md nx:text-sm nx:outline-none',
+          'nx:flex nx:w-full nx:bg-transparent nx:py-2 nx:typography-body-small',
+          'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
           'nx:placeholder:text-muted-foreground',
           'nx:disabled:cursor-not-allowed nx:disabled:opacity-50',
           className
@@ -207,7 +208,10 @@ function CommandEmpty({ className, ...props }: CommandEmptyProps) {
   return (
     <CommandPrimitive.Empty
       data-slot="command-empty"
-      className={cn('nx:py-6 nx:text-center nx:text-sm', className)}
+      className={cn(
+        'nx:py-6 nx:text-center nx:typography-body-small',
+        className
+      )}
       {...props}
     />
   );
@@ -243,7 +247,7 @@ function CommandGroup({ className, ...props }: CommandGroupProps) {
         'nx:overflow-hidden nx:text-popover-foreground',
         'nx:p-1',
         'nx:**:[[cmdk-group-heading]]:px-2 nx:**:[[cmdk-group-heading]]:py-1.5',
-        'nx:**:[[cmdk-group-heading]]:text-xs nx:**:[[cmdk-group-heading]]:font-medium nx:**:[[cmdk-group-heading]]:text-muted-foreground',
+        'nx:**:[[cmdk-group-heading]]:typography-label-small nx:**:[[cmdk-group-heading]]:text-muted-foreground',
         className
       )}
       {...props}
@@ -306,8 +310,8 @@ function CommandItem({ className, ...props }: CommandItemProps) {
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:rounded-sm nx:text-sm nx:outline-none',
-        'nx:gap-2 nx:px-2 nx:py-control-sm',
+        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:rounded-sm nx:typography-body-small nx:outline-none',
+        'nx:gap-2 nx:px-2 nx:py-1.5',
         'nx:data-[selected=true]:bg-popover-hover nx:data-[selected=true]:text-popover-foreground',
         'nx:data-[disabled=true]:pointer-events-none nx:data-[disabled=true]:opacity-50',
         'nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',


### PR DESCRIPTION
## Summary

- Migrate Command input/item spacing off control role tokens to numeric utilities, per the open #433 control-tier decision. This is a deliberate size increase, **not** a 1:1 swap — input `py-control-md`→`py-2`; item `py-control-sm`→`py-2.5`, `gap-2`→`gap-3`, `px-2`→`px-3`; group `p-1`→`p-2` — for a roomier palette rhythm. (The numeric steps still track the density scale per `[data-style]` mode, as the role tokens did — only `py-2`/`p-2` happen to be mode-invariant.)
- Move Command typography to Nexus composites (`typography-body-small` / `typography-label-small` / `typography-label-default`), leaving the intentional `tracking-widest` shortcut treatment untouched.
- Keep the search row's `focus-within` border cue as the deliberate focus affordance: the command-palette input auto-focuses whenever the palette opens, so it intentionally does **not** take the canonical keyboard outline ring (a persistent ring on an always-focused field reads as noise — matches Tier-A palettes). This is a conscious exception to the interactive-control ring in `components.md` § Surface exception map.
- Add a `CommandLoading` subcomponent (async results state, part of #197's loading-state rubric) and expand story coverage (async loading, query-aware empty, rich items, custom filtering) plus `command-empty` / wrapper / shortcut data-slot assertions, and add the `base-variants.config.json` entry.

## GitHub Issue

Refs #197
Refs #433

## Test Plan

- [x] `pnpm --filter @nexus/react generate:base-variants`
- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component command`
- [x] `pnpm test:storybook` (passes; the Storybook vitest project reports no test files found on this branch — gate fix tracked in #429, so the new play functions are not exercised here)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
