### PR TITLE
feat(input-otp): audit component

### DIFF
--- a/packages/react/scripts/base-variants.config.json
+++ b/packages/react/scripts/base-variants.config.json
@@ -82,6 +82,7 @@
       }
     },
     { "name": "InputGroup", "showcase": "AllVariants" },
+    { "name": "InputOtp", "showcase": "AllVariants" },
     { "name": "Item", "showcase": "AllVariants" },
     { "name": "Kbd", "showcase": "AllVariants" },
     {

--- a/packages/react/src/components/ui/input-otp/InputOtp.stories.tsx
+++ b/packages/react/src/components/ui/input-otp/InputOtp.stories.tsx
@@ -68,6 +68,18 @@ export const WithSeparator: Story = {
       </InputOTPGroup>
     </InputOTP>
   ),
+  play: async ({ canvasElement }) => {
+    const separator = canvasElement.querySelector(
+      '[data-slot="input-otp-separator"]'
+    );
+
+    await expect(separator).toBeInTheDocument();
+    await expect(separator).toHaveAttribute('aria-hidden', 'true');
+    await expect(separator).not.toHaveAttribute('role');
+    await expect(
+      canvasElement.querySelectorAll('[data-slot="input-otp-group"]').length
+    ).toBe(2);
+  },
 };
 
 export const Disabled: Story = {
@@ -146,12 +158,15 @@ export const WithDataAttributes: Story = {
     await expect(input).toBeInTheDocument();
     // The data-slot must land on the <input> — every play-fn query depends on it.
     await expect(input?.tagName).toBe('INPUT');
+    await expect(input).toHaveAccessibleName(/one-time password/i);
+    await expect(input).toHaveAttribute('autocomplete', 'one-time-code');
 
     const group = canvasElement.querySelector('[data-slot="input-otp-group"]');
     await expect(group).toBeInTheDocument();
 
-    const slot = canvasElement.querySelector('[data-slot="input-otp-slot"]');
-    await expect(slot).toHaveAttribute('data-slot', 'input-otp-slot');
+    await expect(
+      canvasElement.querySelectorAll('[data-slot="input-otp-slot"]').length
+    ).toBe(6);
   },
 };
 

--- a/packages/react/src/components/ui/input-otp/input-otp.tsx
+++ b/packages/react/src/components/ui/input-otp/input-otp.tsx
@@ -53,8 +53,9 @@ function InputOTP({
   return (
     <OTPInput
       data-slot="input-otp"
+      autoComplete="one-time-code"
       containerClassName={cn(
-        'nx:flex nx:items-center nx:gap-control-md nx:has-[:disabled]:opacity-50',
+        'nx:flex nx:items-center nx:gap-2 nx:has-[:disabled]:opacity-50',
         containerClassName
       )}
       className={cn('nx:disabled:cursor-not-allowed', className)}
@@ -118,7 +119,7 @@ function InputOTPSlot({ index, className, ...props }: InputOTPSlotProps) {
       className={cn(
         'nx:relative nx:flex nx:size-10 nx:items-center nx:justify-center',
         'nx:border-y nx:border-r nx:border-border-default',
-        'nx:bg-background nx:text-foreground nx:text-sm nx:transition-all',
+        'nx:bg-background nx:text-foreground nx:typography-body-small nx:transition-all',
         'nx:first:rounded-l-md nx:first:border-l nx:last:rounded-r-md',
         'nx:data-[active=true]:z-10 nx:data-[active=true]:outline-2 nx:data-[active=true]:outline-focus-default nx:data-[active=true]:outline-offset-(--focus-offset)',
         className
@@ -128,7 +129,7 @@ function InputOTPSlot({ index, className, ...props }: InputOTPSlotProps) {
       {char}
       {hasFakeCaret && (
         <div className="nx:pointer-events-none nx:absolute nx:inset-0 nx:flex nx:items-center nx:justify-center">
-          <div className="nx:h-4 nx:w-px nx:animate-caret-blink nx:bg-foreground nx:duration-1000" />
+          <div className="nx:h-4 nx:w-px nx:animate-caret-blink nx:bg-foreground nx:duration-1000 nx:motion-reduce:animate-none" />
         </div>
       )}
     </div>
@@ -151,14 +152,11 @@ function InputOTPSeparator({ className, ...props }: InputOTPSeparatorProps) {
   return (
     <div
       data-slot="input-otp-separator"
-      role="separator"
+      aria-hidden="true"
       className={cn('nx:flex nx:items-center', className)}
       {...props}
     >
-      <IconPointFilled
-        aria-hidden="true"
-        className="nx:size-2.5 nx:text-muted-foreground"
-      />
+      <IconPointFilled className="nx:size-2.5 nx:text-muted-foreground" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Simplify Input OTP spacing from role-based gap-control-md to numeric gap-2, preserving the default 8px output while removing non-default spacing-mode variance.
- Move the slot character to the typography-body-small composite, make the separator decorative, add reduced-motion handling to the fake caret, and set autocomplete=one-time-code explicitly while preserving consumer overrides.
- Add Input OTP story assertions for the semantic input/separator contract and opt InputOtp into base-variant generation.

## GitHub Issue

Refs #433

## Test Plan

- [x] pnpm --filter @nexus/react audit:storybook-coverage --component input-otp
- [x] pnpm format:check
- [x] pnpm lint
- [x] pnpm typecheck
- [x] pnpm test:storybook exits 0 after regenerating base variants; current Storybook/Vitest setup reports No test files found for the storybook project.

## Spacing Note

The previous gap-control-md value varied by spacing mode: nova 6px, maia 10px, sera 12px, with root/default, mira, vega, luma, and lyra at 8px. gap-2 fixes the gap at 8px. The canonical single InputOTPGroup layout has one flex child, so the root gap is a no-op there; split group layouts keep a fixed slot rhythm because this component has no Figma source to derive a per-mode rhythm from.