### PR TITLE
Audit ContextMenu spacing and typography

### DIFF
--- a/packages/react/src/components/ui/context-menu/ContextMenu.stories.tsx
+++ b/packages/react/src/components/ui/context-menu/ContextMenu.stories.tsx
@@ -21,7 +21,7 @@ import {
 } from './context-menu';
 
 const triggerClass =
-  'nx:flex nx:h-[96px] nx:w-full nx:max-w-md nx:select-none nx:items-center nx:justify-center nx:rounded-md nx:border nx:border-dashed nx:border-border-default nx:text-sm nx:text-muted-foreground';
+  'nx:flex nx:h-[96px] nx:w-full nx:max-w-md nx:select-none nx:items-center nx:justify-center nx:rounded-md nx:border nx:border-dashed nx:border-border-default nx:typography-body-small nx:text-muted-foreground';
 
 const meta: Meta<typeof ContextMenu> = {
   title: 'Components/ContextMenu',
@@ -406,7 +406,7 @@ export const AllVariants: Story = {
   render: (_args) => (
     <div className="nx:flex nx:flex-col nx:gap-8">
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Basic Menu
         </h3>
         <ContextMenu>
@@ -422,7 +422,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           With Shortcuts
         </h3>
         <ContextMenu>
@@ -447,7 +447,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           With Destructive
         </h3>
         <ContextMenu>
@@ -464,7 +464,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           With Submenu
         </h3>
         <ContextMenu>

--- a/packages/react/src/components/ui/context-menu/context-menu.tsx
+++ b/packages/react/src/components/ui/context-menu/context-menu.tsx
@@ -91,7 +91,7 @@ function ContextMenuSubTrigger({
       data-inset={inset}
       className={cn(
         'nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2',
-        'nx:rounded-sm nx:px-2 nx:py-control-sm nx:text-sm nx:outline-none',
+        'nx:rounded-sm nx:px-2 nx:py-1.5 nx:typography-body-small nx:outline-none',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
         'nx:data-[state=open]:bg-popover-hover nx:data-[state=open]:text-popover-foreground',
         'nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
@@ -195,7 +195,7 @@ function ContextMenuContent({ className, ...props }: ContextMenuContentProps) {
 }
 
 const contextMenuItemVariants = cva(
-  'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2 nx:rounded-sm nx:px-2 nx:py-control-sm nx:text-sm nx:outline-none nx:transition-colors nx:focus:bg-popover-hover nx:focus:text-popover-foreground nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+  'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2 nx:rounded-sm nx:px-2 nx:py-1.5 nx:typography-body-small nx:outline-none nx:transition-colors nx:focus:bg-popover-hover nx:focus:text-popover-foreground nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -290,7 +290,7 @@ function ContextMenuCheckboxItem({
       data-slot="context-menu-checkbox-item"
       className={cn(
         'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
-        'nx:rounded-sm nx:py-control-sm nx:pl-8 nx:pr-2 nx:text-sm nx:outline-none',
+        'nx:rounded-sm nx:py-1.5 nx:pl-8 nx:pr-2 nx:typography-body-small nx:outline-none',
         'nx:transition-colors',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
         'nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50',
@@ -341,7 +341,7 @@ function ContextMenuRadioItem({
       data-slot="context-menu-radio-item"
       className={cn(
         'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
-        'nx:rounded-sm nx:py-control-sm nx:pl-8 nx:pr-2 nx:text-sm nx:outline-none',
+        'nx:rounded-sm nx:py-1.5 nx:pl-8 nx:pr-2 nx:typography-body-small nx:outline-none',
         'nx:transition-colors',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
         'nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50',
@@ -394,7 +394,7 @@ function ContextMenuLabel({
       data-slot="context-menu-label"
       data-inset={inset}
       className={cn(
-        'nx:px-2 nx:py-control-sm nx:text-sm nx:font-semibold',
+        'nx:px-2 nx:py-1.5 nx:typography-label-large',
         inset && 'nx:pl-8',
         className
       )}
@@ -460,7 +460,7 @@ function ContextMenuShortcut({
     <span
       data-slot="context-menu-shortcut"
       className={cn(
-        'nx:ml-auto nx:text-xs nx:tracking-widest nx:text-muted-foreground',
+        'nx:ml-auto nx:typography-body-xsmall nx:tracking-widest nx:text-muted-foreground',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

- Replaced ContextMenu role-spacing usage with approved numeric padding where required.
- Migrated ContextMenu raw typography utilities to Nexus typography composites.
- Updated ContextMenu stories to use the matching typography tokens.

## Scope

Changed only:

- `packages/react/src/components/ui/context-menu/context-menu.tsx`
- `packages/react/src/components/ui/context-menu/ContextMenu.stories.tsx`

## Validation

- `pnpm --filter @nexus/react audit:storybook-coverage --component context-menu`
- `pnpm --filter @nexus/react build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm format:check`
- `git diff --check`
- Storybook smoke check on `http://localhost:6006/`

Refs #433
