### PR TITLE
feat(react): align InputGroup frame with Input fixed-height sizing

### DIFF
--- a/docs/plans/input-group-audit.md
+++ b/docs/plans/input-group-audit.md
@@ -1,0 +1,117 @@
+# InputGroup Audit — Input fixed-height parity (implemented)
+
+> **Status:** Implemented on `aish/component-input-group-audit` (commit `835c70a`),
+> stacked on `aish/component-input-audit` (the completed fixed-height Input).
+> Council-reviewed (4-lens) and advisor-checked before implementation.
+
+## What shipped
+
+Aligns the visible **InputGroup field frame** with the completed fixed-height
+`Input` (`h-8`/`h-10`/`h-12`, `py-0`, semantic state tokens) while preserving
+InputGroup's composition API and native input behavior. Two files changed:
+`input-group.tsx` and `InputGroup.stories.tsx`.
+
+## Hard dependency (sequencing)
+
+The mechanism keys on the **new Input** (`data-size={size ?? 'default'}` +
+`h-8/h-10/h-12` + semantic state tokens). The old Input (`data-size={size}`,
+`py-control-*`, `opacity-50`) makes it inert — a default control emits no
+`data-size`, so the height selector never matches. This branch was therefore
+**fast-forwarded onto `aish/component-input-audit`** (`738c8ed`, a clean FF — the
+audit branch had no unique commits). The eventual PR stacks on the Input audit
+(or lands after it merges into `prasad/components-cleanup`).
+
+## 1. Outer height parity (`sm` h-8 · default h-10 · lg h-12)
+
+The wrapper carries the height, reacting to the control's `data-size` via
+`:has()` — **no new prop** (sized via `<InputGroupInput size>`, mirroring
+`<Input>`). Scoped to the inline (non-block) row so stacked layouts and the
+textarea group are never clipped:
+
+```
+nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:has-[[data-slot=input-group-control][data-size=sm]]:h-8
+…[data-size=default]:h-10
+…[data-size=lg]:h-12
+nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:[&>input]:h-full
+```
+
+- **Border doesn't add height:** `box-sizing: border-box` is in effect
+  (`@import 'tailwindcss'` ships the preflight), so wrapper `h-10` = 40px
+  _including_ its 1px border = exact standalone-Input parity. Confirmed.
+- **Mutually exclusive** scoping — no two `height` rules ever both match (no
+  source-order/specificity footgun).
+- **Child fill from the wrapper, not the child** — `[&>input]:h-full` wins over
+  Input's own `h-*` by selector specificity (compound `:has()` descendant); in
+  the stacked case it's released and the control keeps its own height.
+- **Heights are mode-variant** (`h-8/10/12` = `--nx-spacing-8/10/12`): vega
+  32/40/48, nova 30/38/46, maia 36/44/52. Parity is "same utility, follows the
+  mode," matching Input — verified in `nexus.css`.
+- **Emission verified** in built `dist/react.css`:
+  `:not(:has(>[data-align=block-start])):not(:has(>[data-align=block-end])):has([data-slot=input-group-control][data-size=default]){height:var(--nx-spacing-10,40px)}`
+
+## 2. `InputGroupInput`
+
+Keeps native `<input>` via `Input`; `flex-1 rounded-none border-0 bg-transparent
+focus-visible:outline-none`; passes `size` through (per-size `px`/typography +
+`data-size`). Dropped the redundant `shadow-none` (Input has no shadow). Height
+comes from the wrapper's `[&>input]:h-full` (inline) or Input's own `h-*`
+(stacked).
+
+## 3. Visual-state parity with Input
+
+| State           | Implementation                                                                                                                                                                                         |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Rest surface    | `nx:bg-background` (prerequisite for hover parity)                                                                                                                                                     |
+| Hover           | `nx:not-data-[disabled=true]:hover:bg-background-hover` (matches Input's hover token; a `<div>` is never `:enabled`, so gated on `data-disabled` rather than copying Input's `enabled:hover`)          |
+| Disabled        | `nx:data-[disabled=true]:{bg-disabled,border-border-disabled,cursor-not-allowed}`; addon dims via `group-data-[disabled=true]/input-group:text-disabled-foreground` (semantic, **opacity-50 removed**) |
+| Invalid border  | `nx:has-[[data-slot][aria-invalid=true]]:border-border-error` (unchanged)                                                                                                                              |
+| Invalid + focus | `nx:has-[[data-slot=input-group-control][aria-invalid=true]:focus-visible]:outline-focus-error` (specificity 0,4,0 > the default ring's 0,3,0)                                                         |
+| Shadow          | **removed `nx:shadow-xs`**; `transition-[color,box-shadow]` → `transition-colors` (parity + components.md "inputs rely on border, not shadow")                                                         |
+
+## 4. Scope boundaries (held)
+
+No Button `min-w-*`; no new InputGroup props / Geist-style API (height is
+`:has()`-reactive); **`InputGroupTextarea` unchanged** — the height/fill rules
+are inline+input-scoped, so the textarea (block, auto-height, no `data-size`)
+is untouched (its base-`Textarea` `opacity-50` is a separate audit — disclosed
+cross-control inconsistency); no manual edits to generated base-variant stories.
+
+## Retained from the earlier audit pass
+
+Addon offset canonicalization (`has-[>button]:-ml-2`/`-mr-2`,
+`has-[>kbd]:-ml-1.5`/`-mr-1.5`); `InputGroupButton` typography composite +
+`data-slot="input-group-button"`; `InputGroupText` `data-slot`; the four named
+prop types (`InputGroup/Text/Input/Textarea Props`, repo convention,
+lint-safe via `allowInterfaces: 'with-single-extends'`).
+
+## 5. Stories / tests (mirroring the completed Input)
+
+- **`Sizes`** — sm / default (implicit) / lg, visual.
+- **`HeightsFollowModes`** — vega-scoped; asserts control `data-size` + outer
+  group computed heights 32/40/48 (`expectHeightPinned` with the group selector).
+- **`VisualStateTokens`** — hover class + semantic disabled classes; addon
+  `opacity === '1'` (proves opacity dim is gone).
+- **`Invalid`** — `aria-invalid` attribute + invalid-vs-valid `borderTopColor`
+  differs (always-on error border, focus-independent).
+- **`WithKbd`** — addon `marginRight === '-6px'` (canonical `-1.5` step).
+- **`WithDataAttributes`** — asserts all five slots + control `data-size` +
+  button `data-size`.
+
+> The earlier plan's "assert addon `opacity: 0.5`" item is **flipped**: opacity
+> dimming is gone, so `VisualStateTokens` asserts the semantic token + `opacity
+=== '1'` instead.
+
+## Verification
+
+| Gate                                                                          | Result                                                                       |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `pnpm --filter @nexus/react typecheck`                                        | clean                                                                        |
+| `pnpm lint` (`eslint . --max-warnings 0`)                                     | clean                                                                        |
+| `prettier --check` (changed files)                                            | clean                                                                        |
+| `pnpm --filter @nexus/react audit:storybook-coverage --component input-group` | `0 missing, 0 drift, 2 info` (pre-existing info)                             |
+| CSS emission (`dist/react.css`)                                               | all new utilities emit (height/fill/error-focus/offsets/disabled-text/hover) |
+
+**`#429` caveat:** the storybook vitest gate collects 0 tests on this base
+(the #429 fix isn't in `f17957a`), so the new play-fn pins don't _execute_ until
+#429 lands. Verification meanwhile = typecheck + lint + audit + CSS-emission
+grep + by-hand height math. "Green Test (React)" ≠ interaction tests ran.

--- a/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
+++ b/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
@@ -347,18 +347,26 @@ export const VisualStateTokens: Story = {
     const disabled = canvas.getByTestId('ig-disabled');
     const addon = canvas.getByTestId('ig-disabled-addon');
 
+    // Hover token is wired. CSS :hover can't be driven by synthetic userEvent
+    // (no repo story asserts a hover-driven computed style), so this guards the
+    // token name — it caught a container→background regression in review; the
+    // rule itself is verified at the CSS layer.
     await expect(hover).toHaveClass(
       'nx:not-data-[disabled=true]:hover:bg-background-hover'
     );
-    await expect(disabled).toHaveClass('nx:data-[disabled=true]:bg-disabled');
+
+    // Disabled uses semantic surface tokens, not opacity: the disabled frame's
+    // resolved background differs from the enabled frame, and nothing is dimmed.
     await expect(disabled).toHaveClass(
       'nx:data-[disabled=true]:border-border-disabled'
     );
-    // Addon dims via a semantic colour token, not opacity.
+    await expect(window.getComputedStyle(disabled).backgroundColor).not.toBe(
+      window.getComputedStyle(hover).backgroundColor
+    );
+    await expect(window.getComputedStyle(addon).opacity).toBe('1');
     await expect(addon).toHaveClass(
       'nx:group-data-[disabled=true]/input-group:text-disabled-foreground'
     );
-    await expect(window.getComputedStyle(addon).opacity).toBe('1');
   },
 };
 

--- a/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
+++ b/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
@@ -352,14 +352,11 @@ export const VisualStateTokens: Story = {
       'nx:not-data-[disabled=true]:hover:bg-background-hover'
     );
 
-    // Disabled uses semantic surface tokens, not opacity: the resolved
-    // background differs from the enabled frame, and nothing is dimmed.
+    // Disabled = semantic tokens, not opacity (opacity stays 1). No computed
+    // bg check: bg-disabled / background / -hover collapse in dark mode.
     await expect(disabled).toHaveClass('nx:data-[disabled=true]:bg-disabled');
     await expect(disabled).toHaveClass(
       'nx:data-[disabled=true]:border-border-disabled'
-    );
-    await expect(window.getComputedStyle(disabled).backgroundColor).not.toBe(
-      window.getComputedStyle(hover).backgroundColor
     );
     await expect(window.getComputedStyle(addon).opacity).toBe('1');
     await expect(addon).toHaveClass(

--- a/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
+++ b/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
@@ -347,16 +347,14 @@ export const VisualStateTokens: Story = {
     const disabled = canvas.getByTestId('ig-disabled');
     const addon = canvas.getByTestId('ig-disabled-addon');
 
-    // Hover token is wired. CSS :hover can't be driven by synthetic userEvent
-    // (no repo story asserts a hover-driven computed style), so this guards the
-    // token name — it caught a container→background regression in review; the
-    // rule itself is verified at the CSS layer.
+    // Token-name sentinel: synthetic userEvent can't toggle CSS :hover.
     await expect(hover).toHaveClass(
       'nx:not-data-[disabled=true]:hover:bg-background-hover'
     );
 
-    // Disabled uses semantic surface tokens, not opacity: the disabled frame's
-    // resolved background differs from the enabled frame, and nothing is dimmed.
+    // Disabled uses semantic surface tokens, not opacity: the resolved
+    // background differs from the enabled frame, and nothing is dimmed.
+    await expect(disabled).toHaveClass('nx:data-[disabled=true]:bg-disabled');
     await expect(disabled).toHaveClass(
       'nx:data-[disabled=true]:border-border-disabled'
     );

--- a/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
+++ b/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { IconEye, IconMail, IconSearch, IconX } from '@tabler/icons-react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
+import { expectHeightPinned } from '../../../stories/test-utils';
+
 import {
   InputGroup,
   InputGroupAddon,
@@ -138,14 +140,18 @@ export const WithTextarea: Story = {
   ),
 };
 
-// The group is a role=group field; the control + addon carry data-slot hooks.
+// The group is a role=group field; control, addon, text, and button carry
+// data-slot hooks, and the control mirrors Input's data-size.
 export const WithDataAttributes: Story = {
   render: () => (
     <InputGroup className="nx:w-80">
       <InputGroupAddon>
-        <IconSearch aria-hidden />
+        <InputGroupText>https://</InputGroupText>
       </InputGroupAddon>
-      <InputGroupInput aria-label="Search" placeholder="Search…" />
+      <InputGroupInput aria-label="Site URL" placeholder="nexus.dev" />
+      <InputGroupAddon align="inline-end">
+        <InputGroupButton aria-label="Clear">Clear</InputGroupButton>
+      </InputGroupAddon>
     </InputGroup>
   ),
   play: async ({ canvasElement }) => {
@@ -156,8 +162,20 @@ export const WithDataAttributes: Story = {
       canvasElement.querySelector('[data-slot="input-group-addon"]')
     ).toBeInTheDocument();
     await expect(
-      canvasElement.querySelector('[data-slot="input-group-control"]')
+      canvasElement.querySelector('[data-slot="input-group-text"]')
     ).toBeInTheDocument();
+
+    const control = canvasElement.querySelector(
+      '[data-slot="input-group-control"]'
+    );
+    await expect(control).toBeInTheDocument();
+    await expect(control).toHaveAttribute('data-size', 'default');
+
+    const button = canvasElement.querySelector(
+      '[data-slot="input-group-button"]'
+    );
+    await expect(button).toBeInTheDocument();
+    await expect(button).toHaveAttribute('data-size', 'xs');
   },
 };
 
@@ -217,6 +235,186 @@ export const Disabled: Story = {
     await expect(
       canvas.getByRole('button', { name: 'Subscribe' })
     ).toBeDisabled();
+  },
+};
+
+// The three sizes — sm / default (implicit) / lg — match standalone Input.
+export const Sizes: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-80 nx:flex-col nx:gap-3">
+      <InputGroup>
+        <InputGroupAddon>
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput size="sm" aria-label="Small" placeholder="sm" />
+      </InputGroup>
+      <InputGroup>
+        <InputGroupAddon>
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput
+          aria-label="Default"
+          placeholder="default (implicit)"
+        />
+      </InputGroup>
+      <InputGroup>
+        <InputGroupAddon>
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput size="lg" aria-label="Large" placeholder="lg" />
+      </InputGroup>
+    </div>
+  ),
+};
+
+// The visible frame takes the control's size height (h-8 / h-10 / h-12) so the
+// group is never taller than a standalone Input. Heights follow the active
+// spacing mode like Input, so the px pin is scoped to vega.
+export const HeightsFollowModes: Story = {
+  parameters: { a11y: { test: 'off' } },
+  render: () => (
+    <div
+      data-style="vega"
+      className="nx:flex nx:w-80 nx:flex-col nx:gap-4 nx:bg-background nx:p-10"
+    >
+      <InputGroup data-testid="ig-sm">
+        <InputGroupAddon>
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput size="sm" aria-label="Small" placeholder="sm" />
+      </InputGroup>
+      <InputGroup data-testid="ig-default">
+        <InputGroupAddon>
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Default" placeholder="default" />
+      </InputGroup>
+      <InputGroup data-testid="ig-lg">
+        <InputGroupAddon>
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput size="lg" aria-label="Large" placeholder="lg" />
+      </InputGroup>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const groupSelector = { selector: '[data-slot="input-group"]' };
+
+    // Child carries Input's data-size; the frame follows it.
+    await expect(
+      canvas.getByRole('textbox', { name: 'Small' })
+    ).toHaveAttribute('data-size', 'sm');
+    await expect(
+      canvas.getByRole('textbox', { name: 'Default' })
+    ).toHaveAttribute('data-size', 'default');
+    await expect(
+      canvas.getByRole('textbox', { name: 'Large' })
+    ).toHaveAttribute('data-size', 'lg');
+
+    // Outer group heights (vega): h-8 / h-10 / h-12.
+    await expectHeightPinned(canvas, 'ig-sm', 32, groupSelector);
+    await expectHeightPinned(canvas, 'ig-default', 40, groupSelector);
+    await expectHeightPinned(canvas, 'ig-lg', 48, groupSelector);
+  },
+};
+
+// Hover + disabled map to Input's semantic state tokens — no opacity dimming.
+export const VisualStateTokens: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-80 nx:flex-col nx:gap-3">
+      <InputGroup data-testid="ig-hover">
+        <InputGroupAddon>
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Hover surface" placeholder="hover" />
+      </InputGroup>
+      <InputGroup data-testid="ig-disabled" data-disabled="true">
+        <InputGroupAddon data-testid="ig-disabled-addon">
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput
+          aria-label="Disabled"
+          placeholder="disabled"
+          disabled
+        />
+      </InputGroup>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const hover = canvas.getByTestId('ig-hover');
+    const disabled = canvas.getByTestId('ig-disabled');
+    const addon = canvas.getByTestId('ig-disabled-addon');
+
+    await expect(hover).toHaveClass(
+      'nx:not-data-[disabled=true]:hover:bg-background-hover'
+    );
+    await expect(disabled).toHaveClass('nx:data-[disabled=true]:bg-disabled');
+    await expect(disabled).toHaveClass(
+      'nx:data-[disabled=true]:border-border-disabled'
+    );
+    // Addon dims via a semantic colour token, not opacity.
+    await expect(addon).toHaveClass(
+      'nx:group-data-[disabled=true]/input-group:text-disabled-foreground'
+    );
+    await expect(window.getComputedStyle(addon).opacity).toBe('1');
+  },
+};
+
+// An invalid control reddens the group border (always-on, focus-independent).
+export const Invalid: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-80 nx:flex-col nx:gap-3">
+      <InputGroup data-testid="ig-valid">
+        <InputGroupAddon>
+          <IconMail aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Valid email" placeholder="valid" />
+      </InputGroup>
+      <InputGroup data-testid="ig-invalid">
+        <InputGroupAddon>
+          <IconMail aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput
+          aria-label="Invalid email"
+          placeholder="invalid"
+          aria-invalid
+        />
+      </InputGroup>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('textbox', { name: 'Invalid email' })
+    ).toHaveAttribute('aria-invalid', 'true');
+
+    // Error border fires: the invalid group's border colour differs from valid.
+    const valid = canvas.getByTestId('ig-valid');
+    const invalid = canvas.getByTestId('ig-invalid');
+    await expect(window.getComputedStyle(invalid).borderTopColor).not.toBe(
+      window.getComputedStyle(valid).borderTopColor
+    );
+  },
+};
+
+// A trailing kbd hint pulls toward the field edge by the canonical −1.5 step.
+export const WithKbd: Story = {
+  render: () => (
+    <InputGroup className="nx:w-80">
+      <InputGroupInput aria-label="Search" placeholder="Search…" />
+      <InputGroupAddon align="inline-end" data-testid="ig-kbd-addon">
+        <kbd>⌘K</kbd>
+      </InputGroupAddon>
+    </InputGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // has-[>kbd]:-mr-1.5 → −6px (spacing-1.5 is mode-invariant).
+    await expect(
+      window.getComputedStyle(canvas.getByTestId('ig-kbd-addon')).marginRight
+    ).toBe('-6px');
   },
 };
 

--- a/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
+++ b/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
@@ -2,7 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { IconEye, IconMail, IconSearch, IconX } from '@tabler/icons-react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
-import { expectHeightPinned } from '../../../stories/test-utils';
+import { SPACING_MODES } from '../../../stories/spacing-modes';
+import { expectHeightPerMode } from '../../../stories/test-utils';
 
 import {
   InputGroup,
@@ -267,34 +268,61 @@ export const Sizes: Story = {
   ),
 };
 
-// The visible frame takes the control's size height (h-8 / h-10 / h-12) so the
-// group is never taller than a standalone Input. Heights follow the active
-// spacing mode like Input, so the px pin is scoped to vega.
+// The visible frame takes the control's size height (h-8 / h-10 / h-12), so the
+// group is never taller than a standalone Input. Like Input, those heights
+// follow the active spacing mode, so they are pinned per mode — the same scale
+// as Input, since the frame height is the control's h-*.
+const GROUP_SCALE_HEIGHTS = {
+  sm: { vega: 32, lyra: 32, maia: 36, mira: 32, nova: 30, luma: 32, sera: 32 },
+  default: {
+    vega: 40,
+    lyra: 42,
+    maia: 44,
+    mira: 40,
+    nova: 38,
+    luma: 40,
+    sera: 40,
+  },
+  lg: { vega: 48, lyra: 48, maia: 52, mira: 48, nova: 46, luma: 48, sera: 48 },
+} as const;
+
 export const HeightsFollowModes: Story = {
   parameters: { a11y: { test: 'off' } },
   render: () => (
-    <div
-      data-style="vega"
-      className="nx:flex nx:w-80 nx:flex-col nx:gap-4 nx:bg-background nx:p-10"
-    >
-      <InputGroup data-testid="ig-sm">
-        <InputGroupAddon>
-          <IconSearch aria-hidden />
-        </InputGroupAddon>
-        <InputGroupInput size="sm" aria-label="Small" placeholder="sm" />
-      </InputGroup>
-      <InputGroup data-testid="ig-default">
-        <InputGroupAddon>
-          <IconSearch aria-hidden />
-        </InputGroupAddon>
-        <InputGroupInput aria-label="Default" placeholder="default" />
-      </InputGroup>
-      <InputGroup data-testid="ig-lg">
-        <InputGroupAddon>
-          <IconSearch aria-hidden />
-        </InputGroupAddon>
-        <InputGroupInput size="lg" aria-label="Large" placeholder="lg" />
-      </InputGroup>
+    <div className="nx:flex nx:flex-col nx:gap-4 nx:bg-background nx:p-10">
+      {SPACING_MODES.map((mode) => (
+        <div key={mode} data-style={mode} className="nx:flex nx:gap-4">
+          <InputGroup data-testid={`ig-sm-${mode}`}>
+            <InputGroupAddon>
+              <IconSearch aria-hidden />
+            </InputGroupAddon>
+            <InputGroupInput
+              size="sm"
+              aria-label={`${mode} small`}
+              placeholder="sm"
+            />
+          </InputGroup>
+          <InputGroup data-testid={`ig-default-${mode}`}>
+            <InputGroupAddon>
+              <IconSearch aria-hidden />
+            </InputGroupAddon>
+            <InputGroupInput
+              aria-label={`${mode} default`}
+              placeholder="default"
+            />
+          </InputGroup>
+          <InputGroup data-testid={`ig-lg-${mode}`}>
+            <InputGroupAddon>
+              <IconSearch aria-hidden />
+            </InputGroupAddon>
+            <InputGroupInput
+              size="lg"
+              aria-label={`${mode} large`}
+              placeholder="lg"
+            />
+          </InputGroup>
+        </div>
+      ))}
     </div>
   ),
   play: async ({ canvasElement }) => {
@@ -302,20 +330,31 @@ export const HeightsFollowModes: Story = {
     const groupSelector = { selector: '[data-slot="input-group"]' };
 
     // Child carries Input's data-size; the frame follows it.
-    await expect(
-      canvas.getByRole('textbox', { name: 'Small' })
-    ).toHaveAttribute('data-size', 'sm');
-    await expect(
-      canvas.getByRole('textbox', { name: 'Default' })
-    ).toHaveAttribute('data-size', 'default');
-    await expect(
-      canvas.getByRole('textbox', { name: 'Large' })
-    ).toHaveAttribute('data-size', 'lg');
+    await expect(canvas.getByLabelText('vega default')).toHaveAttribute(
+      'data-size',
+      'default'
+    );
 
-    // Outer group heights (vega): h-8 / h-10 / h-12.
-    await expectHeightPinned(canvas, 'ig-sm', 32, groupSelector);
-    await expectHeightPinned(canvas, 'ig-default', 40, groupSelector);
-    await expectHeightPinned(canvas, 'ig-lg', 48, groupSelector);
+    // Frame heights follow the active spacing mode (h-8 / h-10 / h-12 over
+    // mode-scaled tokens), measured on the group across every mode.
+    await expectHeightPerMode(
+      canvas,
+      'ig-sm',
+      GROUP_SCALE_HEIGHTS.sm,
+      groupSelector
+    );
+    await expectHeightPerMode(
+      canvas,
+      'ig-default',
+      GROUP_SCALE_HEIGHTS.default,
+      groupSelector
+    );
+    await expectHeightPerMode(
+      canvas,
+      'ig-lg',
+      GROUP_SCALE_HEIGHTS.lg,
+      groupSelector
+    );
   },
 };
 

--- a/packages/react/src/components/ui/input-group/input-group.tsx
+++ b/packages/react/src/components/ui/input-group/input-group.tsx
@@ -47,17 +47,17 @@ function InputGroup({ className, ...props }: InputGroupProps) {
       className={cn(
         'nx:group/input-group nx:relative nx:flex nx:w-full nx:min-w-0 nx:items-center nx:rounded-md nx:border nx:border-border-default nx:bg-background nx:transition-colors nx:outline-none',
         // Size: an inline group matches standalone Input's height for the
-        // control's data-size. Scoped to non-stacked layouts (no block addon
-        // present) so the fixed-height rule and the auto-height stacked case are
-        // mutually exclusive — they never both match. Heights follow the active
-        // spacing mode (h-8/h-10/h-12), exactly like Input.
-        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:has-[[data-slot=input-group-control][data-size=sm]]:h-8',
-        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:has-[[data-slot=input-group-control][data-size=default]]:h-10',
-        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:has-[[data-slot=input-group-control][data-size=lg]]:h-12',
+        // control's data-size. `not-has-[>[data-align^=block]]` scopes this to
+        // non-stacked layouts (no block addon) so the fixed-height rule and the
+        // auto-height stacked case are mutually exclusive — they never both
+        // match. Heights follow the active spacing mode (h-8/h-10/h-12), like Input.
+        'nx:not-has-[>[data-align^=block]]:has-[[data-slot=input-group-control][data-size=sm]]:h-8',
+        'nx:not-has-[>[data-align^=block]]:has-[[data-slot=input-group-control][data-size=default]]:h-10',
+        'nx:not-has-[>[data-align^=block]]:has-[[data-slot=input-group-control][data-size=lg]]:h-12',
         // The control fills the fixed-height frame without adding height (the
         // compound :has() selector outranks Input's own h-* by specificity).
         // Released in the stacked case, where the control keeps its own height.
-        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:[&>input]:h-full',
+        'nx:not-has-[>[data-align^=block]]:[&>input]:h-full',
         // Alignment: addons push the control's padding to make room.
         'nx:has-[>[data-align=inline-start]]:[&>input]:pl-2',
         'nx:has-[>[data-align=inline-end]]:[&>input]:pr-2',
@@ -132,7 +132,7 @@ function InputGroupAddon({
 }
 
 const inputGroupButtonVariants = cva(
-  'nx:flex nx:items-center nx:py-0 nx:typography-label-default nx:shadow-none',
+  'nx:flex nx:items-center nx:py-0 nx:typography-label-default nx:shadow-none nx:group-data-[disabled=true]/input-group:text-disabled-foreground',
   {
     variants: {
       size: {

--- a/packages/react/src/components/ui/input-group/input-group.tsx
+++ b/packages/react/src/components/ui/input-group/input-group.tsx
@@ -8,6 +8,13 @@ import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 
 /**
+ * InputGroupProps
+ *
+ * Props for the InputGroup component.
+ */
+interface InputGroupProps extends React.ComponentProps<'div'> {}
+
+/**
  * InputGroup
  *
  * Wraps an input (or textarea) with leading/trailing addons — icons, text,
@@ -16,6 +23,11 @@ import { cn } from '@/lib/utils';
  * more `InputGroupAddon`s (positioned with `align`) around it; the whole group
  * lights up when the control is focused, and reflects the control's invalid
  * state.
+ *
+ * The visible frame matches a standalone `Input`: an inline group takes the
+ * control's `size` height (`sm` / `default` / `lg` → `h-8` / `h-10` / `h-12`),
+ * so the wrapper border never makes the field taller than a bare `Input`.
+ * Stacked (block-aligned) groups stay auto-height.
  *
  * @example
  * ```tsx
@@ -27,23 +39,40 @@ import { cn } from '@/lib/utils';
  * </InputGroup>
  * ```
  */
-function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
+function InputGroup({ className, ...props }: InputGroupProps) {
   return (
     <div
       data-slot="input-group"
       role="group"
       className={cn(
-        'nx:group/input-group nx:relative nx:flex nx:w-full nx:min-w-0 nx:items-center nx:rounded-md nx:border nx:border-border-default nx:shadow-xs nx:transition-[color,box-shadow] nx:outline-none',
+        'nx:group/input-group nx:relative nx:flex nx:w-full nx:min-w-0 nx:items-center nx:rounded-md nx:border nx:border-border-default nx:bg-background nx:transition-colors nx:outline-none',
+        // Size: an inline group matches standalone Input's height for the
+        // control's data-size. Scoped to non-stacked layouts (no block addon
+        // present) so the fixed-height rule and the auto-height stacked case are
+        // mutually exclusive — they never both match. Heights follow the active
+        // spacing mode (h-8/h-10/h-12), exactly like Input.
+        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:has-[[data-slot=input-group-control][data-size=sm]]:h-8',
+        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:has-[[data-slot=input-group-control][data-size=default]]:h-10',
+        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:has-[[data-slot=input-group-control][data-size=lg]]:h-12',
+        // The control fills the fixed-height frame without adding height (the
+        // compound :has() selector outranks Input's own h-* by specificity).
+        // Released in the stacked case, where the control keeps its own height.
+        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:[&>input]:h-full',
         // Alignment: addons push the control's padding to make room.
         'nx:has-[>[data-align=inline-start]]:[&>input]:pl-2',
         'nx:has-[>[data-align=inline-end]]:[&>input]:pr-2',
         'nx:has-[>[data-align=block-start]]:flex-col nx:has-[>[data-align=block-start]]:[&>input]:pb-3',
         'nx:has-[>[data-align=block-end]]:flex-col nx:has-[>[data-align=block-end]]:[&>input]:pt-3',
+        // Hover / disabled: Input's semantic state tokens (no opacity dimming).
+        'nx:not-data-[disabled=true]:hover:bg-background-hover',
+        'nx:data-[disabled=true]:cursor-not-allowed nx:data-[disabled=true]:border-border-disabled nx:data-[disabled=true]:bg-disabled',
         // Focus: the group shows the ring when the inner control is focused
         // (the control suppresses its own outline).
         'nx:has-[[data-slot=input-group-control]:focus-visible]:outline-2 nx:has-[[data-slot=input-group-control]:focus-visible]:outline-focus-default nx:has-[[data-slot=input-group-control]:focus-visible]:outline-offset-(--focus-offset)',
-        // Error: an invalid inner control reddens the group border.
+        // Error: an invalid control reddens the border; an invalid focused
+        // control switches the ring to the error colour (matches Input).
         'nx:has-[[data-slot][aria-invalid=true]]:border-border-error',
+        'nx:has-[[data-slot=input-group-control][aria-invalid=true]:focus-visible]:outline-focus-error',
         className
       )}
       {...props}
@@ -52,14 +81,14 @@ function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
 }
 
 const inputGroupAddonVariants = cva(
-  'nx:flex nx:h-auto nx:cursor-text nx:items-center nx:justify-start nx:gap-2 nx:py-1.5 nx:typography-label-default nx:text-muted-foreground nx:select-none nx:group-data-[disabled=true]/input-group:opacity-50 nx:[&>kbd]:rounded-sm nx:[&>svg]:size-4',
+  'nx:flex nx:h-auto nx:cursor-text nx:items-center nx:justify-start nx:gap-2 nx:py-1.5 nx:typography-label-default nx:text-muted-foreground nx:select-none nx:group-data-[disabled=true]/input-group:text-disabled-foreground nx:[&>kbd]:rounded-sm nx:[&>svg]:size-4',
   {
     variants: {
       align: {
         'inline-start':
-          'nx:order-first nx:pl-3 nx:has-[>button]:ml-[-0.45rem] nx:has-[>kbd]:ml-[-0.35rem]',
+          'nx:order-first nx:pl-3 nx:has-[>button]:-ml-2 nx:has-[>kbd]:-ml-1.5',
         'inline-end':
-          'nx:order-last nx:pr-3 nx:has-[>button]:mr-[-0.45rem] nx:has-[>kbd]:mr-[-0.35rem]',
+          'nx:order-last nx:pr-3 nx:has-[>button]:-mr-2 nx:has-[>kbd]:-mr-1.5',
         'block-start': 'nx:order-first nx:w-full nx:px-3 nx:pt-3',
         'block-end': 'nx:order-last nx:w-full nx:px-3 nx:pb-3',
       },
@@ -103,7 +132,7 @@ function InputGroupAddon({
 }
 
 const inputGroupButtonVariants = cva(
-  'nx:flex nx:items-center nx:py-0 nx:text-sm nx:shadow-none',
+  'nx:flex nx:items-center nx:py-0 nx:typography-label-default nx:shadow-none',
   {
     variants: {
       size: {
@@ -145,6 +174,7 @@ function InputGroupButton({
   return (
     <Button
       type={type}
+      data-slot="input-group-button"
       data-size={size}
       variant={variant}
       className={cn(inputGroupButtonVariants({ size }), className)}
@@ -154,13 +184,21 @@ function InputGroupButton({
 }
 
 /**
+ * InputGroupTextProps
+ *
+ * Props for the InputGroupText component.
+ */
+interface InputGroupTextProps extends React.ComponentProps<'span'> {}
+
+/**
  * InputGroupText
  *
  * Inline addon text — a unit, a label, a prefix.
  */
-function InputGroupText({ className, ...props }: React.ComponentProps<'span'>) {
+function InputGroupText({ className, ...props }: InputGroupTextProps) {
   return (
     <span
+      data-slot="input-group-text"
       className={cn(
         'nx:flex nx:items-center nx:gap-2 nx:typography-body-small nx:text-muted-foreground nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4',
         className
@@ -171,20 +209,25 @@ function InputGroupText({ className, ...props }: React.ComponentProps<'span'>) {
 }
 
 /**
+ * InputGroupInputProps
+ *
+ * Props for the InputGroupInput component.
+ */
+interface InputGroupInputProps extends React.ComponentProps<typeof Input> {}
+
+/**
  * InputGroupInput
  *
  * The text input inside an `InputGroup` — borderless and transparent so the
- * group provides the frame and focus ring.
+ * group provides the frame and focus ring. Keeps `Input`'s per-size padding and
+ * typography; the group supplies the height.
  */
-function InputGroupInput({
-  className,
-  ...props
-}: React.ComponentProps<typeof Input>) {
+function InputGroupInput({ className, ...props }: InputGroupInputProps) {
   return (
     <Input
       data-slot="input-group-control"
       className={cn(
-        'nx:flex-1 nx:rounded-none nx:border-0 nx:bg-transparent nx:shadow-none nx:focus-visible:outline-none',
+        'nx:flex-1 nx:rounded-none nx:border-0 nx:bg-transparent nx:focus-visible:outline-none',
         className
       )}
       {...props}
@@ -193,15 +236,21 @@ function InputGroupInput({
 }
 
 /**
+ * InputGroupTextareaProps
+ *
+ * Props for the InputGroupTextarea component.
+ */
+interface InputGroupTextareaProps extends React.ComponentProps<
+  typeof Textarea
+> {}
+
+/**
  * InputGroupTextarea
  *
  * The textarea inside an `InputGroup` — borderless and transparent so the group
  * provides the frame and focus ring.
  */
-function InputGroupTextarea({
-  className,
-  ...props
-}: React.ComponentProps<typeof Textarea>) {
+function InputGroupTextarea({ className, ...props }: InputGroupTextareaProps) {
   return (
     <Textarea
       data-slot="input-group-control"
@@ -223,6 +272,10 @@ export {
   type InputGroupButtonProps,
   inputGroupButtonVariants,
   InputGroupInput,
+  type InputGroupInputProps,
+  type InputGroupProps,
   InputGroupText,
   InputGroupTextarea,
+  type InputGroupTextareaProps,
+  type InputGroupTextProps,
 };


### PR DESCRIPTION
## Summary

Aligns the visible **InputGroup field frame** with the completed fixed-height `Input` (`h-8`/`h-10`/`h-12`, `py-0`, semantic state tokens), preserving InputGroup's composition API and native input behavior.

- **Height parity** — the wrapper takes the control's `data-size` height via `:has()` (`h-8`/`h-10`/`h-12`), scoped to inline layouts so stacked/textarea groups stay auto-height; the control fills the frame (`[&>input]:h-full`, wins by selector specificity). `box-sizing: border-box` keeps the bordered frame the same height as a bare Input. Heights follow the active spacing mode, exactly like Input.
- **Visual-state parity** — `bg-background` rest + `hover:bg-background-hover` (gated off when disabled, matching Input); semantic disabled tokens (`bg-disabled` / `border-border-disabled`; addon dims via `text-disabled-foreground`, **not opacity**); invalid-focus → `outline-focus-error`; `shadow-xs` removed; `transition-colors`.
- **Tidy-ups** — addon button/kbd pull-ins canonicalized (`-ml-2`/`-mr-2`, `-ml-1.5`/`-mr-1.5`); `InputGroupButton` typography composite + `data-slot="input-group-button"`; `InputGroupText` `data-slot`; named prop types exported.
- **Stories** — `Sizes`, `HeightsFollowModes`, `VisualStateTokens`, `Invalid`, `WithKbd`; `WithDataAttributes` asserts all slots + `data-size`.

## GitHub Issue

Refs #322 — advances the rubric (spacing / optical rhythm, hover / focus states, density-mode behaviour, error state). Motion / easing + enter-exit items (depend on #159) remain, so this does not close it.

## ⚠️ Base / stacking

Base is **`aish/component-input-audit`**, not `main` — the parity mechanism is inert without the new Input's `data-size` default + semantic state tokens (a default control otherwise emits no `data-size`, so the `:has()` height selector never matches). Rebase onto the updated parent once the Input audit merges.

## Test Plan

- [x] `pnpm --filter @nexus/react typecheck`
- [x] `pnpm lint` (`eslint . --max-warnings 0`) / `prettier --check`
- [x] `audit:storybook-coverage --component input-group` → `0 missing, 0 drift`
- [x] CSS emission verified in `dist/react.css` (height / fill / hover / disabled / error-focus / offsets)
- [ ] Storybook interaction pins (`HeightsFollowModes`, `VisualStateTokens`, `Invalid`, `WithKbd`) — **run once #429 lands** (the storybook vitest gate collects 0 tests on this base)

🤖 Generated with [Claude Code](https://claude.com/claude-code)