### PR TITLE
refactor(react): per-section overlay padding + Dialog/AlertDialog body slots

### DIFF
--- a/apps/console/src/modules/crm/contacts-toolbar.tsx
+++ b/apps/console/src/modules/crm/contacts-toolbar.tsx
@@ -4,6 +4,7 @@ import {
   Badge,
   Button,
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,
@@ -244,15 +245,17 @@ function SavedViewsMenu({
               Name this view and filter combination to reuse it later.
             </DialogDescription>
           </DialogHeader>
-          <Input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="e.g. Active deals"
-            aria-label="View name"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') handleSave();
-            }}
-          />
+          <DialogBody>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Active deals"
+              aria-label="View name"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleSave();
+              }}
+            />
+          </DialogBody>
           <DialogFooter>
             <DialogClose asChild>
               <Button variant="outline">Cancel</Button>

--- a/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
+++ b/packages/react/src/components/ui/alert-dialog/AlertDialog.stories.tsx
@@ -6,6 +6,7 @@ import { Button } from '../button';
 import {
   AlertDialog,
   AlertDialogAction,
+  AlertDialogBody,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -114,14 +115,14 @@ export const WithBodyContent: Story = {
             This payment method will be removed from the workspace.
           </AlertDialogDescription>
         </AlertDialogHeader>
-        <div className="nx:grid nx:gap-2">
+        <AlertDialogBody className="nx:grid nx:gap-2">
           <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-default">
             Future invoices will use the fallback payment method.
           </div>
           <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-3 nx:typography-body-default">
             Active subscriptions continue until the next billing cycle.
           </div>
-        </div>
+        </AlertDialogBody>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction variant="destructive">
@@ -143,6 +144,18 @@ export const WithBodyContent: Story = {
     await expect(dialog).toHaveTextContent(
       'Future invoices will use the fallback payment method.'
     );
+
+    await expect(dialog).toHaveClass('nx:py-6', 'nx:gap-4');
+    await expect(dialog).not.toHaveClass('nx:p-6');
+    await expect(
+      document.querySelector('[data-slot="alert-dialog-header"]')
+    ).toHaveClass('nx:px-6');
+    await expect(
+      document.querySelector('[data-slot="alert-dialog-footer"]')
+    ).toHaveClass('nx:px-6');
+    await expect(
+      document.querySelector('[data-slot="alert-dialog-body"]')
+    ).toHaveClass('nx:px-6');
 
     await userEvent.keyboard('{Escape}');
     await waitFor(() => {

--- a/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
+++ b/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
@@ -10,7 +10,7 @@ const alertDialogContentVariants = cva(
   [
     'nx:fixed nx:left-1/2 nx:top-1/2 nx:z-modal nx:grid nx:w-full nx:max-w-lg',
     'nx:-translate-x-1/2 nx:-translate-y-1/2',
-    'nx:gap-4 nx:border nx:border-border-default nx:bg-container nx:p-6 nx:shadow-lg',
+    'nx:gap-4 nx:border nx:border-border-default nx:bg-container nx:py-6 nx:shadow-lg',
     'nx:data-[state=open]:duration-300 nx:data-[state=closed]:duration-150',
     'nx:data-[state=open]:ease-out nx:data-[state=closed]:ease-in',
     'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
@@ -21,7 +21,7 @@ const alertDialogContentVariants = cva(
   ].join(' ')
 );
 
-const alertDialogHeaderVariants = cva('nx:flex nx:flex-col nx:gap-1', {
+const alertDialogHeaderVariants = cva('nx:flex nx:flex-col nx:gap-1 nx:px-6', {
   variants: {
     variant: {
       default: 'nx:text-center nx:sm:text-left',
@@ -33,7 +33,7 @@ const alertDialogHeaderVariants = cva('nx:flex nx:flex-col nx:gap-1', {
   },
 });
 
-const alertDialogFooterVariants = cva('nx:flex nx:gap-2', {
+const alertDialogFooterVariants = cva('nx:flex nx:gap-2 nx:px-6', {
   variants: {
     orientation: {
       horizontal:
@@ -251,6 +251,36 @@ function AlertDialogHeader({
 }
 
 /**
+ * AlertDialogBodyProps
+ *
+ * Props for the AlertDialogBody component.
+ */
+interface AlertDialogBodyProps extends React.ComponentProps<'div'> {}
+
+/**
+ * AlertDialogBody
+ *
+ * Container for the alert dialog's body content. Insets content horizontally to
+ * align with the header and footer.
+ *
+ * @example
+ * ```tsx
+ * <AlertDialogBody>
+ *   <p>Supporting detail.</p>
+ * </AlertDialogBody>
+ * ```
+ */
+function AlertDialogBody({ className, ...props }: AlertDialogBodyProps) {
+  return (
+    <div
+      data-slot="alert-dialog-body"
+      className={cn('nx:px-6', className)}
+      {...props}
+    />
+  );
+}
+
+/**
  * AlertDialogFooterProps
  *
  * Props for the AlertDialogFooter component.
@@ -436,6 +466,8 @@ export {
   AlertDialog,
   AlertDialogAction,
   type AlertDialogActionProps,
+  AlertDialogBody,
+  type AlertDialogBodyProps,
   AlertDialogCancel,
   type AlertDialogCancelProps,
   AlertDialogContent,

--- a/packages/react/src/components/ui/dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/ui/dialog/Dialog.stories.tsx
@@ -12,6 +12,7 @@ import { Input } from '../input';
 
 import {
   Dialog,
+  DialogBody,
   DialogClose,
   DialogContent,
   DialogDescription,
@@ -57,9 +58,11 @@ export const Default: Story = {
             This is a basic dialog with a title and description.
           </DialogDescription>
         </DialogHeader>
-        <p className="nx:text-sm nx:text-foreground">
-          Dialog content goes here. You can add any content you need.
-        </p>
+        <DialogBody>
+          <p className="nx:text-sm nx:text-foreground">
+            Dialog content goes here. You can add any content you need.
+          </p>
+        </DialogBody>
         <DialogFooter>
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>
@@ -84,7 +87,7 @@ export const WithDescription: Story = {
             Make changes to your profile here. Click save when you&apos;re done.
           </DialogDescription>
         </DialogHeader>
-        <div className="nx:grid nx:gap-4 nx:py-4">
+        <DialogBody className="nx:grid nx:gap-4 nx:py-4">
           <div className="nx:grid nx:grid-cols-4 nx:items-center nx:gap-4">
             <label
               htmlFor="name"
@@ -111,7 +114,7 @@ export const WithDescription: Story = {
               className="nx:col-span-3"
             />
           </div>
-        </div>
+        </DialogBody>
         <DialogFooter>
           <Button type="submit">Save changes</Button>
         </DialogFooter>
@@ -160,9 +163,11 @@ export const CustomCloseButton: Story = {
             This dialog uses a custom close button in the footer.
           </DialogDescription>
         </DialogHeader>
-        <p className="nx:text-sm nx:text-foreground">
-          You can customize how users close the dialog.
-        </p>
+        <DialogBody>
+          <p className="nx:text-sm nx:text-foreground">
+            You can customize how users close the dialog.
+          </p>
+        </DialogBody>
         <DialogFooter>
           <DialogClose asChild>
             <Button variant="ghost">Dismiss</Button>
@@ -186,7 +191,7 @@ export const ScrollableContent: Story = {
             Please read the following terms carefully.
           </DialogDescription>
         </DialogHeader>
-        <div className="nx:space-y-4 nx:text-sm nx:text-foreground">
+        <DialogBody className="nx:space-y-4 nx:text-sm nx:text-foreground">
           {Array.from({ length: 10 }).map((_, i) => (
             <p key={i}>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
@@ -195,7 +200,7 @@ export const ScrollableContent: Story = {
               nisi ut aliquip ex ea commodo consequat.
             </p>
           ))}
-        </div>
+        </DialogBody>
         <DialogFooter>
           <DialogClose asChild>
             <Button variant="outline">Decline</Button>
@@ -315,7 +320,9 @@ export const WithDataAttributes: Story = {
           <DialogTitle>Data Attributes</DialogTitle>
           <DialogDescription>Testing data-slot attributes.</DialogDescription>
         </DialogHeader>
-        <p className="nx:text-sm">Content here</p>
+        <DialogBody>
+          <p className="nx:text-sm">Content here</p>
+        </DialogBody>
         <DialogFooter>
           <DialogClose asChild>
             <Button>Close</Button>
@@ -357,7 +364,23 @@ export const WithDataAttributes: Story = {
       expect(
         document.querySelector('[data-slot="dialog-close-button"]')
       ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="dialog-body"]')
+      ).toBeInTheDocument();
     });
+
+    const content = document.querySelector('[data-slot="dialog-content"]');
+    await expect(content).toHaveClass('nx:py-6', 'nx:gap-4');
+    await expect(content).not.toHaveClass('nx:p-6');
+    await expect(
+      document.querySelector('[data-slot="dialog-header"]')
+    ).toHaveClass('nx:px-6');
+    await expect(
+      document.querySelector('[data-slot="dialog-footer"]')
+    ).toHaveClass('nx:px-6');
+    await expect(
+      document.querySelector('[data-slot="dialog-body"]')
+    ).toHaveClass('nx:px-6');
 
     // Close the dialog
     await userEvent.keyboard('{Escape}');
@@ -487,15 +510,17 @@ export const NestedOverlayStacking: Story = {
             The dropdown below must appear above this dialog.
           </DialogDescription>
         </DialogHeader>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline">Open menu</Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuItem>Profile</DropdownMenuItem>
-            <DropdownMenuItem>Settings</DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <DialogBody>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline">Open menu</Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem>Profile</DropdownMenuItem>
+              <DropdownMenuItem>Settings</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </DialogBody>
       </DialogContent>
     </Dialog>
   ),

--- a/packages/react/src/components/ui/dialog/dialog.tsx
+++ b/packages/react/src/components/ui/dialog/dialog.tsx
@@ -126,7 +126,7 @@ function DialogContent({
         className={cn(
           'nx:fixed nx:left-1/2 nx:top-1/2 nx:z-modal nx:grid nx:w-full nx:max-w-lg',
           'nx:-translate-x-1/2 nx:-translate-y-1/2',
-          'nx:gap-4 nx:border nx:border-border-default nx:bg-container nx:p-6 nx:shadow-lg',
+          'nx:gap-4 nx:border nx:border-border-default nx:bg-container nx:py-6 nx:shadow-lg',
           'nx:data-[state=open]:duration-300 nx:data-[state=closed]:duration-150',
           'nx:data-[state=open]:ease-out nx:data-[state=closed]:ease-in',
           'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
@@ -187,9 +187,39 @@ function DialogHeader({ className, ...props }: DialogHeaderProps) {
     <div
       data-slot="dialog-header"
       className={cn(
-        'nx:flex nx:flex-col nx:gap-1 nx:text-center nx:sm:text-left',
+        'nx:flex nx:flex-col nx:gap-1 nx:px-6 nx:text-center nx:sm:text-left',
         className
       )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * DialogBodyProps
+ *
+ * Props for the DialogBody component.
+ */
+interface DialogBodyProps extends React.ComponentProps<'div'> {}
+
+/**
+ * DialogBody
+ *
+ * Container for the dialog's body content. Insets content horizontally to align
+ * with the header and footer.
+ *
+ * @example
+ * ```tsx
+ * <DialogBody>
+ *   <p>Main dialog content.</p>
+ * </DialogBody>
+ * ```
+ */
+function DialogBody({ className, ...props }: DialogBodyProps) {
+  return (
+    <div
+      data-slot="dialog-body"
+      className={cn('nx:px-6', className)}
       {...props}
     />
   );
@@ -220,7 +250,7 @@ function DialogFooter({ className, ...props }: DialogFooterProps) {
     <div
       data-slot="dialog-footer"
       className={cn(
-        'nx:flex nx:flex-col-reverse nx:sm:flex-row nx:sm:justify-end nx:sm:gap-2',
+        'nx:flex nx:flex-col-reverse nx:px-6 nx:sm:flex-row nx:sm:justify-end nx:sm:gap-2',
         className
       )}
       {...props}
@@ -293,6 +323,8 @@ function DialogDescription({ className, ...props }: DialogDescriptionProps) {
 
 export {
   Dialog,
+  DialogBody,
+  type DialogBodyProps,
   DialogClose,
   DialogContent,
   type DialogContentProps,


### PR DESCRIPTION
## Summary

- Migrate **Dialog** and **AlertDialog** to the per-section padding model (\"Model Z\"): the content container keeps `nx:grid nx:gap-4` and changes `p-6`→`py-6` (vertical edges + rhythm stay on the container); the header, footer, and the new body slots each own their horizontal inset via `px-6`.
- Add **`DialogBody`** and **`AlertDialogBody`** slots — mirroring the `SheetBody`/`DrawerBody` API (#494) — so the overlay family shares a body-slot API + per-section horizontal model.
- **Zero visual change**: every section combination renders identically. The change relocates *where* padding lives, not its values (verified structurally via class-presence assertions and visually in Storybook).
- Migrate the one freeform consumer: `contacts-toolbar`'s raw `<Input>` → `<DialogBody>`. `command.tsx` is unchanged — its `nx:p-0` stays load-bearing (now overrides `py-6` instead of `p-6`).

## Why Model Z (not a literal Sheet match)

Sheet's symmetric per-section `p-6` works only because Sheet is full-height with an `mt-auto` footer, so header and footer are never adjacent. A content-hugging modal makes them adjacent, so two `p-6` sections would compound to 48px where today's `gap-4` gives 16px. Model Z keeps the container's vertical rhythm (`gap-4` + `py-6`) and moves only the horizontal inset onto the sections — preserving spacing while still delivering the body-slot API. The family aligns on the **API + horizontal model**; vertical handling differs by layout necessity (content-hugging modal vs full-height panel). (Also: CSS grid `gap` pads only *between* tracks, never edges — so `py-6` on the container, not `pt-6`/`pb-6` on sections, is what keeps single-section dialogs from losing an edge inset.)

## GitHub Issue

Closes #501

## Test Plan

- [x] `pnpm typecheck` — 7/7 (incl. `@nexus/console`, which resolves the new `DialogBody` export from dist)
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [x] `pnpm test:storybook` — 743/743 (incl. new theme-independent spacing-gate + `*-body` slot assertions)
- [x] Visual check in Storybook: no-body AlertDialog (16px gap preserved, not 48px), `ScrollableContent` (scrollbar gutter + header/body alignment), command palette (flush)

## Notes

- Base is `prasad/components-cleanup` (integration branch), not `main`.
- Independent of #494 (SheetBody/DrawerBody) — disjoint files, no merge hazard, either order. Once both land, all four overlays expose a `*Body` slot.
- Advances the #486 overlay-family audit (Dialog/AlertDialog per-component sign-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)