### PR TITLE
feat(sheet,drawer): body content slots + close-button hit-area tests (#478)

### DIFF
--- a/packages/react/src/components/ui/dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/ui/dialog/Dialog.stories.tsx
@@ -396,6 +396,11 @@ export const CloseButtonFocus: Story = {
       'nx:focus-visible:outline-focus-default',
       'nx:focus-visible:outline-offset-(--focus-offset)'
     );
+    await expect(closeButton).toHaveClass(
+      'nx:after:absolute',
+      'nx:after:-inset-2.5',
+      'nx:lg:after:hidden'
+    );
 
     await userEvent.keyboard('{Escape}');
     await waitFor(() => {

--- a/packages/react/src/components/ui/drawer/Drawer.stories.tsx
+++ b/packages/react/src/components/ui/drawer/Drawer.stories.tsx
@@ -345,6 +345,7 @@ export const WithDataAttributes: Story = {
         'drawer-handle',
         'drawer-title',
         'drawer-description',
+        'drawer-body',
         'drawer-footer',
       ]) {
         expect(

--- a/packages/react/src/components/ui/drawer/Drawer.stories.tsx
+++ b/packages/react/src/components/ui/drawer/Drawer.stories.tsx
@@ -7,6 +7,7 @@ import { Button } from '../button';
 
 import {
   Drawer,
+  DrawerBody,
   DrawerClose,
   DrawerContent,
   DrawerDescription,
@@ -69,10 +70,12 @@ export const Default: Story = {
             Drag down or press Escape to dismiss this drawer.
           </DrawerDescription>
         </DrawerHeader>
-        <p className="nx:px-4 nx:typography-body-default nx:text-foreground">
-          Drawer content goes here. On touch devices it can be dragged to
-          dismiss.
-        </p>
+        <DrawerBody>
+          <p className="nx:typography-body-default nx:text-foreground">
+            Drawer content goes here. On touch devices it can be dragged to
+            dismiss.
+          </p>
+        </DrawerBody>
         <DrawerFooter>
           <Button>Submit</Button>
           <DrawerClose asChild>
@@ -123,11 +126,10 @@ export const ScrollableContent: Story = {
             scrolls.
           </DrawerDescription>
         </DrawerHeader>
-        <div
+        <DrawerBody
           data-testid="drawer-scroll-area"
-          // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- scrollable region must be keyboard-reachable (axe scrollable-region-focusable)
           tabIndex={0}
-          className="nx:max-h-[45svh] nx:overflow-y-auto nx:px-6 nx:pb-2 nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
+          className="nx:max-h-[45svh] nx:overflow-y-auto nx:pb-2 nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
         >
           <ul className="nx:flex nx:flex-col nx:gap-3">
             {SCROLLABLE_ITEMS.map((item) => (
@@ -144,7 +146,7 @@ export const ScrollableContent: Story = {
               </li>
             ))}
           </ul>
-        </div>
+        </DrawerBody>
         <DrawerFooter className="nx:border-t nx:border-border-default">
           <Button>Save changes</Button>
           <DrawerClose asChild>
@@ -198,10 +200,10 @@ export const WithHeaderActions: Story = {
             </Button>
           </DrawerClose>
         </DrawerHeader>
-        <div className="nx:px-6 nx:pb-6 nx:typography-body-default nx:text-foreground">
+        <DrawerBody className="nx:pb-6 nx:typography-body-default nx:text-foreground">
           Header actions are regular composition: consumers place controls in
           the header and keep Vaul responsible for dismissal.
-        </div>
+        </DrawerBody>
       </DrawerContent>
     </Drawer>
   ),
@@ -314,6 +316,11 @@ export const WithDataAttributes: Story = {
           <DrawerTitle>Data Attributes</DrawerTitle>
           <DrawerDescription>Testing data-slot attributes.</DrawerDescription>
         </DrawerHeader>
+        <DrawerBody>
+          <p className="nx:typography-body-default nx:text-foreground">
+            Content here
+          </p>
+        </DrawerBody>
         <DrawerFooter>
           <DrawerClose asChild>
             <Button>Close</Button>

--- a/packages/react/src/components/ui/drawer/drawer.tsx
+++ b/packages/react/src/components/ui/drawer/drawer.tsx
@@ -135,6 +135,22 @@ function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
 }
 
 /**
+ * DrawerBody
+ *
+ * Container for the drawer's main content between the header and footer. Insets
+ * its content horizontally to match the header and footer.
+ */
+function DrawerBody({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="drawer-body"
+      className={cn('nx:px-6', className)}
+      {...props}
+    />
+  );
+}
+
+/**
  * DrawerFooter
  *
  * Container for the drawer action buttons. Pinned to the bottom of the panel.
@@ -194,6 +210,7 @@ function DrawerDescription({
 
 export {
   Drawer,
+  DrawerBody,
   DrawerClose,
   DrawerContent,
   DrawerDescription,

--- a/packages/react/src/components/ui/sheet/Sheet.stories.tsx
+++ b/packages/react/src/components/ui/sheet/Sheet.stories.tsx
@@ -167,6 +167,40 @@ export const WithForm: Story = {
   ),
 };
 
+export const ScrollableContent: Story = {
+  render: (_args) => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline">Terms & Conditions</Button>
+      </SheetTrigger>
+      <SheetContent className="nx:overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>Terms of Service</SheetTitle>
+          <SheetDescription>
+            Please read the following terms carefully.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="nx:space-y-4 nx:px-4 nx:text-sm nx:text-foreground">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <p key={i}>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex ea commodo consequat.
+            </p>
+          ))}
+        </div>
+        <SheetFooter>
+          <SheetClose asChild>
+            <Button variant="outline">Decline</Button>
+          </SheetClose>
+          <Button>Accept</Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
 // ============================================
 // INTERACTION TESTS
 // ============================================
@@ -314,6 +348,14 @@ export const WithDataAttributes: Story = {
     await expect(
       document.querySelector('[data-slot="sheet-content"]')
     ).toHaveAttribute('data-side', 'right');
+
+    await expect(
+      document.querySelector('[data-slot="sheet-close-button"]')
+    ).toHaveClass(
+      'nx:after:absolute',
+      'nx:after:-inset-2.5',
+      'nx:lg:after:hidden'
+    );
 
     await userEvent.keyboard('{Escape}');
   },

--- a/packages/react/src/components/ui/sheet/Sheet.stories.tsx
+++ b/packages/react/src/components/ui/sheet/Sheet.stories.tsx
@@ -6,6 +6,7 @@ import { Input } from '../input';
 
 import {
   Sheet,
+  SheetBody,
   SheetClose,
   SheetContent,
   SheetDescription,
@@ -53,9 +54,11 @@ export const Default: Story = {
             This panel slides in from the right edge by default.
           </SheetDescription>
         </SheetHeader>
-        <p className="nx:px-4 nx:text-sm nx:text-foreground">
-          Sheet content goes here. You can add any content you need.
-        </p>
+        <SheetBody>
+          <p className="nx:text-sm nx:text-foreground">
+            Sheet content goes here. You can add any content you need.
+          </p>
+        </SheetBody>
         <SheetFooter>
           <SheetClose asChild>
             <Button variant="outline">Cancel</Button>
@@ -139,7 +142,7 @@ export const WithForm: Story = {
             Update your profile here, then save when you are done.
           </SheetDescription>
         </SheetHeader>
-        <div className="nx:grid nx:flex-1 nx:gap-4 nx:px-4">
+        <SheetBody className="nx:grid nx:gap-4">
           <div className="nx:grid nx:gap-1.5">
             <label htmlFor="sheet-name" className="nx:text-sm nx:font-medium">
               Name
@@ -155,7 +158,7 @@ export const WithForm: Story = {
             </label>
             <Input id="sheet-username" defaultValue="@johndoe" />
           </div>
-        </div>
+        </SheetBody>
         <SheetFooter>
           <SheetClose asChild>
             <Button variant="outline">Cancel</Button>
@@ -180,7 +183,7 @@ export const ScrollableContent: Story = {
             Please read the following terms carefully.
           </SheetDescription>
         </SheetHeader>
-        <div className="nx:space-y-4 nx:px-4 nx:text-sm nx:text-foreground">
+        <SheetBody className="nx:space-y-4 nx:text-sm nx:text-foreground">
           {Array.from({ length: 12 }).map((_, i) => (
             <p key={i}>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
@@ -189,7 +192,7 @@ export const ScrollableContent: Story = {
               nisi ut aliquip ex ea commodo consequat.
             </p>
           ))}
-        </div>
+        </SheetBody>
         <SheetFooter>
           <SheetClose asChild>
             <Button variant="outline">Decline</Button>
@@ -303,7 +306,9 @@ export const WithDataAttributes: Story = {
           <SheetTitle>Data Attributes</SheetTitle>
           <SheetDescription>Testing data-slot attributes.</SheetDescription>
         </SheetHeader>
-        <p className="nx:px-4 nx:text-sm">Content here</p>
+        <SheetBody>
+          <p className="nx:text-sm">Content here</p>
+        </SheetBody>
         <SheetFooter>
           <SheetClose asChild>
             <Button>Close</Button>
@@ -335,6 +340,9 @@ export const WithDataAttributes: Story = {
       ).toBeInTheDocument();
       expect(
         document.querySelector('[data-slot="sheet-description"]')
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="sheet-body"]')
       ).toBeInTheDocument();
       expect(
         document.querySelector('[data-slot="sheet-footer"]')

--- a/packages/react/src/components/ui/sheet/sheet.tsx
+++ b/packages/react/src/components/ui/sheet/sheet.tsx
@@ -227,6 +227,37 @@ function SheetHeader({ className, ...props }: SheetHeaderProps) {
 }
 
 /**
+ * SheetBodyProps
+ *
+ * Props for the SheetBody component.
+ */
+interface SheetBodyProps extends React.ComponentProps<'div'> {}
+
+/**
+ * SheetBody
+ *
+ * Container for the sheet's main content between the header and footer. Pads its
+ * content to the same inset as SheetHeader and SheetFooter and grows to fill the
+ * panel.
+ *
+ * @example
+ * ```tsx
+ * <SheetBody>
+ *   <p>Main content.</p>
+ * </SheetBody>
+ * ```
+ */
+function SheetBody({ className, ...props }: SheetBodyProps) {
+  return (
+    <div
+      data-slot="sheet-body"
+      className={cn('nx:flex-1 nx:p-6', className)}
+      {...props}
+    />
+  );
+}
+
+/**
  * SheetFooterProps
  *
  * Props for the SheetFooter component.
@@ -324,6 +355,8 @@ function SheetDescription({ className, ...props }: SheetDescriptionProps) {
 
 export {
   Sheet,
+  SheetBody,
+  type SheetBodyProps,
   SheetClose,
   SheetContent,
   type SheetContentProps,

--- a/packages/react/src/components/ui/sheet/sheet.tsx
+++ b/packages/react/src/components/ui/sheet/sheet.tsx
@@ -91,7 +91,7 @@ function SheetOverlay({ className, ...props }: SheetOverlayProps) {
  */
 const sheetContentVariants = cva(
   cn(
-    'nx:fixed nx:z-modal nx:flex nx:flex-col nx:gap-4',
+    'nx:fixed nx:z-modal nx:flex nx:flex-col',
     'nx:bg-container nx:shadow-lg nx:ease-in-out',
     'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
     'nx:data-[state=open]:duration-500 nx:data-[state=closed]:duration-300',
@@ -236,8 +236,9 @@ interface SheetBodyProps extends React.ComponentProps<'div'> {}
 /**
  * SheetBody
  *
- * Container for the sheet's main content between the header and footer. Pads its
- * content to the same inset as SheetHeader and SheetFooter.
+ * Container for the sheet's main content between the header and footer. Insets
+ * its content horizontally to match SheetHeader and SheetFooter; vertical
+ * separation comes from the header's and footer's padding.
  *
  * @example
  * ```tsx
@@ -250,7 +251,7 @@ function SheetBody({ className, ...props }: SheetBodyProps) {
   return (
     <div
       data-slot="sheet-body"
-      className={cn('nx:p-6', className)}
+      className={cn('nx:px-6', className)}
       {...props}
     />
   );

--- a/packages/react/src/components/ui/sheet/sheet.tsx
+++ b/packages/react/src/components/ui/sheet/sheet.tsx
@@ -237,8 +237,7 @@ interface SheetBodyProps extends React.ComponentProps<'div'> {}
  * SheetBody
  *
  * Container for the sheet's main content between the header and footer. Pads its
- * content to the same inset as SheetHeader and SheetFooter and grows to fill the
- * panel.
+ * content to the same inset as SheetHeader and SheetFooter.
  *
  * @example
  * ```tsx
@@ -251,7 +250,7 @@ function SheetBody({ className, ...props }: SheetBodyProps) {
   return (
     <div
       data-slot="sheet-body"
-      className={cn('nx:flex-1 nx:p-6', className)}
+      className={cn('nx:p-6', className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

Overlay-family audit work (#478 + #486): body content slots for the two edge-panel components, tighter Sheet spacing, and the close-button hit-area tests.

**Sheet**
- `SheetBody` (new) — `px-6` content region between header/footer so body content shares the header/footer inset (consumers no longer hand-roll `px-4`).
- Dropped `gap-4` from `SheetContent` so section spacing comes solely from header/footer `p-6` — uniform 24px, no compounding (matches Drawer).
- Close-button hit-area test (the remaining #478 item; the code itself shipped via #447).
- `ScrollableContent` story.

**Drawer**
- `DrawerBody` (new) — mirrors `SheetBody`; adopted across the stories, replacing the ad-hoc `px-4`/`px-6` body padding (the same inconsistency #486 flagged in Sheet).

**Dialog**
- Close-button hit-area assertion in `CloseButtonFocus` (ships the code, wasn't tested).

## Overlay-family model (#486)

The family resolves to two deliberate, internally-consistent padding models:
- **Dialog / AlertDialog** — container `p-6` on the content; body auto-insets.
- **Sheet / Drawer** — per-section `p-6` on header/footer + a `*Body` slot (`px-6`) for the content; no content gap.

| Dimension | State |
| --- | --- |
| Typography composites | ✅ identical across all four |
| Spacing / body inset | ✅ fixed — `SheetBody` + `DrawerBody` give body content the header/footer inset; Sheet's compounding `gap-4` removed |
| Overlay element | ✅ byte-identical |
| A11y | ✅ Radix roles; labelled title/description |
| z-index | ✅ all `nx:z-modal` |
| Story coverage | ✅ hit-area (Sheet + Dialog), `ScrollableContent` (Sheet) |
| Docs language | ✅ all four metas cross-reference the family |
| Figma parity | ⚠️ not verified — no Figma URL |

Motion divergence stays with #467 PR3.

## Consumer impact (verified)

`SheetBody` / `DrawerBody` are additive — existing consumers keep working. The `gap-4` removal from `SheetContent` only affects `plan-sheet` (header/body/footer are direct children → 16px tighter, aligning with the new rhythm); the form sheets nest in a single `<form>` and Sidebar uses `p-0`, both unaffected.

## GitHub Issue

Closes #478
Refs #486 (Sheet + Drawer body-padding consistency; Sheet sign-off)

## Test Plan

- [x] `pnpm --filter @nexus/react audit:storybook-coverage` (sheet, drawer) — 0 missing, 0 drift
- [x] `pnpm typecheck` — 7/7
- [x] `pnpm lint` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm test:storybook` (Sheet / Dialog / Drawer / AlertDialog) — all pass in Chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code)
