### PR TITLE
refactor(chart): tokenize typography (text-xs → body-small)

### DIFF
--- a/packages/react/src/components/ui/chart/Chart.stories.tsx
+++ b/packages/react/src/components/ui/chart/Chart.stories.tsx
@@ -197,6 +197,8 @@ export const WithDataAttributes: Story = {
     const chart = canvasElement.querySelector('[data-slot="chart"]');
     await expect(chart).toBeInTheDocument();
     await expect(chart).toHaveAttribute('data-chart');
+    // #497: chart base text migrated raw nx:text-xs → typography-body-small (12px).
+    await expect(chart).toHaveClass('nx:typography-body-small');
   },
 };
 

--- a/packages/react/src/components/ui/chart/chart.tsx
+++ b/packages/react/src/components/ui/chart/chart.tsx
@@ -72,7 +72,7 @@ function ChartContainer({
         data-slot="chart"
         data-chart={chartId}
         className={cn(
-          "nx:flex nx:aspect-video nx:justify-center nx:text-xs nx:[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground nx:[&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border-default nx:[&_.recharts-curve.recharts-tooltip-cursor]:stroke-border-default nx:[&_.recharts-dot[stroke='#fff']]:stroke-transparent nx:[&_.recharts-layer]:outline-hidden nx:[&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border-default nx:[&_.recharts-radial-bar-background-sector]:fill-muted nx:[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted nx:[&_.recharts-reference-line_[stroke='#ccc']]:stroke-border-default nx:[&_.recharts-sector]:outline-hidden nx:[&_.recharts-sector[stroke='#fff']]:stroke-transparent nx:[&_.recharts-surface]:outline-hidden",
+          "nx:flex nx:aspect-video nx:justify-center nx:typography-body-small nx:[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground nx:[&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border-default nx:[&_.recharts-curve.recharts-tooltip-cursor]:stroke-border-default nx:[&_.recharts-dot[stroke='#fff']]:stroke-transparent nx:[&_.recharts-layer]:outline-hidden nx:[&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border-default nx:[&_.recharts-radial-bar-background-sector]:fill-muted nx:[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted nx:[&_.recharts-reference-line_[stroke='#ccc']]:stroke-border-default nx:[&_.recharts-sector]:outline-hidden nx:[&_.recharts-sector[stroke='#fff']]:stroke-transparent nx:[&_.recharts-surface]:outline-hidden",
           className
         )}
         style={chartStyle}
@@ -211,7 +211,7 @@ function ChartTooltipContent({
   return (
     <div
       className={cn(
-        'nx:border-border-default nx:bg-popover nx:text-popover-foreground nx:grid nx:min-w-32 nx:items-start nx:gap-1.5 nx:rounded-md nx:border nx:px-3 nx:py-1.5 nx:text-xs nx:shadow-lg',
+        'nx:border-border-default nx:bg-popover nx:text-popover-foreground nx:grid nx:min-w-32 nx:items-start nx:gap-1.5 nx:rounded-md nx:border nx:px-3 nx:py-1.5 nx:typography-body-small nx:shadow-lg',
         className
       )}
     >


### PR DESCRIPTION
## Summary

- Migrate the chart container and `ChartTooltipContent` text from raw `nx:text-xs` → the `nx:typography-body-small` composite (12px).
- Both sites are plain `<div>`s (not `<Button>` consumers), so the composite lands cleanly — no co-located `font-*`/`leading-*` to reconcile.
- On the recharts **container**, the composite's extra properties (family / weight / line-height / tracking / text-wrap) are no-ops or already-defaults for SVG `<text>`, so axis ticks and the legend render unchanged. Verified by screenshot (bar chart: Jan–Jun ticks + Desktop/Mobile legend at 12px/normal, identical).

## GitHub Issue

Closes #497
Part of #495

## Test Plan

- [x] No raw `nx:text-{size}` remain in `chart.tsx`
- [x] `pnpm --filter @nexus/react typecheck` · eslint · prettier — clean
- [x] `pnpm test:storybook` — 743 pass, incl. a new `toHaveClass('nx:typography-body-small')` lock on the container
- [x] Visual: bar-chart axis ticks + legend render unchanged after the container swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)