### PR TITLE
fix(switch): wire aria-invalid error state + drop thumb shadow

### DIFF
--- a/packages/react/src/components/ui/switch/Switch.stories.tsx
+++ b/packages/react/src/components/ui/switch/Switch.stories.tsx
@@ -73,6 +73,45 @@ export const DisabledChecked: Story = {
   },
 };
 
+export const Invalid: Story = {
+  args: {
+    'aria-invalid': true,
+  },
+  render: function InvalidStory(args) {
+    const switchId = React.useId();
+    const errorId = React.useId();
+
+    return (
+      <div className="nx:grid nx:gap-2">
+        <div className="nx:flex nx:items-center nx:gap-2">
+          <Switch {...args} id={switchId} aria-describedby={errorId} />
+          <label htmlFor={switchId} className="nx:text-sm nx:font-medium">
+            Enable required setting
+          </label>
+        </div>
+        <p id={errorId} className="nx:text-sm nx:text-error-subtle-foreground">
+          This setting must be enabled to continue.
+        </p>
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const switchEl = canvas.getByRole('switch');
+    const error = canvas.getByText('This setting must be enabled to continue.');
+
+    await expect(switchEl).toHaveAttribute('aria-invalid', 'true');
+    await expect(switchEl).toHaveAttribute('aria-describedby', error.id);
+    await expect(switchEl).toHaveAccessibleDescription(
+      'This setting must be enabled to continue.'
+    );
+    await expect(switchEl).toHaveClass('nx:aria-invalid:border-border-error');
+    await expect(switchEl).toHaveClass(
+      'nx:aria-invalid:focus-visible:outline-focus-error'
+    );
+  },
+};
+
 export const WithLabel: Story = {
   render: (_args) => (
     <div className="nx:flex nx:items-center nx:gap-2">

--- a/packages/react/src/components/ui/switch/Switch.stories.tsx
+++ b/packages/react/src/components/ui/switch/Switch.stories.tsx
@@ -109,6 +109,9 @@ export const Invalid: Story = {
     await expect(switchEl).toHaveClass(
       'nx:aria-invalid:focus-visible:outline-focus-error'
     );
+    await expect(switchEl).toHaveClass(
+      'nx:aria-invalid:data-[state=checked]:border-primary-background'
+    );
   },
 };
 

--- a/packages/react/src/components/ui/switch/switch.tsx
+++ b/packages/react/src/components/ui/switch/switch.tsx
@@ -42,6 +42,7 @@ function Switch({ className, ...props }: SwitchProps) {
         'nx:transition-colors',
         'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
         'nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error',
+        'nx:aria-invalid:data-[state=checked]:border-primary-background',
         'nx:disabled:cursor-not-allowed nx:disabled:border-border-disabled',
         'nx:data-[state=checked]:border-primary-background nx:data-[state=checked]:bg-primary-background nx:enabled:data-[state=checked]:hover:bg-primary-background-hover nx:data-[state=checked]:disabled:border-primary-disabled nx:data-[state=checked]:disabled:bg-primary-disabled',
         'nx:data-[state=unchecked]:bg-control-background nx:enabled:data-[state=unchecked]:hover:bg-control-background-hover nx:data-[state=unchecked]:disabled:bg-disabled',

--- a/packages/react/src/components/ui/switch/switch.tsx
+++ b/packages/react/src/components/ui/switch/switch.tsx
@@ -41,6 +41,7 @@ function Switch({ className, ...props }: SwitchProps) {
         'nx:rounded-full nx:border-2 nx:border-border-default',
         'nx:transition-colors',
         'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
+        'nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error',
         'nx:disabled:cursor-not-allowed nx:disabled:border-border-disabled',
         'nx:data-[state=checked]:border-primary-background nx:data-[state=checked]:bg-primary-background nx:enabled:data-[state=checked]:hover:bg-primary-background-hover nx:data-[state=checked]:disabled:border-primary-disabled nx:data-[state=checked]:disabled:bg-primary-disabled',
         'nx:data-[state=unchecked]:bg-control-background nx:enabled:data-[state=unchecked]:hover:bg-control-background-hover nx:data-[state=unchecked]:disabled:bg-disabled',
@@ -52,7 +53,7 @@ function Switch({ className, ...props }: SwitchProps) {
         data-slot="switch-thumb"
         className={cn(
           'nx:pointer-events-none nx:block nx:size-4 nx:rounded-full',
-          'nx:bg-control-thumb nx:shadow-sm nx:ring-0 nx:transition-[background-color,transform]',
+          'nx:bg-control-thumb nx:transition-[background-color,transform]',
           'nx:data-[state=checked]:bg-primary-foreground',
           'nx:data-[state=checked]:translate-x-4 nx:data-[state=unchecked]:translate-x-0'
         )}


### PR DESCRIPTION
## Summary

- Wire the canonical `aria-invalid` error state on Switch — verbatim from `input.tsx`: `nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error`. The error focus ring out-specifies the default ring (specificity, order-independent); the track's existing `nx:border-2` makes `border-error` read on the rest (unchecked) state.
- Drop the thumb's `nx:shadow-sm` (focusable controls rely on border/background, not shadow elevation — components.md § "No shadow on focusable elements") and the adjacent inert `nx:ring-0` (only repo-wide occurrence; no `ring-*` utility applies — outline drives focus).
- Add an `Invalid` story (args-based, unchecked, wired to an error message via `aria-describedby`) asserting the attribute, accessible description, and both new classes — never computed color.

## Design notes

- **Minimal pattern, by design.** Unchecked+invalid → red border; any focus → red ring; checked+invalid keeps the primary fill, with the error carried by the always-on focus ring + the associated error message. A switch encodes its value by **thumb position**, so the rest-state border + focus ring + the wired error message are a sufficient error signal — a checkbox-style checked-state track tint would fight the primary fill and is intentionally out of scope. (Rationale grounded in switch semantics, not the unaudited radio/slider siblings — review follow-up.)
- **Checked+invalid is pinned, not emission-order-dependent** (review follow-up `c4de8dd`). `nx:aria-invalid:data-[state=checked]:border-primary-background` (specificity 0,3,0) deterministically keeps the primary border when checked+invalid, rather than relying on Tailwind's emit order to break the (0,2,0) tie with `aria-invalid:border-border-error`. Mirrors checkbox's base + checked-override shape (opposite value, since checkbox tints checked+invalid to error).
- **Issue correction:** the issue's parenthetical *"Switch has no full border edge"* is inaccurate against this base — the track carries `nx:border-2`, which is exactly why `border-error` reads on the rest state without a track tint.
- `nx:ring-0` removal is unconditional ripple cleanup (project-stage: delete, don't preserve).

## GitHub Issue

Closes #476

## Test Plan

- [x] `pnpm --filter @nexus/react typecheck` — exit 0
- [x] `eslint` on both changed files — exit 0
- [x] `pnpm format:check` — clean
- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component switch` — ✓ no gaps
- [x] `vitest run --project=storybook Switch.stories` — 14/14 pass (incl. new `Invalid`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
