### PR TITLE
refactor(tabs): tokenize TabsTrigger typography to label composites

### DIFF
--- a/packages/react/src/components/ui/tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/ui/tabs/Tabs.stories.tsx
@@ -125,7 +125,6 @@ export const SmallSize: Story = {
     const canvas = within(canvasElement);
     const tab = canvas.getByRole('tab', { name: 'Small Tab' });
 
-    // Typography composite + numeric padding (#471)
     await expect(tab).toHaveClass(
       'nx:typography-label-small',
       'nx:px-2',
@@ -492,7 +491,6 @@ export const WithDataAttributes: Story = {
     const tabPanel = canvas.getByRole('tabpanel');
     await expect(tabPanel).toHaveAttribute('data-slot', 'tabs-content');
 
-    // Typography composite + numeric padding (#471)
     await expect(tab1).toHaveClass(
       'nx:typography-label-default',
       'nx:px-3',

--- a/packages/react/src/components/ui/tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/ui/tabs/Tabs.stories.tsx
@@ -121,6 +121,18 @@ export const SmallSize: Story = {
       </TabsContent>
     </Tabs>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tab = canvas.getByRole('tab', { name: 'Small Tab' });
+
+    // Typography composite + numeric padding (#471)
+    await expect(tab).toHaveClass(
+      'nx:typography-label-small',
+      'nx:px-2',
+      'nx:py-1'
+    );
+    await expect(getComputedStyle(tab).fontSize).toBe('12px');
+  },
 };
 
 export const LargeSize: Story = {
@@ -479,6 +491,21 @@ export const WithDataAttributes: Story = {
     // Check tabpanel has data-slot
     const tabPanel = canvas.getByRole('tabpanel');
     await expect(tabPanel).toHaveAttribute('data-slot', 'tabs-content');
+
+    // Typography composite + numeric padding (#471)
+    await expect(tab1).toHaveClass(
+      'nx:typography-label-default',
+      'nx:px-3',
+      'nx:py-1.5'
+    );
+    await expect(getComputedStyle(tab1).fontSize).toBe('14px');
+
+    await expect(tab2).toHaveClass(
+      'nx:typography-label-default',
+      'nx:px-4',
+      'nx:py-2'
+    );
+    await expect(getComputedStyle(tab2).fontSize).toBe('14px');
   },
 };
 

--- a/packages/react/src/components/ui/tabs/tabs.tsx
+++ b/packages/react/src/components/ui/tabs/tabs.tsx
@@ -70,7 +70,7 @@ const tabsTriggerVariants = cva(
   [
     'nx:inline-flex nx:items-center nx:justify-center',
     'nx:whitespace-nowrap',
-    'nx:font-medium nx:text-muted-foreground',
+    'nx:text-muted-foreground',
     'nx:transition-colors',
     'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
     'nx:disabled:pointer-events-none nx:disabled:text-disabled-foreground',
@@ -101,9 +101,9 @@ const tabsTriggerVariants = cva(
        * @default "default"
        */
       size: {
-        sm: 'nx:px-2 nx:py-1 nx:text-xs',
-        default: 'nx:px-3 nx:py-1.5 nx:text-sm',
-        lg: 'nx:px-4 nx:py-2 nx:text-base',
+        sm: 'nx:px-2 nx:py-1 nx:typography-label-small',
+        default: 'nx:px-3 nx:py-1.5 nx:typography-label-default',
+        lg: 'nx:px-4 nx:py-2 nx:typography-label-default',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary

- Tokenize `TabsTrigger` typography to `typography-label-*` composites and delete the now-redundant base `nx:font-medium` (every size carries weight-500 via its composite):
  - sm `text-xs` → `typography-label-small`
  - default `text-sm` → `typography-label-default`
  - lg `text-base` → `typography-label-default`
- Fold per-size regression locks into existing stories (`SmallSize`, `WithDataAttributes`) — no new export: `toHaveClass(composite + numeric padding)` plus `getComputedStyle().fontSize` (12 / 14 / 14).

## Decisions & notes (to preempt re-flags)

- **lg → `label-default` (14px) — #471 Option A, maintainer-chosen.** A deliberate 16→14px shrink: the label tier caps at 14px since #459 retired `label-large`, so lg now differs from `default` by **padding only**. sm/default are metric-identical (no visual change).
- **Spacing was already numeric** — migrated ahead via #489 — so this PR is **typography-only** despite the issue title mentioning spacing.
- **Story demo scaffolding** raw `text-*` (29 sites) is out of scope, tracked under #508.
- The `getComputedStyle().fontSize` lock guards the migrated property: `toHaveClass` only proves the class string, and the height sentinels (34/26) are line-height-driven (font-size-independent), so font-size was otherwise unasserted.
- No raw `text-*` font-size left in `tabs.tsx` → survives #495's eventual `--text-*: initial` reset.

## GitHub Issue

Closes #471

## Test Plan

- [x] `pnpm typecheck` (root) — clean
- [x] `pnpm lint` (root, `--max-warnings 0`) — clean
- [x] `pnpm format:check` (root) — clean
- [x] `pnpm test:storybook` — 744/744 (incl. `Tabs.stories` 16 + `Tabs.base-variants` smoke)
- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component tabs` — no gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)
