### PR TITLE
refactor(react): clean up form-family field styling

### DIFF
--- a/COMPONENT-REVIEW.md
+++ b/COMPONENT-REVIEW.md
@@ -356,7 +356,7 @@ Numeric spacing notes: list `p-1` (55), sm size `px-2`/`py-1` (105). sm "dense p
 
 Resolved in PR #462: `Textarea` uses `nx:typography-body-default`.
 
-Numeric spacing note: `px-3` (38) stays numeric to preserve the fixed form-field geometry; `py-control-md` remains density-responsive. (`aria-invalid` error-state wiring correctly present, line 40.)
+Numeric spacing note: `px-3`/`py-2` (38) stays numeric to preserve the fixed form-field geometry. (`aria-invalid` error-state wiring correctly present, line 40.)
 
 ## toggle
 

--- a/COMPONENT-REVIEW.md
+++ b/COMPONENT-REVIEW.md
@@ -186,7 +186,7 @@ Numeric spacing notes: `gap-6`/`p-6` (root), `gap-2` (header), `gap-4` (content)
 
 ## field
 
-Typography (raw): `text-sm`/`text-base` (legend, title, description, error, separator) + `font-medium`/`font-normal` → composites.
+Unresolved: raw typography remains in `field.tsx`; the legend's 16px/500 treatment has no size-preserving composite, so `field.tsx` stays out of PR #462.
 
 Obsolete numeric notes: legend caption spacing on `mb-3` (line 59) and separator inset on `-my-2` (line 244) — margins were not flagged. Remove.
 
@@ -194,25 +194,25 @@ Numeric spacing notes: `gap-6` (fieldset), `gap-7` (field-group), `gap-3` (field
 
 ## form
 
-Typography (raw): `FormDescription` / `FormMessage` use `nx:text-sm` → `nx:typography-body-small`.
+Resolved in PR #462: `FormDescription` / `FormMessage` use `nx:typography-body-small`; `className` remains last so consumer typography overrides still win by source order.
 
 Numeric spacing note: `FormItem` `gap-2`.
 
 ## input
 
-Typography (raw): `text-sm`/`text-xs`/`text-base` (sizes) + file `text-sm`/`font-medium` → composites.
+Resolved in PR #462: size typography now uses composites (`sm` → `nx:typography-body-small`, `default`/`lg` → `nx:typography-body-default`, file button → `nx:typography-label-default`).
 
-Minor: `data-size` omitted on default (`size` not defaulted in destructure).
+Resolved in PR #462: `data-size` is emitted for the default size.
 
-Numeric spacing notes: `px-3` (default), `px-2.5` (sm), `px-4` (lg).
+Numeric spacing notes: `px-3` (default), `px-2.5` (sm), `px-3.5` (lg). Horizontal padding stays numeric to preserve the fixed form-field geometry; `px-control-*` would over-widen field insets across looser modes.
 
 ## input-group
 
-Obsolete numeric note (line 36): field-internal addon/control padding rhythm on the `InputGroup` base — its insets are `pl/pr/pb/pt` inside `has-[…]` selectors, none were flagged. Remove.
+Resolved in PR #462: obsolete numeric note on field-internal addon/control padding rhythm removed; those `pl`/`pr`/`pb`/`pt` insets live inside `has-[…]` selectors and were not rule findings.
 
-Minor typography: `InputGroupButton` uses raw `nx:text-sm` (addon/text use composites) → composite.
+Resolved in PR #462: `InputGroupButton` uses `nx:typography-label-default` (addon/text already used composites).
 
-Minor: arbitrary magic offsets `ml-[-0.45rem]`/`mr-[-0.35rem]` (button/kbd pull-in) are un-tokenized.
+Resolved in PR #462: arbitrary pull-in offsets use scale utilities instead of magic values.
 
 Numeric spacing notes: addon `gap-2`/`py-1.5`, block `px-3`, button `gap`/`px`, text `gap-2`, textarea `py-3`.
 
@@ -244,9 +244,9 @@ Numeric spacing notes: root `gap-1`/`p-1`, bar trigger `px-2`/`py-1`, sub-trigge
 
 ## native-select
 
-Typography (raw): `text-sm`/`text-xs` (sizes) → composites.
+Resolved in PR #462: default uses `nx:typography-body-default`; `sm` uses `nx:typography-body-small`.
 
-Numeric spacing notes: `px-3` (default), `px-2.5` (sm).
+Numeric spacing notes: `px-3` (default), `px-2.5` (sm), `pr-9` (chevron clearance). Horizontal padding stays numeric to preserve the fixed form-field geometry; `px-control-*` would over-widen field insets across looser modes.
 
 ## navigation-menu
 
@@ -288,11 +288,11 @@ Handle hit area below floor: `::after` drag target is `after:w-1` (4px) / `after
 
 ## select
 
-Typography (raw): trigger `text-sm` (71), label `text-sm`/`font-semibold` (230), item `text-sm` (263) → composites.
+Resolved in PR #462: `SelectTrigger` and `SelectItem` use `nx:typography-body-default`; `SelectLabel` uses `nx:typography-label-default`. The label intentionally moves from 600 to 500 weight because no 14px/600 composite exists.
 
-Mixed padding convention: vertical uses `py-control-*` role utilities, horizontal uses raw `px-3` (trigger 71) / `px-2` (label 230) — numeric comments restate ("px stays numeric") rather than justify. Likely should be `px-control-*`, or document the real reason.
+Mixed padding convention resolved by documentation: vertical uses `py-control-*` role utilities while horizontal padding stays numeric because `px-control-*` would over-widen form-field insets across looser modes.
 
-Numeric spacing notes: trigger `px-3` (71), scroll-up `py-1` (103), scroll-down `py-1` (127), viewport `p-1` (189), label `px-2` (230).
+Numeric spacing notes: trigger `px-3` (70), scroll-up `py-1` (101), scroll-down `py-1` (124), viewport `p-1` (185), label `px-2` (225).
 
 ## separator
 
@@ -354,9 +354,9 @@ Numeric spacing notes: list `p-1` (55), sm size `px-2`/`py-1` (105). sm "dense p
 
 ## textarea
 
-Typography (raw): `text-sm` (39) → composite.
+Resolved in PR #462: `Textarea` uses `nx:typography-body-default`.
 
-Numeric spacing note: `px-3` (38) — same mixed convention as Input/Select (raw `px` + `py-control-md`). (aria-invalid error-state wiring correctly present, line 41.)
+Numeric spacing note: `px-3` (38) stays numeric to preserve the fixed form-field geometry; `py-control-md` remains density-responsive. (`aria-invalid` error-state wiring correctly present, line 40.)
 
 ## toggle
 

--- a/COMPONENT-REVIEW.md
+++ b/COMPONENT-REVIEW.md
@@ -244,9 +244,9 @@ Numeric spacing notes: root `gap-1`/`p-1`, bar trigger `px-2`/`py-1`, sub-trigge
 
 ## native-select
 
-Resolved in PR #462: default uses `nx:typography-body-default`; `sm` uses `nx:typography-body-small`.
+Resolved in PR #462: default uses `nx:typography-body-default`; `sm` uses `nx:typography-body-small`. Vertical padding also stays numeric (`py-2` / `py-1.5`) to match the Input/InputGroup form-field rhythm.
 
-Numeric spacing notes: `px-3` (default), `px-2.5` (sm), `pr-9` (chevron clearance). Horizontal padding stays numeric to preserve the fixed form-field geometry; `px-control-*` would over-widen field insets across looser modes.
+Numeric spacing notes: `px-3`/`py-2` (default), `px-2.5`/`py-1.5` (sm), `pr-9` (chevron clearance). Padding stays numeric to preserve the fixed form-field geometry; role spacing utilities would over-widen / over-tall field insets across looser modes.
 
 ## navigation-menu
 
@@ -290,9 +290,9 @@ Handle hit area below floor: `::after` drag target is `after:w-1` (4px) / `after
 
 Resolved in PR #462: `SelectTrigger` and `SelectItem` use `nx:typography-body-default`; `SelectLabel` uses `nx:typography-label-default`. The label intentionally moves from 600 to 500 weight because no 14px/600 composite exists.
 
-Mixed padding convention resolved by documentation: vertical uses `py-control-*` role utilities while horizontal padding stays numeric because `px-control-*` would over-widen form-field insets across looser modes.
+Role-spacing follow-up resolved: trigger, label, and item spacing now use numeric utilities, matching the Input/InputGroup form-field rhythm.
 
-Numeric spacing notes: trigger `px-3` (70), scroll-up `py-1` (101), scroll-down `py-1` (124), viewport `p-1` (185), label `px-2` (225).
+Numeric spacing notes: trigger `gap-2`/`px-3`/`py-2` (68/70), scroll-up `py-1` (101), scroll-down `py-1` (124), viewport `p-1` (185), label `px-2`/`py-1.5` (225), item `py-1.5` (258).
 
 ## separator
 

--- a/apps/console/public/themes/base-gray.css
+++ b/apps/console/public/themes/base-gray.css
@@ -34,7 +34,7 @@ html {
   --nx-color-border-default: var(--nx-color-black-a200);
   --nx-color-border-default-alpha: var(--nx-color-gray-a200);
   --nx-color-border-active: var(--nx-color-gray-400);
-  --nx-color-border-disabled: var(--nx-color-gray-50);
+  --nx-color-border-disabled: var(--nx-color-black-a200);
   --nx-color-border-warning: var(--nx-color-orange-200);
   --nx-color-border-warning-active: var(--nx-color-orange-400);
   --nx-color-border-success: var(--nx-color-green-200);
@@ -115,7 +115,7 @@ html.dark {
   --nx-color-border-default: var(--nx-color-white-a300);
   --nx-color-border-default-alpha: var(--nx-color-gray-a300);
   --nx-color-border-active: var(--nx-color-gray-400);
-  --nx-color-border-disabled: var(--nx-color-gray-950);
+  --nx-color-border-disabled: var(--nx-color-white-a300);
   --nx-color-border-warning: var(--nx-color-orange-700);
   --nx-color-border-warning-active: var(--nx-color-orange-500);
   --nx-color-border-success: var(--nx-color-green-700);

--- a/apps/console/public/themes/base-neutral.css
+++ b/apps/console/public/themes/base-neutral.css
@@ -34,7 +34,7 @@ html {
   --nx-color-border-default: var(--nx-color-black-a200);
   --nx-color-border-default-alpha: var(--nx-color-neutral-a200);
   --nx-color-border-active: var(--nx-color-neutral-400);
-  --nx-color-border-disabled: var(--nx-color-neutral-50);
+  --nx-color-border-disabled: var(--nx-color-black-a200);
   --nx-color-border-warning: var(--nx-color-orange-200);
   --nx-color-border-warning-active: var(--nx-color-orange-400);
   --nx-color-border-success: var(--nx-color-green-200);
@@ -115,7 +115,7 @@ html.dark {
   --nx-color-border-default: var(--nx-color-white-a300);
   --nx-color-border-default-alpha: var(--nx-color-neutral-a300);
   --nx-color-border-active: var(--nx-color-neutral-400);
-  --nx-color-border-disabled: var(--nx-color-neutral-950);
+  --nx-color-border-disabled: var(--nx-color-white-a300);
   --nx-color-border-warning: var(--nx-color-orange-700);
   --nx-color-border-warning-active: var(--nx-color-orange-500);
   --nx-color-border-success: var(--nx-color-green-700);

--- a/apps/console/public/themes/base-slate.css
+++ b/apps/console/public/themes/base-slate.css
@@ -34,7 +34,7 @@ html {
   --nx-color-border-default: var(--nx-color-black-a200);
   --nx-color-border-default-alpha: var(--nx-color-slate-a200);
   --nx-color-border-active: var(--nx-color-slate-400);
-  --nx-color-border-disabled: var(--nx-color-slate-50);
+  --nx-color-border-disabled: var(--nx-color-black-a200);
   --nx-color-border-warning: var(--nx-color-orange-200);
   --nx-color-border-warning-active: var(--nx-color-orange-400);
   --nx-color-border-success: var(--nx-color-green-200);
@@ -115,7 +115,7 @@ html.dark {
   --nx-color-border-default: var(--nx-color-white-a300);
   --nx-color-border-default-alpha: var(--nx-color-slate-a300);
   --nx-color-border-active: var(--nx-color-slate-400);
-  --nx-color-border-disabled: var(--nx-color-slate-950);
+  --nx-color-border-disabled: var(--nx-color-white-a300);
   --nx-color-border-warning: var(--nx-color-orange-700);
   --nx-color-border-warning-active: var(--nx-color-orange-500);
   --nx-color-border-success: var(--nx-color-green-700);

--- a/apps/console/public/themes/base-stone.css
+++ b/apps/console/public/themes/base-stone.css
@@ -34,7 +34,7 @@ html {
   --nx-color-border-default: var(--nx-color-black-a200);
   --nx-color-border-default-alpha: var(--nx-color-stone-a200);
   --nx-color-border-active: var(--nx-color-stone-400);
-  --nx-color-border-disabled: var(--nx-color-stone-50);
+  --nx-color-border-disabled: var(--nx-color-black-a200);
   --nx-color-border-warning: var(--nx-color-orange-200);
   --nx-color-border-warning-active: var(--nx-color-orange-400);
   --nx-color-border-success: var(--nx-color-green-200);
@@ -115,7 +115,7 @@ html.dark {
   --nx-color-border-default: var(--nx-color-white-a300);
   --nx-color-border-default-alpha: var(--nx-color-stone-a300);
   --nx-color-border-active: var(--nx-color-stone-400);
-  --nx-color-border-disabled: var(--nx-color-stone-950);
+  --nx-color-border-disabled: var(--nx-color-white-a300);
   --nx-color-border-warning: var(--nx-color-orange-700);
   --nx-color-border-warning-active: var(--nx-color-orange-500);
   --nx-color-border-success: var(--nx-color-green-700);

--- a/apps/console/public/themes/base-zinc.css
+++ b/apps/console/public/themes/base-zinc.css
@@ -34,7 +34,7 @@ html {
   --nx-color-border-default: var(--nx-color-black-a200);
   --nx-color-border-default-alpha: var(--nx-color-zinc-a200);
   --nx-color-border-active: var(--nx-color-zinc-400);
-  --nx-color-border-disabled: var(--nx-color-zinc-50);
+  --nx-color-border-disabled: var(--nx-color-black-a200);
   --nx-color-border-warning: var(--nx-color-orange-200);
   --nx-color-border-warning-active: var(--nx-color-orange-400);
   --nx-color-border-success: var(--nx-color-green-200);
@@ -115,7 +115,7 @@ html.dark {
   --nx-color-border-default: var(--nx-color-white-a300);
   --nx-color-border-default-alpha: var(--nx-color-zinc-a300);
   --nx-color-border-active: var(--nx-color-zinc-400);
-  --nx-color-border-disabled: var(--nx-color-zinc-950);
+  --nx-color-border-disabled: var(--nx-color-white-a300);
   --nx-color-border-warning: var(--nx-color-orange-700);
   --nx-color-border-warning-active: var(--nx-color-orange-500);
   --nx-color-border-success: var(--nx-color-green-700);

--- a/apps/console/public/themes/globals.css
+++ b/apps/console/public/themes/globals.css
@@ -64,7 +64,7 @@
   --color-border-default: var(--nx-color-black-a200);
   --color-border-default-alpha: var(--nx-color-slate-a200);
   --color-border-active: var(--nx-color-slate-400);
-  --color-border-disabled: var(--nx-color-slate-50);
+  --color-border-disabled: var(--nx-color-black-a200);
   --color-border-warning: var(--nx-color-orange-200);
   --color-border-warning-active: var(--nx-color-orange-400);
   --color-border-success: var(--nx-color-green-200);

--- a/apps/console/src/styles/globals.css
+++ b/apps/console/src/styles/globals.css
@@ -64,7 +64,7 @@
   --color-border-default: var(--nx-color-black-a200);
   --color-border-default-alpha: var(--nx-color-slate-a200);
   --color-border-active: var(--nx-color-slate-400);
-  --color-border-disabled: var(--nx-color-slate-50);
+  --color-border-disabled: var(--nx-color-black-a200);
   --color-border-warning: var(--nx-color-orange-200);
   --color-border-warning-active: var(--nx-color-orange-400);
   --color-border-success: var(--nx-color-green-200);

--- a/apps/docs/public/themes/base-gray.css
+++ b/apps/docs/public/themes/base-gray.css
@@ -34,7 +34,7 @@ html {
   --nx-color-border-default: var(--nx-color-black-a200);
   --nx-color-border-default-alpha: var(--nx-color-gray-a200);
   --nx-color-border-active: var(--nx-color-gray-400);
-  --nx-color-border-disabled: var(--nx-color-gray-50);
+  --nx-color-border-disabled: var(--nx-color-black-a200);
   --nx-color-border-warning: var(--nx-color-orange-200);
   --nx-color-border-warning-active: var(--nx-color-orange-400);
   --nx-color-border-success: var(--nx-color-green-200);
@@ -115,7 +115,7 @@ html.dark {
   --nx-color-border-default: var(--nx-color-white-a300);
   --nx-color-border-default-alpha: var(--nx-color-gray-a300);
   --nx-color-border-active: var(--nx-color-gray-400);
-  --nx-color-border-disabled: var(--nx-color-gray-950);
+  --nx-color-border-disabled: var(--nx-color-white-a300);
   --nx-color-border-warning: var(--nx-color-orange-700);
   --nx-color-border-warning-active: var(--nx-color-orange-500);
   --nx-color-border-success: var(--nx-color-green-700);

--- a/apps/docs/public/themes/base-neutral.css
+++ b/apps/docs/public/themes/base-neutral.css
@@ -34,7 +34,7 @@ html {
   --nx-color-border-default: var(--nx-color-black-a200);
   --nx-color-border-default-alpha: var(--nx-color-neutral-a200);
   --nx-color-border-active: var(--nx-color-neutral-400);
-  --nx-color-border-disabled: var(--nx-color-neutral-50);
+  --nx-color-border-disabled: var(--nx-color-black-a200);
   --nx-color-border-warning: var(--nx-color-orange-200);
   --nx-color-border-warning-active: var(--nx-color-orange-400);
   --nx-color-border-success: var(--nx-color-green-200);
@@ -115,7 +115,7 @@ html.dark {
   --nx-color-border-default: var(--nx-color-white-a300);
   --nx-color-border-default-alpha: var(--nx-color-neutral-a300);
   --nx-color-border-active: var(--nx-color-neutral-400);
-  --nx-color-border-disabled: var(--nx-color-neutral-950);
+  --nx-color-border-disabled: var(--nx-color-white-a300);
   --nx-color-border-warning: var(--nx-color-orange-700);
   --nx-color-border-warning-active: var(--nx-color-orange-500);
   --nx-color-border-success: var(--nx-color-green-700);

--- a/apps/docs/public/themes/base-slate.css
+++ b/apps/docs/public/themes/base-slate.css
@@ -34,7 +34,7 @@ html {
   --nx-color-border-default: var(--nx-color-black-a200);
   --nx-color-border-default-alpha: var(--nx-color-slate-a200);
   --nx-color-border-active: var(--nx-color-slate-400);
-  --nx-color-border-disabled: var(--nx-color-slate-50);
+  --nx-color-border-disabled: var(--nx-color-black-a200);
   --nx-color-border-warning: var(--nx-color-orange-200);
   --nx-color-border-warning-active: var(--nx-color-orange-400);
   --nx-color-border-success: var(--nx-color-green-200);
@@ -115,7 +115,7 @@ html.dark {
   --nx-color-border-default: var(--nx-color-white-a300);
   --nx-color-border-default-alpha: var(--nx-color-slate-a300);
   --nx-color-border-active: var(--nx-color-slate-400);
-  --nx-color-border-disabled: var(--nx-color-slate-950);
+  --nx-color-border-disabled: var(--nx-color-white-a300);
   --nx-color-border-warning: var(--nx-color-orange-700);
   --nx-color-border-warning-active: var(--nx-color-orange-500);
   --nx-color-border-success: var(--nx-color-green-700);

--- a/apps/docs/public/themes/base-stone.css
+++ b/apps/docs/public/themes/base-stone.css
@@ -34,7 +34,7 @@ html {
   --nx-color-border-default: var(--nx-color-black-a200);
   --nx-color-border-default-alpha: var(--nx-color-stone-a200);
   --nx-color-border-active: var(--nx-color-stone-400);
-  --nx-color-border-disabled: var(--nx-color-stone-50);
+  --nx-color-border-disabled: var(--nx-color-black-a200);
   --nx-color-border-warning: var(--nx-color-orange-200);
   --nx-color-border-warning-active: var(--nx-color-orange-400);
   --nx-color-border-success: var(--nx-color-green-200);
@@ -115,7 +115,7 @@ html.dark {
   --nx-color-border-default: var(--nx-color-white-a300);
   --nx-color-border-default-alpha: var(--nx-color-stone-a300);
   --nx-color-border-active: var(--nx-color-stone-400);
-  --nx-color-border-disabled: var(--nx-color-stone-950);
+  --nx-color-border-disabled: var(--nx-color-white-a300);
   --nx-color-border-warning: var(--nx-color-orange-700);
   --nx-color-border-warning-active: var(--nx-color-orange-500);
   --nx-color-border-success: var(--nx-color-green-700);

--- a/apps/docs/public/themes/base-zinc.css
+++ b/apps/docs/public/themes/base-zinc.css
@@ -34,7 +34,7 @@ html {
   --nx-color-border-default: var(--nx-color-black-a200);
   --nx-color-border-default-alpha: var(--nx-color-zinc-a200);
   --nx-color-border-active: var(--nx-color-zinc-400);
-  --nx-color-border-disabled: var(--nx-color-zinc-50);
+  --nx-color-border-disabled: var(--nx-color-black-a200);
   --nx-color-border-warning: var(--nx-color-orange-200);
   --nx-color-border-warning-active: var(--nx-color-orange-400);
   --nx-color-border-success: var(--nx-color-green-200);
@@ -115,7 +115,7 @@ html.dark {
   --nx-color-border-default: var(--nx-color-white-a300);
   --nx-color-border-default-alpha: var(--nx-color-zinc-a300);
   --nx-color-border-active: var(--nx-color-zinc-400);
-  --nx-color-border-disabled: var(--nx-color-zinc-950);
+  --nx-color-border-disabled: var(--nx-color-white-a300);
   --nx-color-border-warning: var(--nx-color-orange-700);
   --nx-color-border-warning-active: var(--nx-color-orange-500);
   --nx-color-border-success: var(--nx-color-green-700);

--- a/apps/docs/public/themes/globals.css
+++ b/apps/docs/public/themes/globals.css
@@ -64,7 +64,7 @@
   --color-border-default: var(--nx-color-black-a200);
   --color-border-default-alpha: var(--nx-color-slate-a200);
   --color-border-active: var(--nx-color-slate-400);
-  --color-border-disabled: var(--nx-color-slate-50);
+  --color-border-disabled: var(--nx-color-black-a200);
   --color-border-warning: var(--nx-color-orange-200);
   --color-border-warning-active: var(--nx-color-orange-400);
   --color-border-success: var(--nx-color-green-200);

--- a/docs/plans/input-group-audit.md
+++ b/docs/plans/input-group-audit.md
@@ -1,7 +1,7 @@
 # InputGroup Audit — Input fixed-height parity (implemented)
 
-> **Status:** Implemented on `aish/component-input-group-audit` (commit `835c70a`),
-> stacked on `aish/component-input-audit` (the completed fixed-height Input).
+> **Status:** Implemented and combined with the Input fixed-height audit into a
+> single PR against `prasad/components-cleanup`.
 > Council-reviewed (4-lens) and advisor-checked before implementation.
 
 ## What shipped
@@ -16,10 +16,9 @@ InputGroup's composition API and native input behavior. Two files changed:
 The mechanism keys on the **new Input** (`data-size={size ?? 'default'}` +
 `h-8/h-10/h-12` + semantic state tokens). The old Input (`data-size={size}`,
 `py-control-*`, `opacity-50`) makes it inert — a default control emits no
-`data-size`, so the height selector never matches. This branch was therefore
-**fast-forwarded onto `aish/component-input-audit`** (`738c8ed`, a clean FF — the
-audit branch had no unique commits). The eventual PR stacks on the Input audit
-(or lands after it merges into `prasad/components-cleanup`).
+`data-size`, so the height selector never matches. Because of this dependency, the InputGroup work and the Input fixed-height audit
+ship together in a **single combined PR** to `prasad/components-cleanup` — the
+InputGroup changes cannot land without the new Input.
 
 ## 1. Outer height parity (`sm` h-8 · default h-10 · lg h-12)
 

--- a/docs/plans/input-group-audit.md
+++ b/docs/plans/input-group-audit.md
@@ -1,0 +1,117 @@
+# InputGroup Audit — Input fixed-height parity (implemented)
+
+> **Status:** Implemented on `aish/component-input-group-audit` (commit `835c70a`),
+> stacked on `aish/component-input-audit` (the completed fixed-height Input).
+> Council-reviewed (4-lens) and advisor-checked before implementation.
+
+## What shipped
+
+Aligns the visible **InputGroup field frame** with the completed fixed-height
+`Input` (`h-8`/`h-10`/`h-12`, `py-0`, semantic state tokens) while preserving
+InputGroup's composition API and native input behavior. Two files changed:
+`input-group.tsx` and `InputGroup.stories.tsx`.
+
+## Hard dependency (sequencing)
+
+The mechanism keys on the **new Input** (`data-size={size ?? 'default'}` +
+`h-8/h-10/h-12` + semantic state tokens). The old Input (`data-size={size}`,
+`py-control-*`, `opacity-50`) makes it inert — a default control emits no
+`data-size`, so the height selector never matches. This branch was therefore
+**fast-forwarded onto `aish/component-input-audit`** (`738c8ed`, a clean FF — the
+audit branch had no unique commits). The eventual PR stacks on the Input audit
+(or lands after it merges into `prasad/components-cleanup`).
+
+## 1. Outer height parity (`sm` h-8 · default h-10 · lg h-12)
+
+The wrapper carries the height, reacting to the control's `data-size` via
+`:has()` — **no new prop** (sized via `<InputGroupInput size>`, mirroring
+`<Input>`). Scoped to the inline (non-block) row so stacked layouts and the
+textarea group are never clipped:
+
+```
+nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:has-[[data-slot=input-group-control][data-size=sm]]:h-8
+…[data-size=default]:h-10
+…[data-size=lg]:h-12
+nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:[&>input]:h-full
+```
+
+- **Border doesn't add height:** `box-sizing: border-box` is in effect
+  (`@import 'tailwindcss'` ships the preflight), so wrapper `h-10` = 40px
+  _including_ its 1px border = exact standalone-Input parity. Confirmed.
+- **Mutually exclusive** scoping — no two `height` rules ever both match (no
+  source-order/specificity footgun).
+- **Child fill from the wrapper, not the child** — `[&>input]:h-full` wins over
+  Input's own `h-*` by selector specificity (compound `:has()` descendant); in
+  the stacked case it's released and the control keeps its own height.
+- **Heights are mode-variant** (`h-8/10/12` = `--nx-spacing-8/10/12`): vega
+  32/40/48, nova 30/38/46, maia 36/44/52. Parity is "same utility, follows the
+  mode," matching Input — verified in `nexus.css`.
+- **Emission verified** in built `dist/react.css`:
+  `:not(:has(>[data-align=block-start])):not(:has(>[data-align=block-end])):has([data-slot=input-group-control][data-size=default]){height:var(--nx-spacing-10,40px)}`
+
+## 2. `InputGroupInput`
+
+Keeps native `<input>` via `Input`; `flex-1 rounded-none border-0 bg-transparent
+focus-visible:outline-none`; passes `size` through (per-size `px`/typography +
+`data-size`). Dropped the redundant `shadow-none` (Input has no shadow). Height
+comes from the wrapper's `[&>input]:h-full` (inline) or Input's own `h-*`
+(stacked).
+
+## 3. Visual-state parity with Input
+
+| State           | Implementation                                                                                                                                                                                         |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Rest surface    | `nx:bg-background` (prerequisite for hover parity)                                                                                                                                                     |
+| Hover           | `nx:not-data-[disabled=true]:hover:bg-background-hover` (matches Input's hover token; a `<div>` is never `:enabled`, so gated on `data-disabled` rather than copying Input's `enabled:hover`)          |
+| Disabled        | `nx:data-[disabled=true]:{bg-disabled,border-border-disabled,cursor-not-allowed}`; addon dims via `group-data-[disabled=true]/input-group:text-disabled-foreground` (semantic, **opacity-50 removed**) |
+| Invalid border  | `nx:has-[[data-slot][aria-invalid=true]]:border-border-error` (unchanged)                                                                                                                              |
+| Invalid + focus | `nx:has-[[data-slot=input-group-control][aria-invalid=true]:focus-visible]:outline-focus-error` (specificity 0,4,0 > the default ring's 0,3,0)                                                         |
+| Shadow          | **removed `nx:shadow-xs`**; `transition-[color,box-shadow]` → `transition-colors` (parity + components.md "inputs rely on border, not shadow")                                                         |
+
+## 4. Scope boundaries (held)
+
+No Button `min-w-*`; no new InputGroup props / Geist-style API (height is
+`:has()`-reactive); **`InputGroupTextarea` unchanged** — the height/fill rules
+are inline+input-scoped, so the textarea (block, auto-height, no `data-size`)
+is untouched (its base-`Textarea` `opacity-50` is a separate audit — disclosed
+cross-control inconsistency); no manual edits to generated base-variant stories.
+
+## Retained from the earlier audit pass
+
+Addon offset canonicalization (`has-[>button]:-ml-2`/`-mr-2`,
+`has-[>kbd]:-ml-1.5`/`-mr-1.5`); `InputGroupButton` typography composite +
+`data-slot="input-group-button"`; `InputGroupText` `data-slot`; the four named
+prop types (`InputGroup/Text/Input/Textarea Props`, repo convention,
+lint-safe via `allowInterfaces: 'with-single-extends'`).
+
+## 5. Stories / tests (mirroring the completed Input)
+
+- **`Sizes`** — sm / default (implicit) / lg, visual.
+- **`HeightsFollowModes`** — vega-scoped; asserts control `data-size` + outer
+  group computed heights 32/40/48 (`expectHeightPinned` with the group selector).
+- **`VisualStateTokens`** — hover class + semantic disabled classes; addon
+  `opacity === '1'` (proves opacity dim is gone).
+- **`Invalid`** — `aria-invalid` attribute + invalid-vs-valid `borderTopColor`
+  differs (always-on error border, focus-independent).
+- **`WithKbd`** — addon `marginRight === '-6px'` (canonical `-1.5` step).
+- **`WithDataAttributes`** — asserts all five slots + control `data-size` +
+  button `data-size`.
+
+> The earlier plan's "assert addon `opacity: 0.5`" item is **flipped**: opacity
+> dimming is gone, so `VisualStateTokens` asserts the semantic token + `opacity
+=== '1'` instead.
+
+## Verification
+
+| Gate                                                                          | Result                                                                       |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `pnpm --filter @nexus/react typecheck`                                        | clean                                                                        |
+| `pnpm lint` (`eslint . --max-warnings 0`)                                     | clean                                                                        |
+| `prettier --check` (changed files)                                            | clean                                                                        |
+| `pnpm --filter @nexus/react audit:storybook-coverage --component input-group` | `0 missing, 0 drift, 2 info` (pre-existing info)                             |
+| CSS emission (`dist/react.css`)                                               | all new utilities emit (height/fill/error-focus/offsets/disabled-text/hover) |
+
+**`#429` caveat:** the storybook vitest gate collects 0 tests on this base
+(the #429 fix isn't in `f17957a`), so the new play-fn pins don't _execute_ until
+#429 lands. Verification meanwhile = typecheck + lint + audit + CSS-emission
+grep + by-hand height math. "Green Test (React)" ≠ interaction tests ran.

--- a/packages/core/tokens/semantic/base-gray-dark.json
+++ b/packages/core/tokens/semantic/base-gray-dark.json
@@ -135,7 +135,7 @@
       "$type": "color"
     },
     "disabled": {
-      "$value": "{gray.950}",
+      "$value": "{white.a300}",
       "$type": "color"
     },
     "warning": {

--- a/packages/core/tokens/semantic/base-gray-light.json
+++ b/packages/core/tokens/semantic/base-gray-light.json
@@ -135,7 +135,7 @@
       "$type": "color"
     },
     "disabled": {
-      "$value": "{gray.50}",
+      "$value": "{black.a200}",
       "$type": "color"
     },
     "warning": {

--- a/packages/core/tokens/semantic/base-neutral-dark.json
+++ b/packages/core/tokens/semantic/base-neutral-dark.json
@@ -135,7 +135,7 @@
       "$type": "color"
     },
     "disabled": {
-      "$value": "{neutral.950}",
+      "$value": "{white.a300}",
       "$type": "color"
     },
     "warning": {

--- a/packages/core/tokens/semantic/base-neutral-light.json
+++ b/packages/core/tokens/semantic/base-neutral-light.json
@@ -135,7 +135,7 @@
       "$type": "color"
     },
     "disabled": {
-      "$value": "{neutral.50}",
+      "$value": "{black.a200}",
       "$type": "color"
     },
     "warning": {

--- a/packages/core/tokens/semantic/base-slate-dark.json
+++ b/packages/core/tokens/semantic/base-slate-dark.json
@@ -135,7 +135,7 @@
       "$type": "color"
     },
     "disabled": {
-      "$value": "{slate.950}",
+      "$value": "{white.a300}",
       "$type": "color"
     },
     "warning": {

--- a/packages/core/tokens/semantic/base-slate-light.json
+++ b/packages/core/tokens/semantic/base-slate-light.json
@@ -135,7 +135,7 @@
       "$type": "color"
     },
     "disabled": {
-      "$value": "{slate.50}",
+      "$value": "{black.a200}",
       "$type": "color"
     },
     "warning": {

--- a/packages/core/tokens/semantic/base-stone-dark.json
+++ b/packages/core/tokens/semantic/base-stone-dark.json
@@ -135,7 +135,7 @@
       "$type": "color"
     },
     "disabled": {
-      "$value": "{stone.950}",
+      "$value": "{white.a300}",
       "$type": "color"
     },
     "warning": {

--- a/packages/core/tokens/semantic/base-stone-light.json
+++ b/packages/core/tokens/semantic/base-stone-light.json
@@ -135,7 +135,7 @@
       "$type": "color"
     },
     "disabled": {
-      "$value": "{stone.50}",
+      "$value": "{black.a200}",
       "$type": "color"
     },
     "warning": {

--- a/packages/core/tokens/semantic/base-zinc-dark.json
+++ b/packages/core/tokens/semantic/base-zinc-dark.json
@@ -135,7 +135,7 @@
       "$type": "color"
     },
     "disabled": {
-      "$value": "{zinc.950}",
+      "$value": "{white.a300}",
       "$type": "color"
     },
     "warning": {

--- a/packages/core/tokens/semantic/base-zinc-light.json
+++ b/packages/core/tokens/semantic/base-zinc-light.json
@@ -135,7 +135,7 @@
       "$type": "color"
     },
     "disabled": {
-      "$value": "{zinc.50}",
+      "$value": "{black.a200}",
       "$type": "color"
     },
     "warning": {

--- a/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
+++ b/packages/react/src/components/ui/button-group/ButtonGroup.stories.tsx
@@ -289,7 +289,7 @@ export const MixedChildren: Story = {
     const selectTrigger = canvas.getByTestId('button-group-select-trigger');
 
     await expect(text).toHaveAttribute('data-size', 'lg');
-    await expect(input).not.toHaveAttribute('data-size');
+    await expect(input).toHaveAttribute('data-size', 'default');
     await expect(selectTrigger).not.toHaveAttribute('data-size');
     await expect(
       canvas.getByTestId('button-group-mixed-button')

--- a/packages/react/src/components/ui/form/form.tsx
+++ b/packages/react/src/components/ui/form/form.tsx
@@ -257,7 +257,11 @@ function FormDescription({ className, ...props }: FormDescriptionProps) {
       {...props}
       data-slot="form-description"
       id={formDescriptionId}
-      className={cn('nx:text-sm nx:text-muted-foreground', className)}
+      // Keep className last so consumer typography overrides win by source order.
+      className={cn(
+        'nx:typography-body-small nx:text-muted-foreground',
+        className
+      )}
     />
   );
 }
@@ -291,7 +295,11 @@ function FormMessage({
       aria-atomic="true"
       data-slot="form-message"
       id={formMessageId}
-      className={cn('nx:text-sm nx:text-error-subtle-foreground', className)}
+      // Keep className last so consumer typography overrides win by source order.
+      className={cn(
+        'nx:typography-body-small nx:text-error-subtle-foreground',
+        className
+      )}
     >
       {body}
     </p>

--- a/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
+++ b/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
@@ -372,6 +372,7 @@ export const VisualStateTokens: Story = {
         <InputGroupAddon data-testid="ig-disabled-addon">
           <IconSearch aria-hidden />
         </InputGroupAddon>
+        <InputGroupText data-testid="ig-disabled-text">USD</InputGroupText>
         <InputGroupInput
           aria-label="Disabled"
           placeholder="disabled"
@@ -385,6 +386,7 @@ export const VisualStateTokens: Story = {
     const hover = canvas.getByTestId('ig-hover');
     const disabled = canvas.getByTestId('ig-disabled');
     const addon = canvas.getByTestId('ig-disabled-addon');
+    const text = canvas.getByTestId('ig-disabled-text');
 
     // Token-name sentinel: synthetic userEvent can't toggle CSS :hover.
     await expect(hover).toHaveClass(
@@ -399,6 +401,9 @@ export const VisualStateTokens: Story = {
     );
     await expect(window.getComputedStyle(addon).opacity).toBe('1');
     await expect(addon).toHaveClass(
+      'nx:group-data-[disabled=true]/input-group:text-disabled-foreground'
+    );
+    await expect(text).toHaveClass(
       'nx:group-data-[disabled=true]/input-group:text-disabled-foreground'
     );
   },

--- a/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
+++ b/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
@@ -347,18 +347,26 @@ export const VisualStateTokens: Story = {
     const disabled = canvas.getByTestId('ig-disabled');
     const addon = canvas.getByTestId('ig-disabled-addon');
 
+    // Hover token is wired. CSS :hover can't be driven by synthetic userEvent
+    // (no repo story asserts a hover-driven computed style), so this guards the
+    // token name — it caught a container→background regression in review; the
+    // rule itself is verified at the CSS layer.
     await expect(hover).toHaveClass(
       'nx:not-data-[disabled=true]:hover:bg-background-hover'
     );
-    await expect(disabled).toHaveClass('nx:data-[disabled=true]:bg-disabled');
+
+    // Disabled uses semantic surface tokens, not opacity: the disabled frame's
+    // resolved background differs from the enabled frame, and nothing is dimmed.
     await expect(disabled).toHaveClass(
       'nx:data-[disabled=true]:border-border-disabled'
     );
-    // Addon dims via a semantic colour token, not opacity.
+    await expect(window.getComputedStyle(disabled).backgroundColor).not.toBe(
+      window.getComputedStyle(hover).backgroundColor
+    );
+    await expect(window.getComputedStyle(addon).opacity).toBe('1');
     await expect(addon).toHaveClass(
       'nx:group-data-[disabled=true]/input-group:text-disabled-foreground'
     );
-    await expect(window.getComputedStyle(addon).opacity).toBe('1');
   },
 };
 

--- a/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
+++ b/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
@@ -352,14 +352,11 @@ export const VisualStateTokens: Story = {
       'nx:not-data-[disabled=true]:hover:bg-background-hover'
     );
 
-    // Disabled uses semantic surface tokens, not opacity: the resolved
-    // background differs from the enabled frame, and nothing is dimmed.
+    // Disabled = semantic tokens, not opacity (opacity stays 1). No computed
+    // bg check: bg-disabled / background / -hover collapse in dark mode.
     await expect(disabled).toHaveClass('nx:data-[disabled=true]:bg-disabled');
     await expect(disabled).toHaveClass(
       'nx:data-[disabled=true]:border-border-disabled'
-    );
-    await expect(window.getComputedStyle(disabled).backgroundColor).not.toBe(
-      window.getComputedStyle(hover).backgroundColor
     );
     await expect(window.getComputedStyle(addon).opacity).toBe('1');
     await expect(addon).toHaveClass(

--- a/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
+++ b/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
@@ -347,16 +347,14 @@ export const VisualStateTokens: Story = {
     const disabled = canvas.getByTestId('ig-disabled');
     const addon = canvas.getByTestId('ig-disabled-addon');
 
-    // Hover token is wired. CSS :hover can't be driven by synthetic userEvent
-    // (no repo story asserts a hover-driven computed style), so this guards the
-    // token name — it caught a container→background regression in review; the
-    // rule itself is verified at the CSS layer.
+    // Token-name sentinel: synthetic userEvent can't toggle CSS :hover.
     await expect(hover).toHaveClass(
       'nx:not-data-[disabled=true]:hover:bg-background-hover'
     );
 
-    // Disabled uses semantic surface tokens, not opacity: the disabled frame's
-    // resolved background differs from the enabled frame, and nothing is dimmed.
+    // Disabled uses semantic surface tokens, not opacity: the resolved
+    // background differs from the enabled frame, and nothing is dimmed.
+    await expect(disabled).toHaveClass('nx:data-[disabled=true]:bg-disabled');
     await expect(disabled).toHaveClass(
       'nx:data-[disabled=true]:border-border-disabled'
     );

--- a/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
+++ b/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { IconEye, IconMail, IconSearch, IconX } from '@tabler/icons-react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
+import { expectHeightPinned } from '../../../stories/test-utils';
+
 import {
   InputGroup,
   InputGroupAddon,
@@ -138,14 +140,18 @@ export const WithTextarea: Story = {
   ),
 };
 
-// The group is a role=group field; the control + addon carry data-slot hooks.
+// The group is a role=group field; control, addon, text, and button carry
+// data-slot hooks, and the control mirrors Input's data-size.
 export const WithDataAttributes: Story = {
   render: () => (
     <InputGroup className="nx:w-80">
       <InputGroupAddon>
-        <IconSearch aria-hidden />
+        <InputGroupText>https://</InputGroupText>
       </InputGroupAddon>
-      <InputGroupInput aria-label="Search" placeholder="Search…" />
+      <InputGroupInput aria-label="Site URL" placeholder="nexus.dev" />
+      <InputGroupAddon align="inline-end">
+        <InputGroupButton aria-label="Clear">Clear</InputGroupButton>
+      </InputGroupAddon>
     </InputGroup>
   ),
   play: async ({ canvasElement }) => {
@@ -156,8 +162,20 @@ export const WithDataAttributes: Story = {
       canvasElement.querySelector('[data-slot="input-group-addon"]')
     ).toBeInTheDocument();
     await expect(
-      canvasElement.querySelector('[data-slot="input-group-control"]')
+      canvasElement.querySelector('[data-slot="input-group-text"]')
     ).toBeInTheDocument();
+
+    const control = canvasElement.querySelector(
+      '[data-slot="input-group-control"]'
+    );
+    await expect(control).toBeInTheDocument();
+    await expect(control).toHaveAttribute('data-size', 'default');
+
+    const button = canvasElement.querySelector(
+      '[data-slot="input-group-button"]'
+    );
+    await expect(button).toBeInTheDocument();
+    await expect(button).toHaveAttribute('data-size', 'xs');
   },
 };
 
@@ -217,6 +235,186 @@ export const Disabled: Story = {
     await expect(
       canvas.getByRole('button', { name: 'Subscribe' })
     ).toBeDisabled();
+  },
+};
+
+// The three sizes — sm / default (implicit) / lg — match standalone Input.
+export const Sizes: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-80 nx:flex-col nx:gap-3">
+      <InputGroup>
+        <InputGroupAddon>
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput size="sm" aria-label="Small" placeholder="sm" />
+      </InputGroup>
+      <InputGroup>
+        <InputGroupAddon>
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput
+          aria-label="Default"
+          placeholder="default (implicit)"
+        />
+      </InputGroup>
+      <InputGroup>
+        <InputGroupAddon>
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput size="lg" aria-label="Large" placeholder="lg" />
+      </InputGroup>
+    </div>
+  ),
+};
+
+// The visible frame takes the control's size height (h-8 / h-10 / h-12) so the
+// group is never taller than a standalone Input. Heights follow the active
+// spacing mode like Input, so the px pin is scoped to vega.
+export const HeightsFollowModes: Story = {
+  parameters: { a11y: { test: 'off' } },
+  render: () => (
+    <div
+      data-style="vega"
+      className="nx:flex nx:w-80 nx:flex-col nx:gap-4 nx:bg-background nx:p-10"
+    >
+      <InputGroup data-testid="ig-sm">
+        <InputGroupAddon>
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput size="sm" aria-label="Small" placeholder="sm" />
+      </InputGroup>
+      <InputGroup data-testid="ig-default">
+        <InputGroupAddon>
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Default" placeholder="default" />
+      </InputGroup>
+      <InputGroup data-testid="ig-lg">
+        <InputGroupAddon>
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput size="lg" aria-label="Large" placeholder="lg" />
+      </InputGroup>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const groupSelector = { selector: '[data-slot="input-group"]' };
+
+    // Child carries Input's data-size; the frame follows it.
+    await expect(
+      canvas.getByRole('textbox', { name: 'Small' })
+    ).toHaveAttribute('data-size', 'sm');
+    await expect(
+      canvas.getByRole('textbox', { name: 'Default' })
+    ).toHaveAttribute('data-size', 'default');
+    await expect(
+      canvas.getByRole('textbox', { name: 'Large' })
+    ).toHaveAttribute('data-size', 'lg');
+
+    // Outer group heights (vega): h-8 / h-10 / h-12.
+    await expectHeightPinned(canvas, 'ig-sm', 32, groupSelector);
+    await expectHeightPinned(canvas, 'ig-default', 40, groupSelector);
+    await expectHeightPinned(canvas, 'ig-lg', 48, groupSelector);
+  },
+};
+
+// Hover + disabled map to Input's semantic state tokens — no opacity dimming.
+export const VisualStateTokens: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-80 nx:flex-col nx:gap-3">
+      <InputGroup data-testid="ig-hover">
+        <InputGroupAddon>
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Hover surface" placeholder="hover" />
+      </InputGroup>
+      <InputGroup data-testid="ig-disabled" data-disabled="true">
+        <InputGroupAddon data-testid="ig-disabled-addon">
+          <IconSearch aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput
+          aria-label="Disabled"
+          placeholder="disabled"
+          disabled
+        />
+      </InputGroup>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const hover = canvas.getByTestId('ig-hover');
+    const disabled = canvas.getByTestId('ig-disabled');
+    const addon = canvas.getByTestId('ig-disabled-addon');
+
+    await expect(hover).toHaveClass(
+      'nx:not-data-[disabled=true]:hover:bg-background-hover'
+    );
+    await expect(disabled).toHaveClass('nx:data-[disabled=true]:bg-disabled');
+    await expect(disabled).toHaveClass(
+      'nx:data-[disabled=true]:border-border-disabled'
+    );
+    // Addon dims via a semantic colour token, not opacity.
+    await expect(addon).toHaveClass(
+      'nx:group-data-[disabled=true]/input-group:text-disabled-foreground'
+    );
+    await expect(window.getComputedStyle(addon).opacity).toBe('1');
+  },
+};
+
+// An invalid control reddens the group border (always-on, focus-independent).
+export const Invalid: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-80 nx:flex-col nx:gap-3">
+      <InputGroup data-testid="ig-valid">
+        <InputGroupAddon>
+          <IconMail aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput aria-label="Valid email" placeholder="valid" />
+      </InputGroup>
+      <InputGroup data-testid="ig-invalid">
+        <InputGroupAddon>
+          <IconMail aria-hidden />
+        </InputGroupAddon>
+        <InputGroupInput
+          aria-label="Invalid email"
+          placeholder="invalid"
+          aria-invalid
+        />
+      </InputGroup>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('textbox', { name: 'Invalid email' })
+    ).toHaveAttribute('aria-invalid', 'true');
+
+    // Error border fires: the invalid group's border colour differs from valid.
+    const valid = canvas.getByTestId('ig-valid');
+    const invalid = canvas.getByTestId('ig-invalid');
+    await expect(window.getComputedStyle(invalid).borderTopColor).not.toBe(
+      window.getComputedStyle(valid).borderTopColor
+    );
+  },
+};
+
+// A trailing kbd hint pulls toward the field edge by the canonical −1.5 step.
+export const WithKbd: Story = {
+  render: () => (
+    <InputGroup className="nx:w-80">
+      <InputGroupInput aria-label="Search" placeholder="Search…" />
+      <InputGroupAddon align="inline-end" data-testid="ig-kbd-addon">
+        <kbd>⌘K</kbd>
+      </InputGroupAddon>
+    </InputGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // has-[>kbd]:-mr-1.5 → −6px (spacing-1.5 is mode-invariant).
+    await expect(
+      window.getComputedStyle(canvas.getByTestId('ig-kbd-addon')).marginRight
+    ).toBe('-6px');
   },
 };
 

--- a/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
+++ b/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
@@ -2,7 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { IconEye, IconMail, IconSearch, IconX } from '@tabler/icons-react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
-import { expectHeightPinned } from '../../../stories/test-utils';
+import { SPACING_MODES } from '../../../stories/spacing-modes';
+import { expectHeightPerMode } from '../../../stories/test-utils';
 
 import {
   InputGroup,
@@ -267,34 +268,61 @@ export const Sizes: Story = {
   ),
 };
 
-// The visible frame takes the control's size height (h-8 / h-10 / h-12) so the
-// group is never taller than a standalone Input. Heights follow the active
-// spacing mode like Input, so the px pin is scoped to vega.
+// The visible frame takes the control's size height (h-8 / h-10 / h-12), so the
+// group is never taller than a standalone Input. Like Input, those heights
+// follow the active spacing mode, so they are pinned per mode — the same scale
+// as Input, since the frame height is the control's h-*.
+const GROUP_SCALE_HEIGHTS = {
+  sm: { vega: 32, lyra: 32, maia: 36, mira: 32, nova: 30, luma: 32, sera: 32 },
+  default: {
+    vega: 40,
+    lyra: 42,
+    maia: 44,
+    mira: 40,
+    nova: 38,
+    luma: 40,
+    sera: 40,
+  },
+  lg: { vega: 48, lyra: 48, maia: 52, mira: 48, nova: 46, luma: 48, sera: 48 },
+} as const;
+
 export const HeightsFollowModes: Story = {
   parameters: { a11y: { test: 'off' } },
   render: () => (
-    <div
-      data-style="vega"
-      className="nx:flex nx:w-80 nx:flex-col nx:gap-4 nx:bg-background nx:p-10"
-    >
-      <InputGroup data-testid="ig-sm">
-        <InputGroupAddon>
-          <IconSearch aria-hidden />
-        </InputGroupAddon>
-        <InputGroupInput size="sm" aria-label="Small" placeholder="sm" />
-      </InputGroup>
-      <InputGroup data-testid="ig-default">
-        <InputGroupAddon>
-          <IconSearch aria-hidden />
-        </InputGroupAddon>
-        <InputGroupInput aria-label="Default" placeholder="default" />
-      </InputGroup>
-      <InputGroup data-testid="ig-lg">
-        <InputGroupAddon>
-          <IconSearch aria-hidden />
-        </InputGroupAddon>
-        <InputGroupInput size="lg" aria-label="Large" placeholder="lg" />
-      </InputGroup>
+    <div className="nx:flex nx:flex-col nx:gap-4 nx:bg-background nx:p-10">
+      {SPACING_MODES.map((mode) => (
+        <div key={mode} data-style={mode} className="nx:flex nx:gap-4">
+          <InputGroup data-testid={`ig-sm-${mode}`}>
+            <InputGroupAddon>
+              <IconSearch aria-hidden />
+            </InputGroupAddon>
+            <InputGroupInput
+              size="sm"
+              aria-label={`${mode} small`}
+              placeholder="sm"
+            />
+          </InputGroup>
+          <InputGroup data-testid={`ig-default-${mode}`}>
+            <InputGroupAddon>
+              <IconSearch aria-hidden />
+            </InputGroupAddon>
+            <InputGroupInput
+              aria-label={`${mode} default`}
+              placeholder="default"
+            />
+          </InputGroup>
+          <InputGroup data-testid={`ig-lg-${mode}`}>
+            <InputGroupAddon>
+              <IconSearch aria-hidden />
+            </InputGroupAddon>
+            <InputGroupInput
+              size="lg"
+              aria-label={`${mode} large`}
+              placeholder="lg"
+            />
+          </InputGroup>
+        </div>
+      ))}
     </div>
   ),
   play: async ({ canvasElement }) => {
@@ -302,20 +330,31 @@ export const HeightsFollowModes: Story = {
     const groupSelector = { selector: '[data-slot="input-group"]' };
 
     // Child carries Input's data-size; the frame follows it.
-    await expect(
-      canvas.getByRole('textbox', { name: 'Small' })
-    ).toHaveAttribute('data-size', 'sm');
-    await expect(
-      canvas.getByRole('textbox', { name: 'Default' })
-    ).toHaveAttribute('data-size', 'default');
-    await expect(
-      canvas.getByRole('textbox', { name: 'Large' })
-    ).toHaveAttribute('data-size', 'lg');
+    await expect(canvas.getByLabelText('vega default')).toHaveAttribute(
+      'data-size',
+      'default'
+    );
 
-    // Outer group heights (vega): h-8 / h-10 / h-12.
-    await expectHeightPinned(canvas, 'ig-sm', 32, groupSelector);
-    await expectHeightPinned(canvas, 'ig-default', 40, groupSelector);
-    await expectHeightPinned(canvas, 'ig-lg', 48, groupSelector);
+    // Frame heights follow the active spacing mode (h-8 / h-10 / h-12 over
+    // mode-scaled tokens), measured on the group across every mode.
+    await expectHeightPerMode(
+      canvas,
+      'ig-sm',
+      GROUP_SCALE_HEIGHTS.sm,
+      groupSelector
+    );
+    await expectHeightPerMode(
+      canvas,
+      'ig-default',
+      GROUP_SCALE_HEIGHTS.default,
+      groupSelector
+    );
+    await expectHeightPerMode(
+      canvas,
+      'ig-lg',
+      GROUP_SCALE_HEIGHTS.lg,
+      groupSelector
+    );
   },
 };
 

--- a/packages/react/src/components/ui/input-group/input-group.tsx
+++ b/packages/react/src/components/ui/input-group/input-group.tsx
@@ -8,6 +8,13 @@ import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 
 /**
+ * InputGroupProps
+ *
+ * Props for the InputGroup component.
+ */
+interface InputGroupProps extends React.ComponentProps<'div'> {}
+
+/**
  * InputGroup
  *
  * Wraps an input (or textarea) with leading/trailing addons — icons, text,
@@ -16,6 +23,11 @@ import { cn } from '@/lib/utils';
  * more `InputGroupAddon`s (positioned with `align`) around it; the whole group
  * lights up when the control is focused, and reflects the control's invalid
  * state.
+ *
+ * The visible frame matches a standalone `Input`: an inline group takes the
+ * control's `size` height (`sm` / `default` / `lg` → `h-8` / `h-10` / `h-12`),
+ * so the wrapper border never makes the field taller than a bare `Input`.
+ * Stacked (block-aligned) groups stay auto-height.
  *
  * @example
  * ```tsx
@@ -27,23 +39,40 @@ import { cn } from '@/lib/utils';
  * </InputGroup>
  * ```
  */
-function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
+function InputGroup({ className, ...props }: InputGroupProps) {
   return (
     <div
       data-slot="input-group"
       role="group"
       className={cn(
-        'nx:group/input-group nx:relative nx:flex nx:w-full nx:min-w-0 nx:items-center nx:rounded-md nx:border nx:border-border-default nx:shadow-xs nx:transition-[color,box-shadow] nx:outline-none',
+        'nx:group/input-group nx:relative nx:flex nx:w-full nx:min-w-0 nx:items-center nx:rounded-md nx:border nx:border-border-default nx:bg-background nx:transition-colors nx:outline-none',
+        // Size: an inline group matches standalone Input's height for the
+        // control's data-size. Scoped to non-stacked layouts (no block addon
+        // present) so the fixed-height rule and the auto-height stacked case are
+        // mutually exclusive — they never both match. Heights follow the active
+        // spacing mode (h-8/h-10/h-12), exactly like Input.
+        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:has-[[data-slot=input-group-control][data-size=sm]]:h-8',
+        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:has-[[data-slot=input-group-control][data-size=default]]:h-10',
+        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:has-[[data-slot=input-group-control][data-size=lg]]:h-12',
+        // The control fills the fixed-height frame without adding height (the
+        // compound :has() selector outranks Input's own h-* by specificity).
+        // Released in the stacked case, where the control keeps its own height.
+        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:[&>input]:h-full',
         // Alignment: addons push the control's padding to make room.
         'nx:has-[>[data-align=inline-start]]:[&>input]:pl-2',
         'nx:has-[>[data-align=inline-end]]:[&>input]:pr-2',
         'nx:has-[>[data-align=block-start]]:flex-col nx:has-[>[data-align=block-start]]:[&>input]:pb-3',
         'nx:has-[>[data-align=block-end]]:flex-col nx:has-[>[data-align=block-end]]:[&>input]:pt-3',
+        // Hover / disabled: Input's semantic state tokens (no opacity dimming).
+        'nx:not-data-[disabled=true]:hover:bg-background-hover',
+        'nx:data-[disabled=true]:cursor-not-allowed nx:data-[disabled=true]:border-border-disabled nx:data-[disabled=true]:bg-disabled',
         // Focus: the group shows the ring when the inner control is focused
         // (the control suppresses its own outline).
         'nx:has-[[data-slot=input-group-control]:focus-visible]:outline-2 nx:has-[[data-slot=input-group-control]:focus-visible]:outline-focus-default nx:has-[[data-slot=input-group-control]:focus-visible]:outline-offset-(--focus-offset)',
-        // Error: an invalid inner control reddens the group border.
+        // Error: an invalid control reddens the border; an invalid focused
+        // control switches the ring to the error colour (matches Input).
         'nx:has-[[data-slot][aria-invalid=true]]:border-border-error',
+        'nx:has-[[data-slot=input-group-control][aria-invalid=true]:focus-visible]:outline-focus-error',
         className
       )}
       {...props}
@@ -52,14 +81,14 @@ function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
 }
 
 const inputGroupAddonVariants = cva(
-  'nx:flex nx:h-auto nx:cursor-text nx:items-center nx:justify-start nx:gap-2 nx:py-1.5 nx:typography-label-default nx:text-muted-foreground nx:select-none nx:group-data-[disabled=true]/input-group:opacity-50 nx:[&>kbd]:rounded-sm nx:[&>svg]:size-4',
+  'nx:flex nx:h-auto nx:cursor-text nx:items-center nx:justify-start nx:gap-2 nx:py-1.5 nx:typography-label-default nx:text-muted-foreground nx:select-none nx:group-data-[disabled=true]/input-group:text-disabled-foreground nx:[&>kbd]:rounded-sm nx:[&>svg]:size-4',
   {
     variants: {
       align: {
         'inline-start':
-          'nx:order-first nx:pl-3 nx:has-[>button]:ml-[-0.45rem] nx:has-[>kbd]:ml-[-0.35rem]',
+          'nx:order-first nx:pl-3 nx:has-[>button]:-ml-2 nx:has-[>kbd]:-ml-1.5',
         'inline-end':
-          'nx:order-last nx:pr-3 nx:has-[>button]:mr-[-0.45rem] nx:has-[>kbd]:mr-[-0.35rem]',
+          'nx:order-last nx:pr-3 nx:has-[>button]:-mr-2 nx:has-[>kbd]:-mr-1.5',
         'block-start': 'nx:order-first nx:w-full nx:px-3 nx:pt-3',
         'block-end': 'nx:order-last nx:w-full nx:px-3 nx:pb-3',
       },
@@ -103,7 +132,7 @@ function InputGroupAddon({
 }
 
 const inputGroupButtonVariants = cva(
-  'nx:flex nx:items-center nx:py-0 nx:text-sm nx:shadow-none',
+  'nx:flex nx:items-center nx:py-0 nx:typography-label-default nx:shadow-none',
   {
     variants: {
       size: {
@@ -145,6 +174,7 @@ function InputGroupButton({
   return (
     <Button
       type={type}
+      data-slot="input-group-button"
       data-size={size}
       variant={variant}
       className={cn(inputGroupButtonVariants({ size }), className)}
@@ -154,13 +184,21 @@ function InputGroupButton({
 }
 
 /**
+ * InputGroupTextProps
+ *
+ * Props for the InputGroupText component.
+ */
+interface InputGroupTextProps extends React.ComponentProps<'span'> {}
+
+/**
  * InputGroupText
  *
  * Inline addon text — a unit, a label, a prefix.
  */
-function InputGroupText({ className, ...props }: React.ComponentProps<'span'>) {
+function InputGroupText({ className, ...props }: InputGroupTextProps) {
   return (
     <span
+      data-slot="input-group-text"
       className={cn(
         'nx:flex nx:items-center nx:gap-2 nx:typography-body-default nx:text-muted-foreground nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4',
         className
@@ -171,20 +209,25 @@ function InputGroupText({ className, ...props }: React.ComponentProps<'span'>) {
 }
 
 /**
+ * InputGroupInputProps
+ *
+ * Props for the InputGroupInput component.
+ */
+interface InputGroupInputProps extends React.ComponentProps<typeof Input> {}
+
+/**
  * InputGroupInput
  *
  * The text input inside an `InputGroup` — borderless and transparent so the
- * group provides the frame and focus ring.
+ * group provides the frame and focus ring. Keeps `Input`'s per-size padding and
+ * typography; the group supplies the height.
  */
-function InputGroupInput({
-  className,
-  ...props
-}: React.ComponentProps<typeof Input>) {
+function InputGroupInput({ className, ...props }: InputGroupInputProps) {
   return (
     <Input
       data-slot="input-group-control"
       className={cn(
-        'nx:flex-1 nx:rounded-none nx:border-0 nx:bg-transparent nx:shadow-none nx:focus-visible:outline-none',
+        'nx:flex-1 nx:rounded-none nx:border-0 nx:bg-transparent nx:focus-visible:outline-none',
         className
       )}
       {...props}
@@ -193,15 +236,21 @@ function InputGroupInput({
 }
 
 /**
+ * InputGroupTextareaProps
+ *
+ * Props for the InputGroupTextarea component.
+ */
+interface InputGroupTextareaProps extends React.ComponentProps<
+  typeof Textarea
+> {}
+
+/**
  * InputGroupTextarea
  *
  * The textarea inside an `InputGroup` — borderless and transparent so the group
  * provides the frame and focus ring.
  */
-function InputGroupTextarea({
-  className,
-  ...props
-}: React.ComponentProps<typeof Textarea>) {
+function InputGroupTextarea({ className, ...props }: InputGroupTextareaProps) {
   return (
     <Textarea
       data-slot="input-group-control"
@@ -223,6 +272,10 @@ export {
   type InputGroupButtonProps,
   inputGroupButtonVariants,
   InputGroupInput,
+  type InputGroupInputProps,
+  type InputGroupProps,
   InputGroupText,
   InputGroupTextarea,
+  type InputGroupTextareaProps,
+  type InputGroupTextProps,
 };

--- a/packages/react/src/components/ui/input-group/input-group.tsx
+++ b/packages/react/src/components/ui/input-group/input-group.tsx
@@ -200,7 +200,7 @@ function InputGroupText({ className, ...props }: InputGroupTextProps) {
     <span
       data-slot="input-group-text"
       className={cn(
-        'nx:flex nx:items-center nx:gap-2 nx:typography-body-default nx:text-muted-foreground nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4',
+        'nx:flex nx:items-center nx:gap-2 nx:typography-body-default nx:text-muted-foreground nx:group-data-[disabled=true]/input-group:text-disabled-foreground nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/input-group/input-group.tsx
+++ b/packages/react/src/components/ui/input-group/input-group.tsx
@@ -47,17 +47,17 @@ function InputGroup({ className, ...props }: InputGroupProps) {
       className={cn(
         'nx:group/input-group nx:relative nx:flex nx:w-full nx:min-w-0 nx:items-center nx:rounded-md nx:border nx:border-border-default nx:bg-background nx:transition-colors nx:outline-none',
         // Size: an inline group matches standalone Input's height for the
-        // control's data-size. Scoped to non-stacked layouts (no block addon
-        // present) so the fixed-height rule and the auto-height stacked case are
-        // mutually exclusive — they never both match. Heights follow the active
-        // spacing mode (h-8/h-10/h-12), exactly like Input.
-        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:has-[[data-slot=input-group-control][data-size=sm]]:h-8',
-        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:has-[[data-slot=input-group-control][data-size=default]]:h-10',
-        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:has-[[data-slot=input-group-control][data-size=lg]]:h-12',
+        // control's data-size. `not-has-[>[data-align^=block]]` scopes this to
+        // non-stacked layouts (no block addon) so the fixed-height rule and the
+        // auto-height stacked case are mutually exclusive — they never both
+        // match. Heights follow the active spacing mode (h-8/h-10/h-12), like Input.
+        'nx:not-has-[>[data-align^=block]]:has-[[data-slot=input-group-control][data-size=sm]]:h-8',
+        'nx:not-has-[>[data-align^=block]]:has-[[data-slot=input-group-control][data-size=default]]:h-10',
+        'nx:not-has-[>[data-align^=block]]:has-[[data-slot=input-group-control][data-size=lg]]:h-12',
         // The control fills the fixed-height frame without adding height (the
         // compound :has() selector outranks Input's own h-* by specificity).
         // Released in the stacked case, where the control keeps its own height.
-        'nx:not-has-[>[data-align=block-start]]:not-has-[>[data-align=block-end]]:[&>input]:h-full',
+        'nx:not-has-[>[data-align^=block]]:[&>input]:h-full',
         // Alignment: addons push the control's padding to make room.
         'nx:has-[>[data-align=inline-start]]:[&>input]:pl-2',
         'nx:has-[>[data-align=inline-end]]:[&>input]:pr-2',
@@ -132,7 +132,7 @@ function InputGroupAddon({
 }
 
 const inputGroupButtonVariants = cva(
-  'nx:flex nx:items-center nx:py-0 nx:typography-label-default nx:shadow-none',
+  'nx:flex nx:items-center nx:py-0 nx:typography-label-default nx:shadow-none nx:group-data-[disabled=true]/input-group:text-disabled-foreground',
   {
     variants: {
       size: {

--- a/packages/react/src/components/ui/input/Input.stories.tsx
+++ b/packages/react/src/components/ui/input/Input.stories.tsx
@@ -6,7 +6,7 @@ import {
   AllModesRow,
   SPACING_MODES,
 } from '../../../stories/spacing-modes';
-import { expectHeightPinned } from '../../../stories/test-utils';
+import { expectHeightPerMode } from '../../../stories/test-utils';
 
 import { Input } from './input';
 
@@ -82,25 +82,6 @@ const INPUT_SCALE_HEIGHTS = {
     sera: 48,
   },
 } as const;
-
-async function expectInputScaleHeights(
-  canvasElement: HTMLElement,
-  size: keyof typeof INPUT_SCALE_HEIGHTS,
-  testIdPrefix: string
-) {
-  await document.fonts.ready;
-  const canvas = within(canvasElement);
-
-  for (const mode of SPACING_MODES) {
-    const actual = Math.round(
-      canvas.getByTestId(`${testIdPrefix}-${mode}`).getBoundingClientRect()
-        .height
-    );
-    expect(actual, `[data-testid="${testIdPrefix}-${mode}"] height`).toBe(
-      INPUT_SCALE_HEIGHTS[size][mode]
-    );
-  }
-}
 
 // ============================================
 // BASIC STORIES
@@ -298,26 +279,18 @@ export const VisualStateTokens: Story = {
         disabled
         aria-label="Disabled empty input"
       />
-      <Input
-        data-testid="input-disabled-filled"
-        defaultValue="Disabled value"
-        disabled
-        aria-label="Disabled filled input"
-      />
     </div>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const hoverInput = canvas.getByTestId('input-hover-token');
     const disabledEmpty = canvas.getByTestId('input-disabled-empty');
-    const disabledFilled = canvas.getByTestId('input-disabled-filled');
 
     await expect(hoverInput).toHaveClass(
       'nx:enabled:hover:bg-background-hover'
     );
 
     await expect(disabledEmpty).toBeDisabled();
-    await expect(disabledFilled).toBeDisabled();
     await expect(disabledEmpty).toHaveClass('nx:disabled:bg-disabled');
     await expect(disabledEmpty).toHaveClass(
       'nx:disabled:text-disabled-foreground'
@@ -328,8 +301,13 @@ export const VisualStateTokens: Story = {
     await expect(disabledEmpty).toHaveClass(
       'nx:disabled:border-border-disabled'
     );
-    await expect(disabledFilled).not.toHaveClass('nx:disabled:opacity-50');
-    await expect(window.getComputedStyle(disabledFilled).opacity).toBe('1');
+    // Computed-style check (not just class presence): the disabled text token
+    // must resolve to a color distinct from the enabled foreground, and opacity
+    // must stay 1 (the old opacity-50 treatment is gone).
+    await expect(window.getComputedStyle(disabledEmpty).opacity).toBe('1');
+    await expect(window.getComputedStyle(disabledEmpty).color).not.toBe(
+      window.getComputedStyle(hoverInput).color
+    );
   },
 };
 
@@ -523,51 +501,22 @@ export const InputScaleHeightsFollowModes: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const defaultInput = canvas.getByLabelText('vega default input');
-    const smallInput = canvas.getByLabelText('vega small input');
-    const largeInput = canvas.getByLabelText('vega large input');
 
-    await expect(defaultInput).toHaveAttribute('data-size', 'default');
-    await expect(defaultInput).toHaveClass('nx:h-10');
-    await expect(defaultInput).toHaveClass('nx:px-3');
-    await expect(defaultInput).toHaveClass('nx:py-0');
-    await expect(defaultInput).toHaveClass('nx:typography-body-small');
-    await expect(smallInput).toHaveClass('nx:h-8');
-    await expect(smallInput).toHaveClass('nx:px-2.5');
-    await expect(smallInput).toHaveClass('nx:py-0');
-    await expect(smallInput).toHaveClass('nx:typography-body-small');
-    await expect(largeInput).toHaveClass('nx:h-12');
-    await expect(largeInput).toHaveClass('nx:px-3.5');
-    await expect(largeInput).toHaveClass('nx:py-0');
-    await expect(largeInput).toHaveClass('nx:typography-body-default');
+    // The implicit-default input still exposes its size for styling hooks.
+    await expect(canvas.getByLabelText('vega default input')).toHaveAttribute(
+      'data-size',
+      'default'
+    );
 
-    await expectInputScaleHeights(canvasElement, 'default', 'input-default');
-    await expectInputScaleHeights(canvasElement, 'sm', 'input-sm');
-    await expectInputScaleHeights(canvasElement, 'lg', 'input-lg');
-  },
-};
-
-export const VegaDefaultHeightPinned: Story = {
-  parameters: {
-    a11y: { test: 'off' },
-    docs: {
-      description: {
-        story:
-          'Pin on the fixed-height outcome: in vega mode, a default Input renders at exactly 40px via `h-10`.',
-      },
-    },
-  },
-  render: () => (
-    <div
-      data-style="vega"
-      data-testid="input-vega-host"
-      className="nx:p-10 nx:bg-background"
-    >
-      <Input aria-label="vega default input" />
-    </div>
-  ),
-  play: async ({ canvasElement }) => {
-    await expectHeightPinned(within(canvasElement), 'input-vega-host', 40);
+    // Heights vary per mode (fixed h-* over mode-scaled spacing tokens); the
+    // shared helper measures every mode against INPUT_SCALE_HEIGHTS.
+    await expectHeightPerMode(canvas, 'input-sm', INPUT_SCALE_HEIGHTS.sm);
+    await expectHeightPerMode(
+      canvas,
+      'input-default',
+      INPUT_SCALE_HEIGHTS.default
+    );
+    await expectHeightPerMode(canvas, 'input-lg', INPUT_SCALE_HEIGHTS.lg);
   },
 };
 

--- a/packages/react/src/components/ui/input/Input.stories.tsx
+++ b/packages/react/src/components/ui/input/Input.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../../stories/spacing-modes';
 import {
   expectHeightPinned,
-  expectModeCascadeWorks,
+  expectHeightPinnedAcrossModes,
 } from '../../../stories/test-utils';
 
 import { Input } from './input';
@@ -348,7 +348,7 @@ export const AllVariants: Story = {
 };
 
 // ============================================
-// MODE BEHAVIOUR (per-mode spacing variance)
+// MODE BEHAVIOUR (mode-stable numeric spacing)
 // ============================================
 
 export const AllModes: Story = {
@@ -357,7 +357,7 @@ export const AllModes: Story = {
     docs: {
       description: {
         story:
-          'Each row scopes `data-style` locally so the 7 spacing modes render side-by-side regardless of the Style toolbar. Input `padding-y` migrates to `py-control-{sm,md,lg}` per size and so responds to mode; `padding-x` stays numeric per the coupling table (Input is narrower than Button at the same size). Vega / Lyra / Luma / Mira currently share identical control-y tokens (so those four rows render at the same height); Nova compresses, Maia / Sera breathe.',
+          'Each row scopes `data-style` locally so the 7 spacing modes render side-by-side regardless of the Style toolbar. Input now follows the Figma node 843:71944 sizing with numeric vertical padding (`py-1` / `py-1.5`) and `px-3`. The old `py-control-*` role utilities varied per mode; the new vertical spacing is mode-invariant, explicitly satisfying the #433 disclosure that numeric spacing may still vary only where the numeric token itself is mode-tuned.',
       },
     },
   },
@@ -386,31 +386,55 @@ export const AllModes: Story = {
   ),
 };
 
-export const ModesProduceDifferentHeights: Story = {
+export const InputIsDensityStable: Story = {
   parameters: {
     a11y: { test: 'off' },
     docs: {
       description: {
         story:
-          'Regression sentinel for the `data-style` cascade and the role-utility resolver on Input. An Input scoped to `nova` (compact `py`) must render shorter than the same Input scoped to `sera` (breathy `py`). A typo like `nx:py-control-mdd` would fall back to intrinsic and both modes would match — the test catches that.',
+          'Density-stability sentinel for the Figma-aligned numeric sizing. Input sizes use mode-invariant vertical padding, so sm/default/lg pin to 30/34/38px across representative spacing modes. Horizontal `px-3` may still vary cosmetically by mode, but it does not affect height.',
       },
     },
   },
   render: () => (
-    <div className="nx:flex nx:items-center nx:gap-4 nx:p-10 nx:bg-background">
-      <div data-style="nova" data-testid="input-mode-host-nova">
-        <Input aria-label="nova input" />
-      </div>
-      <div data-style="sera" data-testid="input-mode-host-sera">
-        <Input aria-label="sera input" />
-      </div>
+    <div className="nx:flex nx:flex-col nx:gap-4 nx:p-10 nx:bg-background">
+      {(['nova', 'vega', 'maia', 'sera'] as const).map((mode) => (
+        <div key={mode} data-style={mode} className="nx:flex nx:gap-4">
+          <div data-testid={`input-${mode}-sm`}>
+            <Input size="sm" aria-label={`${mode} small input`} />
+          </div>
+          <div data-testid={`input-${mode}-default`}>
+            <Input aria-label={`${mode} default input`} />
+          </div>
+          <div data-testid={`input-${mode}-lg`}>
+            <Input size="lg" aria-label={`${mode} large input`} />
+          </div>
+        </div>
+      ))}
     </div>
   ),
   play: async ({ canvasElement }) => {
-    await expectModeCascadeWorks(
-      within(canvasElement),
-      'input-mode-host-nova',
-      'input-mode-host-sera'
+    const canvas = within(canvasElement);
+
+    await expectHeightPinnedAcrossModes(
+      canvas,
+      ['input-nova-sm', 'input-vega-sm', 'input-maia-sm', 'input-sera-sm'],
+      30
+    );
+    await expectHeightPinnedAcrossModes(
+      canvas,
+      [
+        'input-nova-default',
+        'input-vega-default',
+        'input-maia-default',
+        'input-sera-default',
+      ],
+      34
+    );
+    await expectHeightPinnedAcrossModes(
+      canvas,
+      ['input-nova-lg', 'input-vega-lg', 'input-maia-lg', 'input-sera-lg'],
+      38
     );
   },
 };
@@ -421,7 +445,7 @@ export const VegaDefaultHeightPinned: Story = {
     docs: {
       description: {
         story:
-          'Pin on the migration outcome: in vega mode, a default Input renders at exactly 38px (= `text-sm` 20px line-height + `py-control-md` 8px × 2 + border 1px × 2). If a designer retunes `--control-padding-y-md`, the body type ramp, or the border-width token, this test fails and the change must be acknowledged.',
+          'Pin on the Figma-aligned migration outcome: in vega mode, a default Input renders at exactly 34px (= `typography-body-default` 24px line-height + `py-1` 4px × 2 + border 1px × 2). If a designer retunes the body type ramp, numeric spacing scale, or border-width token, this test fails and the change must be acknowledged.',
       },
     },
   },
@@ -435,7 +459,7 @@ export const VegaDefaultHeightPinned: Story = {
     </div>
   ),
   play: async ({ canvasElement }) => {
-    await expectHeightPinned(within(canvasElement), 'input-vega-host', 38);
+    await expectHeightPinned(within(canvasElement), 'input-vega-host', 34);
   },
 };
 

--- a/packages/react/src/components/ui/input/Input.stories.tsx
+++ b/packages/react/src/components/ui/input/Input.stories.tsx
@@ -73,13 +73,13 @@ const INPUT_SCALE_HEIGHTS = {
     sera: 40,
   },
   lg: {
-    vega: 44,
+    vega: 48,
     lyra: 48,
-    maia: 48,
-    mira: 44,
-    nova: 42,
-    luma: 44,
-    sera: 44,
+    maia: 52,
+    mira: 48,
+    nova: 46,
+    luma: 48,
+    sera: 48,
   },
 } as const;
 
@@ -460,7 +460,7 @@ export const AllModes: Story = {
     docs: {
       description: {
         story:
-          'Each row scopes `data-style` locally so the 7 spacing modes render side-by-side regardless of the Style toolbar. Input follows the approved Button fixed-height utility scale (`h-8` / `h-10` / `h-11`) without copying Button min-widths. Sm/default use body-small text; lg uses body-default text.',
+          'Each row scopes `data-style` locally so the 7 spacing modes render side-by-side regardless of the Style toolbar. Input follows the approved fixed-height utility scale (`h-8` / `h-10` / `h-12`) without copying Button min-widths. Sm/default use body-small text; lg uses body-default text.',
       },
     },
   },
@@ -495,7 +495,7 @@ export const InputScaleHeightsFollowModes: Story = {
     docs: {
       description: {
         story:
-          'Scale-utility sentinel for the Input sizing model. Text Input sizes use `h-8` / `h-10` / `h-11` and therefore follow the active Nexus spacing mode, matching Button height behavior while keeping Input width layout-controlled.',
+          'Scale-utility sentinel for the Input sizing model. Text Input sizes use `h-8` / `h-10` / `h-12` and therefore follow the active Nexus spacing mode while keeping Input width layout-controlled.',
       },
     },
   },
@@ -536,7 +536,7 @@ export const InputScaleHeightsFollowModes: Story = {
     await expect(smallInput).toHaveClass('nx:px-2.5');
     await expect(smallInput).toHaveClass('nx:py-0');
     await expect(smallInput).toHaveClass('nx:typography-body-small');
-    await expect(largeInput).toHaveClass('nx:h-11');
+    await expect(largeInput).toHaveClass('nx:h-12');
     await expect(largeInput).toHaveClass('nx:px-3.5');
     await expect(largeInput).toHaveClass('nx:py-0');
     await expect(largeInput).toHaveClass('nx:typography-body-default');

--- a/packages/react/src/components/ui/input/Input.stories.tsx
+++ b/packages/react/src/components/ui/input/Input.stories.tsx
@@ -429,7 +429,7 @@ export const AllVariants: Story = {
 };
 
 // ============================================
-// MODE BEHAVIOUR (mode-stable numeric spacing)
+// MODE BEHAVIOUR (per-mode heights)
 // ============================================
 
 export const AllModes: Story = {

--- a/packages/react/src/components/ui/input/Input.stories.tsx
+++ b/packages/react/src/components/ui/input/Input.stories.tsx
@@ -312,9 +312,9 @@ export const VisualStateTokens: Story = {
     const disabledEmpty = canvas.getByTestId('input-disabled-empty');
     const disabledFilled = canvas.getByTestId('input-disabled-filled');
 
-    await expect(hoverInput).toHaveClass('nx:enabled:hover:bg-container-hover');
-    await userEvent.hover(hoverInput);
-    await expect(hoverInput).toHaveClass('nx:enabled:hover:bg-container-hover');
+    await expect(hoverInput).toHaveClass(
+      'nx:enabled:hover:bg-background-hover'
+    );
 
     await expect(disabledEmpty).toBeDisabled();
     await expect(disabledFilled).toBeDisabled();

--- a/packages/react/src/components/ui/input/Input.stories.tsx
+++ b/packages/react/src/components/ui/input/Input.stories.tsx
@@ -230,6 +230,63 @@ export const DisabledInteraction: Story = {
   },
 };
 
+export const VisualStateTokens: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Token sentinel for the corrected Figma node 843:71944 visual-state pass. The primitive remains a native input, while hover and disabled visuals map to Nexus semantic state tokens.',
+      },
+    },
+  },
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:gap-3 nx:w-[400px]">
+      <Input
+        data-testid="input-hover-token"
+        placeholder="Hover surface"
+        aria-label="Hover surface input"
+      />
+      <Input
+        data-testid="input-disabled-empty"
+        placeholder="Disabled placeholder"
+        disabled
+        aria-label="Disabled empty input"
+      />
+      <Input
+        data-testid="input-disabled-filled"
+        defaultValue="Disabled value"
+        disabled
+        aria-label="Disabled filled input"
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const hoverInput = canvas.getByTestId('input-hover-token');
+    const disabledEmpty = canvas.getByTestId('input-disabled-empty');
+    const disabledFilled = canvas.getByTestId('input-disabled-filled');
+
+    await expect(hoverInput).toHaveClass('nx:enabled:hover:bg-container-hover');
+    await userEvent.hover(hoverInput);
+    await expect(hoverInput).toHaveClass('nx:enabled:hover:bg-container-hover');
+
+    await expect(disabledEmpty).toBeDisabled();
+    await expect(disabledFilled).toBeDisabled();
+    await expect(disabledEmpty).toHaveClass('nx:disabled:bg-disabled');
+    await expect(disabledEmpty).toHaveClass(
+      'nx:disabled:text-disabled-foreground'
+    );
+    await expect(disabledEmpty).toHaveClass(
+      'nx:disabled:placeholder:text-disabled-foreground'
+    );
+    await expect(disabledEmpty).toHaveClass(
+      'nx:disabled:border-border-disabled'
+    );
+    await expect(disabledFilled).not.toHaveClass('nx:disabled:opacity-50');
+    await expect(window.getComputedStyle(disabledFilled).opacity).toBe('1');
+  },
+};
+
 export const WithDataAttributes: Story = {
   args: {
     size: 'lg',
@@ -357,7 +414,7 @@ export const AllModes: Story = {
     docs: {
       description: {
         story:
-          'Each row scopes `data-style` locally so the 7 spacing modes render side-by-side regardless of the Style toolbar. Input now follows the Figma node 843:71944 sizing with numeric vertical padding (`py-1` / `py-1.5`) and `px-3`. The old `py-control-*` role utilities varied per mode; the new vertical spacing is mode-invariant, explicitly satisfying the #433 disclosure that numeric spacing may still vary only where the numeric token itself is mode-tuned.',
+          'Each row scopes `data-style` locally so the 7 spacing modes render side-by-side regardless of the Style toolbar. The corrected Figma node 843:71944 shows Input frame sizes at 28/32/36px; Nexus uses body-small text for sm/default and body-default text for lg while pinning browser-rendered heights to match the Button text scale at 28/32/36px. Numeric vertical padding (`py-[3px]` / `py-[5px]`) keeps heights mode-invariant and stable across hover, focus, filled, and typing states.',
       },
     },
   },
@@ -392,7 +449,7 @@ export const InputIsDensityStable: Story = {
     docs: {
       description: {
         story:
-          'Density-stability sentinel for the Figma-aligned numeric sizing. Input sizes use mode-invariant vertical padding, so sm/default/lg pin to 30/34/38px across representative spacing modes. Horizontal `px-3` may still vary cosmetically by mode, but it does not affect height.',
+          'Density-stability sentinel for the approved text scale. Figma node 843:71944 frames idle Input at 28/32/36px, and Nexus pins sm/default/lg to browser-rendered 28/32/36px across representative spacing modes so Input matches the Button text height scale. Sm/default use 14px body-small text; lg uses 16px body-default text. Horizontal `px-3` may still vary cosmetically by mode, but it does not affect height.',
       },
     },
   },
@@ -419,7 +476,7 @@ export const InputIsDensityStable: Story = {
     await expectHeightPinnedAcrossModes(
       canvas,
       ['input-nova-sm', 'input-vega-sm', 'input-maia-sm', 'input-sera-sm'],
-      30
+      28
     );
     await expectHeightPinnedAcrossModes(
       canvas,
@@ -429,12 +486,19 @@ export const InputIsDensityStable: Story = {
         'input-maia-default',
         'input-sera-default',
       ],
-      34
+      32
     );
     await expectHeightPinnedAcrossModes(
       canvas,
       ['input-nova-lg', 'input-vega-lg', 'input-maia-lg', 'input-sera-lg'],
-      38
+      36
+    );
+
+    await expect(canvas.getByLabelText('vega large input')).toHaveClass(
+      'nx:typography-body-default'
+    );
+    await expect(canvas.getByLabelText('vega large input')).toHaveClass(
+      'nx:py-[5px]'
     );
   },
 };
@@ -445,7 +509,7 @@ export const VegaDefaultHeightPinned: Story = {
     docs: {
       description: {
         story:
-          'Pin on the Figma-aligned migration outcome: in vega mode, a default Input renders at exactly 34px (= `typography-body-default` 24px line-height + `py-1` 4px × 2 + border 1px × 2). If a designer retunes the body type ramp, numeric spacing scale, or border-width token, this test fails and the change must be acknowledged.',
+          'Pin on the approved default-size text outcome: in vega mode, a default Input renders at exactly 32px (= `typography-body-small` 20px line-height + `py-[5px]` 5px x 2 + border 1px x 2). This keeps the Input default height aligned with the Button text scale. If a designer retunes the body type ramp, numeric spacing scale, or border-width token, this test fails and the change must be acknowledged.',
       },
     },
   },
@@ -459,7 +523,7 @@ export const VegaDefaultHeightPinned: Story = {
     </div>
   ),
   play: async ({ canvasElement }) => {
-    await expectHeightPinned(within(canvasElement), 'input-vega-host', 34);
+    await expectHeightPinned(within(canvasElement), 'input-vega-host', 32);
   },
 };
 

--- a/packages/react/src/components/ui/input/Input.stories.tsx
+++ b/packages/react/src/components/ui/input/Input.stories.tsx
@@ -6,10 +6,7 @@ import {
   AllModesRow,
   SPACING_MODES,
 } from '../../../stories/spacing-modes';
-import {
-  expectHeightPinned,
-  expectHeightPinnedAcrossModes,
-} from '../../../stories/test-utils';
+import { expectHeightPinned } from '../../../stories/test-utils';
 
 import { Input } from './input';
 
@@ -55,6 +52,55 @@ const meta: Meta<typeof Input> = {
 
 export default meta;
 type Story = StoryObj<typeof Input>;
+
+const INPUT_SCALE_HEIGHTS = {
+  sm: {
+    vega: 32,
+    lyra: 32,
+    maia: 36,
+    mira: 32,
+    nova: 30,
+    luma: 32,
+    sera: 32,
+  },
+  default: {
+    vega: 40,
+    lyra: 42,
+    maia: 44,
+    mira: 40,
+    nova: 38,
+    luma: 40,
+    sera: 40,
+  },
+  lg: {
+    vega: 44,
+    lyra: 48,
+    maia: 48,
+    mira: 44,
+    nova: 42,
+    luma: 44,
+    sera: 44,
+  },
+} as const;
+
+async function expectInputScaleHeights(
+  canvasElement: HTMLElement,
+  size: keyof typeof INPUT_SCALE_HEIGHTS,
+  testIdPrefix: string
+) {
+  await document.fonts.ready;
+  const canvas = within(canvasElement);
+
+  for (const mode of SPACING_MODES) {
+    const actual = Math.round(
+      canvas.getByTestId(`${testIdPrefix}-${mode}`).getBoundingClientRect()
+        .height
+    );
+    expect(actual, `[data-testid="${testIdPrefix}-${mode}"] height`).toBe(
+      INPUT_SCALE_HEIGHTS[size][mode]
+    );
+  }
+}
 
 // ============================================
 // BASIC STORIES
@@ -414,7 +460,7 @@ export const AllModes: Story = {
     docs: {
       description: {
         story:
-          'Each row scopes `data-style` locally so the 7 spacing modes render side-by-side regardless of the Style toolbar. The corrected Figma node 843:71944 shows Input frame sizes at 28/32/36px; Nexus uses body-small text for sm/default and body-default text for lg while pinning browser-rendered heights to match the Button text scale at 28/32/36px. Numeric vertical padding (`py-[3px]` / `py-[5px]`) keeps heights mode-invariant and stable across hover, focus, filled, and typing states.',
+          'Each row scopes `data-style` locally so the 7 spacing modes render side-by-side regardless of the Style toolbar. Input follows the approved Button fixed-height utility scale (`h-8` / `h-10` / `h-11`) without copying Button min-widths. Sm/default use body-small text; lg uses body-default text.',
       },
     },
   },
@@ -443,63 +489,61 @@ export const AllModes: Story = {
   ),
 };
 
-export const InputIsDensityStable: Story = {
+export const InputScaleHeightsFollowModes: Story = {
   parameters: {
     a11y: { test: 'off' },
     docs: {
       description: {
         story:
-          'Density-stability sentinel for the approved text scale. Figma node 843:71944 frames idle Input at 28/32/36px, and Nexus pins sm/default/lg to browser-rendered 28/32/36px across representative spacing modes so Input matches the Button text height scale. Sm/default use 14px body-small text; lg uses 16px body-default text. Horizontal `px-3` may still vary cosmetically by mode, but it does not affect height.',
+          'Scale-utility sentinel for the Input sizing model. Text Input sizes use `h-8` / `h-10` / `h-11` and therefore follow the active Nexus spacing mode, matching Button height behavior while keeping Input width layout-controlled.',
       },
     },
   },
   render: () => (
     <div className="nx:flex nx:flex-col nx:gap-4 nx:p-10 nx:bg-background">
-      {(['nova', 'vega', 'maia', 'sera'] as const).map((mode) => (
+      {SPACING_MODES.map((mode) => (
         <div key={mode} data-style={mode} className="nx:flex nx:gap-4">
-          <div data-testid={`input-${mode}-sm`}>
-            <Input size="sm" aria-label={`${mode} small input`} />
-          </div>
-          <div data-testid={`input-${mode}-default`}>
-            <Input aria-label={`${mode} default input`} />
-          </div>
-          <div data-testid={`input-${mode}-lg`}>
-            <Input size="lg" aria-label={`${mode} large input`} />
-          </div>
+          <Input
+            size="sm"
+            aria-label={`${mode} small input`}
+            data-testid={`input-sm-${mode}`}
+          />
+          <Input
+            aria-label={`${mode} default input`}
+            data-testid={`input-default-${mode}`}
+          />
+          <Input
+            size="lg"
+            aria-label={`${mode} large input`}
+            data-testid={`input-lg-${mode}`}
+          />
         </div>
       ))}
     </div>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const defaultInput = canvas.getByLabelText('vega default input');
+    const smallInput = canvas.getByLabelText('vega small input');
+    const largeInput = canvas.getByLabelText('vega large input');
 
-    await expectHeightPinnedAcrossModes(
-      canvas,
-      ['input-nova-sm', 'input-vega-sm', 'input-maia-sm', 'input-sera-sm'],
-      28
-    );
-    await expectHeightPinnedAcrossModes(
-      canvas,
-      [
-        'input-nova-default',
-        'input-vega-default',
-        'input-maia-default',
-        'input-sera-default',
-      ],
-      32
-    );
-    await expectHeightPinnedAcrossModes(
-      canvas,
-      ['input-nova-lg', 'input-vega-lg', 'input-maia-lg', 'input-sera-lg'],
-      36
-    );
+    await expect(defaultInput).toHaveAttribute('data-size', 'default');
+    await expect(defaultInput).toHaveClass('nx:h-10');
+    await expect(defaultInput).toHaveClass('nx:px-3');
+    await expect(defaultInput).toHaveClass('nx:py-0');
+    await expect(defaultInput).toHaveClass('nx:typography-body-small');
+    await expect(smallInput).toHaveClass('nx:h-8');
+    await expect(smallInput).toHaveClass('nx:px-2.5');
+    await expect(smallInput).toHaveClass('nx:py-0');
+    await expect(smallInput).toHaveClass('nx:typography-body-small');
+    await expect(largeInput).toHaveClass('nx:h-11');
+    await expect(largeInput).toHaveClass('nx:px-3.5');
+    await expect(largeInput).toHaveClass('nx:py-0');
+    await expect(largeInput).toHaveClass('nx:typography-body-default');
 
-    await expect(canvas.getByLabelText('vega large input')).toHaveClass(
-      'nx:typography-body-default'
-    );
-    await expect(canvas.getByLabelText('vega large input')).toHaveClass(
-      'nx:py-[5px]'
-    );
+    await expectInputScaleHeights(canvasElement, 'default', 'input-default');
+    await expectInputScaleHeights(canvasElement, 'sm', 'input-sm');
+    await expectInputScaleHeights(canvasElement, 'lg', 'input-lg');
   },
 };
 
@@ -509,7 +553,7 @@ export const VegaDefaultHeightPinned: Story = {
     docs: {
       description: {
         story:
-          'Pin on the approved default-size text outcome: in vega mode, a default Input renders at exactly 32px (= `typography-body-small` 20px line-height + `py-[5px]` 5px x 2 + border 1px x 2). This keeps the Input default height aligned with the Button text scale. If a designer retunes the body type ramp, numeric spacing scale, or border-width token, this test fails and the change must be acknowledged.',
+          'Pin on the fixed-height outcome: in vega mode, a default Input renders at exactly 40px via `h-10`.',
       },
     },
   },
@@ -523,7 +567,7 @@ export const VegaDefaultHeightPinned: Story = {
     </div>
   ),
   play: async ({ canvasElement }) => {
-    await expectHeightPinned(within(canvasElement), 'input-vega-host', 32);
+    await expectHeightPinned(within(canvasElement), 'input-vega-host', 40);
   },
 };
 

--- a/packages/react/src/components/ui/input/Input.stories.tsx
+++ b/packages/react/src/components/ui/input/Input.stories.tsx
@@ -438,7 +438,7 @@ export const AllModes: Story = {
     docs: {
       description: {
         story:
-          'Each row scopes `data-style` locally so the 7 spacing modes render side-by-side regardless of the Style toolbar. Input follows the approved fixed-height utility scale (`h-8` / `h-10` / `h-12`) without copying Button min-widths. Sm/default use body-small text; lg uses body-default text.',
+          'Each row scopes `data-style` locally so the 7 spacing modes render side-by-side regardless of the Style toolbar. Input follows the approved fixed-height utility scale (`h-8` / `h-10` / `h-12`) without copying Button min-widths. Sm uses body-small text; default/lg use body-default text.',
       },
     },
   },

--- a/packages/react/src/components/ui/input/input.tsx
+++ b/packages/react/src/components/ui/input/input.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils';
 const inputVariants = cva(
   [
     'nx:flex nx:w-full nx:rounded-md nx:border nx:border-border-default',
-    'nx:bg-background nx:text-foreground nx:transition-colors nx:enabled:hover:bg-container-hover',
+    'nx:bg-background nx:text-foreground nx:transition-colors nx:enabled:hover:bg-background-hover',
     'nx:file:border-0 nx:file:bg-transparent nx:file:typography-label-default nx:file:text-foreground nx:disabled:file:text-disabled-foreground',
     'nx:placeholder:text-muted-foreground',
     'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',

--- a/packages/react/src/components/ui/input/input.tsx
+++ b/packages/react/src/components/ui/input/input.tsx
@@ -17,9 +17,9 @@ const inputVariants = cva(
   {
     variants: {
       size: {
-        default: 'nx:px-3 nx:py-[5px] nx:typography-body-small',
-        sm: 'nx:px-3 nx:py-[3px] nx:typography-body-small',
-        lg: 'nx:px-3 nx:py-[5px] nx:typography-body-default',
+        default: 'nx:h-10 nx:px-3 nx:py-0 nx:typography-body-small',
+        sm: 'nx:h-8 nx:px-2.5 nx:py-0 nx:typography-body-small',
+        lg: 'nx:h-11 nx:px-3.5 nx:py-0 nx:typography-body-default',
       },
     },
     defaultVariants: {

--- a/packages/react/src/components/ui/input/input.tsx
+++ b/packages/react/src/components/ui/input/input.tsx
@@ -17,7 +17,7 @@ const inputVariants = cva(
   {
     variants: {
       size: {
-        default: 'nx:h-10 nx:px-3 nx:py-0 nx:typography-body-small',
+        default: 'nx:h-10 nx:px-3 nx:py-0 nx:typography-body-default',
         sm: 'nx:h-8 nx:px-2.5 nx:py-0 nx:typography-body-small',
         lg: 'nx:h-12 nx:px-3.5 nx:py-0 nx:typography-body-default',
       },

--- a/packages/react/src/components/ui/input/input.tsx
+++ b/packages/react/src/components/ui/input/input.tsx
@@ -7,19 +7,19 @@ import { cn } from '@/lib/utils';
 const inputVariants = cva(
   [
     'nx:flex nx:w-full nx:rounded-md nx:border nx:border-border-default',
-    'nx:bg-background nx:text-foreground nx:transition-colors',
-    'nx:file:border-0 nx:file:bg-transparent nx:file:typography-label-default nx:file:text-foreground',
+    'nx:bg-background nx:text-foreground nx:transition-colors nx:enabled:hover:bg-container-hover',
+    'nx:file:border-0 nx:file:bg-transparent nx:file:typography-label-default nx:file:text-foreground nx:disabled:file:text-disabled-foreground',
     'nx:placeholder:text-muted-foreground',
     'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
     'nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error',
-    'nx:disabled:cursor-not-allowed nx:disabled:opacity-50',
+    'nx:disabled:cursor-not-allowed nx:disabled:border-border-disabled nx:disabled:bg-disabled nx:disabled:text-disabled-foreground nx:disabled:placeholder:text-disabled-foreground',
   ],
   {
     variants: {
       size: {
-        default: 'nx:px-3 nx:py-1 nx:typography-body-default',
-        sm: 'nx:px-3 nx:py-1 nx:typography-body-small',
-        lg: 'nx:px-3 nx:py-1.5 nx:typography-body-default',
+        default: 'nx:px-3 nx:py-[5px] nx:typography-body-small',
+        sm: 'nx:px-3 nx:py-[3px] nx:typography-body-small',
+        lg: 'nx:px-3 nx:py-[5px] nx:typography-body-default',
       },
     },
     defaultVariants: {

--- a/packages/react/src/components/ui/input/input.tsx
+++ b/packages/react/src/components/ui/input/input.tsx
@@ -19,7 +19,7 @@ const inputVariants = cva(
       size: {
         default: 'nx:h-10 nx:px-3 nx:py-0 nx:typography-body-small',
         sm: 'nx:h-8 nx:px-2.5 nx:py-0 nx:typography-body-small',
-        lg: 'nx:h-11 nx:px-3.5 nx:py-0 nx:typography-body-default',
+        lg: 'nx:h-12 nx:px-3.5 nx:py-0 nx:typography-body-default',
       },
     },
     defaultVariants: {

--- a/packages/react/src/components/ui/input/input.tsx
+++ b/packages/react/src/components/ui/input/input.tsx
@@ -8,7 +8,7 @@ const inputVariants = cva(
   [
     'nx:flex nx:w-full nx:rounded-md nx:border nx:border-border-default',
     'nx:bg-background nx:text-foreground nx:transition-colors',
-    'nx:file:border-0 nx:file:bg-transparent nx:file:text-sm nx:file:font-medium nx:file:text-foreground',
+    'nx:file:border-0 nx:file:bg-transparent nx:file:typography-label-default nx:file:text-foreground',
     'nx:placeholder:text-muted-foreground',
     'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
     'nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error',
@@ -17,9 +17,9 @@ const inputVariants = cva(
   {
     variants: {
       size: {
-        default: 'nx:px-3 nx:py-control-md nx:text-sm',
-        sm: 'nx:px-2.5 nx:py-control-sm nx:text-xs',
-        lg: 'nx:px-4 nx:py-control-lg nx:text-base',
+        default: 'nx:px-3 nx:py-1 nx:typography-body-default',
+        sm: 'nx:px-3 nx:py-1 nx:typography-body-small',
+        lg: 'nx:px-3 nx:py-1.5 nx:typography-body-default',
       },
     },
     defaultVariants: {
@@ -66,7 +66,7 @@ function Input({ className, type, size, ...props }: InputProps) {
     <input
       type={type}
       data-slot="input"
-      data-size={size}
+      data-size={size ?? 'default'}
       className={cn(inputVariants({ size, className }))}
       {...props}
     />

--- a/packages/react/src/components/ui/native-select/NativeSelect.stories.tsx
+++ b/packages/react/src/components/ui/native-select/NativeSelect.stories.tsx
@@ -68,7 +68,7 @@ export const Invalid: Story = {
   ),
 };
 
-// Disabled — the select and its chevron dim together (wrapper has-[select:disabled]).
+// Disabled — semantic disabled tokens on the select and chevron.
 export const Disabled: Story = {
   render: () => (
     <NativeSelect aria-label="Plan" defaultValue="free" disabled>
@@ -78,7 +78,18 @@ export const Disabled: Story = {
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByRole('combobox', { name: 'Plan' })).toBeDisabled();
+    const select = canvas.getByRole('combobox', { name: 'Plan' });
+    await expect(select).toBeDisabled();
+    await expect(select).toHaveClass('nx:disabled:border-border-disabled');
+    await expect(select).toHaveClass('nx:disabled:bg-disabled');
+    await expect(select).toHaveClass('nx:disabled:text-disabled-foreground');
+
+    const icon = canvasElement.querySelector(
+      '[data-slot="native-select-icon"]'
+    );
+    await expect(icon).toHaveClass(
+      'nx:group-has-[select:disabled]/native-select:text-disabled-foreground'
+    );
   },
 };
 

--- a/packages/react/src/components/ui/native-select/native-select.tsx
+++ b/packages/react/src/components/ui/native-select/native-select.tsx
@@ -16,8 +16,8 @@ const nativeSelectVariants = cva(
   {
     variants: {
       size: {
-        default: 'nx:px-3 nx:py-control-md nx:pr-9 nx:text-sm',
-        sm: 'nx:px-2.5 nx:py-control-sm nx:pr-9 nx:text-xs',
+        default: 'nx:px-3 nx:py-control-md nx:pr-9 nx:typography-body-default',
+        sm: 'nx:px-2.5 nx:py-control-sm nx:pr-9 nx:typography-body-small',
       },
     },
     defaultVariants: {

--- a/packages/react/src/components/ui/native-select/native-select.tsx
+++ b/packages/react/src/components/ui/native-select/native-select.tsx
@@ -16,8 +16,8 @@ const nativeSelectVariants = cva(
   {
     variants: {
       size: {
-        default: 'nx:px-3 nx:py-control-md nx:pr-9 nx:typography-body-default',
-        sm: 'nx:px-2.5 nx:py-control-sm nx:pr-9 nx:typography-body-small',
+        default: 'nx:px-3 nx:py-2 nx:pr-9 nx:typography-body-default',
+        sm: 'nx:px-2.5 nx:py-1.5 nx:pr-9 nx:typography-body-small',
       },
     },
     defaultVariants: {

--- a/packages/react/src/components/ui/native-select/native-select.tsx
+++ b/packages/react/src/components/ui/native-select/native-select.tsx
@@ -60,18 +60,22 @@ function NativeSelect({
   return (
     <div
       data-slot="native-select-wrapper"
-      className="nx:group/native-select nx:relative nx:w-fit nx:has-[select:disabled]:opacity-50"
+      className="nx:group/native-select nx:relative nx:w-fit"
     >
       <select
         data-slot="native-select"
         data-size={size}
-        className={cn(nativeSelectVariants({ size }), className)}
+        className={cn(
+          nativeSelectVariants({ size }),
+          'nx:disabled:border-border-disabled nx:disabled:bg-disabled nx:disabled:text-disabled-foreground',
+          className
+        )}
         {...props}
       />
       <IconChevronDown
         aria-hidden="true"
         data-slot="native-select-icon"
-        className="nx:pointer-events-none nx:absolute nx:top-1/2 nx:right-3.5 nx:size-4 nx:-translate-y-1/2 nx:text-muted-foreground nx:opacity-50 nx:select-none"
+        className="nx:pointer-events-none nx:absolute nx:top-1/2 nx:right-3.5 nx:size-4 nx:-translate-y-1/2 nx:text-muted-foreground nx:select-none nx:group-has-[select:disabled]/native-select:text-disabled-foreground"
       />
     </div>
   );

--- a/packages/react/src/components/ui/select/Select.stories.tsx
+++ b/packages/react/src/components/ui/select/Select.stories.tsx
@@ -7,8 +7,8 @@ import {
   SPACING_MODES,
 } from '../../../stories/spacing-modes';
 import {
+  expectHeightFixedAcrossModes,
   expectHeightPinned,
-  expectModeCascadeWorks,
 } from '../../../stories/test-utils';
 
 import {
@@ -598,7 +598,7 @@ export const AllModes: Story = {
     docs: {
       description: {
         story:
-          "Each row scopes `data-style` locally on the trigger wrapper. `SelectTrigger` uses `py-control-md gap-control-md` and `typography-body-default`, so its vertical rhythm and body text follow mode. `px-3` stays numeric because `px-control-*` would over-widen form-field insets across looser modes. `SelectContent` portals to `document.body`, so opened items pick up document-level mode, not the row's wrapper.",
+          "Each row scopes `data-style` locally on the trigger wrapper. `SelectTrigger` uses numeric `py-2 gap-2 px-3` with `typography-body-default`, matching the fixed form-field rhythm instead of role spacing utilities. `SelectContent` portals to `document.body`, so opened items pick up document-level mode, not the row's wrapper.",
       },
     },
   },
@@ -624,45 +624,44 @@ export const AllModes: Story = {
   ),
 };
 
-export const ModesProduceDifferentHeights: Story = {
+export const SelectTriggerIsDensityStable: Story = {
   parameters: {
     a11y: { test: 'off' },
     docs: {
       description: {
         story:
-          'Cascade sentinel on `SelectTrigger`. Uses the `maia` + `sera` pair to spread coverage away from the Button/Input nova+sera and Tabs nova+maia pairs — between them the suite covers `control-md-y` at every distinct value (nova 6 / vega-tier 8 / maia 10 / sera 12). Trigger is not portaled so dimensional measurement on the wrapper works directly.',
+          'Density-stability sentinel for `SelectTrigger`. It stays on numeric `py-2 gap-2 px-3` rather than role spacing utilities, so every spacing mode resolves to the same canonical 38px height. Trigger is not portaled so dimensional measurement on the wrapper works directly.',
       },
     },
   },
   render: () => (
     <div className="nx:flex nx:items-center nx:gap-4 nx:p-10 nx:bg-background">
-      <div data-style="maia" data-testid="select-mode-host-maia">
-        <Select>
-          <SelectTrigger aria-label="maia select" className="nx:w-[160px]">
-            <SelectValue placeholder="Pick" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="a">A</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <div data-style="sera" data-testid="select-mode-host-sera">
-        <Select>
-          <SelectTrigger aria-label="sera select" className="nx:w-[160px]">
-            <SelectValue placeholder="Pick" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="a">A</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
+      {SPACING_MODES.map((mode) => (
+        <div
+          key={mode}
+          data-style={mode}
+          data-testid={`select-stable-host-${mode}`}
+        >
+          <Select>
+            <SelectTrigger
+              aria-label={`${mode} select`}
+              className="nx:w-[160px]"
+            >
+              <SelectValue placeholder="Pick" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="a">A</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      ))}
     </div>
   ),
   play: async ({ canvasElement }) => {
-    await expectModeCascadeWorks(
+    await expectHeightFixedAcrossModes(
       within(canvasElement),
-      'select-mode-host-maia',
-      'select-mode-host-sera'
+      SPACING_MODES.map((mode) => `select-stable-host-${mode}`),
+      38
     );
   },
 };
@@ -673,7 +672,7 @@ export const VegaDefaultHeightPinned: Story = {
     docs: {
       description: {
         story:
-          'Pin on the migration outcome: in vega mode, the `SelectTrigger` renders at exactly 38px (= `typography-body-default` 20px line-height + `py-control-md` 8px × 2 + border 1px × 2 — same intrinsic shape as Input default). If a designer retunes `--control-padding-y-md`, the body type ramp, or the border-width token, this test fails.',
+          'Pin on the migration outcome: in vega mode, the `SelectTrigger` renders at exactly 38px (= `typography-body-default` 20px line-height + `py-2` 8px × 2 + border 1px × 2 — same intrinsic shape as Input default). If a designer retunes `--nx-spacing-2`, the body type ramp, or the border-width token, this test fails.',
       },
     },
   },

--- a/packages/react/src/components/ui/select/Select.stories.tsx
+++ b/packages/react/src/components/ui/select/Select.stories.tsx
@@ -372,6 +372,14 @@ export const DisabledInteraction: Story = {
     // Trigger should be disabled
     const trigger = canvas.getByRole('combobox');
     await expect(trigger).toBeDisabled();
+    await expect(trigger).toHaveClass('nx:disabled:border-border-disabled');
+    await expect(trigger).toHaveClass('nx:disabled:bg-disabled');
+    await expect(trigger).toHaveClass('nx:disabled:text-disabled-foreground');
+
+    const icon = trigger.querySelector('svg');
+    await expect(icon).toHaveClass(
+      'nx:group-disabled/select-trigger:text-disabled-foreground'
+    );
 
     // Try to click - should not open
     await userEvent.click(trigger);

--- a/packages/react/src/components/ui/select/Select.stories.tsx
+++ b/packages/react/src/components/ui/select/Select.stories.tsx
@@ -598,7 +598,7 @@ export const AllModes: Story = {
     docs: {
       description: {
         story:
-          "Each row scopes `data-style` locally on the trigger wrapper. `SelectTrigger` migrates `py-2 gap-2` → `py-control-md gap-control-md` (matches vega byte-identically) and so responds to mode. `px-3` stays numeric per the Input/Select coupling-table note (form fields are narrower than buttons by design; per-mode gap drift between Input/Select and adjacent Buttons is accepted). `SelectContent` portals to `document.body`, so opened items pick up document-level mode, not the row's wrapper.",
+          "Each row scopes `data-style` locally on the trigger wrapper. `SelectTrigger` uses `py-control-md gap-control-md` and `typography-body-default`, so its vertical rhythm and body text follow mode. `px-3` stays numeric because `px-control-*` would over-widen form-field insets across looser modes. `SelectContent` portals to `document.body`, so opened items pick up document-level mode, not the row's wrapper.",
       },
     },
   },
@@ -673,7 +673,7 @@ export const VegaDefaultHeightPinned: Story = {
     docs: {
       description: {
         story:
-          'Pin on the migration outcome: in vega mode, the `SelectTrigger` renders at exactly 38px (= `text-sm` 20px line-height + `py-control-md` 8px × 2 + border 1px × 2 — same intrinsic shape as Input default). If a designer retunes `--control-padding-y-md`, the body type ramp, or the border-width token, this test fails.',
+          'Pin on the migration outcome: in vega mode, the `SelectTrigger` renders at exactly 38px (= `typography-body-default` 20px line-height + `py-control-md` 8px × 2 + border 1px × 2 — same intrinsic shape as Input default). If a designer retunes `--control-padding-y-md`, the body type ramp, or the border-width token, this test fails.',
       },
     },
   },

--- a/packages/react/src/components/ui/select/Select.stories.tsx
+++ b/packages/react/src/components/ui/select/Select.stories.tsx
@@ -403,6 +403,7 @@ export const WithDataAttributes: Story = {
     // Check trigger data-slot
     const trigger = canvas.getByRole('combobox');
     await expect(trigger).toHaveAttribute('data-slot', 'select-trigger');
+    await expect(trigger).toHaveClass('nx:enabled:hover:bg-background-hover');
 
     // Open the select
     await userEvent.click(trigger);

--- a/packages/react/src/components/ui/select/select.tsx
+++ b/packages/react/src/components/ui/select/select.tsx
@@ -65,13 +65,13 @@ function SelectTrigger({ className, children, ...props }: SelectTriggerProps) {
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       className={cn(
-        'nx:flex nx:w-full nx:items-center nx:justify-between nx:gap-2',
+        'nx:group/select-trigger nx:flex nx:w-full nx:items-center nx:justify-between nx:gap-2',
         'nx:rounded-md nx:border nx:border-border-default nx:bg-background nx:transition-colors nx:enabled:hover:bg-background-hover',
         'nx:px-3 nx:py-2 nx:typography-body-default',
         'nx:whitespace-nowrap',
         'nx:placeholder:text-muted-foreground',
         'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
-        'nx:disabled:cursor-not-allowed nx:disabled:opacity-50',
+        'nx:disabled:cursor-not-allowed nx:disabled:border-border-disabled nx:disabled:bg-disabled nx:disabled:text-disabled-foreground',
         'nx:[&>span]:line-clamp-1',
         className
       )}
@@ -79,7 +79,7 @@ function SelectTrigger({ className, children, ...props }: SelectTriggerProps) {
     >
       {children}
       <SelectPrimitive.Icon asChild>
-        <IconChevronDown className="nx:size-4 nx:opacity-50" />
+        <IconChevronDown className="nx:size-4 nx:text-muted-foreground nx:group-disabled/select-trigger:text-disabled-foreground" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   );
@@ -254,7 +254,7 @@ function SelectItem({ className, children, ...props }: SelectItemProps) {
         'nx:relative nx:flex nx:w-full nx:cursor-default nx:select-none nx:items-center',
         'nx:rounded-sm nx:py-1.5 nx:pl-8 nx:pr-2 nx:typography-body-default nx:outline-none',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
-        'nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50',
+        'nx:data-disabled:pointer-events-none nx:data-disabled:text-disabled-foreground',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/select/select.tsx
+++ b/packages/react/src/components/ui/select/select.tsx
@@ -66,7 +66,7 @@ function SelectTrigger({ className, children, ...props }: SelectTriggerProps) {
       data-slot="select-trigger"
       className={cn(
         'nx:flex nx:w-full nx:items-center nx:justify-between nx:gap-control-md',
-        'nx:rounded-md nx:border nx:border-border-default nx:bg-background',
+        'nx:rounded-md nx:border nx:border-border-default nx:bg-background nx:enabled:hover:bg-background-hover',
         'nx:px-3 nx:py-control-md nx:text-sm',
         'nx:whitespace-nowrap',
         'nx:placeholder:text-muted-foreground',

--- a/packages/react/src/components/ui/select/select.tsx
+++ b/packages/react/src/components/ui/select/select.tsx
@@ -66,7 +66,7 @@ function SelectTrigger({ className, children, ...props }: SelectTriggerProps) {
       data-slot="select-trigger"
       className={cn(
         'nx:flex nx:w-full nx:items-center nx:justify-between nx:gap-control-md',
-        'nx:rounded-md nx:border nx:border-border-default nx:bg-background nx:enabled:hover:bg-background-hover',
+        'nx:rounded-md nx:border nx:border-border-default nx:bg-background nx:transition-colors nx:enabled:hover:bg-background-hover',
         'nx:px-3 nx:py-control-md nx:text-sm',
         'nx:whitespace-nowrap',
         'nx:placeholder:text-muted-foreground',

--- a/packages/react/src/components/ui/select/select.tsx
+++ b/packages/react/src/components/ui/select/select.tsx
@@ -67,7 +67,7 @@ function SelectTrigger({ className, children, ...props }: SelectTriggerProps) {
       className={cn(
         'nx:flex nx:w-full nx:items-center nx:justify-between nx:gap-control-md',
         'nx:rounded-md nx:border nx:border-border-default nx:bg-background nx:transition-colors nx:enabled:hover:bg-background-hover',
-        'nx:px-3 nx:py-control-md nx:text-sm',
+        'nx:px-3 nx:py-control-md nx:typography-body-default',
         'nx:whitespace-nowrap',
         'nx:placeholder:text-muted-foreground',
         'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
@@ -222,7 +222,7 @@ function SelectLabel({ className, ...props }: SelectLabelProps) {
     <SelectPrimitive.Label
       data-slot="select-label"
       className={cn(
-        'nx:px-2 nx:py-control-sm nx:text-sm nx:font-semibold',
+        'nx:px-2 nx:py-control-sm nx:typography-label-default',
         className
       )}
       {...props}
@@ -255,7 +255,7 @@ function SelectItem({ className, children, ...props }: SelectItemProps) {
       data-slot="select-item"
       className={cn(
         'nx:relative nx:flex nx:w-full nx:cursor-default nx:select-none nx:items-center',
-        'nx:rounded-sm nx:py-control-sm nx:pl-8 nx:pr-2 nx:text-sm nx:outline-none',
+        'nx:rounded-sm nx:py-control-sm nx:pl-8 nx:pr-2 nx:typography-body-default nx:outline-none',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
         'nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50',
         className

--- a/packages/react/src/components/ui/select/select.tsx
+++ b/packages/react/src/components/ui/select/select.tsx
@@ -65,9 +65,9 @@ function SelectTrigger({ className, children, ...props }: SelectTriggerProps) {
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       className={cn(
-        'nx:flex nx:w-full nx:items-center nx:justify-between nx:gap-control-md',
+        'nx:flex nx:w-full nx:items-center nx:justify-between nx:gap-2',
         'nx:rounded-md nx:border nx:border-border-default nx:bg-background nx:transition-colors nx:enabled:hover:bg-background-hover',
-        'nx:px-3 nx:py-control-md nx:typography-body-default',
+        'nx:px-3 nx:py-2 nx:typography-body-default',
         'nx:whitespace-nowrap',
         'nx:placeholder:text-muted-foreground',
         'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
@@ -221,10 +221,7 @@ function SelectLabel({ className, ...props }: SelectLabelProps) {
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn(
-        'nx:px-2 nx:py-control-sm nx:typography-label-default',
-        className
-      )}
+      className={cn('nx:px-2 nx:py-1.5 nx:typography-label-default', className)}
       {...props}
     />
   );
@@ -255,7 +252,7 @@ function SelectItem({ className, children, ...props }: SelectItemProps) {
       data-slot="select-item"
       className={cn(
         'nx:relative nx:flex nx:w-full nx:cursor-default nx:select-none nx:items-center',
-        'nx:rounded-sm nx:py-control-sm nx:pl-8 nx:pr-2 nx:typography-body-default nx:outline-none',
+        'nx:rounded-sm nx:py-1.5 nx:pl-8 nx:pr-2 nx:typography-body-default nx:outline-none',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
         'nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50',
         className

--- a/packages/react/src/components/ui/textarea/Textarea.stories.tsx
+++ b/packages/react/src/components/ui/textarea/Textarea.stories.tsx
@@ -69,6 +69,13 @@ export const Disabled: Story = {
     const textarea = canvas.getByRole('textbox');
 
     await expect(textarea).toBeDisabled();
+    await expect(textarea).toHaveClass('nx:disabled:border-border-disabled');
+    await expect(textarea).toHaveClass('nx:disabled:bg-disabled');
+    await expect(textarea).toHaveClass('nx:disabled:text-disabled-foreground');
+    await expect(textarea).toHaveClass(
+      'nx:disabled:placeholder:text-disabled-foreground'
+    );
+    await expect(window.getComputedStyle(textarea).opacity).toBe('1');
   },
 };
 

--- a/packages/react/src/components/ui/textarea/Textarea.stories.tsx
+++ b/packages/react/src/components/ui/textarea/Textarea.stories.tsx
@@ -151,6 +151,7 @@ export const WithDataAttributes: Story = {
     const textarea = canvas.getByRole('textbox');
 
     await expect(textarea).toHaveAttribute('data-slot', 'textarea');
+    await expect(textarea).toHaveClass('nx:enabled:hover:bg-background-hover');
   },
 };
 

--- a/packages/react/src/components/ui/textarea/textarea.tsx
+++ b/packages/react/src/components/ui/textarea/textarea.tsx
@@ -33,7 +33,7 @@ function Textarea({ className, ...props }: TextareaProps) {
       data-slot="textarea"
       className={cn(
         'nx:flex nx:min-h-16 nx:w-full nx:rounded-md nx:border nx:border-border-default',
-        'nx:bg-background nx:text-foreground nx:transition-colors',
+        'nx:bg-background nx:text-foreground nx:transition-colors nx:enabled:hover:bg-background-hover',
         'nx:placeholder:text-muted-foreground',
         'nx:px-3 nx:py-control-md nx:text-sm',
         'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',

--- a/packages/react/src/components/ui/textarea/textarea.tsx
+++ b/packages/react/src/components/ui/textarea/textarea.tsx
@@ -35,7 +35,7 @@ function Textarea({ className, ...props }: TextareaProps) {
         'nx:flex nx:min-h-16 nx:w-full nx:rounded-md nx:border nx:border-border-default',
         'nx:bg-background nx:text-foreground nx:transition-colors nx:enabled:hover:bg-background-hover',
         'nx:placeholder:text-muted-foreground',
-        'nx:px-3 nx:py-control-md nx:typography-body-default',
+        'nx:px-3 nx:py-2 nx:typography-body-default',
         'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
         'nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error',
         'nx:disabled:cursor-not-allowed nx:disabled:opacity-50',

--- a/packages/react/src/components/ui/textarea/textarea.tsx
+++ b/packages/react/src/components/ui/textarea/textarea.tsx
@@ -38,7 +38,7 @@ function Textarea({ className, ...props }: TextareaProps) {
         'nx:px-3 nx:py-2 nx:typography-body-default',
         'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
         'nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error',
-        'nx:disabled:cursor-not-allowed nx:disabled:opacity-50',
+        'nx:disabled:cursor-not-allowed nx:disabled:border-border-disabled nx:disabled:bg-disabled nx:disabled:text-disabled-foreground nx:disabled:placeholder:text-disabled-foreground',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/textarea/textarea.tsx
+++ b/packages/react/src/components/ui/textarea/textarea.tsx
@@ -12,7 +12,7 @@ interface TextareaProps extends React.ComponentProps<'textarea'> {}
 /**
  * Textarea
  *
- * A multi-line text input. Mirrors Input's token, focus, and `aria-invalid`
+ * A multi-line text input. Mirrors Input's surface, focus, and `aria-invalid`
  * treatment and accepts all native textarea attributes. Use `rows` (or a
  * `min-height` override via `className`) to set the initial height.
  *

--- a/packages/react/src/components/ui/textarea/textarea.tsx
+++ b/packages/react/src/components/ui/textarea/textarea.tsx
@@ -35,7 +35,7 @@ function Textarea({ className, ...props }: TextareaProps) {
         'nx:flex nx:min-h-16 nx:w-full nx:rounded-md nx:border nx:border-border-default',
         'nx:bg-background nx:text-foreground nx:transition-colors nx:enabled:hover:bg-background-hover',
         'nx:placeholder:text-muted-foreground',
-        'nx:px-3 nx:py-control-md nx:text-sm',
+        'nx:px-3 nx:py-control-md nx:typography-body-default',
         'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
         'nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error',
         'nx:disabled:cursor-not-allowed nx:disabled:opacity-50',

--- a/packages/react/src/stories/test-utils.ts
+++ b/packages/react/src/stories/test-utils.ts
@@ -121,7 +121,7 @@ export async function expectHeightFixedAcrossModes(
 }
 
 /**
- * Per-mode height sentinel — the counterpart to `expectHeightPinnedAcrossModes`
+ * Per-mode height sentinel — the counterpart to `expectHeightFixedAcrossModes`
  * for controls whose height intentionally *varies* per `data-style` mode (fixed
  * `h-*` utilities backed by mode-scaled spacing tokens). Pass a `mode → expected
  * px` map; each control is located by `${testIdPrefix}-${mode}`. Awaits

--- a/packages/react/src/stories/test-utils.ts
+++ b/packages/react/src/stories/test-utils.ts
@@ -119,3 +119,30 @@ export async function expectHeightFixedAcrossModes(
     expect(actual, `[data-testid="${testId}"] height`).toBe(expectedPx);
   }
 }
+
+/**
+ * Per-mode height sentinel — the counterpart to `expectHeightPinnedAcrossModes`
+ * for controls whose height intentionally *varies* per `data-style` mode (fixed
+ * `h-*` utilities backed by mode-scaled spacing tokens). Pass a `mode → expected
+ * px` map; each control is located by `${testIdPrefix}-${mode}`. Awaits
+ * `document.fonts.ready` so Inter fallback metrics cannot skew the measurement.
+ * The optional `selector` is forwarded to `getControlHeight`.
+ */
+export async function expectHeightPerMode(
+  canvas: Canvas,
+  testIdPrefix: string,
+  expectedByMode: Record<string, number>,
+  { selector }: HeightMeasurementOptions = {}
+): Promise<void> {
+  await document.fonts.ready;
+  for (const [mode, expectedPx] of Object.entries(expectedByMode)) {
+    const actual = getControlHeight(
+      canvas,
+      `${testIdPrefix}-${mode}`,
+      selector
+    );
+    expect(actual, `[data-testid="${testIdPrefix}-${mode}"] height`).toBe(
+      expectedPx
+    );
+  }
+}

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -59,7 +59,7 @@
   --color-border-default: var(--nx-color-black-a200);
   --color-border-default-alpha: var(--nx-color-stone-a200);
   --color-border-active: var(--nx-color-stone-400);
-  --color-border-disabled: var(--nx-color-stone-50);
+  --color-border-disabled: var(--nx-color-black-a200);
   --color-border-warning: var(--nx-color-orange-200);
   --color-border-warning-active: var(--nx-color-orange-400);
   --color-border-success: var(--nx-color-green-200);
@@ -276,7 +276,7 @@
   --nx-color-border-default: var(--nx-color-white-a300);
   --nx-color-border-default-alpha: var(--nx-color-stone-a300);
   --nx-color-border-active: var(--nx-color-stone-400);
-  --nx-color-border-disabled: var(--nx-color-stone-950);
+  --nx-color-border-disabled: var(--nx-color-white-a300);
   --nx-color-border-warning: var(--nx-color-orange-700);
   --nx-color-border-warning-active: var(--nx-color-orange-500);
   --nx-color-border-success: var(--nx-color-green-700);


### PR DESCRIPTION
## Summary

- Keeps the existing Input / InputGroup fixed-height work in this PR.
- Extends the same PR to the remaining form-family typography and spacing cleanup for Select, NativeSelect, Textarea, and Form.
- Adds semantic disabled field-state cleanup for InputGroupText, Select, NativeSelect, and Textarea while keeping disabled component usage on `border-border-disabled`.
- Repoints base theme `border.disabled` to match `border.default`, then regenerates the token/theme outputs.
- Reconciles COMPONENT-REVIEW.md so the finished form-family notes are marked resolved and the out-of-scope notes stay explicit.
- Refreshes the ButtonGroup story assertion for the intentional Input default data-size behavior.

## GitHub Issue

Not linked.

## Notes

- Disabled field borders remain tokenized through `border-border-disabled`; light base themes now resolve `border.disabled` to `{black.a200}` and dark base themes to `{white.a300}`.
- The semantic token change also affects existing `border-border-disabled` consumers outside the form family, specifically disabled outline/dashed Button variants and disabled Accordion content; that visual change is intentional because it preserves semantic usage while making disabled borders consistently visible.
- SelectTrigger, NativeSelect, and Textarea now use semantic disabled border/background/foreground classes instead of opacity-only disabled styling.
- Select and NativeSelect chevrons inherit `text-disabled-foreground` from disabled trigger/select state; disabled SelectItems use disabled foreground text.
- SelectTrigger and SelectItem use typography-body-default; SelectLabel uses typography-label-default.
- SelectLabel intentionally moves from 600 to 500 weight because there is no 14px / 600 composite token.
- SelectTrigger, SelectLabel, SelectItem, NativeSelect, and Textarea use numeric spacing utilities for their form-field rhythm.
- NativeSelect keeps px-3 / px-2.5 / pr-9; Textarea keeps px-3 / py-2.
- FormDescription and FormMessage keep consumer className last so typography overrides still win by source order.
- Field padding stays numeric because role spacing utilities would over-widen or over-tall form-field insets across looser spacing modes.
- field.tsx, label, and input-otp stay out of scope; field.tsx remains unresolved because its 16px / 500 legend treatment has no size-preserving composite.

## Test Plan

- [x] pnpm tokens:modular
- [x] pnpm tokens:tailwind
- [x] focused source audit for Input, InputGroup, Select, NativeSelect, and Textarea disabled classes
- [x] token equality audit: every base `border.disabled` equals `border.default`
- [x] pnpm --filter @nexus/react audit:storybook-coverage --component input
- [x] pnpm --filter @nexus/react audit:storybook-coverage --component input-group
- [x] pnpm --filter @nexus/react audit:storybook-coverage --component select
- [x] pnpm --filter @nexus/react audit:storybook-coverage --component native-select
- [x] pnpm --filter @nexus/react audit:storybook-coverage --component textarea
- [x] pnpm --filter @nexus/react audit:storybook-coverage --component form
- [x] pnpm test:storybook - 112 files / 715 tests passed
- [x] pnpm --filter @nexus/react typecheck
- [x] pnpm lint
- [x] pnpm format:check
- [x] pnpm audit:contrast - 528 pairs passed
- [x] git diff --check

Not run locally: bundle-size, per plan; these are class-string / CSS utility changes, not JS bundle-size relevant.
