### PR TITLE
fix(slider,resizable,sonner): error focus ring, ~44px handle hit-area, drop z-toast !important

### DIFF
--- a/.claude/rules/components.md
+++ b/.claude/rules/components.md
@@ -186,11 +186,11 @@ Radix appends portal content to `document.body`. For a **single** overlay open b
 
 ### Consumer override
 
-The utilities reference the CSS variable (`nx:z-sticky` → `z-index: var(--z-index-sticky)`), so a consumer re-points a whole layer by overriding the variable — no component changes:
+The utilities reference the prefixed runtime CSS variable (`nx:z-sticky` → `z-index: var(--nx-z-index-sticky)` — the `nx` prefix lands on the runtime variable even though the `@theme` source key is unprefixed), so a consumer re-points a whole layer by overriding it — no component changes:
 
 ```css
 /* In the consumer's stylesheet, loaded after Nexus */
 :root {
-  --z-index-sticky: 35; /* raise the app shell's sticky chrome above the default 30 */
+  --nx-z-index-sticky: 35; /* raise the app shell's sticky chrome above the default 30 */
 }
 ```

--- a/packages/react/src/components/ui/resizable/Resizable.stories.tsx
+++ b/packages/react/src/components/ui/resizable/Resizable.stories.tsx
@@ -166,6 +166,35 @@ export const WithDataAttributes: Story = {
   },
 };
 
+// The handle's invisible ::after hit area widens to ~44px on coarse (touch)
+// pointers while the slim grip stays put on fine pointers. The class is always
+// present in the attribute; the pointer-coarse media query gates when it applies.
+export const TouchTarget: Story = {
+  render: () => (
+    <ResizablePanelGroup
+      orientation="horizontal"
+      className={groupClass}
+      style={groupStyle}
+    >
+      <ResizablePanel defaultSize={50} style={panelStyle}>
+        <PanelBody label="One" />
+      </ResizablePanel>
+      <ResizableHandle withHandle aria-label="Resize panels" />
+      <ResizablePanel defaultSize={50} style={panelStyle}>
+        <PanelBody label="Two" />
+      </ResizablePanel>
+    </ResizablePanelGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const handle = canvas.getByRole('separator');
+    await expect(handle).toHaveClass('nx:pointer-coarse:after:w-11');
+    await expect(handle).toHaveClass(
+      'nx:pointer-coarse:aria-[orientation=horizontal]:after:h-11'
+    );
+  },
+};
+
 // ============================================
 // ALL VARIANTS GRID
 // ============================================

--- a/packages/react/src/components/ui/resizable/resizable.tsx
+++ b/packages/react/src/components/ui/resizable/resizable.tsx
@@ -64,9 +64,9 @@ function ResizableHandle({
       data-slot="resizable-handle"
       className={cn(
         'nx:relative nx:flex nx:w-px nx:items-center nx:justify-center nx:bg-border-default',
-        'nx:after:absolute nx:after:inset-y-0 nx:after:left-1/2 nx:after:w-1 nx:after:-translate-x-1/2',
+        'nx:after:absolute nx:after:inset-y-0 nx:after:left-1/2 nx:after:w-1 nx:after:-translate-x-1/2 nx:pointer-coarse:after:w-11',
         'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
-        'nx:aria-[orientation=horizontal]:h-px nx:aria-[orientation=horizontal]:w-full nx:aria-[orientation=horizontal]:after:left-0 nx:aria-[orientation=horizontal]:after:h-1 nx:aria-[orientation=horizontal]:after:w-full nx:aria-[orientation=horizontal]:after:translate-x-0 nx:aria-[orientation=horizontal]:after:-translate-y-1/2',
+        'nx:aria-[orientation=horizontal]:h-px nx:aria-[orientation=horizontal]:w-full nx:aria-[orientation=horizontal]:after:left-0 nx:aria-[orientation=horizontal]:after:h-1 nx:aria-[orientation=horizontal]:after:w-full nx:aria-[orientation=horizontal]:after:translate-x-0 nx:aria-[orientation=horizontal]:after:-translate-y-1/2 nx:pointer-coarse:aria-[orientation=horizontal]:after:h-11',
         'nx:aria-[orientation=horizontal]:[&>div]:rotate-90',
         className
       )}

--- a/packages/react/src/components/ui/slider/Slider.stories.tsx
+++ b/packages/react/src/components/ui/slider/Slider.stories.tsx
@@ -128,6 +128,31 @@ export const WithDataAttributes: Story = {
   },
 };
 
+// aria-invalid surfaces the error focus ring on the thumb. It is forwarded to
+// every role="slider" element, so a two-thumb range reddens both.
+export const Invalid: Story = {
+  render: () => (
+    <Slider
+      aria-invalid
+      defaultValue={[25, 75]}
+      max={100}
+      step={1}
+      aria-label="Price range"
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const thumbs = canvas.getAllByRole('slider');
+    await expect(thumbs).toHaveLength(2);
+    for (const thumb of thumbs) {
+      await expect(thumb).toHaveAttribute('aria-invalid', 'true');
+      await expect(thumb).toHaveClass(
+        'nx:aria-invalid:focus-visible:outline-focus-error'
+      );
+    }
+  },
+};
+
 // ============================================
 // ALL VARIANTS GRID
 // ============================================

--- a/packages/react/src/components/ui/slider/slider.tsx
+++ b/packages/react/src/components/ui/slider/slider.tsx
@@ -34,6 +34,7 @@ function Slider({
   max = 100,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledby,
+  'aria-invalid': ariaInvalid,
   ...props
 }: SliderProps) {
   // Derive the thumb count from the controlled/uncontrolled value; fall back to
@@ -70,12 +71,13 @@ function Slider({
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          // Radix names the thumb (role="slider") from its own aria-label, not
-          // the Root's — forward it to the thumb (and keep it off the role-less
-          // Root span, where it would be a prohibited ARIA attribute).
+          // Radix puts role="slider" on the thumb, not the role-less Root span:
+          // forward the thumb-owned ARIA here (naming + invalid state) so it lands
+          // on the right element and stays off the Root, where it'd be prohibited.
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledby}
-          className="nx:block nx:size-4 nx:shrink-0 nx:rounded-full nx:border nx:border-border-primary nx:bg-background nx:transition-colors nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
+          aria-invalid={ariaInvalid}
+          className="nx:block nx:size-4 nx:shrink-0 nx:rounded-full nx:border nx:border-border-primary nx:bg-background nx:transition-colors nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:aria-invalid:focus-visible:outline-focus-error"
         />
       ))}
     </SliderPrimitive.Root>

--- a/packages/react/src/components/ui/sonner/Sonner.stories.tsx
+++ b/packages/react/src/components/ui/sonner/Sonner.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { Button } from '../button';
 
@@ -148,6 +148,31 @@ export const WithDataAttributes: Story = {
     const toaster = canvasElement.querySelector('[data-slot="toaster"]');
     await expect(toaster).toBeInTheDocument();
     await expect(toaster).toHaveAttribute('data-slot', 'toaster');
+  },
+};
+
+// The toaster rides the Nexus toast layer (z-index 100) via an inline style,
+// which outranks sonner's injected z-index:999999999 without `!important`.
+// Sonner only mounts its container once a toast exists, so fire one first.
+export const ToastLayer: Story = {
+  render: () => (
+    <>
+      <Button onClick={() => toast('Event has been created')}>
+        Show toast
+      </Button>
+      <Toaster />
+    </>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Show toast' }));
+    await waitFor(() => {
+      const toaster = document.body.querySelector<HTMLElement>(
+        '[data-sonner-toaster]'
+      );
+      expect(toaster).not.toBeNull();
+      expect(getComputedStyle(toaster as HTMLElement).zIndex).toBe('100');
+    });
   },
 };
 

--- a/packages/react/src/components/ui/sonner/sonner.tsx
+++ b/packages/react/src/components/ui/sonner/sonner.tsx
@@ -9,7 +9,6 @@ import {
   IconInfoCircle,
   IconLoader2,
 } from '@/lib/icons';
-import { cn } from '@/lib/utils';
 
 /**
  * Track the active theme by observing the `.dark` class on the document root
@@ -75,8 +74,8 @@ const toasterThemeVars = {
 /**
  * Toaster
  *
- * Renders toast notifications, themed to Nexus tokens and riding the toast
- * layer (`nx:z-toast`). Mount once near the root of your app, then call
+ * Renders toast notifications, themed to Nexus tokens and riding the Nexus
+ * toast layer (z-index 100). Mount once near the root of your app, then call
  * `toast(...)` (re-exported here) from anywhere. The active theme follows the
  * `.dark` class automatically.
  *
@@ -94,18 +93,23 @@ const toasterThemeVars = {
  * }
  * ```
  */
-function Toaster({ className, style, ...props }: ToasterProps) {
+function Toaster({ style, ...props }: ToasterProps) {
   const theme = useToasterTheme();
-  // Force the toast layer with `!`: sonner injects a runtime <style> that
-  // hardcodes the container to z-index 999999999, which a non-important utility
-  // can't override.
   return (
     <div data-slot="toaster">
       <Sonner
         theme={theme}
         icons={toasterIcons}
-        className={cn('nx:z-toast!', className)}
-        style={{ ...toasterThemeVars, ...style } as React.CSSProperties}
+        style={
+          {
+            ...toasterThemeVars,
+            // Sonner injects a runtime <style> pinning the toaster to
+            // z-index:999999999 (not !important); an inline style outranks that
+            // selector rule, keeping us on the Nexus toast layer without `!`.
+            zIndex: 'var(--nx-z-index-toast, 100)',
+            ...style,
+          } as React.CSSProperties
+        }
         {...props}
       />
     </div>


### PR DESCRIPTION
## Summary

Three scoped Tier-A polish fixes across `slider`, `resizable`, and `sonner` — one component per commit.

- **Slider (#477)** — wire `aria-invalid`: forward it to each `role="slider"` thumb (extracted from props so it stays off the role-less Root span) and add the error focus ring `nx:aria-invalid:focus-visible:outline-focus-error`. The at-rest cue is intentionally **not** added — #477 mandates only the focus ring and defers the rest-state cue to design. Reddening the thumb's `border-border-primary` (an always-on brand ring) would pre-empt that call; switch/input redden a neutral `border-border-default` box border, a different surface, and radio-group wires no error border at all.
- **Resizable (#479)** — widen the handle's invisible `::after` drag target to ~44px on coarse pointers (`nx:pointer-coarse:after:w-11` vertical, `nx:pointer-coarse:aria-[orientation=horizontal]:after:h-11` horizontal) while the slim grip stays on fine pointers. Follows button's `pointer-coarse` hit-area idiom; visible grip unchanged.
- **Sonner (#483)** — drop the `nx:z-toast!` `!important`. Sonner injects a runtime `<style>` pinning `[data-sonner-toaster]` to `z-index:999999999` (a non-`!important` rule); moving the toast-layer z-index to an inline `style` (`var(--nx-z-index-toast, 100)`) outranks it by cascade origin without `!important`. Also removes the now-unused `cn` wrap/import; `className` passes through `{...props}`.

## GitHub Issue

Closes #477
Closes #479
Closes #483

> **#486** (overlay-family tracking) is **not** closed by this PR — its only open dimension (Figma parity) is blocked on a Figma URL.

## Test Plan

- [x] `Invalid` story (slider) — 2-thumb range; `getAllByRole('slider')` asserts each thumb gets `aria-invalid="true"` + the error-ring class
- [x] `TouchTarget` story (resizable) — asserts both `pointer-coarse` hit-area classes; CSS verified to emit `var(--nx-spacing-11, 44px)` inside `@media(pointer:coarse)`
- [x] `ToastLayer` story (sonner) — fires a toast, asserts `[data-sonner-toaster]` computes to `z-index: 100`, proving the inline override beats sonner's injected `999999999`. This pins the toaster to the Nexus toast layer (100), which is strictly above the modal layer (50) — so a redundant live "above a modal" comparison was omitted.
- [x] Full Storybook suite **768/768** · `typecheck` · `lint` · `format:check` clean
- [x] `audit:storybook-coverage` — 0 missing / 0 drift for slider, resizable, sonner

🤖 Generated with [Claude Code](https://claude.com/claude-code)