### PR TITLE
fix(toggle-group): emit data-attr defaults + reconcile variant precedence

### DIFF
--- a/packages/react/src/components/ui/toggle-group/ToggleGroup.stories.tsx
+++ b/packages/react/src/components/ui/toggle-group/ToggleGroup.stories.tsx
@@ -20,6 +20,7 @@ export default meta;
 type Story = StoryObj<typeof ToggleGroup>;
 
 // Single-select: behaves like a radio group (exactly one item pressed).
+// Also guards invariant #3 — data-variant / data-size are emitted on the default.
 export const Default: Story = {
   render: () => (
     <ToggleGroup type="single" defaultValue="left">
@@ -34,6 +35,14 @@ export const Default: Story = {
       </ToggleGroupItem>
     </ToggleGroup>
   ),
+  play: async ({ canvasElement }) => {
+    const group = canvasElement.querySelector('[data-slot="toggle-group"]');
+    await expect(group).toHaveAttribute('data-variant', 'default');
+    await expect(group).toHaveAttribute('data-size', 'default');
+    const item = canvasElement.querySelector('[data-slot="toggle-group-item"]');
+    await expect(item).toHaveAttribute('data-variant', 'default');
+    await expect(item).toHaveAttribute('data-size', 'default');
+  },
 };
 
 // Multiple-select: any number of items pressed at once.
@@ -177,7 +186,7 @@ export const Disabled: Story = {
   },
 };
 
-// The group carries data-slot / data-variant / data-size; items carry data-slot.
+// The group carries data-variant / data-size; items inherit them through context.
 export const WithDataAttributes: Story = {
   render: () => (
     <ToggleGroup type="single" variant="outline" size="sm" defaultValue="left">
@@ -193,9 +202,33 @@ export const WithDataAttributes: Story = {
     const group = canvasElement.querySelector('[data-slot="toggle-group"]');
     await expect(group).toHaveAttribute('data-variant', 'outline');
     await expect(group).toHaveAttribute('data-size', 'sm');
-    await expect(
-      canvasElement.querySelector('[data-slot="toggle-group-item"]')
-    ).toBeInTheDocument();
+    const item = canvasElement.querySelector('[data-slot="toggle-group-item"]');
+    await expect(item).toHaveAttribute('data-variant', 'outline');
+    await expect(item).toHaveAttribute('data-size', 'sm');
+  },
+};
+
+// Item-wins precedence: a per-item variant overrides the group's. The group is
+// outline; the first item opts back to the borderless default, the second inherits.
+export const ItemOverridesGroup: Story = {
+  render: () => (
+    <ToggleGroup type="single" variant="outline" defaultValue="left">
+      <ToggleGroupItem value="left" variant="default" aria-label="Align left">
+        <IconAlignLeft />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="center" aria-label="Align center">
+        <IconAlignCenter />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const [override, inherited] = canvasElement.querySelectorAll(
+      '[data-slot="toggle-group-item"]'
+    );
+    await expect(override).toHaveAttribute('data-variant', 'default');
+    await expect(override).not.toHaveClass('nx:border-border-default');
+    await expect(inherited).toHaveAttribute('data-variant', 'outline');
+    await expect(inherited).toHaveClass('nx:border-border-default');
   },
 };
 

--- a/packages/react/src/components/ui/toggle-group/toggle-group.tsx
+++ b/packages/react/src/components/ui/toggle-group/toggle-group.tsx
@@ -9,8 +9,6 @@ import { cn } from '@/lib/utils';
 const ToggleGroupContext = React.createContext<
   VariantProps<typeof toggleVariants> & { spacing?: number }
 >({
-  size: 'default',
-  variant: 'default',
   spacing: 0,
 });
 
@@ -64,8 +62,8 @@ function ToggleGroup({
   return (
     <ToggleGroupPrimitive.Root
       data-slot="toggle-group"
-      data-variant={variant}
-      data-size={size}
+      data-variant={variant ?? 'default'}
+      data-size={size ?? 'default'}
       data-spacing={spacing}
       // Spacing-scale gap via the runtime spacing var (Nexus resets the base
       // --spacing, so Tailwind's --spacing() function is unavailable here).
@@ -107,18 +105,17 @@ function ToggleGroupItem({
   ...props
 }: ToggleGroupItemProps) {
   const context = React.useContext(ToggleGroupContext);
+  const resolvedVariant = variant ?? context.variant ?? 'default';
+  const resolvedSize = size ?? context.size ?? 'default';
 
   return (
     <ToggleGroupPrimitive.Item
       data-slot="toggle-group-item"
-      data-variant={context.variant || variant}
-      data-size={context.size || size}
+      data-variant={resolvedVariant}
+      data-size={resolvedSize}
       data-spacing={context.spacing}
       className={cn(
-        toggleVariants({
-          variant: context.variant || variant,
-          size: context.size || size,
-        }),
+        toggleVariants({ variant: resolvedVariant, size: resolvedSize }),
         'nx:min-w-0 nx:shrink-0',
         // When joined (spacing=0): drop inner rounding/borders so items share
         // edges; round only the group's ends.


### PR DESCRIPTION
## Summary

Two consistency fixes to `toggle-group.tsx` (#482):

- **`data-variant` / `data-size` defaults (invariant #3).** `ToggleGroup` now emits `data-variant={variant ?? 'default'}` / `data-size={size ?? 'default'}` instead of dropping the attribute when unset — matching #472's `?? 'default'` pattern on `toggle.tsx`.
- **Variant/size precedence → item-wins.** `ToggleGroupItem` resolves `variant ?? context.variant ?? 'default'` (and size) **item-first**, replacing the old group-wins `context.X || prop`. Each axis resolves once into a const used for **both** the `data-*` attribute and `toggleVariants()`, so data and style always agree.

### Why item-wins (not fix-the-doc)

- Matches the canonical precedent in `button.tsx` (`size ?? groupSize ?? 'default'` — the local prop wins over group context).
- Makes the existing `ToggleGroupItem` JSDoc true (*"Inherits … unless overridden"*) rather than rewriting it to document the backwards behavior.
- `context.X || prop` read backwards (also flagged in `COMPONENT-REVIEW.md`).

### Ripple cleanup

Dropped the now-redundant `variant`/`size` from the `ToggleGroupContext` default (kept `spacing: 0`, still load-bearing for the `data-[spacing=0]` selectors). The `?? 'default'` fallback is now the single source of the default. This also fixes a latent bug: under the old group-wins resolution, an orphan `ToggleGroupItem` (no enclosing `<ToggleGroup>`) had its explicit prop shadowed by the context `'default'` default.

### No behavior change for current consumers

Neither console consumer (`contacts-toolbar.tsx`, `analytics-route.tsx`) nor any story sets an item-level `variant`/`size` — all set it at the group level. Item-wins only activates the previously-dead override path.

## GitHub Issue

Closes #482

## Test Plan

- [x] `Default` play asserts `data-variant`/`data-size` emitted on the default (invariant #3 — the group is the load-bearing guard, omitted the attr pre-fix)
- [x] `WithDataAttributes` strengthened to assert the item inherits the group's `outline`/`sm`
- [x] New `ItemOverridesGroup` proves item-wins at both data and style layers (fails against pre-fix group-wins code)
- [x] `vitest --project=storybook ToggleGroup.stories` — 10 play-fn tests pass
- [x] `audit:storybook-coverage --component toggle-group` — 0 missing, 0 drift
- [x] `typecheck`, `eslint` (changed files), `format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)