### PR TITLE
feat(table): adopt cross-DS research findings — a11y, zebra, mobile + recipes

### DIFF
--- a/packages/react/src/components/ui/table/Table.stories.tsx
+++ b/packages/react/src/components/ui/table/Table.stories.tsx
@@ -422,6 +422,50 @@ export const SemanticScope: Story = {
   },
 };
 
+// A sorted column reads as active: TableHead emphasizes its text (muted →
+// foreground) when it carries aria-sort="ascending"/"descending", but not for a
+// merely-sortable "none". The interactive sort control is a recipe (SortableHeader).
+export const AriaSortIndicator: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead aria-sort="ascending">Invoice</TableHead>
+          <TableHead aria-sort="none">Status</TableHead>
+          <TableHead aria-sort="descending" className="nx:text-right">
+            Amount
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableRowHeader>INV001</TableRowHeader>
+          <TableCell>Paid</TableCell>
+          <TableCell className="nx:text-right">$250.00</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  ),
+  play: async ({ canvasElement }) => {
+    const asc = canvasElement.querySelector('[aria-sort="ascending"]');
+    const none = canvasElement.querySelector('[aria-sort="none"]');
+    const desc = canvasElement.querySelector('[aria-sort="descending"]');
+
+    // aria-sort carries only valid values — never asc/desc.
+    await expect(asc).toBeInTheDocument();
+    await expect(none).toBeInTheDocument();
+    await expect(desc).toBeInTheDocument();
+
+    // The emphasis fires for an actively-sorted column, not a sortable-but-unsorted one.
+    await expect(getComputedStyle(asc as Element).color).not.toBe(
+      getComputedStyle(none as Element).color
+    );
+    await expect(getComputedStyle(desc as Element).color).not.toBe(
+      getComputedStyle(none as Element).color
+    );
+  },
+};
+
 // The three border treatments: `borderless` drops the internal rules (Stripe /
 // Linear feel), `default` keeps softened row rules + a header underline, and
 // `grid` adds column rules for a full cell grid (Notion).

--- a/packages/react/src/components/ui/table/Table.stories.tsx
+++ b/packages/react/src/components/ui/table/Table.stories.tsx
@@ -1026,3 +1026,161 @@ export const RowLink: Story = {
     await expect(link).toHaveAccessibleName('INV001');
   },
 };
+
+// Stacked cards on a narrow screen. Rather than restyle tr/td to display:block
+// (which strips <table> semantics for screen readers and would need ARIA grid
+// roles re-applied), swap structures by container width: a real <table> when
+// roomy, a real card list when narrow. Each is correct on its own; neither
+// relies on display:block. (Shown here at a fixed 20rem container = card state.)
+export const StackedCard: Story = {
+  render: () => (
+    <div className="nx:@container nx:w-[20rem]">
+      <div className="nx:@max-sm:hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Invoice</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="nx:text-right">Amount</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {invoices.slice(0, 3).map((row) => (
+              <TableRow key={row.invoice}>
+                <TableRowHeader>{row.invoice}</TableRowHeader>
+                <TableCell>{row.status}</TableCell>
+                <TableCell className="nx:text-right nx:tabular-nums">
+                  {row.amount}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <ul className="nx:hidden nx:flex-col nx:gap-2 nx:@max-sm:flex">
+        {invoices.slice(0, 3).map((row) => (
+          <li
+            key={row.invoice}
+            className="nx:space-y-1 nx:rounded-md nx:border nx:border-border-default-alpha nx:p-3"
+          >
+            <div className="nx:flex nx:justify-between">
+              <span className="nx:text-muted-foreground">Invoice</span>
+              <span className="nx:font-medium">{row.invoice}</span>
+            </div>
+            <div className="nx:flex nx:justify-between">
+              <span className="nx:text-muted-foreground">Status</span>
+              <span>{row.status}</span>
+            </div>
+            <div className="nx:flex nx:justify-between">
+              <span className="nx:text-muted-foreground">Amount</span>
+              <span className="nx:tabular-nums">{row.amount}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const cards = canvasElement.querySelector('ul');
+    const table = canvasElement.querySelector('[data-slot="table-container"]');
+    // At a narrow container the card list shows and the table is hidden — each a
+    // correct structure, so table semantics are never stripped by display:block.
+    await expect(cards).toBeVisible();
+    await expect(table).not.toBeVisible();
+  },
+};
+
+// An empty body renders cleanly: the header keeps its scope, and a single
+// column-spanning row carries the empty-state message. Striping is a no-op here.
+export const EmptyState: Story = {
+  render: () => (
+    <Table striped>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="nx:text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell
+            colSpan={3}
+            className="nx:py-8 nx:text-center nx:text-muted-foreground"
+          >
+            No invoices yet.
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  ),
+  play: async ({ canvasElement }) => {
+    const head = canvasElement.querySelector('[data-slot="table-head"]');
+    await expect(head).toHaveAttribute('scope', 'col');
+    await expect(
+      canvasElement.querySelector('[colspan="3"]')
+    ).toBeInTheDocument();
+  },
+};
+
+// Announce async table changes (sort, filter, load) to screen readers via an
+// aria-live region. Debounce the announcement (~750ms) in production so a burst
+// of fast updates doesn't flood the buffer; this demo announces immediately.
+function LiveRegionDemo() {
+  const [dir, setDir] = useState<'ascending' | 'descending'>('ascending');
+  const rows = [...invoices.slice(0, 3)].sort((a, b) =>
+    dir === 'ascending'
+      ? a.amount.localeCompare(b.amount)
+      : b.amount.localeCompare(a.amount)
+  );
+  return (
+    <div className="nx:space-y-2">
+      <Button
+        size="sm"
+        variant="secondary"
+        onClick={() =>
+          setDir((d) => (d === 'ascending' ? 'descending' : 'ascending'))
+        }
+      >
+        Toggle sort
+      </Button>
+      <div role="status" aria-live="polite" className="nx:sr-only">
+        Sorted by amount, {dir}
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Invoice</TableHead>
+            <TableHead aria-sort={dir} className="nx:text-right">
+              Amount
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={row.invoice}>
+              <TableRowHeader>{row.invoice}</TableRowHeader>
+              <TableCell className="nx:text-right nx:tabular-nums">
+                {row.amount}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+export const LiveRegionAnnouncements: Story = {
+  render: () => <LiveRegionDemo />,
+  play: async ({ canvasElement }) => {
+    const status = canvasElement.querySelector('[role="status"]');
+    await expect(status).toHaveTextContent('Sorted by amount, ascending');
+    await userEvent.click(canvasElement.querySelector('button') as Element);
+    await expect(status).toHaveTextContent('Sorted by amount, descending');
+  },
+};
+
+// The full sort/filter/paginate DataTable recipe — TanStack Table wired over
+// these primitives — lives at apps/console/src/components/data-table.tsx (the
+// logic engine stays a consumer dependency, out of the published bundle).

--- a/packages/react/src/components/ui/table/Table.stories.tsx
+++ b/packages/react/src/components/ui/table/Table.stories.tsx
@@ -988,7 +988,9 @@ export const SelectionWithBulkActions: Story = {
       'tbody [data-slot="table-row"][data-state="selected"]'
     );
     await expect(selectedRows).toHaveLength(invoices.length);
-    await expect(canvasElement).toHaveTextContent('5 selected');
+    await expect(canvasElement).toHaveTextContent(
+      `${invoices.length} selected`
+    );
   },
 };
 
@@ -1028,8 +1030,7 @@ export const RowLink: Story = {
     const link = canvasElement.querySelector('a[href^="#/invoices/"]');
     await expect(link).toBeInTheDocument();
     await expect(link).toHaveAccessibleName('INV001');
-    // The ::after overlay actually generates a box and spans the row, so a click
-    // anywhere on the row follows the link.
+    // after:content-[''] is required for ::after to generate a box at all.
     const overlay = getComputedStyle(link as Element, '::after');
     await expect(overlay.content).not.toBe('none');
     await expect(overlay.position).toBe('absolute');

--- a/packages/react/src/components/ui/table/Table.stories.tsx
+++ b/packages/react/src/components/ui/table/Table.stories.tsx
@@ -13,6 +13,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableRowHeader,
 } from './table';
 
 const meta: Meta<typeof Table> = {
@@ -373,6 +374,51 @@ export const ScrollRegionFocus: Story = {
     // The container is the only focusable element, so the first Tab lands on it.
     await userEvent.tab();
     await expect(container).toHaveFocus();
+  },
+};
+
+// Column headers default to scope="col"; the row's identifying cell uses
+// <TableRowHeader> (scope="row") so each row gets an accessible name. The blank
+// top-left corner opts out with scope={undefined}.
+export const SemanticScope: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead scope={undefined}>
+            <span className="nx:sr-only">Invoice</span>
+          </TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="nx:text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.map((row) => (
+          <TableRow key={row.invoice}>
+            <TableRowHeader>{row.invoice}</TableRowHeader>
+            <TableCell>{row.status}</TableCell>
+            <TableCell className="nx:text-right">{row.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+  play: async ({ canvasElement }) => {
+    const heads = canvasElement.querySelectorAll('[data-slot="table-head"]');
+    const corner = heads[0];
+    const columnHead = heads[1];
+    const rowHeader = canvasElement.querySelector(
+      '[data-slot="table-row-header"]'
+    );
+
+    // Column header defaults to scope="col".
+    await expect(columnHead).toHaveAttribute('scope', 'col');
+    // The blank corner drops scope via scope={undefined}.
+    await expect(corner).not.toHaveAttribute('scope');
+    // The row's identifying cell is a real <th scope="row">.
+    await expect(rowHeader).toBeInTheDocument();
+    await expect(rowHeader).toHaveProperty('tagName', 'TH');
+    await expect(rowHeader).toHaveAttribute('scope', 'row');
   },
 };
 

--- a/packages/react/src/components/ui/table/Table.stories.tsx
+++ b/packages/react/src/components/ui/table/Table.stories.tsx
@@ -1,9 +1,12 @@
 import { useState } from 'react';
 
 import type { Meta, StoryObj } from '@storybook/react';
-import { ChevronDown, ChevronUp } from 'lucide-react';
 import { expect, userEvent } from 'storybook/test';
 
+import { IconChevronDown, IconChevronUp } from '@/lib/icons';
+
+import { Hide } from '../../primitives/hide';
+import { Show } from '../../primitives/show';
 import { Button } from '../button';
 import { Checkbox } from '../checkbox';
 
@@ -853,7 +856,7 @@ export const Bleed: Story = {
 function SortableHeaderDemo() {
   const [sort, setSort] = useState<'asc' | 'desc'>('asc');
   const ariaSort = sort === 'asc' ? 'ascending' : 'descending';
-  const Icon = sort === 'asc' ? ChevronUp : ChevronDown;
+  const Icon = sort === 'asc' ? IconChevronUp : IconChevronDown;
   const rows = [...invoices].sort((a, b) =>
     sort === 'asc'
       ? a.amount.localeCompare(b.amount)
@@ -980,11 +983,12 @@ export const SelectionWithBulkActions: Story = {
       '[aria-label="Select all rows"]'
     );
     await userEvent.click(selectAll as Element);
-    // Select-all selects every row (and reveals the bulk-action bar).
+    // Select-all selects every row and reveals the bulk-action bar.
     const selectedRows = canvasElement.querySelectorAll(
       'tbody [data-slot="table-row"][data-state="selected"]'
     );
     await expect(selectedRows).toHaveLength(invoices.length);
+    await expect(canvasElement).toHaveTextContent('5 selected');
   },
 };
 
@@ -1009,7 +1013,7 @@ export const RowLink: Story = {
             <TableRowHeader>
               <a
                 href={`#/invoices/${row.invoice}`}
-                className="nx:after:absolute nx:after:inset-0 nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
+                className="nx:after:absolute nx:after:inset-0 nx:after:content-[''] nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
               >
                 {row.invoice}
               </a>
@@ -1024,6 +1028,11 @@ export const RowLink: Story = {
     const link = canvasElement.querySelector('a[href^="#/invoices/"]');
     await expect(link).toBeInTheDocument();
     await expect(link).toHaveAccessibleName('INV001');
+    // The ::after overlay actually generates a box and spans the row, so a click
+    // anywhere on the row follows the link.
+    const overlay = getComputedStyle(link as Element, '::after');
+    await expect(overlay.content).not.toBe('none');
+    await expect(overlay.position).toBe('absolute');
   },
 };
 
@@ -1035,7 +1044,7 @@ export const RowLink: Story = {
 export const StackedCard: Story = {
   render: () => (
     <div className="nx:@container nx:w-[20rem]">
-      <div className="nx:@max-sm:hidden">
+      <Hide as="div" containerBelow="sm">
         <Table>
           <TableHeader>
             <TableRow>
@@ -1056,28 +1065,30 @@ export const StackedCard: Story = {
             ))}
           </TableBody>
         </Table>
-      </div>
-      <ul className="nx:hidden nx:flex-col nx:gap-2 nx:@max-sm:flex">
-        {invoices.slice(0, 3).map((row) => (
-          <li
-            key={row.invoice}
-            className="nx:space-y-1 nx:rounded-md nx:border nx:border-border-default-alpha nx:p-3"
-          >
-            <div className="nx:flex nx:justify-between">
-              <span className="nx:text-muted-foreground">Invoice</span>
-              <span className="nx:font-medium">{row.invoice}</span>
-            </div>
-            <div className="nx:flex nx:justify-between">
-              <span className="nx:text-muted-foreground">Status</span>
-              <span>{row.status}</span>
-            </div>
-            <div className="nx:flex nx:justify-between">
-              <span className="nx:text-muted-foreground">Amount</span>
-              <span className="nx:tabular-nums">{row.amount}</span>
-            </div>
-          </li>
-        ))}
-      </ul>
+      </Hide>
+      <Show as="div" containerBelow="sm">
+        <ul className="nx:flex nx:flex-col nx:gap-2">
+          {invoices.slice(0, 3).map((row) => (
+            <li
+              key={row.invoice}
+              className="nx:space-y-1 nx:rounded-md nx:border nx:border-border-default-alpha nx:p-3"
+            >
+              <div className="nx:flex nx:justify-between">
+                <span className="nx:text-muted-foreground">Invoice</span>
+                <span className="nx:font-medium">{row.invoice}</span>
+              </div>
+              <div className="nx:flex nx:justify-between">
+                <span className="nx:text-muted-foreground">Status</span>
+                <span>{row.status}</span>
+              </div>
+              <div className="nx:flex nx:justify-between">
+                <span className="nx:text-muted-foreground">Amount</span>
+                <span className="nx:tabular-nums">{row.amount}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </Show>
     </div>
   ),
   play: async ({ canvasElement }) => {

--- a/packages/react/src/components/ui/table/Table.stories.tsx
+++ b/packages/react/src/components/ui/table/Table.stories.tsx
@@ -656,3 +656,189 @@ export const StickyHeader: Story = {
     await expect(getComputedStyle(head as Element).position).toBe('sticky');
   },
 };
+
+// ============================================
+// RECIPES — patterns a consumer composes; zero added to the published bundle
+// ============================================
+
+// Numeric columns right-align and use tabular figures so digits line up by place
+// value. Apply `nx:text-right nx:tabular-nums` to the header and its cells.
+export const NumericColumn: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead className="nx:text-right nx:tabular-nums">
+            Amount
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.map((row) => (
+          <TableRow key={row.invoice}>
+            <TableRowHeader>{row.invoice}</TableRowHeader>
+            <TableCell className="nx:text-right nx:tabular-nums">
+              {row.amount}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+};
+
+// Cells default to nowrap. To clip overflow with an ellipsis, wrap the content in
+// a width-bounded `nx:truncate` box — truncate is inert without a constrained
+// width (table-layout is auto), so the box, not the cell, sets the bound.
+export const TruncatedCells: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Note</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableRowHeader>INV001</TableRowHeader>
+          <TableCell>
+            <div className="nx:max-w-[16ch] nx:truncate">
+              A long memo that exceeds the cell width and must be clipped
+            </div>
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  ),
+  play: async ({ canvasElement }) => {
+    const clip = canvasElement.querySelector('[data-slot="table-cell"] div');
+    await expect(clip).toBeInTheDocument();
+    // The text genuinely overflows its box — proves real clipping, not just the class.
+    await expect((clip as Element).scrollWidth).toBeGreaterThan(
+      (clip as Element).clientWidth
+    );
+  },
+};
+
+// Pin a column during horizontal scroll with data-sticky + sticky utilities. The
+// row carries an opaque surface bg and the sticky cell uses `nx:bg-inherit`, so
+// the pinned cell tracks the row's hover/selected/stripe state instead of a flat
+// fill that would mismatch on a tinted row.
+export const StickyColumn: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow className="nx:bg-background">
+          <TableHead
+            data-sticky="start"
+            className="nx:sticky nx:left-0 nx:z-10 nx:bg-inherit"
+          >
+            Invoice
+          </TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Method</TableHead>
+          <TableHead className="nx:text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.map((row, i) => (
+          <TableRow
+            key={row.invoice}
+            className="nx:bg-background"
+            data-state={i === 0 ? 'selected' : undefined}
+          >
+            <TableRowHeader
+              data-sticky="start"
+              className="nx:sticky nx:left-0 nx:z-10 nx:bg-inherit"
+            >
+              {row.invoice}
+            </TableRowHeader>
+            <TableCell>{row.status}</TableCell>
+            <TableCell>{row.method}</TableCell>
+            <TableCell className="nx:text-right">{row.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+  play: async ({ canvasElement }) => {
+    const selectedRow = canvasElement.querySelector(
+      'tbody [data-slot="table-row"][data-state="selected"]'
+    );
+    const stickyCell = selectedRow?.querySelector('[data-sticky="start"]');
+
+    await expect(stickyCell).toBeInTheDocument();
+    // The column is actually pinned.
+    await expect(getComputedStyle(stickyCell as Element).position).toBe(
+      'sticky'
+    );
+    // bg-inherit makes the sticky cell resolve to its row's bg — the selection
+    // tint here, not a flat fill that would show a mismatched stripe.
+    await expect(getComputedStyle(stickyCell as Element).backgroundColor).toBe(
+      getComputedStyle(selectedRow as Element).backgroundColor
+    );
+  },
+};
+
+// Drop low-priority columns on a narrow container. Apply a container-query hide
+// (`nx:@max-md:hidden`) to BOTH the column's header and its cells, so the column
+// vanishes cleanly instead of leaving a gap. Drive it off `@container` (the
+// table's own width), not the viewport.
+export const ColumnPriority: Story = {
+  render: () => (
+    <div className="nx:@container nx:w-[20rem]">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Invoice</TableHead>
+            <TableHead className="nx:@max-md:hidden">Method</TableHead>
+            <TableHead className="nx:text-right">Amount</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {invoices.slice(0, 3).map((row) => (
+            <TableRow key={row.invoice}>
+              <TableRowHeader>{row.invoice}</TableRowHeader>
+              <TableCell className="nx:@max-md:hidden">{row.method}</TableCell>
+              <TableCell className="nx:text-right">{row.amount}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const heads = canvasElement.querySelectorAll('[data-slot="table-head"]');
+    const methodHead = heads[1]; // the @max-md:hidden Method column header
+    await expect(methodHead).toBeInTheDocument();
+    // At a 20rem container (< md) the low-priority column is hidden.
+    await expect(getComputedStyle(methodHead as Element).display).toBe('none');
+  },
+};
+
+// `bleed`: let the scroll area run flush to the edge on a narrow screen via a
+// single `--gutter` var on the container — negative margin out, padding back in.
+export const Bleed: Story = {
+  render: () => (
+    <Table containerClassName="nx:[--gutter:1rem] nx:-mx-(--gutter) nx:px-(--gutter)">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="nx:text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.slice(0, 3).map((row) => (
+          <TableRow key={row.invoice}>
+            <TableRowHeader>{row.invoice}</TableRowHeader>
+            <TableCell>{row.status}</TableCell>
+            <TableCell className="nx:text-right">{row.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+};

--- a/packages/react/src/components/ui/table/Table.stories.tsx
+++ b/packages/react/src/components/ui/table/Table.stories.tsx
@@ -1,4 +1,7 @@
+import { useState } from 'react';
+
 import type { Meta, StoryObj } from '@storybook/react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import { expect, userEvent } from 'storybook/test';
 
 import { Button } from '../button';
@@ -841,4 +844,185 @@ export const Bleed: Story = {
       </TableBody>
     </Table>
   ),
+};
+
+// Sortable header: a <button> in the <th>, with aria-sort mapped from the app's
+// sort state to the valid ascending/descending/none values (never the 'asc'/'desc'
+// a sort lib returns). The chevron is aria-hidden; sort logic stays the consumer's
+// (a local useState here; TanStack Table in production).
+function SortableHeaderDemo() {
+  const [sort, setSort] = useState<'asc' | 'desc'>('asc');
+  const ariaSort = sort === 'asc' ? 'ascending' : 'descending';
+  const Icon = sort === 'asc' ? ChevronUp : ChevronDown;
+  const rows = [...invoices].sort((a, b) =>
+    sort === 'asc'
+      ? a.amount.localeCompare(b.amount)
+      : b.amount.localeCompare(a.amount)
+  );
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead aria-sort={ariaSort} className="nx:text-right">
+            <button
+              type="button"
+              onClick={() => setSort((s) => (s === 'asc' ? 'desc' : 'asc'))}
+              className="nx:ml-auto nx:inline-flex nx:items-center nx:gap-1 nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
+            >
+              Amount
+              <Icon className="nx:size-4" aria-hidden />
+            </button>
+          </TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((row) => (
+          <TableRow key={row.invoice}>
+            <TableRowHeader>{row.invoice}</TableRowHeader>
+            <TableCell className="nx:text-right nx:tabular-nums">
+              {row.amount}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}
+
+export const SortableHeader: Story = {
+  render: () => <SortableHeaderDemo />,
+  play: async ({ canvasElement }) => {
+    const header = canvasElement.querySelector('[aria-sort]');
+    const button = canvasElement.querySelector('th button');
+    // aria-sort carries the valid token, never the lib's 'asc'/'desc'.
+    await expect(header).toHaveAttribute('aria-sort', 'ascending');
+    await userEvent.click(button as Element);
+    await expect(header).toHaveAttribute('aria-sort', 'descending');
+  },
+};
+
+// Multi-select with a partial-state header checkbox and a bulk-action bar that
+// appears on selection. Select-all toggles every row; the header checkbox reads
+// indeterminate while the selection is partial. Selection state is local here;
+// in production it's TanStack Table's row-selection model.
+function SelectionDemo() {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const allSelected = selected.size === invoices.length;
+  const someSelected = selected.size > 0 && !allSelected;
+  const toggleAll = () =>
+    setSelected(
+      allSelected ? new Set() : new Set(invoices.map((r) => r.invoice))
+    );
+  const toggleRow = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  return (
+    <div className="nx:space-y-2">
+      {selected.size > 0 && (
+        <div className="nx:flex nx:items-center nx:gap-3 nx:rounded-md nx:bg-muted nx:px-3 nx:py-2 nx:typography-label-default">
+          <span>{selected.size} selected</span>
+          <Button size="sm" variant="secondary">
+            Export
+          </Button>
+          <Button size="sm" variant="destructive">
+            Delete
+          </Button>
+        </div>
+      )}
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>
+              <Checkbox
+                checked={
+                  allSelected ? true : someSelected ? 'indeterminate' : false
+                }
+                onCheckedChange={toggleAll}
+                aria-label="Select all rows"
+              />
+            </TableHead>
+            <TableHead>Invoice</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {invoices.map((row) => (
+            <TableRow
+              key={row.invoice}
+              data-state={selected.has(row.invoice) ? 'selected' : undefined}
+            >
+              <TableCell>
+                <Checkbox
+                  checked={selected.has(row.invoice)}
+                  onCheckedChange={() => toggleRow(row.invoice)}
+                  aria-label={`Select ${row.invoice}`}
+                />
+              </TableCell>
+              <TableRowHeader>{row.invoice}</TableRowHeader>
+              <TableCell>{row.status}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+export const SelectionWithBulkActions: Story = {
+  render: () => <SelectionDemo />,
+  play: async ({ canvasElement }) => {
+    const selectAll = canvasElement.querySelector(
+      '[aria-label="Select all rows"]'
+    );
+    await userEvent.click(selectAll as Element);
+    // Select-all selects every row (and reveals the bulk-action bar).
+    const selectedRows = canvasElement.querySelectorAll(
+      'tbody [data-slot="table-row"][data-state="selected"]'
+    );
+    await expect(selectedRows).toHaveLength(invoices.length);
+  },
+};
+
+// Whole-row link: an <a> in the row header whose absolutely-positioned ::after
+// covers the positioned row, so a click anywhere on the row follows the link —
+// without nesting other interactive controls under the overlay.
+export const RowLink: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Status</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.slice(0, 3).map((row) => (
+          <TableRow
+            key={row.invoice}
+            className="nx:relative nx:hover:bg-background-hover nx:focus-within:bg-background-hover"
+          >
+            <TableRowHeader>
+              <a
+                href={`#/invoices/${row.invoice}`}
+                className="nx:after:absolute nx:after:inset-0 nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
+              >
+                {row.invoice}
+              </a>
+            </TableRowHeader>
+            <TableCell>{row.status}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+  play: async ({ canvasElement }) => {
+    const link = canvasElement.querySelector('a[href^="#/invoices/"]');
+    await expect(link).toBeInTheDocument();
+    await expect(link).toHaveAccessibleName('INV001');
+  },
 };

--- a/packages/react/src/components/ui/table/Table.stories.tsx
+++ b/packages/react/src/components/ui/table/Table.stories.tsx
@@ -466,6 +466,49 @@ export const AriaSortIndicator: Story = {
   },
 };
 
+// Zebra striping tints alternating body rows. Selection and hover beat the
+// stripe — a selected even row shows the selection tint, not the stripe.
+export const Striped: Story = {
+  render: () => (
+    <Table striped>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead className="nx:text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.slice(0, 4).map((row, i) => (
+          <TableRow
+            key={row.invoice}
+            data-state={i === 1 ? 'selected' : undefined}
+          >
+            <TableRowHeader>{row.invoice}</TableRowHeader>
+            <TableCell>{row.status}</TableCell>
+            <TableCell className="nx:text-right">{row.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+  play: async ({ canvasElement }) => {
+    const rows = canvasElement.querySelectorAll(
+      'tbody [data-slot="table-row"]'
+    );
+    const bg = (el: Element) => getComputedStyle(el).backgroundColor;
+    const oddRest = rows[0] as Element; // 1st body row: odd, no stripe
+    const evenSelected = rows[1] as Element; // 2nd body row: even + selected
+    const evenRest = rows[3] as Element; // 4th body row: even, striped
+
+    await expect(rows).toHaveLength(4);
+    // Striping: an even (unselected) row is tinted; an odd row is not.
+    await expect(bg(evenRest)).not.toBe(bg(oddRest));
+    // Selection beats the stripe: the selected even row shows the selection tint.
+    await expect(bg(evenSelected)).not.toBe(bg(evenRest));
+  },
+};
+
 // The three border treatments: `borderless` drops the internal rules (Stripe /
 // Linear feel), `default` keeps softened row rules + a header underline, and
 // `grid` adds column rules for a full cell grid (Notion).

--- a/packages/react/src/components/ui/table/table.tsx
+++ b/packages/react/src/components/ui/table/table.tsx
@@ -291,6 +291,7 @@ function TableHead({ className, ...props }: TableHeadProps) {
   const { variant, density, stickyHeader } = useTableContext();
   return (
     <th
+      scope="col"
       data-slot="table-head"
       className={cn(
         tableHeadVariants({ variant, density }),
@@ -344,6 +345,37 @@ function TableCell({ className, ...props }: TableCellProps) {
 }
 
 /**
+ * TableRowHeaderProps
+ *
+ * Props for the TableRowHeader component.
+ */
+interface TableRowHeaderProps extends React.ComponentProps<'th'> {}
+
+/**
+ * TableRowHeader
+ *
+ * The identifying header cell of a row (`<th scope="row">`) — an invoice number,
+ * a person's name. Scoping it to the row gives every row an accessible name, so
+ * a screen reader announces which row a data cell belongs to. Styled like a data
+ * cell but with medium weight.
+ */
+function TableRowHeader({ className, ...props }: TableRowHeaderProps) {
+  const { variant, density } = useTableContext();
+  return (
+    <th
+      scope="row"
+      data-slot="table-row-header"
+      className={cn(
+        tableCellVariants({ variant, density }),
+        'nx:font-medium',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
  * TableCaptionProps
  *
  * Props for the TableCaption component.
@@ -384,5 +416,7 @@ export {
   type TableHeadProps,
   type TableProps,
   TableRow,
+  TableRowHeader,
+  type TableRowHeaderProps,
   type TableRowProps,
 };

--- a/packages/react/src/components/ui/table/table.tsx
+++ b/packages/react/src/components/ui/table/table.tsx
@@ -64,6 +64,13 @@ interface TableProps extends React.ComponentProps<'table'> {
    */
   stickyHeader?: boolean;
   /**
+   * Zebra striping — tint alternating body rows so the eye tracks across a wide
+   * row. Selection and hover take precedence over the stripe.
+   *
+   * @default false
+   */
+  striped?: boolean;
+  /**
    * Classes for the scroll container (the element that owns horizontal — and,
    * with `stickyHeader`, vertical — overflow). Use it to bound the height
    * (`"nx:max-h-96"`) or set the surface. `className` still targets the `<table>`.
@@ -103,6 +110,7 @@ function Table({
   variant = 'default',
   density = 'comfortable',
   stickyHeader = false,
+  striped = false,
   containerClassName,
   ...props
 }: TableProps) {
@@ -126,8 +134,9 @@ function Table({
           data-variant={variant}
           data-density={density}
           data-sticky-header={stickyHeader || undefined}
+          data-striped={striped || undefined}
           className={cn(
-            'nx:w-full nx:caption-bottom nx:typography-body-default',
+            'nx:w-full nx:caption-bottom nx:typography-body-default nx:[&[data-striped]_tbody_tr:nth-child(even):not(:hover):not([data-state=selected])]:bg-muted',
             className
           )}
           {...props}

--- a/packages/react/src/components/ui/table/table.tsx
+++ b/packages/react/src/components/ui/table/table.tsx
@@ -136,7 +136,7 @@ function Table({
           data-sticky-header={stickyHeader || undefined}
           data-striped={striped || undefined}
           className={cn(
-            'nx:w-full nx:caption-bottom nx:typography-body-default nx:[&[data-striped]_tbody_tr:nth-child(even):not(:hover):not([data-state=selected])]:bg-muted',
+            'nx:w-full nx:caption-bottom nx:typography-body-default nx:[&[data-striped]_tbody_tr:nth-child(even):not(:hover):not([data-state=selected])]:bg-muted nx:[&[data-striped]_tfoot]:border-t nx:[&[data-striped]_tfoot]:border-border-default-alpha',
             className
           )}
           {...props}

--- a/packages/react/src/components/ui/table/table.tsx
+++ b/packages/react/src/components/ui/table/table.tsx
@@ -261,7 +261,7 @@ function TableRow({ className, ...props }: TableRowProps) {
 interface TableHeadProps extends React.ComponentProps<'th'> {}
 
 const tableHeadVariants = cva(
-  'nx:px-2 nx:text-left nx:align-middle nx:typography-label-default nx:whitespace-nowrap nx:text-muted-foreground nx:has-[[role=checkbox]]:pr-0 nx:*:[[role=checkbox]]:translate-y-0.5',
+  'nx:px-2 nx:text-left nx:align-middle nx:typography-label-default nx:whitespace-nowrap nx:text-muted-foreground nx:has-[[role=checkbox]]:pr-0 nx:*:[[role=checkbox]]:translate-y-0.5 nx:[&[aria-sort=ascending]]:text-foreground nx:[&[aria-sort=descending]]:text-foreground',
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary

Stacks on #493. Adopts all 15 findings from a cross-design-system Table study (shadcn / Radix / Catalyst / Tremor · MUI / AntD / AG Grid · Carbon / Atlassian / Primer / React-Aria · Chakra / Mantine / Polaris / Fluent), each routed by what belongs in a primitives-first, bundle-constrained DS.

**In-component (4 — cheap, correct):**
- `scope="col"` default on `TableHead` (overridable; blank corner via `scope={undefined}`).
- New `<TableRowHeader>` → a real `<th scope="row">`, so each row gets an accessible name.
- `aria-sort` indicator — an actively-sorted header emphasizes muted→foreground (keyed on the valid `ascending`/`descending`, never `asc`/`desc`).
- `striped` prop → `data-striped` zebra; precedence is **structural** (`:not(:hover):not([data-state=selected])`), so selection and hover always win.

**Recipes (11 — zero published-bundle, tested Storybook stories):** sortable-header button · multi-select + indeterminate + bulk-action bar · whole-row link · sticky column (`bg-inherit` tracks row state) · container-query column-priority hide · numeric / tabular · width-bounded truncate · `--gutter` bleed · a11y-safe stacked-card (structure swap, not `display:block`) · live-region announcer · DataTable (TanStack — lives in `apps/console`).

## Council fixes

A 4-lens plan council caught 5 blockers the naive plan would have shipped green:
- stacked-card via `display:block` strips `<table>` semantics for screen readers → **structure swap** instead;
- `<Hide containerBelow>` can't hide a table column (wraps children) → **container-query class on cell+header**;
- `<td scope="row">` is inert (scope is `<th>`-only) → **`<TableRowHeader>`**;
- sticky-column opaque bg paints over the row tint → **`bg-inherit`**;
- zebra `nth-child` out-specifies `data-state=selected` → **structural `:not()` exclusion**.

## Guardrails
- `role="table"` stays the default — never a silent `role="grid"` (that 2-D keyboard contract is the consumer's logic layer).
- Bundle: **JS 86.53 / 88 kB**, **CSS 14.7 / 30 kB**. The 4 in-component changes cost ~0.14 kB JS; the recipes cost 0 (they live in stories).

## Test Plan
- [x] `pnpm --filter @nexus/react typecheck` · `pnpm lint` · `pnpm format:check` — clean
- [x] `pnpm size-limit` — JS 86.53/88 kB, CSS 14.7/30 kB
- [x] `pnpm test:storybook` — Table **26 stories** + base-variants grid **1/1** (27 total), with computed-style proofs for zebra precedence, sticky `bg-inherit` tracking, truncate clipping, column-priority hide, the stacked-card swap, and the `aria-sort` value
- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component table` — 0 missing / 0 drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)