### PR TITLE
refactor(date-picker): tokenize typography (text-sm → body-default)

### DIFF
--- a/packages/react/src/components/ui/date-picker/DatePicker.stories.tsx
+++ b/packages/react/src/components/ui/date-picker/DatePicker.stories.tsx
@@ -528,6 +528,12 @@ export const WithDataAttributes: Story = {
     const canvas = within(canvasElement);
     const day15 = canvas.getByText('15').closest('button');
     await expect(day15).toHaveAttribute('data-day');
+    // #498: day cells + weekday headers use the typography-body-default composite
+    // (migrated from raw nx:text-sm); both share the same 14px/400 type.
+    await expect(day15).toHaveClass('nx:typography-body-default');
+    await expect(canvasElement.querySelector('.rdp-weekday')).toHaveClass(
+      'nx:typography-body-default'
+    );
   },
 };
 

--- a/packages/react/src/components/ui/date-picker/date-picker.tsx
+++ b/packages/react/src/components/ui/date-picker/date-picker.tsx
@@ -81,9 +81,7 @@ const staticDayPickerClassNames = {
   table: 'nx:w-full nx:border-collapse',
   weekdays: cn('nx:flex', defaultClassNames.weekdays),
   weekday: cn(
-    // Match the day buttons' type (Button's raw text-sm + font-normal,
-    // inherited family).
-    'nx:flex-1 nx:rounded-md nx:text-sm nx:font-normal nx:text-muted-foreground-subtle nx:select-none',
+    'nx:flex-1 nx:rounded-md nx:typography-body-default nx:text-muted-foreground-subtle nx:select-none',
     defaultClassNames.weekday
   ),
   week: cn('nx:mt-2 nx:flex nx:w-full', defaultClassNames.week),
@@ -338,7 +336,7 @@ function DatePickerDayButton({
       data-today={isToday}
       data-outside={isOutside || undefined}
       className={cn(
-        'nx:flex nx:aspect-square nx:size-(--cell-size) nx:min-w-(--cell-size) nx:text-sm nx:leading-none nx:font-normal',
+        'nx:flex nx:aspect-square nx:size-(--cell-size) nx:min-w-(--cell-size) nx:typography-body-default nx:leading-none',
         'nx:disabled:text-disabled-foreground nx:aria-disabled:text-disabled-foreground',
         isOutside && 'nx:text-muted-foreground-subtle',
         // Keyboard-focus ring on the focused day (modality-independent — paints above neighbours).


### PR DESCRIPTION
## Summary

- Migrate the weekday header and day-cell text from raw `nx:text-sm` → the `nx:typography-body-default` composite (14px/400) — removes the last raw font-size sites in date-picker.
- The day cell is a `<Button size="icon">`, which carries **no** typography of its own (only Button's `sm`/`default`/`lg` sizes apply `label-default`), so the composite lands cleanly with no source-order conflict.
- Dropped the redundant `nx:font-normal` (body-default is already weight 400) and the now-stale "matches Button's raw text-sm" comment. **Kept `nx:leading-none`** — it wins the line-height cascade over the composite (confirmed in compiled `react.css`), preserving the day cell's `line-height:1`.
- Added `toHaveClass` regression locks for both sites.

## GitHub Issue

Closes #498
Part of #495

## Test Plan

- [x] No raw `nx:text-{size}` remain in `date-picker.tsx`
- [x] `pnpm --filter @nexus/react typecheck` · eslint · prettier — clean
- [x] `pnpm test:storybook` — 743 pass, incl. the new DatePicker `toHaveClass` assertions
- [x] Visual: calendar renders identically (centered day numbers, `today` `::before` marker intact, weekday↔day type matched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)