### PR TITLE
docs(react): strip rationale/context comments from components

### DIFF
--- a/packages/react/src/components/primitives/responsive-visibility.ts
+++ b/packages/react/src/components/primitives/responsive-visibility.ts
@@ -6,14 +6,14 @@
  * no box of its own, so its children keep their natural flow: inline stays
  * inline, flex/grid children stay flex/grid items. Forcing `block` (or reverting
  * to the element's UA default) would override the wrapper's display and break
- * those layouts. This is the conclusion of the #103 pre-implementation spike.
+ * those layouts.
  *
  * Class strings are full static literals in the maps below: Tailwind only emits
  * a utility it can see as a complete string, so a computed `nx:${bp}:contents`
  * would never ship in the CSS bundle.
  *
  * Container axes use Tailwind's native `@container` scale (`@md` = 28rem), which
- * is intentionally smaller than the viewport scale (`md` = 48rem) — a component
+ * is smaller than the viewport scale (`md` = 48rem) — a component
  * reads as "md" at a narrower width than the whole viewport. The two axes
  * therefore resolve the same breakpoint name to different rem values.
  */
@@ -55,7 +55,7 @@ export type VisibilityAxis =
 export type ResponsiveVisibilityProps = HTMLAttributes<HTMLElement> & {
   /**
    * Wrapper tag: `span` (inline) or `div` (block) — match the child's layout.
-   * Tag-only by design and intentionally non-semantic: `display: contents` can
+   * Tag-only and non-semantic: `display: contents` can
    * drop a semantic element's box from the accessibility tree, so put semantics
    * on a child *inside* `<Show>` / `<Hide>` instead.
    * @default 'span'

--- a/packages/react/src/components/ui/accordion/Accordion.stories.tsx
+++ b/packages/react/src/components/ui/accordion/Accordion.stories.tsx
@@ -693,10 +693,6 @@ export const AllVariants: Story = {
   ),
 };
 
-// ============================================
-// MODE BEHAVIOUR (density stability)
-// ============================================
-
 export const AllModes: Story = {
   parameters: {
     a11y: { test: 'off' },
@@ -729,7 +725,7 @@ export const AccordionTriggerModesCascade: Story = {
     docs: {
       description: {
         story:
-          'Density-cascade sentinel for AccordionTrigger. Its numeric `nx:py-4` resolves to a per-mode `--nx-spacing-4` (nova 14 → maia 18), so the trigger height tracks the active spacing mode — 48px in nova, 56px in maia. Asserts the cascade is wired through (nova < maia); the exact vega contract (52px) is pinned in `AccordionTriggerVegaHeightPinned`.',
+          'Density-cascade sentinel: the AccordionTrigger height tracks the active spacing mode.',
       },
     },
   },

--- a/packages/react/src/components/ui/alert/Alert.stories.tsx
+++ b/packages/react/src/components/ui/alert/Alert.stories.tsx
@@ -1225,17 +1225,13 @@ export const AllBannerVariants: Story = {
   },
 };
 
-// ============================================
-// MODE BEHAVIOUR (callout rhythm)
-// ============================================
-
 export const AllModes: Story = {
   parameters: {
     a11y: { test: 'off' },
     docs: {
       description: {
         story:
-          'Alert stays on the document spacing scale (`nx:p-4`) rather than migrating to `p-container`. Alert still mode-couples through `--nx-spacing-4` (nova 14 / vega-cluster 16 / maia 18), so the visual height shifts between nova / vega-cluster / maia rows. The point is that Alert uses numeric document padding even though its default visual surface uses `nx:bg-container`.',
+          'Each row scopes `data-style` locally so the spacing modes render side-by-side.',
       },
     },
   },
@@ -1261,7 +1257,7 @@ export const ModesProduceDifferentHeights: Story = {
     docs: {
       description: {
         story:
-          'Cascade sentinel for Alert. Uses the `nova` + `maia` pair — the two modes where `--nx-spacing-4` diverges from the vega cluster (nova 14, maia 18). An Alert scoped to `nova` must render shorter than the same Alert scoped to `maia`. If a future PR accidentally swaps `p-4` for `p-container` the heights would still differ (and the pinned sentinel would catch the change in vega).',
+          'Sentinel: an Alert renders at different heights across spacing modes.',
       },
     },
   },

--- a/packages/react/src/components/ui/badge/Badge.stories.tsx
+++ b/packages/react/src/components/ui/badge/Badge.stories.tsx
@@ -695,17 +695,13 @@ export const AllVariants: Story = {
   },
 };
 
-// ============================================
-// MODE BEHAVIOUR (density stability)
-// ============================================
-
 export const AllModes: Story = {
   parameters: {
     a11y: { test: 'off' },
     docs: {
       description: {
         story:
-          'Badge is intentionally density-stable — its utilities sit on the canonical numeric step set (`px-2`, `py-1`, `gap-1`) rather than the `control-*` role family, because a chip is not a control (its padding is sub-control by design). All 7 rows should render at the same height regardless of mode. The `BadgeIsDensityStable` sentinel below asserts this.',
+          'All spacing-mode rows render at the same Badge height; the `BadgeIsDensityStable` sentinel below asserts it.',
       },
     },
   },
@@ -737,7 +733,7 @@ export const BadgeIsDensityStable: Story = {
     docs: {
       description: {
         story:
-          'Mode-invariance sentinel. Badge stays 24px in every density mode because its height = label-caps line-height 16px + `py-1` × 2, and `py-1` resolves to `spacing-1` = 4px — a small index that is identical across all modes (density cannot meaningfully shrink it). This flatness is the exception, not a rule: numeric spacing is not inherently mode-stable (`spacing-4` is 14/16/18 across nova/vega/maia). If Badge migrates onto a `control-*` role utility its height starts tracking density and this test fails for that mode — bump the expected px to the new canonical value.',
+          'Mode-invariance sentinel: Badge renders at the same height in every spacing mode.',
       },
     },
   },

--- a/packages/react/src/components/ui/breadcrumb/breadcrumb.tsx
+++ b/packages/react/src/components/ui/breadcrumb/breadcrumb.tsx
@@ -113,10 +113,9 @@ interface BreadcrumbLinkProps extends React.ComponentProps<'a'> {
 /**
  * BreadcrumbLink
  *
- * A link to an ancestor page. It follows the compact Figma item rhythm and keeps
- * the canonical focus ring since it is reachable by keyboard. Wrap the label in a
- * `<span>` so it truncates at the 150px cap — both for plain text and when
- * composing an icon with text.
+ * A link to an ancestor page. It keeps the canonical focus ring since it is
+ * reachable by keyboard. Wrap the label in a `<span>` so it truncates at the
+ * 150px cap — both for plain text and when composing an icon with text.
  */
 function BreadcrumbLink({ asChild, className, ...props }: BreadcrumbLinkProps) {
   const Comp = asChild ? Slot : 'a';

--- a/packages/react/src/components/ui/button/Button.stories.tsx
+++ b/packages/react/src/components/ui/button/Button.stories.tsx
@@ -808,10 +808,6 @@ export const AllVariants: Story = {
   ),
 };
 
-// ============================================
-// MODE BEHAVIOUR
-// ============================================
-
 export const AllModes: Story = {
   parameters: {
     // 7 rows × 3 buttons each duplicates the same accessible names; the
@@ -820,7 +816,7 @@ export const AllModes: Story = {
     docs: {
       description: {
         story:
-          'Each row scopes `data-style` locally, so the 7 spacing modes render side-by-side regardless of the Style toolbar. Button sizes use Nexus scale utilities (`h-8`/`h-10`/`h-12`) so they follow the active spacing mode.',
+          'Each row scopes `data-style` locally so the 7 spacing modes render side-by-side.',
       },
     },
   },

--- a/packages/react/src/components/ui/button/button.tsx
+++ b/packages/react/src/components/ui/button/button.tsx
@@ -88,15 +88,15 @@ interface ButtonProps
 
   /**
    * Decorative icon rendered before the button label. Use either `startIcon`
-   * or `endIcon` — the Figma anatomy has a single icon slot. Hidden while
-   * `loading` (the spinner replaces all content).
+   * or `endIcon`, not both. Hidden while `loading` (the spinner replaces all
+   * content).
    */
   startIcon?: React.ReactNode;
 
   /**
    * Decorative icon rendered after the button label. Use either `endIcon`
-   * or `startIcon` — the Figma anatomy has a single icon slot. Hidden while
-   * `loading` (the spinner replaces all content).
+   * or `startIcon`, not both. Hidden while `loading` (the spinner replaces all
+   * content).
    */
   endIcon?: React.ReactNode;
 }

--- a/packages/react/src/components/ui/card/Card.stories.tsx
+++ b/packages/react/src/components/ui/card/Card.stories.tsx
@@ -525,10 +525,6 @@ export const AllVariants: Story = {
   },
 };
 
-// ============================================
-// MODE BEHAVIOUR (per-mode spacing variance)
-// ============================================
-
 export const AllModes: Story = {
   parameters: {
     a11y: { test: 'off' },
@@ -598,8 +594,7 @@ export const VegaDefaultHeightPinned: Story = {
     a11y: { test: 'off' },
     docs: {
       description: {
-        story:
-          'Pin on the migration outcome: in vega mode, a Card containing a single `CardContent` with a 40px fixed-height child renders at exactly 66px (= border 1px × 2 + `CardContent` pt-0 + child 40 + `p-6` bottom 24). If a designer retunes spacing-6 or the border-width token, this test fails.',
+        story: 'Regression sentinel: pins the Card height in vega mode.',
       },
     },
   },

--- a/packages/react/src/components/ui/chart/chart.tsx
+++ b/packages/react/src/components/ui/chart/chart.tsx
@@ -15,9 +15,9 @@ import { cn } from '@/lib/utils';
  * for generated color variables must contain only letters, numbers, `_`, or
  * `-`; other keys can still provide labels and icons.
  *
- * Nexus semantic tokens already adapt across light/dark, so — unlike shadcn —
- * there is no `theme: { light, dark }` split. Point `color` at a Nexus chart
- * token (`var(--nx-color-chart-categorical-N)`) and it tracks the theme for you.
+ * Nexus semantic tokens already adapt across light/dark, so there is no
+ * `theme: { light, dark }` split. Point `color` at a Nexus chart token
+ * (`var(--nx-color-chart-categorical-N)`) and it tracks the theme for you.
  * Treat `color` as trusted component CSS, not user-provided data.
  */
 export type ChartConfig = {

--- a/packages/react/src/components/ui/checkbox/checkbox.tsx
+++ b/packages/react/src/components/ui/checkbox/checkbox.tsx
@@ -69,8 +69,7 @@ function Checkbox({ className, ...props }: CheckboxProps) {
         'nx:enabled:data-[state=indeterminate]:active:border-primary-background-hover nx:enabled:data-[state=indeterminate]:active:bg-primary-background-active',
         'nx:data-[state=checked]:disabled:border-primary-disabled nx:data-[state=checked]:disabled:bg-primary-disabled',
         'nx:data-[state=indeterminate]:disabled:border-primary-disabled nx:data-[state=indeterminate]:disabled:bg-primary-disabled',
-        // Invalid + checked/indeterminate follows Figma's destructive checkbox
-        // treatment while preserving aria-invalid as the single authoring hook.
+        // Invalid + checked/indeterminate: aria-invalid is the single authoring hook.
         'nx:aria-invalid:data-[state=checked]:border-border-error nx:aria-invalid:data-[state=checked]:bg-error-background nx:aria-invalid:data-[state=checked]:text-error-foreground',
         'nx:aria-invalid:data-[state=indeterminate]:border-border-error nx:aria-invalid:data-[state=indeterminate]:bg-error-background nx:aria-invalid:data-[state=indeterminate]:text-error-foreground',
         'nx:enabled:aria-invalid:data-[state=checked]:hover:border-border-error nx:enabled:aria-invalid:data-[state=checked]:hover:bg-error-background-hover',

--- a/packages/react/src/components/ui/date-picker/date-picker.tsx
+++ b/packages/react/src/components/ui/date-picker/date-picker.tsx
@@ -82,7 +82,7 @@ const staticDayPickerClassNames = {
   weekdays: cn('nx:flex', defaultClassNames.weekdays),
   weekday: cn(
     // Match the day buttons' type (Button's raw text-sm + font-normal,
-    // inherited family) rather than the label composite (Inter/medium).
+    // inherited family).
     'nx:flex-1 nx:rounded-md nx:text-sm nx:font-normal nx:text-muted-foreground-subtle nx:select-none',
     defaultClassNames.weekday
   ),
@@ -343,7 +343,7 @@ function DatePickerDayButton({
         isOutside && 'nx:text-muted-foreground-subtle',
         // Keyboard-focus ring on the focused day (modality-independent — paints above neighbours).
         'nx:group-data-[focused=true]/day:relative nx:group-data-[focused=true]/day:z-10 nx:group-data-[focused=true]/day:outline-2 nx:group-data-[focused=true]/day:outline-focus-default nx:group-data-[focused=true]/day:outline-offset-(--focus-offset)',
-        // Today → Figma's inner error circle while keeping the button target at cell size.
+        // Today → inner error circle while keeping the button target at cell size.
         'nx:data-[today=true]:relative nx:data-[today=true]:bg-transparent nx:data-[today=true]:font-medium nx:data-[today=true]:text-error-foreground nx:data-[today=true]:hover:bg-transparent nx:data-[today=true]:hover:text-error-foreground',
         'nx:data-[today=true]:before:absolute nx:data-[today=true]:before:top-1/2 nx:data-[today=true]:before:left-1/2 nx:data-[today=true]:before:size-(--today-marker-size) nx:data-[today=true]:before:-translate-x-1/2 nx:data-[today=true]:before:-translate-y-1/2 nx:data-[today=true]:before:rounded-full nx:data-[today=true]:before:bg-error-background nx:data-[today=true]:hover:before:bg-error-background-hover',
         "nx:data-[today=true]:before:content-['']",

--- a/packages/react/src/components/ui/dropdown-menu/DropdownMenu.stories.tsx
+++ b/packages/react/src/components/ui/dropdown-menu/DropdownMenu.stories.tsx
@@ -512,17 +512,13 @@ export const AllVariants: Story = {
   },
 };
 
-// ============================================
-// MODE BEHAVIOUR (item padding pinned across spacing modes)
-// ============================================
-
 export const ItemPaddingPinnedAcrossModes: Story = {
   parameters: {
     a11y: { test: 'off' },
     docs: {
       description: {
         story:
-          'Regression sentinel: opened `DropdownMenuItem` padding stays pinned to numeric `py-1.5` (6px via `--nx-spacing-1_5`) across document-level spacing modes — `py-1.5` is mode-invariant. Because the content portals to `document.body`, this asserts runtime resolution on the portaled item and restores the document mode in `finally`.',
+          'Regression sentinel: opened `DropdownMenuItem` padding stays constant across document spacing modes.',
       },
     },
   },

--- a/packages/react/src/components/ui/input-group/input-group.tsx
+++ b/packages/react/src/components/ui/input-group/input-group.tsx
@@ -25,9 +25,7 @@ interface InputGroupProps extends React.ComponentProps<'div'> {}
  * state.
  *
  * The visible frame matches a standalone `Input`: an inline group takes the
- * control's `size` height (`sm` / `default` / `lg` → `h-8` / `h-10` / `h-12`),
- * so the wrapper border never makes the field taller than a bare `Input`.
- * Stacked (block-aligned) groups stay auto-height.
+ * control's `size` height. Stacked (block-aligned) groups stay auto-height.
  *
  * @example
  * ```tsx
@@ -50,7 +48,7 @@ function InputGroup({ className, ...props }: InputGroupProps) {
         // control's data-size. `not-has-[>[data-align^=block]]` scopes this to
         // non-stacked layouts (no block addon) so the fixed-height rule and the
         // auto-height stacked case are mutually exclusive — they never both
-        // match. Heights follow the active spacing mode (h-8/h-10/h-12), like Input.
+        // match.
         'nx:not-has-[>[data-align^=block]]:has-[[data-slot=input-group-control][data-size=sm]]:h-8',
         'nx:not-has-[>[data-align^=block]]:has-[[data-slot=input-group-control][data-size=default]]:h-10',
         'nx:not-has-[>[data-align^=block]]:has-[[data-slot=input-group-control][data-size=lg]]:h-12',

--- a/packages/react/src/components/ui/input/Input.stories.tsx
+++ b/packages/react/src/components/ui/input/Input.stories.tsx
@@ -558,10 +558,6 @@ export const AllVariants: Story = {
   },
 };
 
-// ============================================
-// MODE BEHAVIOUR (per-mode heights)
-// ============================================
-
 export const AllModes: Story = {
   parameters: {
     a11y: { test: 'off' },

--- a/packages/react/src/components/ui/navigation-menu/navigation-menu.tsx
+++ b/packages/react/src/components/ui/navigation-menu/navigation-menu.tsx
@@ -181,7 +181,6 @@ function NavigationMenuContent({
         'nx:data-[motion=to-end]:slide-out-to-right-52 nx:data-[motion=to-start]:slide-out-to-left-52',
         'nx:data-[motion^=from-]:animate-in nx:data-[motion^=from-]:fade-in nx:data-[motion^=to-]:animate-out nx:data-[motion^=to-]:fade-out',
         'nx:motion-reduce:data-[motion^=from-]:animate-none nx:motion-reduce:data-[motion^=to-]:animate-none',
-        // @container conversion of shadcn's `md:absolute md:w-auto`
         'nx:@md/navmenu:absolute nx:@md/navmenu:w-auto',
         'nx:group-data-[viewport=false]/navigation-menu:top-full',
         'nx:group-data-[viewport=false]/navigation-menu:mt-1.5',
@@ -229,7 +228,6 @@ function NavigationMenuViewport({
           'nx:rounded-md nx:border nx:border-border-default nx:bg-popover nx:text-popover-foreground nx:shadow-lg',
           'nx:data-[state=closed]:animate-out nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:animate-in nx:data-[state=open]:zoom-in-90',
           'nx:motion-reduce:data-[state=closed]:animate-none nx:motion-reduce:data-[state=open]:animate-none',
-          // @container conversion of shadcn's `md:w-[var(...)]`
           'nx:@md/navmenu:w-(--radix-navigation-menu-viewport-width)',
           className
         )}

--- a/packages/react/src/components/ui/select/Select.stories.tsx
+++ b/packages/react/src/components/ui/select/Select.stories.tsx
@@ -764,10 +764,6 @@ export const AllVariants: Story = {
   },
 };
 
-// ============================================
-// MODE BEHAVIOUR (per-mode spacing variance)
-// ============================================
-
 export const AllModes: Story = {
   parameters: {
     a11y: { test: 'off' },
@@ -848,7 +844,7 @@ export const VegaDefaultHeightPinned: Story = {
     docs: {
       description: {
         story:
-          'Pin on the migration outcome: in vega mode, the `SelectTrigger` renders at exactly 38px (= `typography-body-default` 20px line-height + `py-2` 8px × 2 + border 1px × 2). It is mode-stable via numeric `py-2`; Input instead uses a fixed `h-10` (= per-mode `--nx-spacing-10`, 40px in vega) and so tracks density — the two are deliberately not the same height. If a designer retunes `--nx-spacing-2`, the body type ramp, or the border-width token, this test fails.',
+          'Regression sentinel: pins the `SelectTrigger` height in vega mode.',
       },
     },
   },

--- a/packages/react/src/components/ui/tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/ui/tabs/Tabs.stories.tsx
@@ -615,17 +615,13 @@ export const AllVariants: Story = {
   ),
 };
 
-// ============================================
-// MODE BEHAVIOUR (per-mode spacing variance)
-// ============================================
-
 export const AllModes: Story = {
   parameters: {
     a11y: { test: 'off' },
     docs: {
       description: {
         story:
-          'Each row scopes `data-style` locally so the 7 spacing modes render side-by-side. `TabsTrigger` `default` uses `px-3 py-1.5`, `lg` uses `px-4 py-2`, and `sm` stays on `px-2 py-1`. Vertical padding (`py-1.5` / `py-2`) is mode-invariant, so trigger heights are identical across every mode; only the horizontal padding (`px-3` / `px-4`) varies — Nova compresses, Maia / Sera breathe.',
+          'Each row scopes `data-style` locally so the 7 spacing modes render side-by-side.',
       },
     },
   },
@@ -661,7 +657,7 @@ export const TabsTriggerVegaDefaultHeightPinned: Story = {
     docs: {
       description: {
         story:
-          'Pin on the migration outcome: a `TabsTrigger` at `default` size renders at exactly 34px (= `text-sm` 20px line-height + `py-1.5` 6px × 2 + transparent border 1px × 2). `py-1.5` is mode-invariant, so this height now holds in every mode. If a designer retunes `--nx-spacing-1_5`, the body type ramp, or the trigger border, this test fails.',
+          'Regression sentinel: pins the `default` `TabsTrigger` height in vega mode.',
       },
     },
   },
@@ -689,7 +685,7 @@ export const TabsSmIsDensityStable: Story = {
     docs: {
       description: {
         story:
-          'Density-stability sentinel for the `sm` size. `TabsTrigger` `sm` stays on the sub-control numeric rhythm (`px-2 py-1 text-xs`). Every spacing mode therefore renders it at the same canonical 26px height (= `text-xs` line-height 16px + `py-1` 4px × 2 + transparent border 1px × 2). If a future PR migrates `py-1` → a mode-varying step (e.g. `py-3`, which resolves 10 / 12 / 14px across nova / vega / maia), this test fails for nova/sera — the regression signal is that intent (sub-control, mode-stable) has been broken.',
+          'Density-stability sentinel: the `sm` `TabsTrigger` renders at the same height across spacing modes.',
       },
     },
   },

--- a/packages/react/src/components/ui/tooltip/Tooltip.stories.tsx
+++ b/packages/react/src/components/ui/tooltip/Tooltip.stories.tsx
@@ -330,10 +330,6 @@ export const AllVariants: Story = {
   },
 };
 
-// ============================================
-// MODE BEHAVIOUR (per-mode spacing variance)
-// ============================================
-
 export const AllModes: Story = {
   parameters: {
     a11y: { test: 'off' },


### PR DESCRIPTION
## Summary

Enforces `.claude/rules/code-comments.md` across `packages/react/src/components/` — design rationale, cross-library comparisons, and per-mode/px arithmetic belong in the PR, not the code.

- **8 source files** — trimmed the rationale/attribution clause from each comment, keeping the logic: `button`, `checkbox`, `breadcrumb`, `chart`, `input-group`, `date-picker`, `navigation-menu`, `responsive-visibility`. Cut clauses include Figma-anatomy / Figma-treatment attributions, the `@container conversion of shadcn's …` porting notes, the `unlike shadcn` comparison, the `#103 spike` provenance line, and height/mode arithmetic (`h-8/h-10/h-12`, `like Input`).
- **10 stories** — removed the `// MODE BEHAVIOUR (…)` section-divider banners.
- **8 story files (~12 strings)** — reduced `docs.description.story` sentinel / AllModes prose to plain one-line descriptions, dropping the px/mode arithmetic. e.g. _"renders at exactly 34px (= text-sm 20px line-height + py-1.5 6px × 2 …)"_ → _"Regression sentinel: pins the `default` `TabsTrigger` height in vega mode."_

### Kept (earns its place)

All logic / control-flow, a11y (WCAG/axe), third-party quirks (Radix, react-day-picker, cmdk, Embla, sonner), type coercions, `eslint-disable` reasons, and `@example` / one-line prop & component descriptions. Consumer-facing **API-limitation** notes (Input warning-vs-error, Alert AlertClose-omitted, Select item-affordances) and in-`play`-body assertion comments are kept by design.

## GitHub Issue

Rules-driven cleanup on the `prasad/components-cleanup` integration line, continuing the `.claude/rules/code-comments.md` enforcement begun with the native-select JSDoc trim. No dedicated tracking issue.

## Test Plan

- [x] `pnpm --filter @nexus/react typecheck`
- [x] `eslint --max-warnings 0` on all changed files
- [x] `pnpm exec prettier --check 'packages/react/src/components/**/*.{ts,tsx}'`
- [x] Comments & docs-strings only — no runtime code changed; Storybook interaction / a11y tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
