### PR TITLE
[codex] Audit Label typography and coverage

### DIFF
--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -83,6 +83,7 @@
     },
     { "name": "InputGroup", "showcase": "AllVariants" },
     { "name": "Item", "showcase": "AllVariants" },
+    { "name": "Label", "showcase": "AllVariants" },
     { "name": "Kbd", "showcase": "AllVariants" },
     {
       "name": "Menubar",

--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -83,8 +83,8 @@
     },
     { "name": "InputGroup", "showcase": "AllVariants" },
     { "name": "Item", "showcase": "AllVariants" },
-    { "name": "Label", "showcase": "AllVariants" },
     { "name": "Kbd", "showcase": "AllVariants" },
+    { "name": "Label", "showcase": "AllVariants" },
     {
       "name": "Menubar",
       "showcase": "AllVariants",

--- a/packages/react/src/components/ui/field/field.tsx
+++ b/packages/react/src/components/ui/field/field.tsx
@@ -191,7 +191,7 @@ function FieldTitle({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="field-label"
       className={cn(
-        'nx:flex nx:w-fit nx:items-center nx:gap-2 nx:text-sm nx:leading-snug nx:font-medium nx:group-data-[disabled=true]/field:opacity-50',
+        'nx:flex nx:w-fit nx:items-center nx:gap-2 nx:typography-label-default nx:group-data-[disabled=true]/field:opacity-50',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/field/field.tsx
+++ b/packages/react/src/components/ui/field/field.tsx
@@ -170,7 +170,7 @@ function FieldLabel({
     <Label
       data-slot="field-label"
       className={cn(
-        'nx:group/field-label nx:peer/field-label nx:flex nx:w-fit nx:gap-2 nx:leading-snug nx:group-data-[disabled=true]/field:opacity-50',
+        'nx:group/field-label nx:peer/field-label nx:flex nx:w-fit nx:gap-2 nx:group-data-[disabled=true]/field:opacity-50',
         'nx:has-[>[data-slot=field]]:w-full nx:has-[>[data-slot=field]]:flex-col nx:has-[>[data-slot=field]]:rounded-md nx:has-[>[data-slot=field]]:border nx:*:data-[slot=field]:p-4',
         'nx:has-data-[state=checked]:border-border-primary nx:has-data-[state=checked]:bg-primary-subtle',
         className

--- a/packages/react/src/components/ui/label/Label.stories.tsx
+++ b/packages/react/src/components/ui/label/Label.stories.tsx
@@ -44,6 +44,16 @@ export const Disabled: Story = {
   ),
 };
 
+export const LongContent: Story = {
+  render: () => (
+    <div className="nx:w-56">
+      <Label>
+        Notification preference for product updates and workspace activity
+      </Label>
+    </div>
+  ),
+};
+
 // ============================================
 // INTERACTION TESTS
 // ============================================
@@ -87,6 +97,12 @@ export const AllVariants: Story = {
   render: () => (
     <div className="nx:flex nx:flex-col nx:gap-4">
       <Label>Default label</Label>
+
+      <div className="nx:w-56">
+        <Label>
+          Notification preference for product updates and workspace activity
+        </Label>
+      </div>
 
       <Label>
         <input type="checkbox" aria-label="Nested checkbox" />

--- a/packages/react/src/components/ui/label/label.tsx
+++ b/packages/react/src/components/ui/label/label.tsx
@@ -30,7 +30,7 @@ function Label({ className, ...props }: LabelProps) {
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        'nx:flex nx:items-center nx:gap-2 nx:select-none nx:text-sm nx:font-medium nx:leading-none nx:text-foreground',
+        'nx:flex nx:items-center nx:gap-2 nx:select-none nx:typography-label-default nx:text-foreground',
         'nx:peer-disabled:cursor-not-allowed nx:peer-disabled:opacity-50',
         className
       )}


### PR DESCRIPTION
## Summary
- Replace Label raw typography utilities with `nx:typography-label-default`.
- Remove the redundant `nx:leading-snug` override from FieldLabel after the Label typography swap.
- Add Label long-content Storybook coverage and include Label in generated base-variant coverage.

## Validation
- `pnpm --filter @nexus/react generate:base-variants`
- `pnpm --filter @nexus/react audit:storybook-coverage --component label`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- Manual Storybook checks on `http://localhost:6006/` for Label long content, Label all variants, Label base variants, Field checkbox card, and Field disabled.

## Notes
- No public API changes.
- Scope is limited to Label, the FieldLabel typography ripple, Label stories, and base-variant config.