### PR TITLE
fix(pagination): drop redundant nav role + decouple ellipsis padding

### DIFF
--- a/COMPONENT-REVIEW.md
+++ b/COMPONENT-REVIEW.md
@@ -256,11 +256,9 @@ Numeric spacing notes: list `gap-1`, trigger `px-4`/`py-2`, content `p-2`, link 
 
 ## pagination
 
-Redundant ARIA: `role="navigation"` on the `<nav>` (line 55) — `<nav>` already is the navigation landmark; only the `aria-label` is needed.
+Resolved in #480: dropped the redundant `role="navigation"` on the `<nav>` (the element already is the navigation landmark, so only `aria-label` is needed), and replaced `PaginationEllipsis`'s hardcoded `nx:p-2.5` with `nx:size-10` — the icon link's own footprint token — so the two can't drift. (The old `p-2.5` rendered a 36px box and never actually matched the 40px icon link; the swap also aligns them.)
 
-Keep-in-sync smell: `PaginationEllipsis` hardcodes `nx:p-2.5` (line 219) to match the `size="icon"` link footprint — manual coupling to `buttonVariants` icon padding, drifts silently if that changes.
-
-Numeric spacing notes: content `gap-1` (line 85), ellipsis `p-2.5` (line 219).
+Numeric spacing note: content `gap-1`.
 
 ## popover
 

--- a/packages/react/src/components/ui/pagination/Pagination.stories.tsx
+++ b/packages/react/src/components/ui/pagination/Pagination.stories.tsx
@@ -203,6 +203,28 @@ export const WithDataAttributes: Story = {
   },
 };
 
+// The pagination root is a navigation landmark named by its aria-label — the
+// <nav> element already is that landmark, so it carries no redundant `role`.
+export const NavigationLandmark: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>
+            1
+          </PaginationLink>
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const nav = canvas.getByRole('navigation', { name: 'pagination' });
+
+    await expect(nav).not.toHaveAttribute('role');
+  },
+};
+
 // Composition: `asChild` routes the link styling onto a framework router link
 // (next/link, TanStack Router) instead of the native <a>. The router link
 // renders its own <a>, so the styling merges onto it — no nested <a><a>. The

--- a/packages/react/src/components/ui/pagination/Pagination.stories.tsx
+++ b/packages/react/src/components/ui/pagination/Pagination.stories.tsx
@@ -225,6 +225,48 @@ export const NavigationLandmark: Story = {
   },
 };
 
+// The ellipsis stands in at the same footprint as an icon page link, tracking
+// the link's live size token rather than a hand-copied value; a consumer
+// className can still override it.
+export const EllipsisFootprint: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationLink href="#">1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis className="nx:size-8" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link', { name: '1' });
+    const [ellipsis, overridden] = canvasElement.querySelectorAll(
+      '[data-slot="pagination-ellipsis"]'
+    );
+    if (!ellipsis || !overridden) {
+      throw new Error('EllipsisFootprint expects two ellipsis slots');
+    }
+
+    // Parity: the ellipsis carries the icon link's own size token, so this
+    // breaks if buttonVariants' icon size ever moves.
+    const linkSize = link.className.match(/nx:size-\d+/)?.[0];
+    const ellipsisSize = ellipsis.className.match(/nx:size-\d+/)?.[0];
+    await expect(linkSize).toBe('nx:size-10');
+    await expect(ellipsisSize).toBe(linkSize);
+
+    // A consumer className still overrides the footprint.
+    await expect(overridden).toHaveClass('nx:size-8');
+    await expect(overridden).not.toHaveClass('nx:size-10');
+  },
+};
+
 // Composition: `asChild` routes the link styling onto a framework router link
 // (next/link, TanStack Router) instead of the native <a>. The router link
 // renders its own <a>, so the styling merges onto it — no nested <a><a>. The

--- a/packages/react/src/components/ui/pagination/Pagination.stories.tsx
+++ b/packages/react/src/components/ui/pagination/Pagination.stories.tsx
@@ -225,9 +225,8 @@ export const NavigationLandmark: Story = {
   },
 };
 
-// The ellipsis stands in at the same footprint as an icon page link, tracking
-// the link's live size token rather than a hand-copied value; a consumer
-// className can still override it.
+// The ellipsis matches an icon page link's footprint, and a consumer className
+// can still override it.
 export const EllipsisFootprint: Story = {
   render: () => (
     <Pagination>
@@ -261,7 +260,6 @@ export const EllipsisFootprint: Story = {
     await expect(linkSize).toBe('nx:size-10');
     await expect(ellipsisSize).toBe(linkSize);
 
-    // A consumer className still overrides the footprint.
     await expect(overridden).toHaveClass('nx:size-8');
     await expect(overridden).not.toHaveClass('nx:size-10');
   },

--- a/packages/react/src/components/ui/pagination/pagination.tsx
+++ b/packages/react/src/components/ui/pagination/pagination.tsx
@@ -241,7 +241,7 @@ function PaginationEllipsis({ className, ...props }: PaginationEllipsisProps) {
       aria-hidden
       data-slot="pagination-ellipsis"
       className={cn(
-        'nx:flex nx:items-center nx:justify-center nx:p-2.5',
+        'nx:flex nx:items-center nx:justify-center nx:size-10',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/pagination/pagination.tsx
+++ b/packages/react/src/components/ui/pagination/pagination.tsx
@@ -54,7 +54,6 @@ interface PaginationProps extends React.ComponentProps<'nav'> {}
 function Pagination({ className, ...props }: PaginationProps) {
   return (
     <nav
-      role="navigation"
       aria-label="pagination"
       data-slot="pagination"
       className={cn(


### PR DESCRIPTION
## Summary

- **Drop the redundant `role="navigation"`** on the `<nav>` — the element is already the navigation landmark, so only `aria-label` is needed.
- **Match `PaginationEllipsis`'s footprint to the icon link** — replace the hardcoded `nx:p-2.5` with `nx:size-10` (the icon link's own dimension), so the two can no longer drift. The old `p-2.5` rendered a **36px** box and never actually matched the **40px** icon link, so this also corrects that misalignment (the dots glyph stays 16px).
- **Two focused stories:** `NavigationLandmark` asserts the `<nav>` carries no `role` while still resolving as the landmark by its `aria-label`; `EllipsisFootprint` ties the ellipsis to the link's *live* size token and confirms a consumer `className` still overrides the footprint.

### Why `nx:size-10`, not `buttonVariants({ size: 'icon' })`

The issue suggests sharing `buttonVariants({ size: 'icon' })` sizing. We didn't, because `buttonVariants` has `defaultVariants: { variant: 'default' }` — so `buttonVariants({ size: 'icon' })` with no variant resolves to a **solid primary-blue button** (`nx:bg-primary-background …`), and its base string also carries `nx:[&_svg]:size-3.5`, which would shrink the dots glyph. Applying that recipe to a non-interactive `aria-hidden` span renders wrong. Instead we use the icon link's own dimension token (`nx:size-10`) and make `EllipsisFootprint` read the link's **live** size token and assert the ellipsis matches it — so CI fails if `buttonVariants`' icon size ever moves. That parity test provides the drift protection without coupling the two files.

## GitHub Issue

Closes #480

## Test Plan

- [x] `pnpm --filter @nexus/react typecheck` — clean
- [x] `pnpm --filter @nexus/react lint` — clean
- [x] `pnpm exec prettier --check` (touched files) — clean
- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component pagination` — 0 missing, 0 drift
- [ ] `NavigationLandmark` + `EllipsisFootprint` play functions — execute in **CI** (storybook-vitest hangs in the `.claude/worktrees/` checkout; verified locally only via typecheck/lint/format/audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)