### PR TITLE
refactor(tooltip): tokenize content typography

### DIFF
--- a/packages/react/src/components/ui/tooltip/Tooltip.stories.tsx
+++ b/packages/react/src/components/ui/tooltip/Tooltip.stories.tsx
@@ -422,6 +422,54 @@ export const TooltipContentResolvesRoleUtility: Story = {
   },
 };
 
+export const TooltipContentUsesTypographyComposite: Story = {
+  parameters: {
+    a11y: { test: 'off' },
+    docs: {
+      description: {
+        story:
+          'Regression sentinel — verifies `TooltipContent` carries the canonical `nx:typography-body-small` composite (replacing raw `text-xs`). `toHaveClass` is sufficient here because `typography-*` composites are invisible to the tailwind-merge conflict groups, so the class cannot be silently collapsed under a consumer override. The content is portaled, so the assertion queries `document`.',
+      },
+    },
+  },
+  render: (_args) => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="outline">Hover me</Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>Tooltip content</p>
+      </TooltipContent>
+    </Tooltip>
+  ),
+  play: async ({ canvasElement }) => {
+    await document.fonts.ready;
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Hover me' });
+
+    try {
+      await userEvent.hover(trigger);
+
+      const tooltip = await waitFor(() => {
+        const el = document.querySelector<HTMLElement>(
+          '[data-slot="tooltip-content"]'
+        );
+        if (!el) throw new Error('tooltip not visible yet');
+        return el;
+      });
+
+      expect(tooltip).toHaveClass('nx:typography-body-small');
+    } finally {
+      await userEvent.unhover(trigger);
+      await waitFor(() => {
+        expect(
+          document.querySelector('[data-slot="tooltip-content"]')
+        ).toBeNull();
+      });
+    }
+  },
+};
+
 // ============================================
 // A11Y is tested automatically on ALL stories
 // via addon-a11y with test: 'error'

--- a/packages/react/src/components/ui/tooltip/tooltip.tsx
+++ b/packages/react/src/components/ui/tooltip/tooltip.tsx
@@ -76,7 +76,7 @@ function TooltipContent({
         className={cn(
           'nx:z-popover nx:overflow-hidden nx:rounded-md',
           'nx:border nx:border-border-default nx:bg-popover nx:px-control-sm nx:py-control-sm nx:shadow-lg',
-          'nx:text-xs nx:text-popover-foreground',
+          'nx:typography-body-small nx:text-popover-foreground',
           'nx:animate-in nx:fade-in-0 nx:zoom-in-95',
           'nx:data-[state=closed]:animate-out nx:data-[state=closed]:fade-out-0 nx:data-[state=closed]:zoom-out-95',
           'nx:data-[side=bottom]:slide-in-from-top-2',


### PR DESCRIPTION
## Summary

Replace `TooltipContent`'s raw `text-xs` with the canonical `nx:typography-body-small` composite, plus a dedicated regression sentinel for it.

**Independent of #489** — this PR no longer stacks on the control→numeric spacing sweep. It changes only the tooltip's typography line (`text-xs` → `typography-body-small`); the content padding stays on the existing `px-control-sm` / `py-control-sm` role utilities, which **#489** migrates to numeric separately.

Because the two PRs touch **different lines** of `tooltip.tsx` and own **different stories**, they merge into `prasad/components-cleanup` cleanly in **either order**, converging on `px-3` / `py-1.5` + `typography-body-small`. If this lands before #489, the tooltip ships the composite while still on the `control-*` spacing token (functionally identical in vega) until #489 completes the spacing migration.

## Test

New `TooltipContentUsesTypographyComposite` sentinel asserts `toHaveClass('nx:typography-body-small')` on the portaled content. `toHaveClass` is sufficient here (not `getComputedStyle`) because `typography-*` composites are invisible to the tailwind-merge conflict groups, so the class can't be silently collapsed under a consumer override.

- [x] `vitest --project=storybook` Tooltip — **14 pass** (incl. the new sentinel + the existing spacing sentinel)
- [x] `pnpm --filter @nexus/react typecheck` — clean
- [x] `eslint` + `prettier --check` (changed files) — clean

## GitHub Issue

Closes #468 (typography half; the spacing half is owned by #489).
