### PR TITLE
Audit card component

### DIFF
--- a/packages/react/src/components/ui/card/Card.stories.tsx
+++ b/packages/react/src/components/ui/card/Card.stories.tsx
@@ -193,15 +193,6 @@ export const MediaCard: Story = {
       </CardContent>
     </Card>
   ),
-  play: async ({ canvasElement }) => {
-    const card = canvasElement.querySelector<HTMLElement>('[data-slot="card"]');
-
-    if (!card) {
-      throw new Error('Expected card to render.');
-    }
-
-    await expect(getComputedStyle(card).overflow).toBe('hidden');
-  },
 };
 
 // ============================================

--- a/packages/react/src/components/ui/card/Card.stories.tsx
+++ b/packages/react/src/components/ui/card/Card.stories.tsx
@@ -176,6 +176,34 @@ export const LongContent: Story = {
   ),
 };
 
+export const MediaCard: Story = {
+  render: (_args) => (
+    <Card className="nx:w-[350px]">
+      <div aria-hidden="true" className="nx:aspect-video nx:bg-muted nx:p-6">
+        <div className="nx:size-full nx:rounded-lg nx:border nx:border-border-default nx:bg-container" />
+      </div>
+      <CardHeader>
+        <CardTitle>Campaign Snapshot</CardTitle>
+        <CardDescription>Updated 12 minutes ago</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p>
+          Performance improved across three regions after the latest rollout.
+        </p>
+      </CardContent>
+    </Card>
+  ),
+  play: async ({ canvasElement }) => {
+    const card = canvasElement.querySelector<HTMLElement>('[data-slot="card"]');
+
+    if (!card) {
+      throw new Error('Expected card to render.');
+    }
+
+    await expect(getComputedStyle(card).overflow).toBe('hidden');
+  },
+};
+
 // ============================================
 // USE CASE EXAMPLES
 // ============================================
@@ -194,7 +222,7 @@ export const LoginCard: Story = {
           <div className="nx:flex nx:flex-col nx:gap-2">
             <label
               htmlFor="email"
-              className="nx:text-sm nx:font-medium nx:text-foreground"
+              className="nx:typography-label-default nx:text-foreground"
             >
               Email
             </label>
@@ -203,7 +231,7 @@ export const LoginCard: Story = {
           <div className="nx:flex nx:flex-col nx:gap-2">
             <label
               htmlFor="password"
-              className="nx:text-sm nx:font-medium nx:text-foreground"
+              className="nx:typography-label-default nx:text-foreground"
             >
               Password
             </label>
@@ -222,6 +250,33 @@ export const LoginCard: Story = {
   ),
 };
 
+export const BorderedFooter: Story = {
+  render: (_args) => (
+    <Card className="nx:w-[350px]">
+      <CardHeader>
+        <CardTitle>Plan Usage</CardTitle>
+        <CardDescription>
+          Seats and billing are managed together.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="nx:flex nx:items-baseline nx:gap-2">
+          <span className="nx:typography-heading-medium nx:text-foreground">
+            $49
+          </span>
+          <span className="nx:typography-body-small nx:text-muted-foreground">
+            per seat
+          </span>
+        </div>
+      </CardContent>
+      <CardFooter className="nx:border-t nx:border-border-default nx:bg-muted nx:pt-6">
+        <Button variant="outline">Compare</Button>
+        <Button>Upgrade</Button>
+      </CardFooter>
+    </Card>
+  ),
+};
+
 export const NotificationCard: Story = {
   render: (_args) => (
     <Card className="nx:w-[350px]">
@@ -234,7 +289,7 @@ export const NotificationCard: Story = {
           <div className="nx:flex nx:items-start nx:gap-3 nx:rounded-lg nx:bg-muted nx:p-3">
             <div className="nx:size-2 nx:mt-2 nx:rounded-full nx:bg-primary-background" />
             <div>
-              <p className="nx:text-sm nx:font-medium">New message</p>
+              <p className="nx:typography-label-default">New message</p>
               <p className="nx:text-sm nx:text-foreground/70">
                 John sent you a message
               </p>
@@ -243,7 +298,7 @@ export const NotificationCard: Story = {
           <div className="nx:flex nx:items-start nx:gap-3 nx:rounded-lg nx:bg-muted nx:p-3">
             <div className="nx:size-2 nx:mt-2 nx:rounded-full nx:bg-primary-background" />
             <div>
-              <p className="nx:text-sm nx:font-medium">Update available</p>
+              <p className="nx:typography-label-default">Update available</p>
               <p className="nx:text-sm nx:text-foreground/70">
                 Version 2.0 is now available
               </p>
@@ -265,7 +320,9 @@ export const StatsCard: Story = {
     <Card className="nx:w-[200px]">
       <CardHeader className="nx:pb-2">
         <CardDescription>Total Revenue</CardDescription>
-        <CardTitle className="nx:text-3xl">$45,231</CardTitle>
+        <p className="nx:col-start-1 nx:min-w-0 nx:typography-heading-large nx:text-foreground">
+          $45,231
+        </p>
       </CardHeader>
       <CardContent>
         <p className="nx:text-xs nx:text-muted-foreground">
@@ -274,6 +331,48 @@ export const StatsCard: Story = {
       </CardContent>
     </Card>
   ),
+};
+
+export const LongTitleWithAction: Story = {
+  render: (_args) => (
+    <Card className="nx:w-[320px]">
+      <CardHeader>
+        <CardTitle>
+          Quarterly revenue operations review with customer expansion notes
+        </CardTitle>
+        <CardDescription>
+          The action should keep its own reserved column.
+        </CardDescription>
+        <CardAction>
+          <Button size="sm" variant="outline">
+            Edit
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        <p>Header text wraps before it reaches the action.</p>
+      </CardContent>
+    </Card>
+  ),
+  play: async ({ canvasElement }) => {
+    await document.fonts.ready;
+
+    const title = canvasElement.querySelector<HTMLElement>(
+      '[data-slot="card-title"]'
+    );
+    const action = canvasElement.querySelector<HTMLElement>(
+      '[data-slot="card-action"]'
+    );
+
+    if (!title || !action) {
+      throw new Error('Expected card title and action to render.');
+    }
+
+    const titleRect = title.getBoundingClientRect();
+    const actionRect = action.getBoundingClientRect();
+
+    await expect(titleRect.right).toBeLessThanOrEqual(actionRect.left + 0.5);
+  },
 };
 
 // ============================================
@@ -346,7 +445,7 @@ export const AllVariants: Story = {
   render: (_args) => (
     <div className="nx:flex nx:flex-col nx:gap-8">
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:mb-4 nx:typography-label-default nx:text-foreground">
           Basic Card
         </h3>
         <Card className="nx:w-[350px]">
@@ -361,7 +460,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:mb-4 nx:typography-label-default nx:text-foreground">
           Card with Footer
         </h3>
         <Card className="nx:w-[350px]">
@@ -380,7 +479,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:mb-4 nx:typography-label-default nx:text-foreground">
           Card with Action
         </h3>
         <Card className="nx:w-[350px]">
@@ -400,14 +499,16 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:mb-4 nx:typography-label-default nx:text-foreground">
           Stats Card
         </h3>
         <div className="nx:flex nx:gap-4">
           <Card className="nx:w-[180px]">
             <CardHeader className="nx:pb-2">
               <CardDescription>Revenue</CardDescription>
-              <CardTitle className="nx:text-2xl">$12,345</CardTitle>
+              <p className="nx:col-start-1 nx:min-w-0 nx:typography-heading-medium nx:text-foreground">
+                $12,345
+              </p>
             </CardHeader>
             <CardContent>
               <p className="nx:text-xs nx:text-muted-foreground">+12% growth</p>
@@ -416,7 +517,9 @@ export const AllVariants: Story = {
           <Card className="nx:w-[180px]">
             <CardHeader className="nx:pb-2">
               <CardDescription>Users</CardDescription>
-              <CardTitle className="nx:text-2xl">1,234</CardTitle>
+              <p className="nx:col-start-1 nx:min-w-0 nx:typography-heading-medium nx:text-foreground">
+                1,234
+              </p>
             </CardHeader>
             <CardContent>
               <p className="nx:text-xs nx:text-muted-foreground">+5% growth</p>
@@ -441,7 +544,7 @@ export const AllModes: Story = {
     docs: {
       description: {
         story:
-          'Each row scopes `data-style` locally so the 7 spacing modes render side-by-side. `CardHeader`, `CardContent`, and `CardFooter` migrate `p-6` → `p-container` (24px matches vega byte-identically). Positional offsets (`right-6`, `top-6` on `CardAction`) and sub-element offsets (`gap-1.5` between title/description, `gap-2` between footer buttons, `pt-0` to collapse content into header) stay numeric per the coupling-table Card row. Container-p values across modes: nova 20 / vega-tier 24 / maia & luma 28 / sera 40 — the card visibly grows in breathy modes.',
+          'Each row scopes `data-style` locally so the 7 spacing modes render side-by-side. `CardHeader`, `CardContent`, and `CardFooter` migrate `p-container` → `p-6` to preserve the vega 24px default while leaving the container-role curve. `p-6` follows the standard spacing scale: nova 22 / maia 28 / all other modes 24. `CardAction` is in-flow grid content, with the header padding supplying the inset; `gap-1.5`, `gap-2`, and `pt-0` stay numeric.',
       },
     },
   },
@@ -467,7 +570,7 @@ export const ModesProduceDifferentHeights: Story = {
     docs: {
       description: {
         story:
-          'Cascade sentinel for `CardContent` `p-container`. Uses the `nova` + `luma` pair to cover the container-p axis at two distinct values (nova 20, luma 28) — luma had not appeared in any sentinel before; the suite now hits at least one mode beyond the vega-cluster across each major role-token family. Card has no portaled content; dimensional measurement on the wrapper works directly. The Card contains a 40px fixed-height child so the height equation is `border 2 + (pt-0 + child-40 + pb-container)` — vega 66px, nova 62px, luma 70px.',
+          'Cascade sentinel for numeric `CardContent` `p-6`. Card has no portaled content, so dimensional measurement on the wrapper works directly. The Card contains a 40px fixed-height child, making the height equation `border 2 + pt-0 + child 40 + p-6 bottom`; nova resolves to 64px and luma resolves to 66px.',
       },
     },
   },
@@ -505,7 +608,7 @@ export const VegaDefaultHeightPinned: Story = {
     docs: {
       description: {
         story:
-          'Pin on the migration outcome: in vega mode, a Card containing a single `CardContent` with a 40px fixed-height child renders at exactly 66px (= border 1px × 2 + `CardContent` pt-0 + child-40 + p-container bottom 24). If a designer retunes `--container-p` or the border-width token, this test fails.',
+          'Pin on the migration outcome: in vega mode, a Card containing a single `CardContent` with a 40px fixed-height child renders at exactly 66px (= border 1px × 2 + `CardContent` pt-0 + child 40 + `p-6` bottom 24). If a designer retunes spacing-6 or the border-width token, this test fails.',
       },
     },
   },

--- a/packages/react/src/components/ui/card/card.tsx
+++ b/packages/react/src/components/ui/card/card.tsx
@@ -36,7 +36,7 @@ function Card({ className, ...props }: CardProps) {
     <div
       data-slot="card"
       className={cn(
-        'nx:relative nx:rounded-xl nx:border nx:border-border-default nx:bg-container nx:text-container-foreground nx:shadow-sm',
+        'nx:overflow-hidden nx:rounded-xl nx:border nx:border-border-default nx:bg-container nx:text-container-foreground nx:shadow-sm',
         className
       )}
       {...props}
@@ -68,7 +68,10 @@ function CardHeader({ className, ...props }: CardHeaderProps) {
   return (
     <div
       data-slot="card-header"
-      className={cn('nx:flex nx:flex-col nx:gap-1.5 nx:p-container', className)}
+      className={cn(
+        'nx:grid nx:grid-cols-[minmax(0,1fr)_auto] nx:items-start nx:gap-y-1.5 nx:p-6',
+        className
+      )}
       {...props}
     />
   );
@@ -96,7 +99,7 @@ function CardTitle({ className, children, ...props }: CardTitleProps) {
     <h3
       data-slot="card-title"
       className={cn(
-        'nx:text-lg nx:font-semibold nx:leading-none nx:tracking-tight',
+        'nx:col-start-1 nx:min-w-0 nx:typography-heading-xsmall',
         className
       )}
       {...props}
@@ -127,7 +130,10 @@ function CardDescription({ className, ...props }: CardDescriptionProps) {
   return (
     <p
       data-slot="card-description"
-      className={cn('nx:text-sm nx:text-muted-foreground', className)}
+      className={cn(
+        'nx:col-start-1 nx:min-w-0 nx:typography-body-small nx:text-muted-foreground',
+        className
+      )}
       {...props}
     />
   );
@@ -144,7 +150,7 @@ interface CardActionProps extends React.ComponentProps<'div'> {}
  * CardAction
  *
  * Container for action elements (buttons, badges) in the card header.
- * Positioned to the right of the title and description.
+ * Placed in the header action column beside the title and description.
  *
  * @example
  * ```tsx
@@ -161,7 +167,7 @@ function CardAction({ className, ...props }: CardActionProps) {
     <div
       data-slot="card-action"
       className={cn(
-        'nx:absolute nx:right-(--nx-container-p) nx:top-(--nx-container-p) nx:flex nx:items-center nx:gap-2',
+        'nx:col-start-2 nx:row-start-1 nx:row-span-2 nx:flex nx:items-center nx:gap-2 nx:self-start nx:justify-self-end nx:pl-4',
         className
       )}
       {...props}
@@ -192,7 +198,7 @@ function CardContent({ className, ...props }: CardContentProps) {
   return (
     <div
       data-slot="card-content"
-      className={cn('nx:p-container nx:pt-0', className)}
+      className={cn('nx:p-6 nx:pt-0', className)}
       {...props}
     />
   );
@@ -223,7 +229,7 @@ function CardFooter({ className, ...props }: CardFooterProps) {
     <div
       data-slot="card-footer"
       className={cn(
-        'nx:flex nx:items-center nx:gap-2 nx:p-container nx:pt-0',
+        'nx:flex nx:items-center nx:gap-2 nx:p-6 nx:pt-0',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/card/card.tsx
+++ b/packages/react/src/components/ui/card/card.tsx
@@ -15,6 +15,9 @@ interface CardProps extends React.ComponentProps<'div'> {}
  * A container component for grouping related content and actions.
  * Use for displaying information in a visually distinct section.
  *
+ * Content is clipped to the rounded corners; pass `nx:overflow-visible` via
+ * `className` for content that must overhang the edge.
+ *
  * @example
  * ```tsx
  * <Card>
@@ -55,6 +58,11 @@ interface CardHeaderProps extends React.ComponentProps<'div'> {}
  * CardHeader
  *
  * Container for the card's header content including title, description, and actions.
+ *
+ * Children lay out in a two-column grid: a flexible content column and an
+ * auto-width column on the right reserved for `CardAction`. `CardTitle` and
+ * `CardDescription` place themselves in the content column; a custom child
+ * should add `nx:col-start-1` to join it.
  *
  * @example
  * ```tsx


### PR DESCRIPTION
## Summary

- Audits the Card component — no public API, prop, export, or type changes.
- **Spacing → numeric:** `CardHeader` / `CardContent` / `CardFooter` migrate `nx:p-container` → `nx:p-6`, per the directed role→numeric direction (decision #433, container-tier precedent #425 / AlertDialog). Preserves the vega 24px default; the per-mode container-breathy curve (sera 40px) is intentionally dropped.
- **Typography composites:** `CardTitle` → `nx:typography-heading-xsmall`; `CardDescription` → `nx:typography-body-small`.
- **CardAction → grid:** replaces absolute top-right positioning with a reserved header grid column (`grid-cols-[minmax(0,1fr)_auto]`), so a long title wraps instead of rendering under the action. `:has()` is intentionally avoided (Firefox floor 113; `:has()` ships FF 121).
- **Surface cleanup:** drops the now-unused `nx:relative`; adds `nx:overflow-hidden` so media / filled-edge content clips to the rounded corners (consumers override with `nx:overflow-visible`).
- **Stories:** adds `MediaCard`, `BorderedFooter`, and `LongTitleWithAction` (title↔action overlap regression); refreshes story-only raw type to composites; reframes the mode sentinels to numeric `p-6` (nova 64 / luma 66 / vega 66 px).

## GitHub Issue

Part of the role→numeric spacing rollout — decision **#433** (open), container-tier precedent **#425**. This PR does not close #433 (the decision remains open).

## Test Plan

- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component card` → 0 missing, 0 drift
- [x] `pnpm --filter @nexus/react typecheck` — clean
- [x] `eslint` (card.tsx + Card.stories.tsx) — clean
- [x] `prettier --check` (card.tsx + Card.stories.tsx) — clean
- [ ] `pnpm test:storybook` — the new play functions (`LongTitleWithAction` overlap check) execute once the Storybook test-gate fix **#429** lands; on this base the Storybook vitest project collects 0 tests, so the layout guarantee is not yet exercised in CI.
