### PR TITLE
feat(react): audit EmptyState + add bordered prop

### DIFF
--- a/apps/console/src/components/error-state.tsx
+++ b/apps/console/src/components/error-state.tsx
@@ -26,9 +26,7 @@ interface ErrorStateProps {
  */
 export function ErrorState({ message, onRetry, bordered }: ErrorStateProps) {
   return (
-    <EmptyState
-      className={bordered ? 'nx:border nx:border-border-default' : undefined}
-    >
+    <EmptyState bordered={bordered}>
       <EmptyStateHeader>
         <EmptyStateMedia variant="icon">
           <IconAlertTriangle />

--- a/apps/console/src/components/not-found-state.tsx
+++ b/apps/console/src/components/not-found-state.tsx
@@ -33,7 +33,7 @@ export function NotFoundState({
   children,
 }: NotFoundStateProps) {
   return (
-    <EmptyState className="nx:border nx:border-border-default">
+    <EmptyState bordered>
       <EmptyStateHeader>
         <EmptyStateMedia variant="icon">
           <IconFileOff />

--- a/apps/console/src/modules/crm/contacts-route.tsx
+++ b/apps/console/src/modules/crm/contacts-route.tsx
@@ -116,7 +116,7 @@ export function ContactsSkeleton() {
 
 export function ContactsEmpty() {
   return (
-    <EmptyState className="nx:border nx:border-border-default">
+    <EmptyState bordered>
       <EmptyStateHeader>
         <EmptyStateMedia variant="icon">
           <IconUsers />

--- a/apps/console/src/modules/people/people-route.tsx
+++ b/apps/console/src/modules/people/people-route.tsx
@@ -111,7 +111,7 @@ function PeopleSkeleton() {
 
 function PeopleEmpty() {
   return (
-    <EmptyState className="nx:border nx:border-border-default">
+    <EmptyState bordered>
       <EmptyStateHeader>
         <EmptyStateMedia variant="icon">
           <IconUsers />

--- a/apps/console/src/modules/projects/issues-route.tsx
+++ b/apps/console/src/modules/projects/issues-route.tsx
@@ -85,7 +85,7 @@ function IssuesSkeleton() {
 
 function IssuesEmpty() {
   return (
-    <EmptyState className="nx:border nx:border-border-default">
+    <EmptyState bordered>
       <EmptyStateHeader>
         <EmptyStateMedia variant="icon">
           <IconBriefcase />

--- a/packages/react/src/components/ui/empty-state/EmptyState.stories.tsx
+++ b/packages/react/src/components/ui/empty-state/EmptyState.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { IconUsers } from '@tabler/icons-react';
-import { expect } from 'storybook/test';
+import { expect, userEvent, within } from 'storybook/test';
 
 import { Button } from '../button';
 
@@ -94,6 +94,50 @@ export const WithDataAttributes: Story = {
       '[data-slot="empty-state-media"]'
     );
     await expect(media).toHaveAttribute('data-variant', 'icon');
+  },
+};
+
+// Long copy stresses the centered text-balance wrapping; an inline link in the
+// description exercises the [&>a] anchor hooks — the only story that does.
+export const LongCopyWithLink: Story = {
+  render: () => (
+    <EmptyState>
+      <EmptyStateHeader>
+        <EmptyStateMedia variant="icon">
+          <IconUsers aria-hidden />
+        </EmptyStateMedia>
+        <EmptyStateTitle>
+          No team members match the filters you have applied to this view
+        </EmptyStateTitle>
+        <EmptyStateDescription>
+          Try broadening your search, clearing a filter, or inviting someone
+          new. You can also{' '}
+          <a href="/docs/team">learn more about managing your team</a> in the
+          docs.
+        </EmptyStateDescription>
+      </EmptyStateHeader>
+    </EmptyState>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: /learn more/i });
+
+    // The [&>a] hooks only style an <a> that is a direct child of the
+    // description <p> — assert that structure first (CSS-independent).
+    await expect(link.parentElement).toHaveAttribute(
+      'data-slot',
+      'empty-state-description'
+    );
+    // underline-offset-4 is unique to the hook — no anchor defaults to 4px.
+    await expect(link).toHaveStyle({ textUnderlineOffset: '4px' });
+
+    // The link is the only focusable element, so Tab must land on it.
+    await userEvent.tab();
+    await expect(link).toHaveFocus();
+
+    await expect(
+      canvas.getByText(/broadening your search/i)
+    ).toBeInTheDocument();
   },
 };
 

--- a/packages/react/src/components/ui/empty-state/EmptyState.stories.tsx
+++ b/packages/react/src/components/ui/empty-state/EmptyState.stories.tsx
@@ -156,6 +156,7 @@ export const Bordered: Story = {
   play: async ({ canvasElement }) => {
     const root = canvasElement.querySelector('[data-slot="empty-state"]');
     await expect(root).toHaveAttribute('data-bordered', 'true');
+    await expect(root).toHaveStyle({ borderStyle: 'dashed' });
   },
 };
 

--- a/packages/react/src/components/ui/empty-state/EmptyState.stories.tsx
+++ b/packages/react/src/components/ui/empty-state/EmptyState.stories.tsx
@@ -122,8 +122,6 @@ export const LongCopyWithLink: Story = {
     const canvas = within(canvasElement);
     const link = canvas.getByRole('link', { name: /learn more/i });
 
-    // The [&>a] hooks only style an <a> that is a direct child of the
-    // description <p> — assert that structure first (CSS-independent).
     await expect(link.parentElement).toHaveAttribute(
       'data-slot',
       'empty-state-description'
@@ -131,7 +129,6 @@ export const LongCopyWithLink: Story = {
     // underline-offset-4 is unique to the hook — no anchor defaults to 4px.
     await expect(link).toHaveStyle({ textUnderlineOffset: '4px' });
 
-    // The link is the only focusable element, so Tab must land on it.
     await userEvent.tab();
     await expect(link).toHaveFocus();
 

--- a/packages/react/src/components/ui/empty-state/EmptyState.stories.tsx
+++ b/packages/react/src/components/ui/empty-state/EmptyState.stories.tsx
@@ -138,6 +138,27 @@ export const LongCopyWithLink: Story = {
   },
 };
 
+// The `bordered` prop renders the dashed frame and advertises via data-bordered.
+export const Bordered: Story = {
+  render: () => (
+    <EmptyState bordered>
+      <EmptyStateHeader>
+        <EmptyStateMedia variant="icon">
+          <IconUsers aria-hidden />
+        </EmptyStateMedia>
+        <EmptyStateTitle>No contacts yet</EmptyStateTitle>
+        <EmptyStateDescription>
+          Add your first contact to get started.
+        </EmptyStateDescription>
+      </EmptyStateHeader>
+    </EmptyState>
+  ),
+  play: async ({ canvasElement }) => {
+    const root = canvasElement.querySelector('[data-slot="empty-state"]');
+    await expect(root).toHaveAttribute('data-bordered', 'true');
+  },
+};
+
 // ============================================
 // ALL VARIANTS GRID
 // ============================================
@@ -148,7 +169,7 @@ export const LongCopyWithLink: Story = {
 export const AllVariants: Story = {
   render: () => (
     <div className="nx:flex nx:flex-col nx:gap-6">
-      <EmptyState className="nx:border nx:border-border-default">
+      <EmptyState bordered>
         <EmptyStateHeader>
           <EmptyStateMedia variant="icon">
             <IconUsers aria-hidden />

--- a/packages/react/src/components/ui/empty-state/empty-state.tsx
+++ b/packages/react/src/components/ui/empty-state/empty-state.tsx
@@ -69,7 +69,7 @@ function EmptyStateHeader({ className, ...props }: EmptyStateHeaderProps) {
     <div
       data-slot="empty-state-header"
       className={cn(
-        'nx:flex nx:max-w-sm nx:flex-col nx:items-center nx:gap-2 nx:text-center',
+        'nx:flex nx:max-w-sm nx:flex-col nx:items-center nx:gap-2',
         className
       )}
       {...props}
@@ -82,7 +82,7 @@ const emptyStateMediaVariants = cva(
   {
     variants: {
       variant: {
-        default: 'nx:bg-transparent',
+        default: '',
         icon: 'nx:size-10 nx:rounded-lg nx:bg-muted nx:text-foreground nx:[&_svg]:size-6',
       },
     },
@@ -134,7 +134,8 @@ interface EmptyStateTitleProps extends React.ComponentProps<'div'> {}
 /**
  * EmptyStateTitle
  *
- * The headline of the empty state — what is missing.
+ * The headline of the empty state — what is missing. Renders a `div`, not a
+ * heading element — set the heading level in your app if the region needs one.
  */
 function EmptyStateTitle({ className, ...props }: EmptyStateTitleProps) {
   return (
@@ -191,7 +192,7 @@ function EmptyStateContent({ className, ...props }: EmptyStateContentProps) {
     <div
       data-slot="empty-state-content"
       className={cn(
-        'nx:flex nx:w-full nx:max-w-sm nx:min-w-0 nx:flex-col nx:items-center nx:gap-4 nx:text-balance',
+        'nx:flex nx:w-full nx:max-w-sm nx:min-w-0 nx:flex-col nx:items-center nx:gap-4',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/empty-state/empty-state.tsx
+++ b/packages/react/src/components/ui/empty-state/empty-state.tsx
@@ -9,7 +9,15 @@ import { cn } from '@/lib/utils';
  *
  * Props for the EmptyState component.
  */
-interface EmptyStateProps extends React.ComponentProps<'div'> {}
+interface EmptyStateProps extends React.ComponentProps<'div'> {
+  /**
+   * Render the dashed frame around the empty state — use it to match a
+   * bordered skeleton slot so a loading→empty swap doesn't reflow.
+   *
+   * @default false
+   */
+  bordered?: boolean;
+}
 
 /**
  * EmptyState
@@ -18,8 +26,8 @@ interface EmptyStateProps extends React.ComponentProps<'div'> {}
  * content yet — an icon, a title, a short description, and an optional action.
  * Compose with the sub-components: `EmptyStateHeader` groups the
  * `EmptyStateMedia` (icon), `EmptyStateTitle`, and `EmptyStateDescription`;
- * `EmptyStateContent` holds the call to action. Carries a dashed border style
- * that only shows when a consumer adds a border width.
+ * `EmptyStateContent` holds the call to action. Pass `bordered` to render the
+ * dashed frame (e.g. to match a bordered skeleton slot).
  *
  * @example
  * ```tsx
@@ -39,12 +47,18 @@ interface EmptyStateProps extends React.ComponentProps<'div'> {}
  * </EmptyState>
  * ```
  */
-function EmptyState({ className, ...props }: EmptyStateProps) {
+function EmptyState({
+  className,
+  bordered = false,
+  ...props
+}: EmptyStateProps) {
   return (
     <div
       data-slot="empty-state"
+      data-bordered={bordered || undefined}
       className={cn(
-        'nx:flex nx:min-w-0 nx:flex-1 nx:flex-col nx:items-center nx:justify-center nx:gap-6 nx:rounded-lg nx:border-dashed nx:p-6 nx:text-center nx:text-balance',
+        'nx:flex nx:min-w-0 nx:flex-1 nx:flex-col nx:items-center nx:justify-center nx:gap-6 nx:rounded-lg nx:p-6 nx:text-center nx:text-balance',
+        bordered && 'nx:border nx:border-dashed nx:border-border-default',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Audit of the `EmptyState` component, stacked on `prasad/components-cleanup` (component-cleanup series).

- **Cleanup** — removed three redundant/dead utilities: `nx:text-center` (header) and `nx:text-balance` (content) both cascade from the root; `nx:bg-transparent` on the media `default` variant is a no-op. Rendered output unchanged.
- **Docs** — JSDoc note that `EmptyStateTitle` renders a `div`, not a heading (consistent with `FieldTitle`/`ItemTitle`; heading level is the consumer's).
- **Coverage** — new `LongCopyWithLink` story covering two previously-untested paths: `text-balance` wrapping on long copy and the `[&>a]` description-anchor hooks.
- **New `bordered` prop** — replaces the inert base `nx:border-dashed` (which rendered nothing until a consumer hand-added a width) with an explicit `bordered` prop that owns the full dashed frame and advertises via `data-bordered`. The 5 console consumers that hand-rolled `className="nx:border nx:border-border-default"` are migrated to it — including `ErrorState`, whose conditional className collapses to `bordered={bordered}`. New `Bordered` story asserts the attribute.

No spacing changes — the role→numeric spacing question is tracked in #433.

## Verification

- `pnpm --filter @nexus/react typecheck` + `pnpm --filter @nexus/console typecheck` — clean
- eslint + prettier `--check` on all changed files — clean
- `audit:storybook-coverage --component empty-state` — `0 missing, 0 drift, 3 info`
- Play functions verified live in Storybook + Playwright (the `vitest --project=storybook` gate is a no-op on this branch; #429 owns the fix): the link story (direct-child link, `text-underline-offset: 4px`, focusable, long copy), and the bordered prop (`bordered` → 1px dashed border + `data-bordered="true"`; default → 0px border).

## Test Plan

- [ ] Story play functions pass in the Storybook Interactions panel (after #429 restores the gate)
- [ ] `EmptyState` reads correctly across the 5 bases × 2 themes (generated base-variants story)
- [ ] Console error / empty / not-found states still render the dashed frame after the `bordered` migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)