### PR TITLE
refactor(typography): switch the reference brand to the OS system font stack

### DIFF
--- a/.claude/rules/tokens.md
+++ b/.claude/rules/tokens.md
@@ -56,9 +56,9 @@ CSS output: light values in the `@theme` block, dark overrides in the `.dark` se
 
 The generated global CSS also owns native browser UI theming. `:root` advertises `color-scheme: light dark`, `:root:not(.dark)` pins native controls/scrollbars to light, and `.dark` pins them to dark so browser-rendered UI follows the same class switch as semantic tokens. Native checkbox, radio, range, and progress controls receive `accent-color: var(--color-primary-background)`; custom Nexus controls remain token-styled components. Keep `light-dark()` out of emitted token CSS until it clears the repo browser floor.
 
-## Font loading — variable-font axes
+## Font loading — system stack, no web fonts
 
-A `fontFamily` token can carry `$extensions.nx-font-source` (`type: "google"` with `family`/`weights`/`styles`, or `"system"`) to drive `@import` generation. The `weights` array requests Inter's variable `wght` axis as a single payload. **Only `wght` is requested** — Inter also ships an `opsz` (optical-size) axis, but Google Fonts serves only the axes named in the request URL, so `opsz` is never delivered and the utilities deliberately do **not** emit `font-optical-sizing: auto` (a no-op without the axis loaded). Activating it would mean requesting `opsz` in the import; no token field consumes one today.
+All three families ship as **system fonts**: `font-sans` → the OS `ui-sans-serif` stack, `font-mono` → `ui-monospace`, `font-serif` → Georgia. Because none is a web font, **no Google Fonts `@import` is generated and the design system pulls zero font payload**. The mechanism still exists for re-aiming: a `fontFamily` token's `$extensions.nx-font-source` is either `{ type: "system" }` (emit the `$value` stack verbatim, no import) or `{ type: "google", family, weights, styles }` (drive an `@import url(...)` for that family). `extractGoogleFonts` collects only `type: "google"` families, so a consumer brand can re-aim any family to a hosted face without touching the generator — and with all three `system` today, the import line is omitted entirely.
 
 ## Spacing & CSS-variable gotchas
 
@@ -72,9 +72,9 @@ A `fontFamily` token can carry `$extensions.nx-font-source` (`type: "google"` wi
 
 ## Typography
 
-`typography-*` composite utilities emit `text-wrap: pretty` on the **body tier only** — orphan/widow protection for multi-line copy, unwanted on headings. The two body tiers are `body-default` (14px) and `body-small` (12px). Letter-spacing is uniformly `normal` (0) across all eleven tiers — the lone exception is `label-caps` at `wider` (+0.8px) for all-caps legibility. For inline emphasis in body copy, apply `nx:font-bold` (700); the bold weight is loaded but deliberately not bound to its own composite.
+`typography-*` composite utilities emit `text-wrap: pretty` on the **body tier only** — orphan/widow protection for multi-line copy, unwanted on headings. The two body tiers are `body-default` (14px) and `body-small` (12px). Letter-spacing is uniformly `normal` (0) across all eleven tiers — the lone exception is `label-caps` at `wider` (+0.8px) for all-caps legibility. For inline emphasis in body copy, apply `nx:font-bold` (700) — not bound to its own composite. The scale uses weights 400 / 500 / 600 + 700 for emphasis; **weight 300 is retired** (system fonts don't reliably ship it).
 
-Typography ships a **single scale** (`vega`) on Inter / Georgia / JetBrains Mono — the former `nova` / `maia` density modes were removed, leaving it the lone single-mode token axis (every other axis — base, brand, spacing, shadow, radius, borderwidth — remains multi-mode). Reintroduce a typography mode only behind a real typeface or scale-ratio decision.
+Typography ships a **single scale** (`vega`) on the OS system sans / Georgia / system monospace stacks — the former `nova` / `maia` density modes were removed, leaving it the lone single-mode token axis (every other axis — base, brand, spacing, shadow, radius, borderwidth — remains multi-mode). Reintroduce a typography mode only behind a real typeface or scale-ratio decision.
 
 ## Do Not
 

--- a/.claude/rules/tokens.md
+++ b/.claude/rules/tokens.md
@@ -72,7 +72,7 @@ All three families ship as **system fonts**: `font-sans` → the OS `ui-sans-ser
 
 ## Typography
 
-`typography-*` composite utilities emit `text-wrap: pretty` on the **body tier only** — orphan/widow protection for multi-line copy, unwanted on headings. The two body tiers are `body-default` (14px) and `body-small` (12px). Letter-spacing is uniformly `normal` (0) across all eleven tiers — the lone exception is `label-caps` at `wider` (+0.8px) for all-caps legibility. For inline emphasis in body copy, apply `nx:font-bold` (700) — not bound to its own composite. The scale uses weights 400 / 500 / 600 + 700 for emphasis; **weight 300 is retired** (system fonts don't reliably ship it).
+`typography-*` composite utilities emit `text-wrap: pretty` on the **body tier only** — orphan/widow protection for multi-line copy, unwanted on headings. The two body tiers are `body-default` (14px) and `body-small` (12px). Letter-spacing is uniformly `normal` (0) across all eleven tiers — the lone exception is `label-caps` at `wider` (+0.8px) for all-caps legibility. For inline emphasis in body copy, apply `nx:font-bold` (700) — not bound to its own composite. The scale uses weights 400 / 500 / 600 + 700 for emphasis; **weight 300 is retired from the composite scale** (system fonts don't reliably ship it) — the raw weight primitives keep the full 100–900 ramp.
 
 Typography ships a **single scale** (`vega`) on the OS system sans / Georgia / system monospace stacks — the former `nova` / `maia` density modes were removed, leaving it the lone single-mode token axis (every other axis — base, brand, spacing, shadow, radius, borderwidth — remains multi-mode). Reintroduce a typography mode only behind a real typeface or scale-ratio decision.
 

--- a/apps/console/public/themes/globals.css
+++ b/apps/console/public/themes/globals.css
@@ -10,9 +10,6 @@
  * Color theme switching loads different primitive CSS files; spacing mode
  * switching uses [data-style="X"] on <html> (no file load).
  */
-/* Google Fonts - auto-generated from typography tokens */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
-
 @import 'tailwindcss' prefix(nx);
 @import './color.css';
 @import './focus-default.css';

--- a/apps/console/public/themes/typography-vega.css
+++ b/apps/console/public/themes/typography-vega.css
@@ -1,9 +1,13 @@
 /* typography: vega */
 
 :root {
-  --nx-typography-family-font-sans: Inter;
+  --nx-typography-family-font-sans:
+    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, sans-serif;
   --nx-typography-family-font-serif: Georgia;
-  --nx-typography-family-font-mono: JetBrains Mono;
+  --nx-typography-family-font-mono:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono',
+    monospace;
   --nx-typography-size-xs: 12px;
   --nx-typography-size-sm: 14px;
   --nx-typography-size-base: 16px;

--- a/apps/console/src/styles/globals.css
+++ b/apps/console/src/styles/globals.css
@@ -10,9 +10,6 @@
  * Color theme switching loads different primitive CSS files; spacing mode
  * switching uses [data-style="X"] on <html> (no file load).
  */
-/* Google Fonts - auto-generated from typography tokens */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
-
 @import 'tailwindcss' prefix(nx);
 @import './color.css';
 @import './focus-default.css';

--- a/apps/docs/app/_pages/Typography.tsx
+++ b/apps/docs/app/_pages/Typography.tsx
@@ -87,7 +87,7 @@ const FAMILIES: {
   style?: React.CSSProperties;
 }[] = [
   {
-    name: 'Inter',
+    name: 'System UI',
     role: 'Sans — UI, headings, body',
     sample: 'The quick brown fox jumps over the lazy dog',
   },
@@ -98,7 +98,7 @@ const FAMILIES: {
     style: { fontFamily: 'Georgia, "Times New Roman", serif' },
   },
   {
-    name: 'JetBrains Mono',
+    name: 'System mono',
     role: 'Mono — code, token names, labels',
     sample: 'const token = "--nx-color-primary-background"',
     cls: 'nx:font-mono',
@@ -119,7 +119,8 @@ export function Typography() {
       <p className="nx:typography-body-default nx:text-muted-foreground nx:mt-2 nx:mb-8 nx:max-w-[64ch]">
         One scale for the whole system. Every tier is a composite utility —
         size, weight, line-height, and letter-spacing in one class — built on
-        Inter, with Georgia for editorial accents and JetBrains Mono for code.
+        the OS system font stack, with Georgia for editorial accents and the
+        system monospace stack for code.
       </p>
 
       {/* ── The scale ───────────────────────────────────────── */}

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -85,7 +85,7 @@ export default function Home() {
           <span className="nx:size-1.5 nx:rounded-full nx:bg-primary-background" />
           AI-native design system
         </span>
-        <h1 className="nx:text-[clamp(2.5rem,5vw,3.75rem)] nx:font-light nx:leading-[1.05] nx:tracking-[-0.01em] nx:mt-6 nx:text-balance">
+        <h1 className="nx:text-[clamp(2.5rem,5vw,3.75rem)] nx:font-normal nx:leading-[1.05] nx:tracking-[-0.01em] nx:mt-6 nx:text-balance">
           Design once. Ship every brand.
         </h1>
         <p className="nx:typography-body-default nx:text-muted-foreground nx:mt-5 nx:max-w-[36rem] nx:mx-auto nx:text-pretty">

--- a/apps/docs/public/themes/globals.css
+++ b/apps/docs/public/themes/globals.css
@@ -10,9 +10,6 @@
  * Color theme switching loads different primitive CSS files; spacing mode
  * switching uses [data-style="X"] on <html> (no file load).
  */
-/* Google Fonts - auto-generated from typography tokens */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
-
 @import 'tailwindcss' prefix(nx);
 @import './color.css';
 @import './focus-default.css';

--- a/apps/docs/public/themes/typography-vega.css
+++ b/apps/docs/public/themes/typography-vega.css
@@ -1,9 +1,13 @@
 /* typography: vega */
 
 :root {
-  --nx-typography-family-font-sans: Inter;
+  --nx-typography-family-font-sans:
+    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, sans-serif;
   --nx-typography-family-font-serif: Georgia;
-  --nx-typography-family-font-mono: JetBrains Mono;
+  --nx-typography-family-font-mono:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono',
+    monospace;
   --nx-typography-size-xs: 12px;
   --nx-typography-size-sm: 14px;
   --nx-typography-size-base: 16px;

--- a/packages/core/tokens/primitives/typography/typography-vega.json
+++ b/packages/core/tokens/primitives/typography/typography-vega.json
@@ -1,14 +1,11 @@
 {
   "family": {
     "font-sans": {
-      "$value": "Inter",
+      "$value": "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
       "$type": "fontFamily",
       "$extensions": {
         "nx-font-source": {
-          "type": "google",
-          "family": "Inter",
-          "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
-          "styles": ["normal"]
+          "type": "system"
         }
       }
     },
@@ -22,14 +19,11 @@
       }
     },
     "font-mono": {
-      "$value": "JetBrains Mono",
+      "$value": "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace",
       "$type": "fontFamily",
       "$extensions": {
         "nx-font-source": {
-          "type": "google",
-          "family": "JetBrains+Mono",
-          "weights": [400, 500, 600, 700],
-          "styles": ["normal"]
+          "type": "system"
         }
       }
     }

--- a/packages/react/src/stories/Typography.stories.tsx
+++ b/packages/react/src/stories/Typography.stories.tsx
@@ -136,6 +136,11 @@ const WEIGHT_SAMPLE = 'The quick brown fox';
 const LINE_HEIGHT_SAMPLE =
   'Typography is the art and technique of arranging type to make written language legible, readable, and appealing when displayed.';
 const FAMILY_SAMPLE = 'The quick brown fox jumps over the lazy dog. 0123456789';
+const FAMILY_LABEL: Record<FamilyKey, string> = {
+  'font-sans': 'System UI',
+  'font-serif': 'Georgia',
+  'font-mono': 'System mono',
+};
 
 function formatDimension(d: Dimension) {
   return `${d.value}${d.unit}`;
@@ -321,8 +326,8 @@ export const FontFamilies: Story = {
           Font Families
         </h2>
         <p className="nx:text-muted-foreground nx:typography-body-small nx:max-w-2xl">
-          Sans, serif, and mono font families — Inter, Georgia, and JetBrains
-          Mono.
+          Sans, serif, and mono font families — the OS system stack, Georgia,
+          and the system monospace stack. No web fonts are loaded.
         </p>
       </div>
       <section className="nx:flex nx:flex-col">
@@ -332,7 +337,7 @@ export const FontFamilies: Story = {
             <TokenRow
               key={fk}
               label={fk}
-              value={family}
+              value={FAMILY_LABEL[fk]}
               labelWidth="nx:w-24"
               valueWidth="nx:w-32"
               preview={
@@ -340,7 +345,7 @@ export const FontFamilies: Story = {
                   className="nx:text-foreground"
                   style={{
                     fontSize: 18,
-                    fontFamily: `'${family}', system-ui, sans-serif`,
+                    fontFamily: family,
                   }}
                 >
                   {FAMILY_SAMPLE}

--- a/packages/react/src/stories/test-utils.ts
+++ b/packages/react/src/stories/test-utils.ts
@@ -49,8 +49,10 @@ type HeightMeasurementOptions = {
  * designer retunes of any single mode do not break the test — only a broken
  * cascade does. Consumers in different components can pick different pairs
  * (`nova`+`sera`, `nova`+`maia`, …) to spread coverage across the 7 modes.
- * Awaits `document.fonts.ready` so Inter fallback metrics cannot collapse a
- * one-pixel cascade difference into equality. The optional `selector` is
+ * Awaits `document.fonts.ready` so a loading web-font's fallback metrics
+ * cannot collapse a one-pixel cascade difference into equality — a no-op under
+ * the system-font stack, kept so a brand that re-aims to a web font stays
+ * covered. The optional `selector` is
  * forwarded to `getControlHeight` so non-control elements (e.g. a Card root
  * `<div data-slot="card">`) can be measured.
  */
@@ -68,8 +70,10 @@ export async function expectModeCascadeWorks(
 
 /**
  * Contract pin — asserts that a control rendered under a specific `data-style`
- * scope hits an exact pixel height. Awaits `document.fonts.ready` first; Inter
- * fallback metrics would skew the measurement. The optional `selector` is
+ * scope hits an exact pixel height. Awaits `document.fonts.ready` first; a
+ * loading web-font's fallback metrics would skew the measurement (a no-op
+ * under the system-font stack, kept for brands that re-aim to a web font). The
+ * optional `selector` is
  * forwarded to `getControlHeight` so non-control elements (e.g. a Card root
  * `<div data-slot="card">`) can be measured.
  */

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -6,9 +6,6 @@
  * that can be overridden by .dark selector for theme switching.
  */
 
-/* Google Fonts - auto-generated from typography tokens */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
-
 @import 'tailwindcss' prefix(nx);
 @import './variables.css';
 @import './typography-utilities.css';

--- a/packages/tailwind/variables.css
+++ b/packages/tailwind/variables.css
@@ -417,9 +417,13 @@
   --nx-shadow-inner-layer-1-color: oklch(0 0 0 / 0.0392);
 
   /* typography (vega) */
-  --nx-typography-family-font-sans: Inter;
+  --nx-typography-family-font-sans:
+    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, 'Helvetica Neue', Arial, sans-serif;
   --nx-typography-family-font-serif: Georgia;
-  --nx-typography-family-font-mono: JetBrains Mono;
+  --nx-typography-family-font-mono:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono',
+    monospace;
   --nx-typography-size-xs: 12px;
   --nx-typography-size-sm: 14px;
   --nx-typography-size-base: 16px;


### PR DESCRIPTION
## Summary

Re-aims the **reference brand's** sans and mono families from web fonts to OS **system font stacks**, matching how Stripe and Notion run their authenticated products (their brand faces are marketing-only). Serif (Georgia) was already `system`, so with sans + mono switched too, **no Google font remains and the generated `@import` line disappears entirely** — the design system now pulls **zero web-font payload**.

- `family.font-sans` → `ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif`
- `family.font-mono` → `ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace`
- Both `nx-font-source` → `{ "type": "system" }` (mirrors the existing `font-serif: Georgia` declaration)

The single source edit is `typography-vega.json`; everything else is regenerated (`tokens:tailwind` + `tokens:modular`) or a small hand fix.

**Multi-brand is untouched.** The per-token `nx-font-source` mechanism (`google` | `system`) stays in place, so a consumer brand can still re-aim its typography to Inter or any hosted face without touching the generator — only the *reference brand's* default changed.

### Retired weight 300

System fonts don't reliably ship a 300 (Light), so weight 300 is retired from use:
- docs hero `<h1>`: `nx:font-light` → `nx:font-normal` (was the last 300 consumer)
- `.claude/rules/tokens.md` documents the retirement

The 100–900 primitive ramp is left intact (orphan-tolerant, consistent with the trim PR); only the *use* is removed.

## Intentional tradeoffs (documented, not defects)

- **Weight 500 may render as 400 on some platforms.** A few label tiers (`label-default`, `label-small`) use weight 500 (Medium). Platforms lacking a Medium cut of their system UI font (e.g. Windows 10 Segoe UI) round 500→400, so those labels can lose a little emphasis over 400 body copy. This is the inherent Stripe/Notion system-font tradeoff — macOS (SF), modern Windows (Segoe UI Variable), and Android (Roboto) all ship a real Medium, so it only affects older platforms.
- **Text metrics shift (Inter → system), absorbed by the sizing model.** Glyph metrics differ between Inter and the system stack, but Nexus sizes controls by **padding + explicit px line-height**, never fixed heights or `line-height: normal`. Every control composite (`label-*`, `body-*`, `heading-*`) sets an explicit line-height (16/20/28px) that dominates the glyph content box, so rendered control heights are font-face-independent. Verified against every `expectHeightPinned` / `expectHeightPinnedAcrossModes` / `expectModeCascadeWorks` call site (Accordion, Alert, Badge, Button, ButtonGroup, Card, Input, Select, Tabs) — all pins are line-height-dominated, so this change does not move them.

## Stack

Standalone PR against `prasad/components-cleanup`. The typography trim (#459) and mode collapse (#460) have both since merged into `components-cleanup`, so this rebases directly onto that integration branch. Basing here (not `main`) follows the rest of the typography/component-audit work; retiring weight 300 / fixing the `font-light` hero depends on the merged trim.

## Test Plan

- [x] `pnpm typecheck` (7/7), `lint` (clean, `--max-warnings 0`), `format:check` (clean)
- [x] `pnpm test:unit` (423 passed — incl. the `formatTokenValue` identity-pass for multi-family stacks)
- [x] `pnpm --filter @nexus/react build` · `@nexus/docs build` · `@nexus/console build` — all green
- [x] Built docs + console CSS grepped for `fonts.googleapis` / `Inter` → **0**; system sans stack present in both
- [x] Regenerated from JSON source → **zero drift** vs committed generated CSS (proves the replayed CSS is correct against the merged base)
- [ ] Visual: Storybook `Tokens/Typography` specimen + `FontFamilies` render in the system font; docs hero renders at weight 400