### PR TITLE
refactor(react): typography/menu tier + dead-class lint guardrail (PR2 of #467)

### DIFF
--- a/packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js
+++ b/packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js
@@ -22,6 +22,13 @@ ruleTester.run('nx-class-conventions', rule, {
     'const c = `nx:p-4 ${cond} nx:gap-2`;',
     // Non-nx classes are ignored.
     "const c = 'flex items-center gap-2';",
+    // Live typography composites must not be flagged — negative guard for the
+    // deadTypography check across the label / body / heading families.
+    "const c = 'nx:typography-label-default';",
+    "const c = 'nx:px-2 nx:py-1.5 nx:typography-body-default';",
+    "const c = 'nx:typography-heading-xsmall';",
+    // A typography-* substring without the nx: prefix (e.g. a filename) is ignored.
+    "const path = '../tokens/typography/typography-vega.json';",
   ],
   invalid: [
     {
@@ -68,6 +75,19 @@ ruleTester.run('nx-class-conventions', rule, {
     {
       code: 'const c = `nx:bg-blue-500 ${x}`;',
       errors: [{ messageId: 'rawPrimitive' }],
+    },
+    // Dead typography composites (removed by the #459 trim) render nothing.
+    {
+      code: "const c = 'nx:typography-label-large';",
+      errors: [{ messageId: 'deadTypography' }],
+    },
+    {
+      code: "const c = 'nx:px-2 nx:typography-body-xsmall nx:opacity-70';",
+      errors: [{ messageId: 'deadTypography' }],
+    },
+    {
+      code: "const c = 'nx:hover:typography-display-large';",
+      errors: [{ messageId: 'deadTypography' }],
     },
   ],
 });

--- a/packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js
+++ b/packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js
@@ -1,7 +1,11 @@
 import { RuleTester } from 'eslint';
-import { describe, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
 
 import plugin from '../src/index.js';
+import { LIVE_TYPOGRAPHY } from '../src/rules/nx-class-conventions.js';
 
 RuleTester.describe = describe;
 RuleTester.it = it;
@@ -29,6 +33,11 @@ ruleTester.run('nx-class-conventions', rule, {
     "const c = 'nx:typography-heading-xsmall';",
     // A typography-* substring without the nx: prefix (e.g. a filename) is ignored.
     "const path = '../tokens/typography/typography-vega.json';",
+    // A modifier-prefixed live tier passes — the `(?:[\\w-]+:)*` branch must exempt
+    // a valid composite, not just flag dead ones (cf. the invalid hover case below).
+    "const c = 'nx:focus:typography-label-default';",
+    // The code-* family is live too.
+    "const c = 'nx:typography-code-block';",
   ],
   invalid: [
     {
@@ -90,4 +99,23 @@ ruleTester.run('nx-class-conventions', rule, {
       errors: [{ messageId: 'deadTypography' }],
     },
   ],
+});
+
+// Drift guard: assert the rule's hardcoded LIVE_TYPOGRAPHY stays 1:1 with the
+// emitted `@utility typography-*` set, so a dropped tier can't go un-flagged.
+// Reads the committed CSS — safe at test time, unlike the rule, which must not
+// read it at lint time (it may be unbuilt then).
+describe('LIVE_TYPOGRAPHY drift guard', () => {
+  it('stays 1:1 with the emitted @utility typography-* set', () => {
+    const dir = path.dirname(fileURLToPath(import.meta.url));
+    const css = fs.readFileSync(
+      path.resolve(dir, '../../tailwind/typography-utilities.css'),
+      'utf8'
+    );
+    const emitted = [...css.matchAll(/@utility typography-([a-z-]+) \{/g)].map(
+      (m) => m[1]
+    );
+
+    expect([...emitted].sort()).toEqual([...LIVE_TYPOGRAPHY].sort());
+  });
 });

--- a/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
+++ b/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
@@ -5,10 +5,12 @@
 // `pnpm lint` and the pre-commit hook for every contributor — not only on
 // in-session Claude edits.
 
-// The typography composites emitted by packages/tailwind/typography-utilities.css.
-// Any other `nx:…typography-*` utility is dead — it renders nothing (e.g. the
-// `label-large` / `body-xsmall` tiers removed by the #459 typography trim).
-const LIVE_TYPOGRAPHY = [
+// The 11 live typography composites emitted as `@utility typography-*` by
+// packages/tailwind/typography-utilities.css; any other `nx:…typography-*` is
+// dead — it renders nothing (e.g. the `label-large` / `body-xsmall` tiers dropped
+// by the #459 trim). A drift guard in the rule's test fails if this list and the
+// emitted set diverge, so it can't silently rot.
+export const LIVE_TYPOGRAPHY = [
   'body-default',
   'body-small',
   'code-block',

--- a/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
+++ b/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
@@ -5,6 +5,23 @@
 // `pnpm lint` and the pre-commit hook for every contributor — not only on
 // in-session Claude edits.
 
+// The typography composites emitted by packages/tailwind/typography-utilities.css.
+// Any other `nx:…typography-*` utility is dead — it renders nothing (e.g. the
+// `label-large` / `body-xsmall` tiers removed by the #459 typography trim).
+const LIVE_TYPOGRAPHY = [
+  'body-default',
+  'body-small',
+  'code-block',
+  'code-inline',
+  'heading-large',
+  'heading-medium',
+  'heading-small',
+  'heading-xsmall',
+  'label-caps',
+  'label-default',
+  'label-small',
+];
+
 const CHECKS = [
   {
     messageId: 'prefixOrder',
@@ -21,6 +38,12 @@ const CHECKS = [
   {
     messageId: 'rawPrimitive',
     re: /nx:(?:[\w-]+:)*(?:bg|text|border)-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d{2,3}/,
+  },
+  {
+    messageId: 'deadTypography',
+    re: new RegExp(
+      `nx:(?:[\\w-]+:)*typography-(?!(?:${LIVE_TYPOGRAPHY.join('|')})\\b)[\\w-]+`
+    ),
   },
 ];
 
@@ -51,6 +74,8 @@ export default {
         'Incomplete semantic token path — add a `-background`, `-foreground`, or `-subtle` suffix (e.g. `nx:bg-primary-background`).',
       rawPrimitive:
         'Raw Tailwind primitive color — use a semantic token instead (e.g. `nx:bg-primary-background`, not `nx:bg-blue-500`).',
+      deadTypography:
+        'Unknown typography composite — this `nx:typography-*` utility is not emitted by typography-utilities.css and renders nothing. Use a live tier (e.g. `nx:typography-body-default`, `nx:typography-label-default`).',
     },
   },
   create(context) {

--- a/packages/react/src/components/ui/date-picker/DatePicker.stories.tsx
+++ b/packages/react/src/components/ui/date-picker/DatePicker.stories.tsx
@@ -257,7 +257,7 @@ export const CustomDayContent: Story = {
       renderDayContent={({ date }) => (
         <>
           <span>{date.getDate()}</span>
-          <span className="nx:typography-body-xsmall nx:opacity-70">
+          <span className="nx:typography-body-small nx:opacity-70">
             ${date.getDate() * 5}
           </span>
         </>

--- a/packages/react/src/components/ui/dropdown-menu/dropdown-menu.tsx
+++ b/packages/react/src/components/ui/dropdown-menu/dropdown-menu.tsx
@@ -91,7 +91,7 @@ function DropdownMenuSubTrigger({
       data-inset={inset}
       className={cn(
         'nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2',
-        'nx:rounded-sm nx:px-2 nx:py-1.5 nx:typography-body-small nx:outline-none',
+        'nx:rounded-sm nx:px-2 nx:py-1.5 nx:typography-body-default nx:outline-none',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
         'nx:data-[state=open]:bg-popover-hover nx:data-[state=open]:text-popover-foreground',
         'nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
@@ -200,7 +200,7 @@ function DropdownMenuContent({
 }
 
 const dropdownMenuItemVariants = cva(
-  'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2 nx:rounded-sm nx:px-2 nx:py-1.5 nx:typography-body-small nx:outline-none nx:transition-colors nx:focus:bg-popover-hover nx:focus:text-popover-foreground nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+  'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2 nx:rounded-sm nx:px-2 nx:py-1.5 nx:typography-body-default nx:outline-none nx:transition-colors nx:focus:bg-popover-hover nx:focus:text-popover-foreground nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -295,7 +295,7 @@ function DropdownMenuCheckboxItem({
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
         'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
-        'nx:rounded-sm nx:py-1.5 nx:pl-8 nx:pr-2 nx:typography-body-small nx:outline-none',
+        'nx:rounded-sm nx:py-1.5 nx:pl-8 nx:pr-2 nx:typography-body-default nx:outline-none',
         'nx:transition-colors',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
         'nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50',
@@ -346,7 +346,7 @@ function DropdownMenuRadioItem({
       data-slot="dropdown-menu-radio-item"
       className={cn(
         'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
-        'nx:rounded-sm nx:py-1.5 nx:pl-8 nx:pr-2 nx:typography-body-small nx:outline-none',
+        'nx:rounded-sm nx:py-1.5 nx:pl-8 nx:pr-2 nx:typography-body-default nx:outline-none',
         'nx:transition-colors',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
         'nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50',
@@ -399,7 +399,7 @@ function DropdownMenuLabel({
       data-slot="dropdown-menu-label"
       data-inset={inset}
       className={cn(
-        'nx:px-2 nx:py-1.5 nx:typography-label-large',
+        'nx:px-2 nx:py-1.5 nx:typography-label-default',
         inset && 'nx:pl-8',
         className
       )}

--- a/packages/react/src/components/ui/menubar/menubar.tsx
+++ b/packages/react/src/components/ui/menubar/menubar.tsx
@@ -100,7 +100,7 @@ function MenubarTrigger({ className, ...props }: MenubarTriggerProps) {
       data-slot="menubar-trigger"
       className={cn(
         'nx:flex nx:select-none nx:items-center nx:rounded-sm nx:px-2 nx:py-1',
-        'nx:text-sm nx:font-medium nx:outline-none',
+        'nx:typography-label-default nx:outline-none',
         'nx:focus:bg-background-hover nx:focus:text-foreground',
         'nx:data-[state=open]:bg-background-hover nx:data-[state=open]:text-foreground',
         className
@@ -142,7 +142,7 @@ function MenubarSubTrigger({
       data-inset={inset}
       className={cn(
         'nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2',
-        'nx:rounded-sm nx:px-2 nx:py-control-sm nx:text-sm nx:outline-none',
+        'nx:rounded-sm nx:px-2 nx:py-control-sm nx:typography-body-default nx:outline-none',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
         'nx:data-[state=open]:bg-popover-hover nx:data-[state=open]:text-popover-foreground',
         'nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
@@ -251,7 +251,7 @@ function MenubarContent({
 }
 
 const menubarItemVariants = cva(
-  'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2 nx:rounded-sm nx:px-2 nx:py-control-sm nx:text-sm nx:outline-none nx:transition-colors nx:focus:bg-popover-hover nx:focus:text-popover-foreground nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+  'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:gap-2 nx:rounded-sm nx:px-2 nx:py-control-sm nx:typography-body-default nx:outline-none nx:transition-colors nx:focus:bg-popover-hover nx:focus:text-popover-foreground nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -346,7 +346,7 @@ function MenubarCheckboxItem({
       data-slot="menubar-checkbox-item"
       className={cn(
         'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
-        'nx:rounded-sm nx:py-control-sm nx:pl-8 nx:pr-2 nx:text-sm nx:outline-none',
+        'nx:rounded-sm nx:py-control-sm nx:pl-8 nx:pr-2 nx:typography-body-default nx:outline-none',
         'nx:transition-colors',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
         'nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50',
@@ -397,7 +397,7 @@ function MenubarRadioItem({
       data-slot="menubar-radio-item"
       className={cn(
         'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
-        'nx:rounded-sm nx:py-control-sm nx:pl-8 nx:pr-2 nx:text-sm nx:outline-none',
+        'nx:rounded-sm nx:py-control-sm nx:pl-8 nx:pr-2 nx:typography-body-default nx:outline-none',
         'nx:transition-colors',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
         'nx:data-disabled:pointer-events-none nx:data-disabled:opacity-50',


### PR DESCRIPTION
## Summary

Second PR of the worked-component sweep (#467), **stacked on PR1 (#469)**. Adds the dead-class lint guardrail and aligns the menu family onto the canonical typography tier.

**Lint guardrail** — `@nexus/eslint-plugin-nexus` `nx-class-conventions` gains a `deadTypography` check: any `nx:…typography-*` utility outside the 11 emitted composites fails lint. The live set is a named const; the check is `nx:`-anchored so token *filenames* (`typography-vega.json`) can't trip it. RuleTester gains valid cases (live composites + a filename negative guard) and invalid cases. This is the guard that would have caught the two dead classes below at the #459 merge.

**Dead-class fixes** (the rule now catches these at lint time)
- dropdown-menu label: `typography-label-large` → `typography-label-default`
- date-picker story: `typography-body-xsmall` → `typography-body-small`

**Canonical menu-item tier** (`body-default`, matching command / context-menu / select)
- dropdown-menu items `body-small` → `body-default` (12px → 14px) — the one intended visual change
- menubar (off raw `text-sm`): trigger → `label-default`; sub-trigger / item / checkbox / radio items → `body-default` (exact-match swaps, ~0 rendered change)

## Left raw (deliberate)

- **menubar label** (`text-sm font-semibold`, 14px/600) and **field legend** (16px/500) keep raw type — no surviving composite matches their size/weight (the scale jumps 14px → 18px), and they use raw Tailwind (not dead `typography-*`), so they're lint-clean. Re-pointing would change the rendered size/weight — a design call. This is why the field legend listed under #467's PR2 is intentionally not re-pointed here.
- **Shortcut `text-xs`** (dropdown, menubar) → left for #440 (the proposed `typography-shortcut` utility).

## GitHub Issue

Part of #467 — stays open for PR3 (sizing / motion / stories).

## Test Plan

- [x] `vitest packages/eslint-plugin-nexus` — **23/23** (dead classes flagged; live composites + filename guard pass)
- [x] ESLint over `packages/react/src` with the rule active — **0 violations** (the two dead classes were the only ones repo-wide)
- [x] `pnpm --filter @nexus/react build` + `typecheck` — clean
- [x] `prettier --check` (changed files) — clean
- [x] `vitest --project=storybook` DropdownMenu / Menubar / Command / DatePicker — **61/61**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
