### PR TITLE
fix(tokens): emit --focus-offset at :root so focus rings resolve at runtime

### DIFF
--- a/apps/console/public/themes/globals.css
+++ b/apps/console/public/themes/globals.css
@@ -128,7 +128,6 @@
   --color-border-primary-active: var(--nx-color-blue-400);
   --color-focus-default: var(--nx-focus-color-default);
   --color-focus-error: var(--nx-focus-color-error);
-  --focus-offset: 2px;
 
   /* Spacing tokens */
   --spacing-0: 0px;
@@ -236,6 +235,11 @@
   --breakpoint-lg: 64rem;
   --breakpoint-xl: 80rem;
   --breakpoint-2xl: 96rem;
+}
+
+/* ===== RUNTIME DIMENSION TOKENS ===== */
+:root {
+  --focus-offset: 2px;
 }
 
 /* ===== PER-MODE SPACING (mode swap via [data-style="X"] on any ancestor) ===== */

--- a/apps/console/src/styles/globals.css
+++ b/apps/console/src/styles/globals.css
@@ -128,7 +128,6 @@
   --color-border-primary-active: var(--nx-color-blue-400);
   --color-focus-default: var(--nx-focus-color-default);
   --color-focus-error: var(--nx-focus-color-error);
-  --focus-offset: 2px;
 
   /* Spacing tokens */
   --spacing-0: 0px;
@@ -236,6 +235,11 @@
   --breakpoint-lg: 64rem;
   --breakpoint-xl: 80rem;
   --breakpoint-2xl: 96rem;
+}
+
+/* ===== RUNTIME DIMENSION TOKENS ===== */
+:root {
+  --focus-offset: 2px;
 }
 
 /* ===== PER-MODE SPACING (mode swap via [data-style="X"] on any ancestor) ===== */

--- a/apps/docs/public/themes/globals.css
+++ b/apps/docs/public/themes/globals.css
@@ -128,7 +128,6 @@
   --color-border-primary-active: var(--nx-color-blue-400);
   --color-focus-default: var(--nx-focus-color-default);
   --color-focus-error: var(--nx-focus-color-error);
-  --focus-offset: 2px;
 
   /* Spacing tokens */
   --spacing-0: 0px;
@@ -236,6 +235,11 @@
   --breakpoint-lg: 64rem;
   --breakpoint-xl: 80rem;
   --breakpoint-2xl: 96rem;
+}
+
+/* ===== RUNTIME DIMENSION TOKENS ===== */
+:root {
+  --focus-offset: 2px;
 }
 
 /* ===== PER-MODE SPACING (mode swap via [data-style="X"] on any ancestor) ===== */

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -107,10 +107,10 @@ describe('generateTailwindPackage', () => {
   // outline-focus-* utilities. The ring is outline-only — no focus box-shadow
   // tokens of any kind (the geometry-composed --shadow-focus-* are gone).
   // The 2px C40 offset is also tokenised so components share one tune-point.
-  // Count-based assertion on --focus-offset guards against duplicate emission
-  // through the standalone-semantic dimension scan colliding with a dedicated
-  // collector (the same trap that broke --breakpoint-*).
-  it('promotes focus colours to --color-* and emits --focus-offset exactly once; no focus box-shadow', () => {
+  // --focus-offset emits once at :root (not @theme: Tailwind tree-shakes @theme
+  // vars referenced only via arbitrary utilities, #506). The count guard also
+  // catches duplicate emission via the dimension scan (the --breakpoint-* trap).
+  it('promotes focus colours to --color-* and emits --focus-offset once at :root; no focus box-shadow', () => {
     const themeBlock = extractBlock(nexusCSS, '@theme');
     expect(themeBlock).toMatch(
       /--color-focus-default: var\(--nx-focus-color-default\);/
@@ -118,8 +118,9 @@ describe('generateTailwindPackage', () => {
     expect(themeBlock).toMatch(
       /--color-focus-error: var\(--nx-focus-color-error\);/
     );
-    expect(themeBlock.match(/--focus-offset:/g)).toHaveLength(1);
-    expect(themeBlock).toMatch(/--focus-offset: 2px;/);
+    expect(nexusCSS.match(/--focus-offset:/g)).toHaveLength(1);
+    expect(themeBlock).not.toMatch(/--focus-offset/);
+    expect(nexusCSS).toMatch(/:root\s*\{[^}]*--focus-offset: 2px;[^}]*\}/);
     expect(nexusCSS).not.toMatch(/--shadow-focus-/);
   });
 

--- a/packages/core/scripts/generate-modular.js
+++ b/packages/core/scripts/generate-modular.js
@@ -22,6 +22,7 @@ import {
   formatTokenValue,
   generateBorderWidthUtilitiesCSS,
   generateNativeBrowserUIThemeCSS,
+  generateRootDimensionsCSS,
   generateSpacingModesCSS,
   generateSpacingRoleUtilitiesCSS,
   generateThemeCSS,
@@ -262,11 +263,13 @@ function generateModularGlobalsCSS(
     'brands-blue-light.json',
     primitiveMap
   );
-  // Standalone semantic files (e.g. focus.json) contribute both color tokens
-  // (--color-focus-*) and dimension tokens (--focus-offset) into @theme so
-  // their utilities emit in the app build. Files owned by a dedicated
-  // collector (spacing.json, breakpoints.json, z-index.json) are skipped from
-  // the generic dimension scan to avoid duplicate emission.
+  // Standalone semantic files (e.g. focus.json) contribute color tokens
+  // (--color-focus-* utilities in @theme) and dimension tokens (--focus-offset).
+  // Dimensions go to a :root block, not @theme — used only via arbitrary utilities
+  // Tailwind doesn't track as @theme usage (see generateRootDimensionsCSS / #506).
+  // Files owned by a dedicated collector (spacing/breakpoints/z-index) are skipped
+  // from the generic dimension scan to avoid duplicate emission.
+  const dimensionTokens = [];
   const standaloneTokens = semantics.standalone.flatMap((file) => {
     const tokens = collectSemanticColorTokensVarRef(
       SEMANTIC_DIR,
@@ -274,7 +277,9 @@ function generateModularGlobalsCSS(
       primitiveMap
     );
     if (!FILES_WITH_DEDICATED_DIMENSION_COLLECTORS.has(file)) {
-      tokens.push(...collectSemanticDimensionTokens(SEMANTIC_DIR, file));
+      dimensionTokens.push(
+        ...collectSemanticDimensionTokens(SEMANTIC_DIR, file)
+      );
     }
     return tokens;
   });
@@ -334,6 +339,9 @@ function generateModularGlobalsCSS(
     breakpointTokens,
     // No dark mode block - the app uses dynamic theme switching
   });
+
+  // Fixed dimension primitives at :root (e.g. --focus-offset) — see #506.
+  css += generateRootDimensionsCSS(dimensionTokens);
 
   // Per-mode spacing override blocks. `spacingDefault` picks which mode lands
   // under `:root, [data-style="X"]`; the other six emit as bare

--- a/packages/core/scripts/generate-tailwind-package.js
+++ b/packages/core/scripts/generate-tailwind-package.js
@@ -23,6 +23,7 @@ import {
   generateBaseLayerCSS,
   generateBorderWidthUtilitiesCSS,
   generateNativeBrowserUIThemeCSS,
+  generateRootDimensionsCSS,
   generateSpacingModesCSS,
   generateSpacingRoleUtilitiesCSS,
   generateThemeCSS,
@@ -410,10 +411,12 @@ function generateNexusCSS(
     );
   }
 
-  // Light + dark semantic accumulators. Holds color tokens and any dimension
-  // tokens contributed by standalone files (e.g. focus.json's focus.offset).
+  // Light + dark semantic color accumulators. Dimension tokens (e.g.
+  // focus.offset) are collected separately into `dimensionTokens` so they emit
+  // at :root, not @theme (see generateRootDimensionsCSS / #506).
   const lightSemanticTokens = [];
   const darkSemanticTokens = [];
+  const dimensionTokens = [];
 
   for (const themed of semanticFiles.themed) {
     const lightTokens = collectSemanticColorTokensVarRef(
@@ -430,10 +433,9 @@ function generateNexusCSS(
     darkSemanticTokens.push(...darkTokens);
   }
 
-  // Process standalone semantic files (like focus.json) for light tokens.
-  // Each file can contribute both color tokens (--color-*) and dimension
-  // tokens (--<path>) — focus.json's color leaves promote to --color-focus-*
-  // utilities, and focus.offset emits as --focus-offset for outline-offset.
+  // Process standalone semantic files (like focus.json). Color leaves promote to
+  // --color-focus-* utilities in @theme; dimension leaves (focus.offset) go to
+  // dimensionTokens for the :root block, not @theme (see generateRootDimensionsCSS).
   for (const standaloneFile of semanticFiles.standalone) {
     lightSemanticTokens.push(
       ...collectSemanticColorTokensVarRef(
@@ -443,7 +445,7 @@ function generateNexusCSS(
       )
     );
     if (!FILES_WITH_DEDICATED_DIMENSION_COLLECTORS.has(standaloneFile)) {
-      lightSemanticTokens.push(
+      dimensionTokens.push(
         ...collectSemanticDimensionTokens(SEMANTIC_DIR, standaloneFile)
       );
     }
@@ -505,6 +507,9 @@ function generateNexusCSS(
     darkSelector: '.dark',
     prefixDarkVars: true, // Use --nx-color-* for dark mode overrides
   });
+
+  // Fixed dimension primitives at :root (e.g. --focus-offset) — see #506.
+  css += generateRootDimensionsCSS(dimensionTokens);
 
   // Per-mode spacing override blocks (`:root, [data-style="<default>"]` for
   // the consumer-chosen default + plain `[data-style="X"]` for the others).

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -1526,6 +1526,28 @@ export function generateThemeCSS(config) {
   return css;
 }
 
+/**
+ * Emit fixed dimension primitives (e.g. --focus-offset) as a `:root {}` block.
+ *
+ * Kept out of @theme: they're consumed only via arbitrary utilities like
+ * `outline-offset-(--focus-offset)`, which Tailwind doesn't track as @theme
+ * usage and therefore tree-shakes from the runtime cascade (#506).
+ *
+ * @param {object[]} dimensionTokens - Array of { cssName, value }
+ * @returns {string} CSS `:root {}` block, or '' when empty
+ */
+export function generateRootDimensionsCSS(dimensionTokens = []) {
+  if (dimensionTokens.length === 0) return '';
+
+  let css = `\n/* ===== RUNTIME DIMENSION TOKENS ===== */\n`;
+  css += `:root {\n`;
+  for (const token of dimensionTokens) {
+    css += `  --${token.cssName}: ${token.value};\n`;
+  }
+  css += `}\n`;
+  return css;
+}
+
 export function generateNativeBrowserUIThemeCSS() {
   return `
 /* ===== NATIVE BROWSER UI THEME ===== */

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -1398,7 +1398,7 @@ export function collectSemanticDimensionTokens(semanticDir, fileName) {
  * @param {string} [config.googleFontsImport] - Google Fonts @import statement
  * @param {string[]} config.imports - CSS imports (e.g., ['tailwindcss', './variables.css'])
  * @param {string} [config.tailwindPrefix='nx'] - Tailwind prefix
- * @param {object[]} config.semanticTokens - Array of { cssName, value } for semantic colours and dimensions
+ * @param {object[]} config.semanticTokens - Array of { cssName, value } for semantic colours (dimensions emit at :root via generateRootDimensionsCSS)
  * @param {object[]} config.spacingTokens - Array of { cssName, value } for numeric spacing (Vega defaults; per-mode overrides live outside @theme)
  * @param {object[]} config.radiusTokens - Array of { cssName, varRef } for radius
  * @param {object[]} config.borderwidthTokens - Array of { cssName, varRef } for borderwidth
@@ -1453,7 +1453,7 @@ export function generateThemeCSS(config) {
   css += `  --shadow-*: initial;\n`;
   css += `  --breakpoint-*: initial;\n\n`;
 
-  // Semantic tokens (colours + dimensions like --focus-offset)
+  // Semantic colour tokens (dimensions like --focus-offset emit at :root)
   if (semanticTokens.length > 0) {
     css += `  /* Semantic tokens */\n`;
     for (const token of semanticTokens) {

--- a/packages/react/src/components/ui/button/Button.stories.tsx
+++ b/packages/react/src/components/ui/button/Button.stories.tsx
@@ -479,6 +479,13 @@ export const FocusManagement: Story = {
     await userEvent.tab();
     await expect(button).toHaveFocus();
 
+    // #506: --focus-offset must resolve to 2px at runtime, not collapse to 0.
+    const root = canvasElement.ownerDocument.documentElement;
+    await expect(
+      getComputedStyle(root).getPropertyValue('--focus-offset').trim()
+    ).toBe('2px');
+    await expect(getComputedStyle(button).outlineOffset).toBe('2px');
+
     // Shift+Tab should blur
     await userEvent.tab({ shift: true });
     await expect(button).not.toHaveFocus();

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -128,7 +128,6 @@
   --color-chart-categorical-5: var(--nx-color-indigo-600);
   --color-focus-default: var(--nx-focus-color-default);
   --color-focus-error: var(--nx-focus-color-error);
-  --focus-offset: 2px;
 
   /* Spacing tokens */
   --spacing-0: 0px;
@@ -343,6 +342,11 @@
   --nx-color-chart-categorical-3: var(--nx-color-orange-200);
   --nx-color-chart-categorical-4: var(--nx-color-rose-200);
   --nx-color-chart-categorical-5: var(--nx-color-indigo-200);
+}
+
+/* ===== RUNTIME DIMENSION TOKENS ===== */
+:root {
+  --focus-offset: 2px;
 }
 
 /* ===== PER-MODE SPACING (mode swap via [data-style="X"] on any ancestor) ===== */


### PR DESCRIPTION
## Summary

`--focus-offset` was emitted **only inside `@theme`**, where Tailwind v4 tree-shakes it: the token is consumed solely through arbitrary `outline-offset-(--focus-offset)` utilities, which Tailwind doesn't count as `@theme` usage, so it dropped the variable from the runtime `:root` cascade. Every focus ring across ~24 components rendered at `outline-offset: 0` instead of the documented `2px` (`dist/react.css` shipped the dangling `var(--focus-offset)` reference).

## Fix

- New shared helper `generateRootDimensionsCSS()` emits fixed dimension primitives (e.g. `--focus-offset`) as a plain `:root {}` block, **outside `@theme`** — so they're never subject to usage-based tree-shaking.
- Both generators (`generate-tailwind-package.js`, `generate-modular.js`) now collect dimension tokens separately from `@theme` color tokens and pass them to the helper.
- Regenerated `packages/tailwind/nexus.css` + the app theme CSS now declare `--focus-offset` at `:root` (a 6-line move: out of `@theme`, into the new block). No token *values* changed; `audit:contrast` is unaffected.

`@nexus/react`'s `dist/react.css` stays utilities-only by design (`@reference '@nexus/tailwind'`) — the declaration ships from `@nexus/tailwind`, which storybook/consumers import.

## GitHub Issue

Closes #506

## Test Plan

Verified in an isolated worktree off `prasad/components-cleanup`:

- [x] Button `FocusManagement` play-fn asserts `getComputedStyle(:root)['--focus-offset'] === '2px'` and the focused button's `outlineOffset === '2px'` (was `0px`) — a runtime guard, since class presence can't catch the value collapsing.
- [x] `pnpm test:storybook` — Button 42/42; full suite green.
- [x] `pnpm --filter @nexus/react typecheck` · `pnpm lint` · `pnpm format:check` — clean
- [x] `pnpm --filter @nexus/core audit:contrast` — clean (no value change)
- [x] `pnpm size-limit` — within limits
- [x] Rebuilt `nexus.css` confirmed declaring `--focus-offset` at `:root`, removed from `@theme`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
