### PR TITLE
fix(react): mute outside date picker days

### DIFF
--- a/packages/react/src/components/ui/date-picker/DatePicker.stories.tsx
+++ b/packages/react/src/components/ui/date-picker/DatePicker.stories.tsx
@@ -177,6 +177,26 @@ export const Default: Story = {
       selected={new Date(2025, 0, 15)}
     />
   ),
+  play: async ({ canvasElement }) => {
+    const currentMonthDay = canvasElement.querySelector<HTMLButtonElement>(
+      'button[data-day="2025-01-01"]'
+    );
+    const outsideMonthDay = canvasElement.querySelector<HTMLButtonElement>(
+      'button[data-day="2024-12-29"]'
+    );
+    const outsideMonthCell = outsideMonthDay?.closest('.rdp-day');
+
+    await expect(currentMonthDay).toBeInTheDocument();
+    await expect(outsideMonthDay).toBeInTheDocument();
+    await expect(outsideMonthDay).toHaveAttribute('data-outside', 'true');
+
+    const currentColor = getComputedStyle(currentMonthDay!).color;
+    const outsideColor = getComputedStyle(outsideMonthDay!).color;
+    const outsideCellColor = getComputedStyle(outsideMonthCell!).color;
+
+    expect(outsideColor).not.toBe(currentColor);
+    expect(outsideColor).toBe(outsideCellColor);
+  },
 };
 
 // Today uses the Figma red inner-circle treatment.

--- a/packages/react/src/components/ui/date-picker/DatePicker.stories.tsx
+++ b/packages/react/src/components/ui/date-picker/DatePicker.stories.tsx
@@ -188,6 +188,7 @@ export const Default: Story = {
 
     await expect(currentMonthDay).toBeInTheDocument();
     await expect(outsideMonthDay).toBeInTheDocument();
+    await expect(outsideMonthCell).toBeInTheDocument();
     await expect(outsideMonthDay).toHaveAttribute('data-outside', 'true');
 
     const currentColor = getComputedStyle(currentMonthDay!).color;

--- a/packages/react/src/components/ui/date-picker/date-picker.tsx
+++ b/packages/react/src/components/ui/date-picker/date-picker.tsx
@@ -336,8 +336,7 @@ function DatePickerDayButton({
       className={cn(
         'nx:flex nx:aspect-square nx:size-(--cell-size) nx:min-w-(--cell-size) nx:text-sm nx:leading-none nx:font-normal',
         'nx:disabled:opacity-50 nx:aria-disabled:opacity-50',
-        isOutside &&
-          'nx:text-muted-foreground-subtle nx:hover:text-muted-foreground-subtle',
+        isOutside && 'nx:text-muted-foreground-subtle',
         // Keyboard-focus ring on the focused day (modality-independent — paints above neighbours).
         'nx:group-data-[focused=true]/day:relative nx:group-data-[focused=true]/day:z-10 nx:group-data-[focused=true]/day:outline-2 nx:group-data-[focused=true]/day:outline-focus-default nx:group-data-[focused=true]/day:outline-offset-(--focus-offset)',
         // Today → Figma's inner error circle while keeping the button target at cell size.

--- a/packages/react/src/components/ui/date-picker/date-picker.tsx
+++ b/packages/react/src/components/ui/date-picker/date-picker.tsx
@@ -310,6 +310,8 @@ function DatePickerDayButton({
     modifiers.range_middle ||
     modifiers.range_end;
   const isToday = modifiers.today && !isSelected && !modifiers.disabled;
+  const isOutside =
+    modifiers.outside && !isSelected && !isToday && !modifiers.disabled;
   const content = renderDayContent
     ? renderDayContent({ date: day.date, day, modifiers })
     : children;
@@ -330,9 +332,12 @@ function DatePickerDayButton({
       data-range-end={modifiers.range_end}
       data-range-middle={modifiers.range_middle}
       data-today={isToday}
+      data-outside={isOutside || undefined}
       className={cn(
         'nx:flex nx:aspect-square nx:size-(--cell-size) nx:min-w-(--cell-size) nx:text-sm nx:leading-none nx:font-normal',
         'nx:disabled:opacity-50 nx:aria-disabled:opacity-50',
+        isOutside &&
+          'nx:text-muted-foreground-subtle nx:hover:text-muted-foreground-subtle',
         // Keyboard-focus ring on the focused day (modality-independent — paints above neighbours).
         'nx:group-data-[focused=true]/day:relative nx:group-data-[focused=true]/day:z-10 nx:group-data-[focused=true]/day:outline-2 nx:group-data-[focused=true]/day:outline-focus-default nx:group-data-[focused=true]/day:outline-offset-(--focus-offset)',
         // Today → Figma's inner error circle while keeping the button target at cell size.


### PR DESCRIPTION
## Summary
- Mute unselected outside-month DatePicker day buttons with muted-foreground-subtle
- Add a Default story play assertion for outside-day button color

## Validation
- pnpm --filter @nexus/react typecheck
- pnpm --filter @nexus/react audit:storybook-coverage --component date-picker
- pnpm format:check
- pnpm lint
- pnpm test:storybook
- in-app browser computed style check on http://127.0.0.1:6007/iframe.html?id=components-datepicker--default&viewMode=story