### PR TITLE
refactor(navigation-menu): tokenize trigger/link typography

### DIFF
--- a/packages/react/src/components/ui/navigation-menu/NavigationMenu.stories.tsx
+++ b/packages/react/src/components/ui/navigation-menu/NavigationMenu.stories.tsx
@@ -308,6 +308,9 @@ export const WithDataAttributes: Story = {
       'data-slot',
       'navigation-menu-trigger'
     );
+    // #470: trigger reuses navigationMenuTriggerStyle → typography-label-default
+    // (migrated from raw nx:text-sm nx:font-medium).
+    await expect(trigger).toHaveClass('nx:typography-label-default');
 
     // Open → content + link slots render
     await userEvent.click(trigger);
@@ -319,6 +322,10 @@ export const WithDataAttributes: Story = {
         canvasElement.querySelector('[data-slot="navigation-menu-link"]')
       ).toBeInTheDocument();
     });
+    // #470: flyout link migrated raw nx:text-sm → typography-body-default.
+    await expect(
+      canvasElement.querySelector('[data-slot="navigation-menu-link"]')
+    ).toHaveClass('nx:typography-body-default');
 
     await userEvent.keyboard('{Escape}');
   },

--- a/packages/react/src/components/ui/navigation-menu/navigation-menu.tsx
+++ b/packages/react/src/components/ui/navigation-menu/navigation-menu.tsx
@@ -115,7 +115,7 @@ function NavigationMenuItem({ className, ...props }: NavigationMenuItemProps) {
 }
 
 const navigationMenuTriggerStyle = cva(
-  'nx:group nx:inline-flex nx:w-max nx:items-center nx:justify-center nx:rounded-md nx:bg-background nx:px-4 nx:py-2 nx:text-sm nx:font-medium nx:outline-none nx:transition-colors nx:motion-reduce:transition-none nx:hover:bg-background-hover nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:pointer-events-none nx:disabled:text-disabled-foreground nx:data-[state=open]:bg-background-hover nx:data-[state=open]:text-foreground'
+  'nx:group nx:inline-flex nx:w-max nx:items-center nx:justify-center nx:rounded-md nx:bg-background nx:px-4 nx:py-2 nx:typography-label-default nx:outline-none nx:transition-colors nx:motion-reduce:transition-none nx:hover:bg-background-hover nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:pointer-events-none nx:disabled:text-disabled-foreground nx:data-[state=open]:bg-background-hover nx:data-[state=open]:text-foreground'
 );
 
 /**
@@ -256,7 +256,7 @@ function NavigationMenuLink({ className, ...props }: NavigationMenuLinkProps) {
     <NavigationMenuPrimitive.Link
       data-slot="navigation-menu-link"
       className={cn(
-        'nx:flex nx:flex-col nx:gap-1 nx:rounded-sm nx:p-2 nx:text-sm nx:outline-none nx:transition-colors',
+        'nx:flex nx:flex-col nx:gap-1 nx:rounded-sm nx:p-2 nx:typography-body-default nx:outline-none nx:transition-colors',
         'nx:motion-reduce:transition-none',
         'nx:hover:bg-popover-hover nx:hover:text-popover-foreground',
         'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',


### PR DESCRIPTION
## Summary

- Migrate the two raw `nx:text-sm` sites to typography composites:
  - **`navigationMenuTriggerStyle` cva** (the trigger + any trigger-styled links): `nx:text-sm nx:font-medium` → `nx:typography-label-default` — the pair *is* 14px/500, an exact composite match.
  - **`NavigationMenuLink`** (flyout link): `nx:text-sm` → `nx:typography-body-default` (14px/400).
- Both are Radix primitives (not Nexus `<Button>` consumers), so there's no composite-source-order conflict.
- Added `toHaveClass` regression locks for the trigger and the flyout link in `WithDataAttributes`.

## GitHub Issue

Closes #470
Part of #495

## Test Plan

- [x] No raw `nx:text-{size}` remain in `navigation-menu.tsx`
- [x] `pnpm --filter @nexus/react typecheck` · eslint · prettier — clean
- [x] `pnpm test:storybook` — 743 pass, incl. the two new `toHaveClass` locks (the play fn opens the flyout to exercise the link)
- [x] Visual: open flyout renders triggers at medium weight (label-default) and links at normal weight (body-default), cleanly spaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)