### PR TITLE
refactor(toggle): tokenize typography composites + data-attr defaults

### DIFF
--- a/packages/react/src/components/ui/toggle/Toggle.stories.tsx
+++ b/packages/react/src/components/ui/toggle/Toggle.stories.tsx
@@ -19,6 +19,14 @@ export const Default: Story = {
       <IconBold />
     </Toggle>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggle = canvas.getByRole('button', { name: 'Bold' });
+    // data-variant / data-size fall back to 'default' when no prop is set.
+    await expect(toggle).toHaveAttribute('data-slot', 'toggle');
+    await expect(toggle).toHaveAttribute('data-variant', 'default');
+    await expect(toggle).toHaveAttribute('data-size', 'default');
+  },
 };
 
 // The two variants: borderless default and bordered outline.
@@ -50,6 +58,24 @@ export const Sizes: Story = {
       </Toggle>
     </div>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const sm = canvas.getByRole('button', { name: 'Small' });
+    const md = canvas.getByRole('button', { name: 'Default' });
+    const lg = canvas.getByRole('button', { name: 'Large' });
+
+    // sm uses the label-small composite; the raw text-xs is gone.
+    await expect(sm).toHaveClass('nx:typography-label-small');
+    await expect(sm).not.toHaveClass('nx:text-xs');
+    await expect(sm).toHaveClass('nx:px-3', 'nx:py-1.5', 'nx:gap-1.5');
+
+    // default + lg use label-default; the base no longer carries text-sm.
+    await expect(md).toHaveClass('nx:typography-label-default');
+    await expect(md).not.toHaveClass('nx:text-sm');
+    await expect(md).toHaveClass('nx:px-4', 'nx:py-2', 'nx:gap-2');
+    await expect(lg).toHaveClass('nx:typography-label-default');
+    await expect(lg).toHaveClass('nx:px-8', 'nx:py-3', 'nx:gap-2.5');
+  },
 };
 
 // A toggle with text alongside the icon, shown pressed.

--- a/packages/react/src/components/ui/toggle/Toggle.stories.tsx
+++ b/packages/react/src/components/ui/toggle/Toggle.stories.tsx
@@ -22,7 +22,6 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const toggle = canvas.getByRole('button', { name: 'Bold' });
-    // data-variant / data-size fall back to 'default' when no prop is set.
     await expect(toggle).toHaveAttribute('data-slot', 'toggle');
     await expect(toggle).toHaveAttribute('data-variant', 'default');
     await expect(toggle).toHaveAttribute('data-size', 'default');
@@ -64,12 +63,10 @@ export const Sizes: Story = {
     const md = canvas.getByRole('button', { name: 'Default' });
     const lg = canvas.getByRole('button', { name: 'Large' });
 
-    // sm uses the label-small composite; the raw text-xs is gone.
     await expect(sm).toHaveClass('nx:typography-label-small');
     await expect(sm).not.toHaveClass('nx:text-xs');
     await expect(sm).toHaveClass('nx:px-3', 'nx:py-1.5', 'nx:gap-1.5');
 
-    // default + lg use label-default; the base no longer carries text-sm.
     await expect(md).toHaveClass('nx:typography-label-default');
     await expect(md).not.toHaveClass('nx:text-sm');
     await expect(md).toHaveClass('nx:px-4', 'nx:py-2', 'nx:gap-2');

--- a/packages/react/src/components/ui/toggle/toggle.tsx
+++ b/packages/react/src/components/ui/toggle/toggle.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const toggleVariants = cva(
-  'nx:inline-flex nx:items-center nx:justify-center nx:rounded-md nx:text-sm nx:font-medium nx:whitespace-nowrap nx:transition-colors nx:outline-none nx:hover:bg-background-hover nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:pointer-events-none nx:disabled:text-disabled-foreground nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error nx:data-[state=on]:bg-control-background nx:data-[state=on]:text-foreground nx:data-[state=on]:hover:bg-control-background-hover nx:[&_svg]:pointer-events-none nx:[&_svg]:shrink-0 nx:[&_svg]:size-4',
+  'nx:inline-flex nx:items-center nx:justify-center nx:rounded-md nx:whitespace-nowrap nx:transition-colors nx:outline-none nx:hover:bg-background-hover nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:pointer-events-none nx:disabled:text-disabled-foreground nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error nx:data-[state=on]:bg-control-background nx:data-[state=on]:text-foreground nx:data-[state=on]:hover:bg-control-background-hover nx:[&_svg]:pointer-events-none nx:[&_svg]:shrink-0 nx:[&_svg]:size-4',
   {
     variants: {
       variant: {
@@ -14,9 +14,9 @@ const toggleVariants = cva(
         outline: 'nx:border nx:border-border-default nx:bg-transparent',
       },
       size: {
-        default: 'nx:px-4 nx:py-2 nx:gap-2',
-        sm: 'nx:px-3 nx:py-1.5 nx:gap-1.5 nx:text-xs',
-        lg: 'nx:px-8 nx:py-3 nx:gap-2.5',
+        default: 'nx:px-4 nx:py-2 nx:gap-2 nx:typography-label-default',
+        sm: 'nx:px-3 nx:py-1.5 nx:gap-1.5 nx:typography-label-small',
+        lg: 'nx:px-8 nx:py-3 nx:gap-2.5 nx:typography-label-default',
       },
     },
     defaultVariants: {
@@ -53,8 +53,8 @@ function Toggle({ className, variant, size, ...props }: ToggleProps) {
   return (
     <TogglePrimitive.Root
       data-slot="toggle"
-      data-variant={variant}
-      data-size={size}
+      data-variant={variant ?? 'default'}
+      data-size={size ?? 'default'}
       className={cn(toggleVariants({ variant, size }), className)}
       {...props}
     />


### PR DESCRIPTION
## Summary

Audit pass on **Toggle** (issue #472). Of the issue's three asks, the role→numeric **spacing** migration already landed via the #489 sweep, so this PR carries the two remaining items:

- **Typography → composites.** Typography moves into the size variants — `default`/`lg` carry `nx:typography-label-default`, `sm` carries `nx:typography-label-small` — and the raw `nx:text-sm nx:font-medium` / `nx:text-xs` are dropped from the base cva string. This mirrors `button.tsx` (typography lives per-size, never on the base) so no element ever carries two typography composites, avoiding the source-order collision (twMerge can't dedupe composites).
- **Data-attr defaults.** A prop-less `<Toggle>` now emits `data-variant="default" data-size="default"` (`variant ?? 'default'` / `size ?? 'default'`), matching the house form used by alert/badge/input.

### Notes

- **No visual delta.** The composites pin the same values the raw utilities resolved to: `label-default` = 14px / 500 / 20px line-height (= Tailwind's computed `text-sm`); `label-small` = 12px / 500 / 16px (= computed `text-xs`). Verified the `nx:typography-label-small` rule emits in the built `dist/react.css`.
- **Spacing left untouched** — already numeric (`px-4 py-2 gap-2` / `px-3 py-1.5 gap-1.5` / `px-8 py-3 gap-2.5`). The toggle review note's "uses `control-*` role utilities" parenthetical is stale.
- **Ripple to `ToggleGroupItem`** flows automatically through the shared `toggleVariants` (ToggleGroup story tests pass); `toggle-group.tsx` is not edited. Its own data-attr defaults + the variant/size precedence note (`COMPONENT-REVIEW.md:365`) are out of scope for this toggle-only issue and belong to ToggleGroup's audit.

## GitHub Issue

Closes #472

## Test Plan

- [x] `pnpm typecheck` — exit 0
- [x] `pnpm lint` (root, `--max-warnings 0`) — exit 0
- [x] `pnpm format:check` — clean
- [x] Toggle story tests (browser/chromium) — 9/9, incl. new `Default` (data-attr defaults) + `Sizes` (per-size composite + spacing + `text-xs`/`text-sm` removal guards)
- [x] ToggleGroup story tests (ripple) — 9/9
- [x] `audit:storybook-coverage --component toggle` — 0 missing / 0 drift
- [x] Both `typography-label-{default,small}` emit in `dist/react.css`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
