### PR TITLE
feat(dialog): Tier-A polish — typography, spacing, close button, motion

### DIFF
--- a/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
+++ b/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
@@ -20,6 +20,14 @@ const meta: Meta<typeof AlertDialog> = {
   component: AlertDialog,
   parameters: {
     layout: 'padded',
+    docs: {
+      description: {
+        component: [
+          'Use AlertDialog for consequential confirmations where the user must explicitly confirm or cancel before continuing.',
+          'Use Dialog for lower-stakes modal tasks, Sheet for deterministic edge panels such as settings or filters, and Drawer for gesture-driven mobile-style panels with drag-to-dismiss behavior.',
+        ].join(' '),
+      },
+    },
   },
 };
 

--- a/packages/react/src/components/ui/dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/ui/dialog/Dialog.stories.tsx
@@ -335,7 +335,7 @@ export const WithDataAttributes: Story = {
     await within(document.body).findByRole('dialog');
 
     // Check data-slot attributes using querySelector on document body
-    const closeButton = await waitFor(() => {
+    await waitFor(() => {
       expect(
         document.querySelector('[data-slot="dialog-overlay"]')
       ).toBeInTheDocument();
@@ -357,17 +357,7 @@ export const WithDataAttributes: Story = {
       expect(
         document.querySelector('[data-slot="dialog-close-button"]')
       ).toBeInTheDocument();
-      return document.querySelector(
-        '[data-slot="dialog-close-button"]'
-      ) as HTMLElement;
     });
-
-    await expect(closeButton).toHaveClass(
-      'nx:p-1',
-      'nx:text-muted-foreground-subtle',
-      'nx:after:-inset-2.5',
-      'nx:lg:after:hidden'
-    );
 
     // Close the dialog
     await userEvent.keyboard('{Escape}');
@@ -400,8 +390,7 @@ export const CloseButtonFocus: Story = {
     const dialog = await within(document.body).findByRole('dialog');
     const closeButton = within(dialog).getByRole('button', { name: 'Close' });
 
-    await userEvent.tab();
-    await expect(closeButton).toHaveFocus();
+    await waitFor(() => expect(closeButton).toHaveFocus());
     await expect(closeButton).toHaveClass(
       'nx:focus-visible:outline-2',
       'nx:focus-visible:outline-focus-default',

--- a/packages/react/src/components/ui/dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/ui/dialog/Dialog.stories.tsx
@@ -26,6 +26,14 @@ const meta: Meta<typeof Dialog> = {
   component: Dialog,
   parameters: {
     layout: 'padded',
+    docs: {
+      description: {
+        component: [
+          'Use Dialog for general modal tasks that temporarily interrupt the page and can be dismissed without forcing a choice.',
+          'Use AlertDialog when the user must explicitly confirm or cancel a consequential action, Sheet for deterministic edge panels such as settings or filters, and Drawer for gesture-driven mobile-style panels with drag-to-dismiss behavior.',
+        ].join(' '),
+      },
+    },
   },
 };
 

--- a/packages/react/src/components/ui/dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/ui/dialog/Dialog.stories.tsx
@@ -1,11 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
-import {
-  AllModesGrid,
-  AllModesRow,
-  SPACING_MODES,
-} from '../../../stories/spacing-modes';
 import { Button } from '../button';
 import {
   DropdownMenu,
@@ -332,7 +327,7 @@ export const WithDataAttributes: Story = {
     await within(document.body).findByRole('dialog');
 
     // Check data-slot attributes using querySelector on document body
-    await waitFor(() => {
+    const closeButton = await waitFor(() => {
       expect(
         document.querySelector('[data-slot="dialog-overlay"]')
       ).toBeInTheDocument();
@@ -354,10 +349,61 @@ export const WithDataAttributes: Story = {
       expect(
         document.querySelector('[data-slot="dialog-close-button"]')
       ).toBeInTheDocument();
+      return document.querySelector(
+        '[data-slot="dialog-close-button"]'
+      ) as HTMLElement;
     });
+
+    await expect(closeButton).toHaveClass(
+      'nx:p-1',
+      'nx:text-muted-foreground-subtle',
+      'nx:after:-inset-2.5',
+      'nx:lg:after:hidden'
+    );
 
     // Close the dialog
     await userEvent.keyboard('{Escape}');
+  },
+};
+
+export const CloseButtonFocus: Story = {
+  render: (_args) => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline">Open focus dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Close button focus</DialogTitle>
+          <DialogDescription>
+            The close button keeps the canonical focus outline.
+          </DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Open focus dialog' })
+    );
+
+    const dialog = await within(document.body).findByRole('dialog');
+    const closeButton = within(dialog).getByRole('button', { name: 'Close' });
+
+    await userEvent.tab();
+    await expect(closeButton).toHaveFocus();
+    await expect(closeButton).toHaveClass(
+      'nx:focus-visible:outline-2',
+      'nx:focus-visible:outline-focus-default',
+      'nx:focus-visible:outline-offset-(--focus-offset)'
+    );
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(document.querySelector('[role="dialog"]')).toBeNull();
+    });
   },
 };
 
@@ -592,108 +638,6 @@ export const AllVariants: Story = {
   ),
   parameters: {
     layout: 'padded',
-  },
-};
-
-// ============================================
-// MODE BEHAVIOUR (per-mode spacing variance)
-// ============================================
-
-export const AllModes: Story = {
-  parameters: {
-    a11y: { test: 'off' },
-    docs: {
-      description: {
-        story:
-          "Each row scopes `data-style` locally on the trigger wrapper. `DialogContent` migrates `p-6` → `p-container` and `gap-4` → `gap-container` (24px / 16px match vega byte-identically). DialogContent portals to `document.body`, so opening the dialog from any row resolves to the document-level mode, not the wrapper's — the triggers (Buttons) respond to the wrapper, but the opened dialog renders at the Style-toolbar mode. The `DialogContentResolvesContainerRole` sentinel below verifies the role utilities resolve to the right pixel values at runtime.",
-      },
-    },
-  },
-  render: () => (
-    <AllModesGrid>
-      {SPACING_MODES.map((mode) => (
-        <AllModesRow key={mode} mode={mode}>
-          <Dialog>
-            <DialogTrigger asChild>
-              <Button variant="outline">Open ({mode})</Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Dialog in {mode}</DialogTitle>
-                <DialogDescription>
-                  Padding renders at document-level mode regardless of row.
-                </DialogDescription>
-              </DialogHeader>
-            </DialogContent>
-          </Dialog>
-        </AllModesRow>
-      ))}
-    </AllModesGrid>
-  ),
-};
-
-export const DialogContentResolvesContainerRole: Story = {
-  parameters: {
-    a11y: { test: 'off' },
-    docs: {
-      description: {
-        story:
-          "Regression sentinel — verifies opened `DialogContent` resolves `p-container` to vega's 24px and `gap-container` to vega's 16px. Because content portals to `document.body`, this asserts runtime resolution rather than wrapper cascade (a `toHaveClass` check would survive a `cn()` override and miss the real regression — `getComputedStyle` catches it). Closes the dialog in `finally` via Escape so the open portal does not leak into subsequent stories.",
-      },
-    },
-  },
-  render: () => (
-    <Dialog>
-      <DialogTrigger asChild>
-        <Button variant="outline">Open Dialog</Button>
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Title</DialogTitle>
-          <DialogDescription>Description</DialogDescription>
-        </DialogHeader>
-        <p>Body row</p>
-      </DialogContent>
-    </Dialog>
-  ),
-  play: async ({ canvasElement }) => {
-    await document.fonts.ready;
-    const canvas = within(canvasElement);
-    const trigger = canvas.getByRole('button', { name: 'Open Dialog' });
-    const previousStyle = document.documentElement.dataset.style;
-    document.documentElement.dataset.style = 'vega';
-
-    try {
-      await userEvent.click(trigger);
-
-      const content = await waitFor(() => {
-        const el = document.querySelector<HTMLElement>(
-          '[data-slot="dialog-content"]'
-        );
-        if (!el) throw new Error('dialog content not visible yet');
-        return el;
-      });
-
-      const styles = getComputedStyle(content);
-      expect(styles.paddingTop).toBe('24px');
-      expect(styles.paddingRight).toBe('24px');
-      expect(styles.paddingBottom).toBe('24px');
-      expect(styles.paddingLeft).toBe('24px');
-      expect(styles.rowGap).toBe('16px');
-      expect(styles.columnGap).toBe('16px');
-    } finally {
-      await userEvent.keyboard('{Escape}');
-      await waitFor(() => {
-        expect(
-          document.querySelector('[data-slot="dialog-content"]')
-        ).toBeNull();
-      });
-      if (previousStyle === undefined) {
-        delete document.documentElement.dataset.style;
-      } else {
-        document.documentElement.dataset.style = previousStyle;
-      }
-    }
   },
 };
 

--- a/packages/react/src/components/ui/dialog/dialog.tsx
+++ b/packages/react/src/components/ui/dialog/dialog.tsx
@@ -131,8 +131,6 @@ function DialogContent({
           'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
           'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
           'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',
-          'nx:data-[state=closed]:slide-out-to-left-1/2 nx:data-[state=closed]:slide-out-to-top-[48%]',
-          'nx:data-[state=open]:slide-in-from-left-1/2 nx:data-[state=open]:slide-in-from-top-[48%]',
           'nx:motion-reduce:duration-0 nx:motion-reduce:data-[state=open]:animate-none nx:motion-reduce:data-[state=closed]:animate-none',
           'nx:sm:rounded-lg',
           className

--- a/packages/react/src/components/ui/dialog/dialog.tsx
+++ b/packages/react/src/components/ui/dialog/dialog.tsx
@@ -144,11 +144,12 @@ function DialogContent({
           <DialogPrimitive.Close
             data-slot="dialog-close-button"
             className={cn(
-              'nx:absolute nx:right-4 nx:top-4 nx:rounded-sm nx:opacity-70',
-              'nx:transition-opacity',
+              'nx:absolute nx:right-4 nx:top-4 nx:rounded-sm nx:p-1 nx:text-muted-foreground-subtle',
+              'nx:after:absolute nx:after:-inset-2.5 nx:lg:after:hidden',
+              'nx:transition-colors',
               'nx:motion-reduce:transition-none',
-              'nx:hover:bg-background-hover nx:hover:text-foreground nx:hover:opacity-100',
-              'nx:focus-visible:bg-background-hover nx:focus-visible:text-foreground nx:focus-visible:opacity-100',
+              'nx:hover:bg-background-hover nx:hover:text-foreground',
+              'nx:focus-visible:bg-background-hover nx:focus-visible:text-foreground',
               'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
               'nx:disabled:pointer-events-none'
             )}

--- a/packages/react/src/components/ui/dialog/dialog.tsx
+++ b/packages/react/src/components/ui/dialog/dialog.tsx
@@ -126,7 +126,7 @@ function DialogContent({
         className={cn(
           'nx:fixed nx:left-1/2 nx:top-1/2 nx:z-modal nx:grid nx:w-full nx:max-w-lg',
           'nx:-translate-x-1/2 nx:-translate-y-1/2',
-          'nx:gap-container nx:border nx:border-border-default nx:bg-container nx:p-container nx:shadow-lg',
+          'nx:gap-4 nx:border nx:border-border-default nx:bg-container nx:p-6 nx:shadow-lg',
           'nx:duration-200',
           'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
           'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',

--- a/packages/react/src/components/ui/dialog/dialog.tsx
+++ b/packages/react/src/components/ui/dialog/dialog.tsx
@@ -187,7 +187,7 @@ function DialogHeader({ className, ...props }: DialogHeaderProps) {
     <div
       data-slot="dialog-header"
       className={cn(
-        'nx:flex nx:flex-col nx:gap-1.5 nx:text-center nx:sm:text-left',
+        'nx:flex nx:flex-col nx:gap-1 nx:text-center nx:sm:text-left',
         className
       )}
       {...props}
@@ -251,10 +251,7 @@ function DialogTitle({ className, ...props }: DialogTitleProps) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn(
-        'nx:text-lg nx:font-semibold nx:leading-none nx:tracking-tight',
-        className
-      )}
+      className={cn('nx:typography-heading-xsmall', className)}
       {...props}
     />
   );
@@ -285,7 +282,10 @@ function DialogDescription({ className, ...props }: DialogDescriptionProps) {
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn('nx:text-sm nx:text-muted-foreground', className)}
+      className={cn(
+        'nx:typography-body-small nx:text-muted-foreground',
+        className
+      )}
       {...props}
     />
   );

--- a/packages/react/src/components/ui/drawer/Drawer.stories.tsx
+++ b/packages/react/src/components/ui/drawer/Drawer.stories.tsx
@@ -19,6 +19,14 @@ const meta: Meta<typeof Drawer> = {
   component: Drawer,
   parameters: {
     layout: 'padded',
+    docs: {
+      description: {
+        component: [
+          'Use Drawer for gesture-driven mobile-style panels, especially bottom drawers that can be dragged to dismiss.',
+          'Use Sheet for deterministic side panels, Dialog for centered modal tasks, and AlertDialog for choice-forcing confirmations.',
+        ].join(' '),
+      },
+    },
   },
 };
 

--- a/packages/react/src/components/ui/sheet/Sheet.stories.tsx
+++ b/packages/react/src/components/ui/sheet/Sheet.stories.tsx
@@ -20,6 +20,14 @@ const meta: Meta<typeof Sheet> = {
   component: Sheet,
   parameters: {
     layout: 'padded',
+    docs: {
+      description: {
+        component: [
+          'Use Sheet for deterministic edge panels such as settings, filters, navigation, or supporting forms tied to a viewport side.',
+          'Use Dialog for centered modal tasks, AlertDialog for choice-forcing confirmations, and Drawer for gesture-driven mobile-style panels with drag-to-dismiss behavior.',
+        ].join(' '),
+      },
+    },
   },
 };
 

--- a/packages/react/src/components/ui/sheet/sheet.tsx
+++ b/packages/react/src/components/ui/sheet/sheet.tsx
@@ -91,7 +91,7 @@ function SheetOverlay({ className, ...props }: SheetOverlayProps) {
  */
 const sheetContentVariants = cva(
   cn(
-    'nx:fixed nx:z-modal nx:flex nx:flex-col nx:gap-container',
+    'nx:fixed nx:z-modal nx:flex nx:flex-col nx:gap-4',
     'nx:bg-container nx:shadow-lg nx:ease-in-out',
     'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
     'nx:data-[state=open]:duration-500 nx:data-[state=closed]:duration-300',
@@ -220,7 +220,7 @@ function SheetHeader({ className, ...props }: SheetHeaderProps) {
   return (
     <div
       data-slot="sheet-header"
-      className={cn('nx:flex nx:flex-col nx:gap-1 nx:p-container', className)}
+      className={cn('nx:flex nx:flex-col nx:gap-1 nx:p-6', className)}
       {...props}
     />
   );
@@ -251,7 +251,7 @@ function SheetFooter({ className, ...props }: SheetFooterProps) {
     <div
       data-slot="sheet-footer"
       className={cn(
-        'nx:mt-auto nx:flex nx:flex-col nx:gap-2 nx:p-container',
+        'nx:mt-auto nx:flex nx:flex-col nx:gap-2 nx:p-6',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/sheet/sheet.tsx
+++ b/packages/react/src/components/ui/sheet/sheet.tsx
@@ -177,11 +177,12 @@ function SheetContent({
           <DialogPrimitive.Close
             data-slot="sheet-close-button"
             className={cn(
-              'nx:absolute nx:right-4 nx:top-4 nx:rounded-sm nx:opacity-70',
-              'nx:transition-opacity',
+              'nx:absolute nx:right-4 nx:top-4 nx:rounded-sm nx:p-1 nx:text-muted-foreground-subtle',
+              'nx:after:absolute nx:after:-inset-2.5 nx:lg:after:hidden',
+              'nx:transition-colors',
               'nx:motion-reduce:transition-none',
-              'nx:hover:bg-background-hover nx:hover:text-foreground nx:hover:opacity-100',
-              'nx:focus-visible:bg-background-hover nx:focus-visible:text-foreground nx:focus-visible:opacity-100',
+              'nx:hover:bg-background-hover nx:hover:text-foreground',
+              'nx:focus-visible:bg-background-hover nx:focus-visible:text-foreground',
               'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
               'nx:disabled:pointer-events-none'
             )}

--- a/packages/react/src/components/ui/sheet/sheet.tsx
+++ b/packages/react/src/components/ui/sheet/sheet.tsx
@@ -219,7 +219,7 @@ function SheetHeader({ className, ...props }: SheetHeaderProps) {
   return (
     <div
       data-slot="sheet-header"
-      className={cn('nx:flex nx:flex-col nx:gap-1.5 nx:p-container', className)}
+      className={cn('nx:flex nx:flex-col nx:gap-1 nx:p-container', className)}
       {...props}
     />
   );
@@ -281,10 +281,7 @@ function SheetTitle({ className, ...props }: SheetTitleProps) {
   return (
     <DialogPrimitive.Title
       data-slot="sheet-title"
-      className={cn(
-        'nx:text-lg nx:font-semibold nx:leading-none nx:tracking-tight',
-        className
-      )}
+      className={cn('nx:typography-heading-xsmall', className)}
       {...props}
     />
   );
@@ -315,7 +312,10 @@ function SheetDescription({ className, ...props }: SheetDescriptionProps) {
   return (
     <DialogPrimitive.Description
       data-slot="sheet-description"
-      className={cn('nx:text-sm nx:text-muted-foreground', className)}
+      className={cn(
+        'nx:typography-body-small nx:text-muted-foreground',
+        className
+      )}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

- Align Dialog + Sheet title/description typography to Nexus composites (`typography-heading-xsmall` / `typography-body-small`) and overlay container spacing to numeric tokens (`p-6` / `gap-4`). AlertDialog already landed this in #425.
- Full close-button parity for Dialog + Sheet: 24px tap target (`p-1` + `after:-inset-2.5 lg:after:hidden`), `muted-foreground-subtle` rest colour, colour-based hover.
- Drop the centered slide motion from Dialog (fade + zoom only), matching AlertDialog (slide-free on the base via #425).
- Add Storybook docs language distinguishing Dialog / AlertDialog / Sheet / Drawer; add Dialog close-button focus coverage; drop the obsolete role-spacing mode stories.

## GitHub Issue

Closes #206

## Decisions / context

- **Spacing — #433:** the role → numeric migration (`p-container`/`gap-container` → `p-6`/`gap-4`) is the open decision #433; AlertDialog (#425) and Button (#432) migrated ahead of it. This brings Dialog + Sheet in line with the merged AlertDialog precedent. Drawer/Card/etc. remain on role tokens pending #433.
- **Storybook gate — #429:** play functions do not execute on the `prasad/components-cleanup` lineage until #429 merges, so the new close-button/focus assertions are not yet CI-enforced.

## Validation

- pnpm --filter @nexus/react audit:storybook-coverage --component dialog
- pnpm typecheck / lint / format:check
- git diff --check