### PR TITLE
docs(form-field): add guidance stories

### DIFF
--- a/packages/react/src/components/ui/form/Form.stories.tsx
+++ b/packages/react/src/components/ui/form/Form.stories.tsx
@@ -6,6 +6,7 @@ import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { z } from 'zod';
 
 import { Button } from '../button';
+import { Field, FieldDescription, FieldLabel } from '../field';
 import { Input } from '../input';
 
 import {
@@ -203,6 +204,127 @@ function AnatomyForm() {
   );
 }
 
+function FieldVsFormErgonomicsExample() {
+  const form = useForm<{ email: string }>({
+    defaultValues: { email: '' },
+  });
+
+  return (
+    <div className="nx:grid nx:max-w-3xl nx:gap-6 nx:lg:grid-cols-2">
+      <section className="nx:grid nx:gap-3 nx:rounded-md nx:border nx:border-border-default nx:p-4">
+        <h3 className="nx:typography-label-default nx:text-foreground">
+          Field
+        </h3>
+        <p className="nx:typography-body-small nx:text-muted-foreground">
+          Low-level and library-agnostic. You own ids, validation state, and
+          form-library wiring.
+        </p>
+        <Field>
+          <FieldLabel htmlFor="field-library-email">Library email</FieldLabel>
+          <Input
+            id="field-library-email"
+            type="email"
+            placeholder="jane@example.com"
+          />
+          <FieldDescription>
+            Use Field when the form library is not React Hook Form.
+          </FieldDescription>
+        </Field>
+      </section>
+      <section className="nx:grid nx:gap-3 nx:rounded-md nx:border nx:border-border-default nx:p-4">
+        <h3 className="nx:typography-label-default nx:text-foreground">Form</h3>
+        <p className="nx:typography-body-small nx:text-muted-foreground">
+          React Hook Form-specific. FormField and FormControl wire ids,
+          descriptions, invalid state, and messages from RHF state.
+        </p>
+        <Form {...form}>
+          <form className="nx:grid nx:gap-3">
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>RHF email</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="jane@example.com"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Use Form when React Hook Form owns field state.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </form>
+        </Form>
+      </section>
+    </div>
+  );
+}
+
+function RequiredOptionalHouseRuleExample() {
+  return (
+    <div className="nx:grid nx:max-w-3xl nx:gap-6 nx:lg:grid-cols-2">
+      <section className="nx:grid nx:gap-4 nx:rounded-md nx:border nx:border-border-default nx:p-4">
+        <div className="nx:grid nx:gap-1">
+          <h3 className="nx:typography-label-default nx:text-foreground">
+            Most fields required
+          </h3>
+          <p className="nx:typography-body-small nx:text-muted-foreground">
+            Mark only the exceptions as optional.
+          </p>
+        </div>
+        <Field>
+          <FieldLabel htmlFor="required-house-company">Company</FieldLabel>
+          <Input id="required-house-company" />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor="required-house-email">Work email</FieldLabel>
+          <Input id="required-house-email" type="email" />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor="required-house-po">
+            Purchase order{' '}
+            <span className="nx:text-muted-foreground">(optional)</span>
+          </FieldLabel>
+          <Input id="required-house-po" />
+        </Field>
+      </section>
+      <section className="nx:grid nx:gap-4 nx:rounded-md nx:border nx:border-border-default nx:p-4">
+        <div className="nx:grid nx:gap-1">
+          <h3 className="nx:typography-label-default nx:text-foreground">
+            Most fields optional
+          </h3>
+          <p className="nx:typography-body-small nx:text-muted-foreground">
+            Mark only the required fields.
+          </p>
+        </div>
+        <Field>
+          <FieldLabel htmlFor="optional-house-linkedin">
+            LinkedIn profile
+          </FieldLabel>
+          <Input id="optional-house-linkedin" type="url" />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor="optional-house-phone">Phone</FieldLabel>
+          <Input id="optional-house-phone" type="tel" />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor="optional-house-email">
+            Work email{' '}
+            <span className="nx:text-muted-foreground">(required)</span>
+          </FieldLabel>
+          <Input id="optional-house-email" type="email" required />
+        </Field>
+      </section>
+    </div>
+  );
+}
+
 const meta = {
   title: 'Components/Form',
   component: Form,
@@ -234,6 +356,44 @@ export const BasicValidation: Story = {
           'Fields are validated with a Zod schema via `zodResolver`. Each FormItem composes a label, control, description, and message; FormMessage renders the resolver error when a field is invalid.',
       },
     },
+  },
+};
+
+export const FieldVsFormErgonomics: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Field is the low-level, library-agnostic field anatomy. Form is the React Hook Form-specific binding layer. PR 1 keeps this as story/docs guidance; read-only source semantics, warning source semantics, rich Select slots, and Combobox/MultiSelect boundaries stay in later roadmap PRs.',
+      },
+    },
+  },
+  render: () => <FieldVsFormErgonomicsExample />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const fieldInput = canvas.getByLabelText('Library email');
+    const formInput = canvas.getByLabelText('RHF email');
+
+    await expect(fieldInput).toHaveAttribute('id', 'field-library-email');
+    await expect(formInput).toHaveAttribute('aria-describedby');
+  },
+};
+
+export const RequiredOptionalHouseRule: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'House rule: when most fields are required, mark optional exceptions. When most fields are optional, mark required exceptions. Avoid marking every field in both directions.',
+      },
+    },
+  },
+  render: () => <RequiredOptionalHouseRuleExample />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('(optional)')).toBeInTheDocument();
+    await expect(canvas.getByText('(required)')).toBeInTheDocument();
   },
 };
 

--- a/packages/react/src/components/ui/form/Form.stories.tsx
+++ b/packages/react/src/components/ui/form/Form.stories.tsx
@@ -364,7 +364,7 @@ export const FieldVsFormErgonomics: Story = {
     docs: {
       description: {
         story:
-          'Field is the low-level, library-agnostic field anatomy. Form is the React Hook Form-specific binding layer. PR 1 keeps this as story/docs guidance; read-only source semantics, warning source semantics, rich Select slots, and Combobox/MultiSelect boundaries stay in later roadmap PRs.',
+          'Field is the low-level, library-agnostic field anatomy. Form is the React Hook Form-specific binding layer. This story is documentation guidance only; read-only source semantics, warning source semantics, rich Select slots, and Combobox/MultiSelect boundaries remain on the roadmap.',
       },
     },
   },

--- a/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
+++ b/packages/react/src/components/ui/input-group/InputGroup.stories.tsx
@@ -4,6 +4,7 @@ import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { SPACING_MODES } from '../../../stories/spacing-modes';
 import { expectHeightPerMode } from '../../../stories/test-utils';
+import { Spinner } from '../spinner';
 
 import {
   InputGroup,
@@ -236,6 +237,155 @@ export const Disabled: Story = {
     await expect(
       canvas.getByRole('button', { name: 'Subscribe' })
     ).toBeDisabled();
+  },
+};
+
+export const StateMatrix: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Form-field state guidance using current APIs only. Default, read-only, disabled, error, warning, and loading are composed in stories; warning remains advisory and does not use `aria-invalid`, while loading uses InputGroup plus Spinner rather than adding a loading prop.',
+      },
+    },
+  },
+  render: () => (
+    <div className="nx:flex nx:w-[420px] nx:flex-col nx:gap-4">
+      <div className="nx:grid nx:gap-1.5">
+        <span className="nx:typography-label-default nx:text-foreground">
+          Default
+        </span>
+        <InputGroup>
+          <InputGroupInput
+            aria-label="Default email"
+            placeholder="jane@example.com"
+          />
+        </InputGroup>
+      </div>
+      <div className="nx:grid nx:gap-1.5">
+        <span className="nx:typography-label-default nx:text-foreground">
+          Read-only
+        </span>
+        <InputGroup>
+          <InputGroupInput
+            aria-label="Read-only email"
+            aria-describedby="state-readonly-message"
+            defaultValue="jane@example.com"
+            readOnly
+          />
+          <InputGroupAddon align="block-end">
+            <InputGroupText id="state-readonly-message">
+              Submitted value; selectable, focusable, and not editable here.
+            </InputGroupText>
+          </InputGroupAddon>
+        </InputGroup>
+      </div>
+      <div className="nx:grid nx:gap-1.5">
+        <span className="nx:typography-label-default nx:text-foreground">
+          Disabled
+        </span>
+        <InputGroup data-disabled="true">
+          <InputGroupInput
+            aria-label="Disabled email"
+            defaultValue="jane@example.com"
+            disabled
+          />
+        </InputGroup>
+      </div>
+      <div className="nx:grid nx:gap-1.5">
+        <span className="nx:typography-label-default nx:text-foreground">
+          Warning
+        </span>
+        <InputGroup className="nx:border-border-warning">
+          <InputGroupInput
+            aria-label="Warning email"
+            aria-describedby="state-warning-message"
+            defaultValue="jane@contractor.example"
+          />
+          <InputGroupAddon align="block-end">
+            <InputGroupText
+              id="state-warning-message"
+              className="nx:text-warning-subtle-foreground"
+            >
+              External domain. You can continue after review.
+            </InputGroupText>
+          </InputGroupAddon>
+        </InputGroup>
+      </div>
+      <div className="nx:grid nx:gap-1.5">
+        <span className="nx:typography-label-default nx:text-foreground">
+          Error
+        </span>
+        <InputGroup>
+          <InputGroupInput
+            aria-label="Invalid email"
+            aria-errormessage="state-error-message"
+            aria-invalid
+            defaultValue="jane@"
+          />
+          <InputGroupAddon align="block-end">
+            <InputGroupText
+              id="state-error-message"
+              role="alert"
+              className="nx:text-error-subtle-foreground"
+            >
+              Enter a complete email address.
+            </InputGroupText>
+          </InputGroupAddon>
+        </InputGroup>
+      </div>
+      <div className="nx:grid nx:gap-1.5">
+        <span className="nx:typography-label-default nx:text-foreground">
+          Loading
+        </span>
+        <InputGroup data-testid="state-loading-group" aria-busy="true">
+          <InputGroupInput
+            aria-label="Loading username"
+            aria-describedby="state-loading-message"
+            defaultValue="janedoe"
+          />
+          <InputGroupAddon align="inline-end">
+            <Spinner
+              aria-label="Checking username"
+              className="nx:text-muted-foreground"
+            />
+          </InputGroupAddon>
+          <InputGroupAddon align="block-end">
+            <InputGroupText id="state-loading-message">
+              Checking availability...
+            </InputGroupText>
+          </InputGroupAddon>
+        </InputGroup>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const readOnly = canvas.getByRole('textbox', { name: 'Read-only email' });
+    const disabled = canvas.getByRole('textbox', { name: 'Disabled email' });
+    const warning = canvas.getByRole('textbox', { name: 'Warning email' });
+    const error = canvas.getByRole('textbox', { name: 'Invalid email' });
+
+    await expect(readOnly).toHaveAttribute('readonly');
+    await expect(readOnly).not.toBeDisabled();
+    await expect(disabled).toBeDisabled();
+    await expect(warning).not.toHaveAttribute('aria-invalid');
+    await expect(warning).toHaveAttribute(
+      'aria-describedby',
+      'state-warning-message'
+    );
+    await expect(error).toHaveAttribute('aria-invalid', 'true');
+    await expect(error).toHaveAttribute(
+      'aria-errormessage',
+      'state-error-message'
+    );
+    await expect(canvas.getByTestId('state-loading-group')).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+    await expect(
+      canvas.getByRole('status', { name: 'Checking username' })
+    ).toBeInTheDocument();
   },
 };
 

--- a/packages/react/src/components/ui/input/Input.stories.tsx
+++ b/packages/react/src/components/ui/input/Input.stories.tsx
@@ -203,7 +203,7 @@ export const WarningVsError: Story = {
     docs: {
       description: {
         story:
-          'Warning is advisory guidance and must not set `aria-invalid`. Error means the current value is invalid, so it uses `aria-invalid` and an error message relationship. First-class warning source semantics are intentionally left for the warning semantics follow-up PR.',
+          'Warning is advisory guidance and must not set `aria-invalid`. Error means the current value is invalid, so it uses `aria-invalid` and an error message relationship. First-class warning source semantics are intentionally left for a future iteration.',
       },
     },
   },

--- a/packages/react/src/components/ui/input/Input.stories.tsx
+++ b/packages/react/src/components/ui/input/Input.stories.tsx
@@ -136,6 +136,141 @@ export const Invalid: Story = {
   },
 };
 
+export const ReadOnlyVsDisabled: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Read-only keeps the control focusable and submittable while preventing edits. Disabled removes the control from editing and native form submission. Input has no special read-only visual treatment today, so pair read-only fields with helper copy when the distinction matters.',
+      },
+    },
+  },
+  render: () => (
+    <div className="nx:flex nx:w-[400px] nx:flex-col nx:gap-4">
+      <div className="nx:grid nx:gap-1.5">
+        <span className="nx:typography-label-default nx:text-foreground">
+          Read-only
+        </span>
+        <Input
+          aria-label="Read-only account id"
+          aria-describedby="input-readonly-note"
+          defaultValue="acct_1024"
+          readOnly
+        />
+        <p
+          id="input-readonly-note"
+          className="nx:typography-body-small nx:text-muted-foreground"
+        >
+          Value can be selected and submitted, but not edited here.
+        </p>
+      </div>
+      <div className="nx:grid nx:gap-1.5">
+        <span className="nx:typography-label-default nx:text-foreground">
+          Disabled
+        </span>
+        <Input
+          aria-label="Disabled account id"
+          aria-describedby="input-disabled-note"
+          defaultValue="acct_1024"
+          disabled
+        />
+        <p
+          id="input-disabled-note"
+          className="nx:typography-body-small nx:text-muted-foreground"
+        >
+          Value is unavailable and should not be submitted from this control.
+        </p>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const readOnly = canvas.getByRole('textbox', {
+      name: 'Read-only account id',
+    });
+    const disabled = canvas.getByRole('textbox', {
+      name: 'Disabled account id',
+    });
+
+    await expect(readOnly).toHaveAttribute('readonly');
+    await expect(readOnly).not.toBeDisabled();
+    await expect(disabled).toBeDisabled();
+  },
+};
+
+export const WarningVsError: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Warning is advisory guidance and must not set `aria-invalid`. Error means the current value is invalid, so it uses `aria-invalid` and an error message relationship. First-class warning source semantics are intentionally left for the warning semantics follow-up PR.',
+      },
+    },
+  },
+  render: () => (
+    <div className="nx:flex nx:w-[400px] nx:flex-col nx:gap-4">
+      <div className="nx:grid nx:gap-1.5">
+        <span className="nx:typography-label-default nx:text-foreground">
+          Warning
+        </span>
+        <Input
+          aria-label="Warning budget"
+          aria-describedby="input-warning-message"
+          defaultValue="95"
+          className="nx:border-border-warning"
+        />
+        <p
+          id="input-warning-message"
+          className="nx:typography-body-small nx:text-warning-subtle-foreground"
+        >
+          Near the monthly limit. You can continue.
+        </p>
+      </div>
+      <div className="nx:grid nx:gap-1.5">
+        <span className="nx:typography-label-default nx:text-foreground">
+          Error
+        </span>
+        <Input
+          aria-label="Invalid budget"
+          aria-describedby="input-error-help"
+          aria-errormessage="input-error-message"
+          aria-invalid
+          defaultValue="125"
+        />
+        <p
+          id="input-error-help"
+          className="nx:typography-body-small nx:text-muted-foreground"
+        >
+          Enter a value from 0 to 100.
+        </p>
+        <p
+          id="input-error-message"
+          role="alert"
+          className="nx:typography-body-small nx:text-error-subtle-foreground"
+        >
+          Budget cannot exceed 100.
+        </p>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const warning = canvas.getByRole('textbox', { name: 'Warning budget' });
+    const error = canvas.getByRole('textbox', { name: 'Invalid budget' });
+
+    await expect(warning).not.toHaveAttribute('aria-invalid');
+    await expect(warning).toHaveAttribute(
+      'aria-describedby',
+      'input-warning-message'
+    );
+    await expect(error).toHaveAttribute('aria-invalid', 'true');
+    await expect(error).toHaveAttribute(
+      'aria-errormessage',
+      'input-error-message'
+    );
+  },
+};
+
 // ============================================
 // TYPE STORIES
 // ============================================

--- a/packages/react/src/components/ui/native-select/NativeSelect.stories.tsx
+++ b/packages/react/src/components/ui/native-select/NativeSelect.stories.tsx
@@ -93,6 +93,65 @@ export const Disabled: Story = {
   },
 };
 
+export const ReadOnlyBoundary: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'NativeSelect wraps a native `select`, which has disabled but no native readOnly state. Use disabled when the control is unavailable. If a locked value must still submit with a form, render a display-only value and a hidden input instead of passing a readOnly prop.',
+      },
+    },
+  },
+  render: () => (
+    <div className="nx:flex nx:w-[320px] nx:flex-col nx:gap-4">
+      <div className="nx:grid nx:gap-1.5">
+        <span className="nx:typography-label-default nx:text-foreground">
+          Disabled native select
+        </span>
+        <NativeSelect
+          aria-label="Disabled native plan"
+          defaultValue="pro"
+          disabled
+        >
+          <NativeSelectOption value="free">Free</NativeSelectOption>
+          <NativeSelectOption value="pro">Pro</NativeSelectOption>
+        </NativeSelect>
+      </div>
+      <form className="nx:grid nx:gap-1.5">
+        <span className="nx:typography-label-default nx:text-foreground">
+          Display-only submission value
+        </span>
+        <div
+          data-testid="native-select-display-only-value"
+          className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:px-3 nx:py-2 nx:typography-body-default nx:text-foreground"
+        >
+          Pro
+        </div>
+        <input type="hidden" name="plan" value="pro" />
+        <p className="nx:typography-body-small nx:text-muted-foreground">
+          The hidden input carries the locked value through native form
+          submission.
+        </p>
+      </form>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const select = canvas.getByRole('combobox', {
+      name: 'Disabled native plan',
+    });
+    const hiddenInput = canvasElement.querySelector('input[type="hidden"]');
+
+    await expect(select).toBeDisabled();
+    await expect(select).not.toHaveAttribute('readonly');
+    await expect(
+      canvas.getByTestId('native-select-display-only-value')
+    ).toHaveTextContent('Pro');
+    await expect(hiddenInput).toHaveAttribute('name', 'plan');
+    await expect(hiddenInput).toHaveAttribute('value', 'pro');
+  },
+};
+
 // Selecting an option updates the value and fires onChange.
 export const ClickInteraction: Story = {
   args: { onChange: fn() },

--- a/packages/react/src/components/ui/select/Select.stories.tsx
+++ b/packages/react/src/components/ui/select/Select.stories.tsx
@@ -10,6 +10,7 @@ import {
   expectHeightFixedAcrossModes,
   expectHeightPinned,
 } from '../../../stories/test-utils';
+import { NativeSelect, NativeSelectOption } from '../native-select';
 
 import {
   Select,
@@ -97,6 +98,169 @@ export const WithDisabledItems: Story = {
         <SelectItem value="option3">Available</SelectItem>
       </SelectContent>
     </Select>
+  ),
+};
+
+export const CapabilityLadder: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Capability ladder: use NativeSelect for native form submission and OS pickers with simple text options; use Select for a styled trigger/listbox with groups, separators, and disabled items. Future Combobox and MultiSelect remain roadmap-only boundaries in PR 5 and are not implemented here.',
+      },
+    },
+  },
+  render: () => (
+    <div className="nx:grid nx:max-w-3xl nx:gap-4 nx:md:grid-cols-2">
+      <section className="nx:grid nx:gap-2 nx:rounded-md nx:border nx:border-border-default nx:p-4">
+        <h3 className="nx:typography-label-default nx:text-foreground">
+          NativeSelect
+        </h3>
+        <p className="nx:typography-body-small nx:text-muted-foreground">
+          Native picker, native form semantics, simple text options.
+        </p>
+        <NativeSelect aria-label="Native plan" defaultValue="pro">
+          <NativeSelectOption value="free">Free</NativeSelectOption>
+          <NativeSelectOption value="pro">Pro</NativeSelectOption>
+          <NativeSelectOption value="team">Team</NativeSelectOption>
+        </NativeSelect>
+      </section>
+      <section className="nx:grid nx:gap-2 nx:rounded-md nx:border nx:border-border-default nx:p-4">
+        <h3 className="nx:typography-label-default nx:text-foreground">
+          Select
+        </h3>
+        <p className="nx:typography-body-small nx:text-muted-foreground">
+          Styled trigger and listbox, groups, separators, disabled items.
+        </p>
+        <Select defaultValue="pro">
+          <SelectTrigger aria-label="Styled plan">
+            <SelectValue placeholder="Plan" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectLabel>Plans</SelectLabel>
+              <SelectItem value="free">Free</SelectItem>
+              <SelectItem value="pro">Pro</SelectItem>
+              <SelectItem value="team" disabled>
+                Team
+              </SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </section>
+      <section className="nx:grid nx:gap-2 nx:rounded-md nx:border nx:border-dashed nx:border-border-default nx:p-4">
+        <h3 className="nx:typography-label-default nx:text-foreground">
+          Future Combobox
+        </h3>
+        <p className="nx:typography-body-small nx:text-muted-foreground">
+          Roadmap boundary for searchable or async single selection.
+        </p>
+      </section>
+      <section className="nx:grid nx:gap-2 nx:rounded-md nx:border nx:border-dashed nx:border-border-default nx:p-4">
+        <h3 className="nx:typography-label-default nx:text-foreground">
+          Future MultiSelect
+        </h3>
+        <p className="nx:typography-body-small nx:text-muted-foreground">
+          Roadmap boundary for multiple selected values and chip summaries.
+        </p>
+      </section>
+    </div>
+  ),
+};
+
+export const ReadOnlyBoundary: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Select has disabled state today, but no first-class read-only state. Use disabled when users cannot interact and the value should not behave like an editable control. If a locked value still needs to submit with a form, render a display-only value plus a hidden input.',
+      },
+    },
+  },
+  render: () => (
+    <div className="nx:flex nx:w-[360px] nx:flex-col nx:gap-4">
+      <div className="nx:grid nx:gap-1.5">
+        <span className="nx:typography-label-default nx:text-foreground">
+          Disabled Select
+        </span>
+        <Select disabled defaultValue="team">
+          <SelectTrigger aria-label="Disabled team select">
+            <SelectValue placeholder="Team" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="team">Team</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <form className="nx:grid nx:gap-1.5">
+        <span className="nx:typography-label-default nx:text-foreground">
+          Display-only submission value
+        </span>
+        <div
+          data-testid="select-display-only-value"
+          className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:px-3 nx:py-2 nx:typography-body-default nx:text-foreground"
+        >
+          Team
+        </div>
+        <input type="hidden" name="plan" value="team" />
+        <p className="nx:typography-body-small nx:text-muted-foreground">
+          Hidden input preserves form submission without exposing an editable
+          select.
+        </p>
+      </form>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('combobox', {
+      name: 'Disabled team select',
+    });
+    const hiddenInput = canvasElement.querySelector('input[type="hidden"]');
+
+    await expect(trigger).toBeDisabled();
+    await expect(
+      canvas.getByTestId('select-display-only-value')
+    ).toHaveTextContent('Team');
+    await expect(hiddenInput).toHaveAttribute('name', 'plan');
+    await expect(hiddenInput).toHaveAttribute('value', 'team');
+  },
+};
+
+export const RichItemFutureBoundary: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Current Select items are text-first options with disabled support. Rich item affordances such as description, icon/avatar, metadata, and disabled reason belong to a future compositional-slot API, not render props, and are intentionally not implemented in this PR.',
+      },
+    },
+  },
+  render: () => (
+    <div className="nx:grid nx:max-w-xl nx:gap-4">
+      <Select defaultValue="owner">
+        <SelectTrigger className="nx:w-[260px]" aria-label="Current role">
+          <SelectValue placeholder="Role" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="owner">Owner</SelectItem>
+          <SelectItem value="admin" disabled>
+            Billing admin unavailable
+          </SelectItem>
+          <SelectItem value="viewer">Viewer</SelectItem>
+        </SelectContent>
+      </Select>
+      <div className="nx:grid nx:gap-2 nx:rounded-md nx:border nx:border-dashed nx:border-border-default nx:p-4">
+        <h3 className="nx:typography-label-default nx:text-foreground">
+          Future rich item slots
+        </h3>
+        <ul className="nx:ml-4 nx:list-disc nx:typography-body-small nx:text-muted-foreground">
+          <li>Icon or avatar slot before item text.</li>
+          <li>Description slot below the primary label.</li>
+          <li>Metadata slot aligned to the far edge.</li>
+          <li>Disabled reason slot for unavailable choices.</li>
+        </ul>
+      </div>
+    </div>
   ),
 };
 

--- a/packages/react/src/components/ui/select/Select.stories.tsx
+++ b/packages/react/src/components/ui/select/Select.stories.tsx
@@ -106,7 +106,7 @@ export const CapabilityLadder: Story = {
     docs: {
       description: {
         story:
-          'Capability ladder: use NativeSelect for native form submission and OS pickers with simple text options; use Select for a styled trigger/listbox with groups, separators, and disabled items. Future Combobox and MultiSelect remain roadmap-only boundaries in PR 5 and are not implemented here.',
+          'Capability ladder: use NativeSelect for native form submission and OS pickers with simple text options; use Select for a styled trigger/listbox with groups, separators, and disabled items. Future Combobox and MultiSelect remain roadmap-only boundaries and are not implemented here.',
       },
     },
   },

--- a/packages/react/src/components/ui/textarea/Textarea.stories.tsx
+++ b/packages/react/src/components/ui/textarea/Textarea.stories.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
@@ -41,6 +43,80 @@ const meta: Meta<typeof Textarea> = {
 
 export default meta;
 type Story = StoryObj<typeof Textarea>;
+
+function CharacterCounterTextarea() {
+  const textareaId = React.useId();
+  const descriptionId = React.useId();
+  const counterId = React.useId();
+  const maxLength = 160;
+  const [value, setValue] = React.useState(
+    'Shipped keyboard fixes and updated the empty state copy.'
+  );
+
+  return (
+    <div className="nx:grid nx:gap-2">
+      <Label htmlFor={textareaId}>Release note</Label>
+      <Textarea
+        id={textareaId}
+        aria-describedby={`${descriptionId} ${counterId}`}
+        value={value}
+        maxLength={maxLength}
+        onChange={(event) => setValue(event.currentTarget.value)}
+      />
+      <div className="nx:flex nx:items-start nx:justify-between nx:gap-3">
+        <p
+          id={descriptionId}
+          className="nx:typography-body-small nx:text-muted-foreground"
+        >
+          Keep the note short enough for the activity feed.
+        </p>
+        <p
+          id={counterId}
+          className="nx:shrink-0 nx:typography-body-small nx:text-muted-foreground"
+        >
+          {value.length} / {maxLength} characters
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function WordCounterTextarea() {
+  const textareaId = React.useId();
+  const descriptionId = React.useId();
+  const counterId = React.useId();
+  const [value, setValue] = React.useState(
+    'Summarize the customer outcome and the next decision.'
+  );
+  const wordCount = value.trim().split(/\s+/).filter(Boolean).length;
+
+  return (
+    <div className="nx:grid nx:gap-2">
+      <Label htmlFor={textareaId}>Executive summary</Label>
+      <Textarea
+        id={textareaId}
+        aria-describedby={`${descriptionId} ${counterId}`}
+        value={value}
+        rows={5}
+        onChange={(event) => setValue(event.currentTarget.value)}
+      />
+      <div className="nx:flex nx:items-start nx:justify-between nx:gap-3">
+        <p
+          id={descriptionId}
+          className="nx:typography-body-small nx:text-muted-foreground"
+        >
+          Aim for one short paragraph.
+        </p>
+        <p
+          id={counterId}
+          className="nx:shrink-0 nx:typography-body-small nx:text-muted-foreground"
+        >
+          {wordCount} words
+        </p>
+      </div>
+    </div>
+  );
+}
 
 // ============================================
 // BASIC STORIES
@@ -109,6 +185,80 @@ export const WithLabel: Story = {
     const textarea = canvas.getByLabelText('Bio');
 
     await expect(textarea).toBeInTheDocument();
+  },
+};
+
+export const CharacterCounter: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Character counters are story-local composition: keep the count in local state and connect both helper text and counter with `aria-describedby`.',
+      },
+    },
+  },
+  render: () => <CharacterCounterTextarea />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByLabelText('Release note');
+    const counter = canvas.getByText(/characters$/);
+
+    await expect(textarea).toHaveAttribute(
+      'aria-describedby',
+      expect.stringContaining(counter.id)
+    );
+    await expect(counter).toHaveTextContent('characters');
+  },
+};
+
+export const WordCounter: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Word counters follow the same pattern as character counters: local story state, visible count, and `aria-describedby` on the textarea.',
+      },
+    },
+  },
+  render: () => <WordCounterTextarea />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByLabelText('Executive summary');
+    const counter = canvas.getByText(/words$/);
+
+    await expect(textarea).toHaveAttribute(
+      'aria-describedby',
+      expect.stringContaining(counter.id)
+    );
+    await expect(counter).toHaveTextContent('words');
+  },
+};
+
+export const ResizeGuidance: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Textarea accepts native textarea attributes and className overrides. Use `rows` for the initial height and `nx:resize-y` when standalone vertical resizing is useful; InputGroupTextarea keeps `resize-none` so the grouped frame stays stable.',
+      },
+    },
+  },
+  render: () => (
+    <div className="nx:grid nx:gap-2">
+      <Label htmlFor="textarea-resize">Resizable notes</Label>
+      <Textarea
+        id="textarea-resize"
+        rows={5}
+        className="nx:resize-y"
+        placeholder="Drag the bottom edge to resize vertically."
+      />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByLabelText('Resizable notes')).toHaveClass(
+      'nx:resize-y'
+    );
   },
 };
 


### PR DESCRIPTION
## Summary
- Add story-only form-field family guidance across Input, InputGroup, Select, NativeSelect, Textarea, and Form.
- Document read-only vs disabled, warning vs error, loading composition, textarea counters/resize, Select/NativeSelect boundaries, rich Select item roadmap, Field vs Form ergonomics, and required/optional labeling.
- Preserve the roadmap: PR 1 story/docs only; PR 2 read-only source semantics; PR 3 warning source semantics; PR 4 rich Select item slots; PR 5 future Combobox/MultiSelect boundary.

## GitHub Issue
N/A

## Test Plan
- [x] pnpm --filter @nexus/react audit:storybook-coverage --component input
- [x] pnpm --filter @nexus/react audit:storybook-coverage --component input-group
- [x] pnpm --filter @nexus/react audit:storybook-coverage --component select
- [x] pnpm --filter @nexus/react audit:storybook-coverage --component native-select
- [x] pnpm --filter @nexus/react audit:storybook-coverage --component textarea
- [x] pnpm --filter @nexus/react audit:storybook-coverage --component form
- [x] pnpm test:storybook
- [x] pnpm --filter @nexus/react typecheck
- [x] pnpm lint
- [x] pnpm format:check
- [x] git diff --check