### PR TITLE
refactor(typography): migrate phase 2 raw text utilities

### DIFF
--- a/apps/console/src/app/auth-layout.tsx
+++ b/apps/console/src/app/auth-layout.tsx
@@ -17,21 +17,21 @@ export function AuthLayout() {
       <aside className="nx:bg-primary-background nx:text-primary-foreground nx:hidden nx:w-1/2 nx:flex-col nx:justify-between nx:p-12 nx:lg:flex">
         <div className="nx:flex nx:items-center nx:gap-2">
           <div className="nx:bg-primary-foreground nx:flex nx:size-8 nx:items-center nx:justify-center nx:rounded-lg">
-            <span className="nx:text-primary-background nx:text-sm nx:font-bold">
+            <span className="nx:text-primary-background nx:typography-label-default nx:font-bold">
               A
             </span>
           </div>
-          <span className="nx:text-lg nx:font-semibold">Atlas</span>
+          <span className="nx:typography-heading-xsmall">Atlas</span>
         </div>
         <div className="nx:space-y-3">
-          <p className="nx:text-2xl nx:font-semibold nx:leading-snug">
+          <p className="nx:typography-heading-medium nx:leading-snug">
             The operating system for your whole company.
           </p>
-          <p className="nx:text-primary-foreground/80 nx:text-sm">
+          <p className="nx:text-primary-foreground/80 nx:typography-body-default">
             CRM, projects, billing, and analytics — themed end to end by Nexus.
           </p>
         </div>
-        <p className="nx:text-primary-foreground/70 nx:text-xs">
+        <p className="nx:text-primary-foreground/70 nx:typography-label-small">
           Built on the Nexus design system.
         </p>
       </aside>

--- a/apps/console/src/components/data-pager.tsx
+++ b/apps/console/src/components/data-pager.tsx
@@ -25,9 +25,11 @@ export function DataPager({
 }: DataPagerProps) {
   return (
     <div className="nx:flex nx:items-center nx:justify-between nx:gap-4">
-      <p className="nx:text-muted-foreground nx:text-sm">{total} row(s)</p>
+      <p className="nx:text-muted-foreground nx:typography-body-default">
+        {total} row(s)
+      </p>
       <div className="nx:flex nx:items-center nx:gap-3">
-        <span className="nx:text-muted-foreground nx:text-sm">
+        <span className="nx:text-muted-foreground nx:typography-label-default">
           Page {page + 1} of {pageCount}
         </span>
         <Button

--- a/apps/console/src/components/data-table.tsx
+++ b/apps/console/src/components/data-table.tsx
@@ -152,13 +152,13 @@ export function DataTable<TData>({
 
       {/* App-local pager — the polished @nexus/react Pagination is tracked in #281. */}
       <div className="nx:flex nx:items-center nx:justify-between nx:gap-4">
-        <p className="nx:text-muted-foreground nx:text-sm">
+        <p className="nx:text-muted-foreground nx:typography-body-default">
           {enableSelection
             ? `${selectedCount} of ${totalCount} row(s) selected.`
             : `${totalCount} row(s)`}
         </p>
         <div className="nx:flex nx:items-center nx:gap-3">
-          <span className="nx:text-muted-foreground nx:text-sm">
+          <span className="nx:text-muted-foreground nx:typography-label-default">
             Page {pageIndex + 1} of {Math.max(table.getPageCount(), 1)}
           </span>
           <Button

--- a/apps/console/src/components/record-card.tsx
+++ b/apps/console/src/components/record-card.tsx
@@ -25,7 +25,7 @@ export function RecordCard({ title, badge, children }: RecordCardProps) {
         <div className="nx:min-w-0 nx:flex-1">{title}</div>
         {badge ? <div className="nx:shrink-0">{badge}</div> : null}
       </div>
-      <div className="nx:text-muted-foreground nx:mt-2 nx:space-y-1 nx:text-sm">
+      <div className="nx:text-muted-foreground nx:mt-2 nx:space-y-1 nx:typography-label-default">
         {children}
       </div>
     </li>

--- a/apps/console/src/modules/analytics/analytics-route.tsx
+++ b/apps/console/src/modules/analytics/analytics-route.tsx
@@ -124,12 +124,14 @@ function KpiCard({ kpi }: { kpi: Kpi }) {
 
   return (
     <Card className="nx:space-y-1 nx:p-6">
-      <p className="nx:text-muted-foreground nx:text-sm">{kpi.label}</p>
+      <p className="nx:text-muted-foreground nx:typography-body-default">
+        {kpi.label}
+      </p>
       <p className="nx:typography-heading-medium nx:text-foreground nx:tabular-nums">
         {formatKpi(kpi)}
       </p>
       <p
-        className={`nx:flex nx:items-center nx:gap-1 nx:text-xs nx:tabular-nums ${
+        className={`nx:flex nx:items-center nx:gap-1 nx:typography-label-small nx:tabular-nums ${
           up
             ? 'nx:text-success-subtle-foreground'
             : 'nx:text-error-subtle-foreground'

--- a/apps/console/src/modules/auth/forgot-route.tsx
+++ b/apps/console/src/modules/auth/forgot-route.tsx
@@ -51,7 +51,7 @@ export function ForgotRoute() {
         <CardFooter>
           <Link
             to="/login"
-            className="nx:text-primary-subtle-foreground nx:text-sm nx:hover:underline"
+            className="nx:text-primary-subtle-foreground nx:typography-label-default nx:hover:underline"
           >
             Back to sign in
           </Link>
@@ -102,7 +102,7 @@ export function ForgotRoute() {
             </Button>
             <Link
               to="/login"
-              className="nx:text-muted-foreground nx:text-sm nx:hover:underline"
+              className="nx:text-muted-foreground nx:typography-label-default nx:hover:underline"
             >
               Back to sign in
             </Link>

--- a/apps/console/src/modules/auth/login-route.tsx
+++ b/apps/console/src/modules/auth/login-route.tsx
@@ -95,7 +95,7 @@ export function LoginRoute() {
                     <FormLabel>Password</FormLabel>
                     <Link
                       to="/forgot"
-                      className="nx:text-primary-subtle-foreground nx:text-sm nx:hover:underline"
+                      className="nx:text-primary-subtle-foreground nx:typography-label-default nx:hover:underline"
                     >
                       Forgot password?
                     </Link>
@@ -123,7 +123,7 @@ export function LoginRoute() {
             >
               Continue
             </Button>
-            <p className="nx:text-muted-foreground nx:text-sm">
+            <p className="nx:text-muted-foreground nx:typography-body-default">
               No account?{' '}
               <Link
                 to="/signup"

--- a/apps/console/src/modules/auth/signup-route.tsx
+++ b/apps/console/src/modules/auth/signup-route.tsx
@@ -136,7 +136,7 @@ export function SignupRoute() {
             >
               Create account
             </Button>
-            <p className="nx:text-muted-foreground nx:text-sm">
+            <p className="nx:text-muted-foreground nx:typography-body-default">
               Already have an account?{' '}
               <Link
                 to="/login"

--- a/apps/console/src/modules/auth/verify-route.tsx
+++ b/apps/console/src/modules/auth/verify-route.tsx
@@ -90,7 +90,7 @@ export function VerifyRoute() {
         </Button>
         <Link
           to="/login"
-          className="nx:text-muted-foreground nx:text-sm nx:hover:underline"
+          className="nx:text-muted-foreground nx:typography-label-default nx:hover:underline"
         >
           Back to sign in
         </Link>

--- a/apps/console/src/modules/billing/billing-route.tsx
+++ b/apps/console/src/modules/billing/billing-route.tsx
@@ -152,7 +152,7 @@ function PlanCard({
           )}
         </div>
 
-        <p className="nx:text-muted-foreground nx:text-sm">
+        <p className="nx:text-muted-foreground nx:typography-body-default">
           {canceling
             ? `Your plan is set to cancel on ${formatDate(subscription.renewsAt)}. You'll keep access until then.`
             : `Renews on ${formatDate(subscription.renewsAt)}.`}
@@ -242,7 +242,7 @@ function PaymentCard({ method }: { method: PaymentMethod }) {
             <p className="nx:text-foreground nx:font-medium">
               {method.brand} ···· {method.last4}
             </p>
-            <p className="nx:text-muted-foreground nx:text-sm nx:tabular-nums">
+            <p className="nx:text-muted-foreground nx:typography-body-default nx:tabular-nums">
               Expires {String(method.expMonth).padStart(2, '0')}/
               {method.expYear}
             </p>
@@ -281,11 +281,11 @@ export function UsageMeterBar({ meter }: { meter: UsageMeter }) {
   return (
     <div className="nx:space-y-2">
       <div className="nx:flex nx:items-baseline nx:justify-between nx:gap-2">
-        <span className="nx:text-foreground nx:text-sm nx:font-medium">
+        <span className="nx:text-foreground nx:typography-label-default">
           {meter.label}
         </span>
         <span
-          className={`nx:text-xs nx:tabular-nums ${nearCap ? 'nx:text-warning-subtle-foreground' : 'nx:text-muted-foreground'}`}
+          className={`nx:typography-label-small nx:tabular-nums ${nearCap ? 'nx:text-warning-subtle-foreground' : 'nx:text-muted-foreground'}`}
         >
           {meter.used} / {meter.limit} {meter.unit}
         </span>

--- a/apps/console/src/modules/billing/plan-sheet.tsx
+++ b/apps/console/src/modules/billing/plan-sheet.tsx
@@ -87,7 +87,7 @@ export function PlanSheet({
           <div className="nx:border-border-default nx:flex nx:items-center nx:justify-between nx:gap-4 nx:rounded-lg nx:border nx:p-3">
             <div className="nx:space-y-0.5">
               <Label htmlFor="billing-cycle">Annual billing</Label>
-              <p className="nx:text-muted-foreground nx:text-sm">
+              <p className="nx:text-muted-foreground nx:typography-body-default">
                 Save with a yearly commitment.
               </p>
             </div>
@@ -123,14 +123,14 @@ export function PlanSheet({
                       <span className="nx:text-foreground nx:font-medium">
                         {plan.name}
                       </span>
-                      <span className="nx:text-foreground nx:text-sm">
+                      <span className="nx:text-foreground nx:typography-label-default">
                         {price === 0 ? 'Free' : `${formatCurrency(price)}/mo`}
                       </span>
                     </div>
-                    <p className="nx:text-muted-foreground nx:text-sm">
+                    <p className="nx:text-muted-foreground nx:typography-body-default">
                       {plan.blurb}
                     </p>
-                    <ul className="nx:text-muted-foreground nx:space-y-1 nx:pt-1 nx:text-sm">
+                    <ul className="nx:text-muted-foreground nx:space-y-1 nx:pt-1 nx:typography-label-default">
                       {plan.features.map((feature) => (
                         <li
                           key={feature}

--- a/apps/console/src/modules/crm/contact-detail-route.tsx
+++ b/apps/console/src/modules/crm/contact-detail-route.tsx
@@ -147,10 +147,10 @@ function DetailContent({ contact }: { contact: ContactDetail }) {
                       <ActivityIcon kind={item.kind} />
                     </div>
                     <div className="nx:space-y-0.5">
-                      <p className="nx:text-foreground nx:text-sm">
+                      <p className="nx:text-foreground nx:typography-body-default">
                         {item.summary}
                       </p>
-                      <p className="nx:text-muted-foreground nx:text-xs">
+                      <p className="nx:text-muted-foreground nx:typography-label-small">
                         {formatDate(item.date)}
                       </p>
                     </div>
@@ -174,8 +174,10 @@ function DetailContent({ contact }: { contact: ContactDetail }) {
 function Field({ label, value }: { label: string; value: string }) {
   return (
     <div className="nx:flex nx:items-center nx:justify-between nx:py-3">
-      <span className="nx:text-muted-foreground nx:text-sm">{label}</span>
-      <span className="nx:text-foreground nx:text-sm nx:font-medium">
+      <span className="nx:text-muted-foreground nx:typography-label-default">
+        {label}
+      </span>
+      <span className="nx:text-foreground nx:typography-label-default">
         {value}
       </span>
     </div>

--- a/apps/console/src/modules/crm/contacts-board.tsx
+++ b/apps/console/src/modules/crm/contacts-board.tsx
@@ -127,7 +127,7 @@ function BoardColumn({
         <span className="nx:typography-label-default nx:text-foreground">
           {label}
         </span>
-        <span className="nx:text-muted-foreground nx:text-xs">
+        <span className="nx:text-muted-foreground nx:typography-label-small">
           {contacts.length}
         </span>
       </div>
@@ -155,21 +155,21 @@ function BoardCard({ contact }: { contact: Contact }) {
       }`}
     >
       <div className="nx:text-foreground nx:font-medium">{contact.name}</div>
-      <div className="nx:text-muted-foreground nx:text-sm">
+      <div className="nx:text-muted-foreground nx:typography-label-default">
         {contact.company}
       </div>
       <div className="nx:flex nx:items-center nx:justify-between">
         <div className="nx:flex nx:items-center nx:gap-2">
           <Avatar className="nx:size-6">
-            <AvatarFallback className="nx:text-xs">
+            <AvatarFallback className="nx:typography-label-small">
               {initials(contact.owner)}
             </AvatarFallback>
           </Avatar>
-          <span className="nx:text-muted-foreground nx:text-xs">
+          <span className="nx:text-muted-foreground nx:typography-label-small">
             {contact.owner}
           </span>
         </div>
-        <span className="nx:text-xs nx:tabular-nums">
+        <span className="nx:typography-label-small nx:tabular-nums">
           {formatCurrency(contact.value)}
         </span>
       </div>

--- a/apps/console/src/modules/crm/contacts-card-list.tsx
+++ b/apps/console/src/modules/crm/contacts-card-list.tsx
@@ -24,7 +24,7 @@ export function ContactCardList({ contacts }: { contacts: Contact[] }) {
         placeholder="Filter by name…"
       />
       {pageItems.length === 0 ? (
-        <p className="nx:text-muted-foreground nx:py-8 nx:text-center nx:text-sm">
+        <p className="nx:text-muted-foreground nx:py-8 nx:text-center nx:typography-body-default">
           No results.
         </p>
       ) : (

--- a/apps/console/src/modules/crm/contacts-columns.tsx
+++ b/apps/console/src/modules/crm/contacts-columns.tsx
@@ -106,7 +106,7 @@ export const contactColumns: ColumnDef<Contact>[] = [
     cell: ({ row }) => (
       <div className="nx:flex nx:items-center nx:gap-2">
         <Avatar className="nx:size-6">
-          <AvatarFallback className="nx:text-xs">
+          <AvatarFallback className="nx:typography-label-small">
             {initials(row.original.owner)}
           </AvatarFallback>
         </Avatar>

--- a/apps/console/src/modules/crm/contacts-toolbar.tsx
+++ b/apps/console/src/modules/crm/contacts-toolbar.tsx
@@ -191,7 +191,7 @@ function SavedViewsMenu({
             Saved views
           </p>
           {views.length === 0 ? (
-            <p className="nx:text-muted-foreground nx:px-3 nx:pb-3 nx:text-sm">
+            <p className="nx:text-muted-foreground nx:px-3 nx:pb-3 nx:typography-body-default">
               No saved views yet.
             </p>
           ) : (

--- a/apps/console/src/modules/design-system/ComponentShowcase.tsx
+++ b/apps/console/src/modules/design-system/ComponentShowcase.tsx
@@ -13,11 +13,11 @@ function Section({
   return (
     <section className="nx:bg-container nx:rounded-xl nx:border nx:border-border-default nx:overflow-hidden">
       <div className="nx:px-5 nx:py-4 nx:border-b nx:border-border-default nx:bg-background-hover-alpha">
-        <h2 className="nx:text-base nx:font-semibold nx:text-foreground">
+        <h2 className="nx:typography-heading-xsmall nx:text-foreground">
           {title}
         </h2>
         {description && (
-          <p className="nx:text-sm nx:text-muted-foreground nx:mt-0.5">
+          <p className="nx:typography-body-default nx:text-muted-foreground nx:mt-0.5">
             {description}
           </p>
         )}
@@ -34,7 +34,7 @@ export function ComponentShowcase() {
         <Section title="Typography" description="Text styles and font scales">
           <div className="nx:space-y-6">
             <div className="nx:space-y-2">
-              <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+              <span className="nx:typography-label-caps nx:text-muted-foreground nx:uppercase">
                 Headings
               </span>
               <div className="nx:space-y-1">
@@ -46,7 +46,7 @@ export function ComponentShowcase() {
             </div>
 
             <div className="nx:space-y-2">
-              <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+              <span className="nx:typography-label-caps nx:text-muted-foreground nx:uppercase">
                 Body
               </span>
               <div className="nx:space-y-2">
@@ -61,7 +61,7 @@ export function ComponentShowcase() {
 
             <div className="nx:grid nx:grid-cols-2 nx:gap-6">
               <div className="nx:space-y-2">
-                <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+                <span className="nx:typography-label-caps nx:text-muted-foreground nx:uppercase">
                   Labels
                 </span>
                 <div className="nx:flex nx:flex-wrap nx:gap-4">
@@ -73,7 +73,7 @@ export function ComponentShowcase() {
                 </div>
               </div>
               <div className="nx:space-y-2">
-                <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+                <span className="nx:typography-label-caps nx:text-muted-foreground nx:uppercase">
                   Code
                 </span>
                 <div className="nx:flex nx:flex-wrap nx:gap-4">
@@ -166,10 +166,10 @@ export function ComponentShowcase() {
             <ColorSwatch name="Nav Border" className="nx:bg-nav-border" />
           </div>
           <div className="nx:mt-4 nx:bg-nav-background nx:border nx:border-nav-border nx:rounded-md nx:p-4">
-            <p className="nx:text-nav-foreground nx:text-sm nx:font-medium">
+            <p className="nx:text-nav-foreground nx:typography-label-default">
               Nav item label
             </p>
-            <p className="nx:text-nav-muted-foreground nx:text-xs nx:mt-1">
+            <p className="nx:text-nav-muted-foreground nx:typography-label-small nx:mt-1">
               Nav muted helper text
             </p>
           </div>
@@ -227,22 +227,22 @@ export function ComponentShowcase() {
           <div className="nx:space-y-6">
             {/* Container */}
             <div className="nx:space-y-2">
-              <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+              <span className="nx:typography-label-caps nx:text-muted-foreground nx:uppercase">
                 Container — p-container, gap-container
               </span>
               <div className="nx:bg-container nx:border nx:border-border-default nx:rounded-lg nx:flex nx:flex-col nx:p-container nx:gap-container">
                 <h4 className="nx:text-foreground nx:font-medium">
                   Card header
                 </h4>
-                <p className="nx:text-sm nx:text-muted-foreground">
+                <p className="nx:typography-body-default nx:text-muted-foreground">
                   Card body — interior padding and the gap between siblings both
                   scale with the active Spacing mode.
                 </p>
                 <div className="nx:flex nx:flex-wrap nx:gap-2">
-                  <button className="nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:px-3 nx:py-1.5 nx:text-sm nx:font-medium">
+                  <button className="nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:px-3 nx:py-1.5 nx:typography-label-default">
                     Confirm
                   </button>
-                  <button className="nx:border nx:border-border-default nx:bg-background nx:rounded-md nx:px-3 nx:py-1.5 nx:text-sm nx:font-medium">
+                  <button className="nx:border nx:border-border-default nx:bg-background nx:rounded-md nx:px-3 nx:py-1.5 nx:typography-label-default">
                     Cancel
                   </button>
                 </div>
@@ -251,7 +251,7 @@ export function ComponentShowcase() {
 
             {/* Layout */}
             <div className="nx:space-y-2">
-              <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+              <span className="nx:typography-label-caps nx:text-muted-foreground nx:uppercase">
                 Layout — gap-layout-section, gap-layout-stack
               </span>
               <div className="nx:flex nx:flex-col nx:gap-layout-section nx:bg-muted nx:rounded-lg nx:p-4">
@@ -260,13 +260,13 @@ export function ComponentShowcase() {
                     key={label}
                     className="nx:flex nx:flex-col nx:gap-layout-stack"
                   >
-                    <span className="nx:text-xs nx:font-semibold nx:text-foreground">
+                    <span className="nx:typography-label-small nx:font-semibold nx:text-foreground">
                       {label}
                     </span>
-                    <span className="nx:text-sm nx:text-muted-foreground">
+                    <span className="nx:typography-label-default nx:text-muted-foreground">
                       Stack item one
                     </span>
-                    <span className="nx:text-sm nx:text-muted-foreground">
+                    <span className="nx:typography-label-default nx:text-muted-foreground">
                       Stack item two
                     </span>
                   </div>
@@ -283,19 +283,19 @@ export function ComponentShowcase() {
         <Section title="Buttons" description="Interactive button variants">
           <div className="nx:space-y-4">
             <div className="nx:flex nx:flex-wrap nx:gap-3">
-              <button className="nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium nx:hover:opacity-90 nx:transition-opacity">
+              <button className="nx:bg-primary-background nx:text-primary-foreground nx:rounded-md nx:px-4 nx:py-2 nx:typography-label-default nx:hover:opacity-90 nx:transition-opacity">
                 Primary
               </button>
-              <button className="nx:bg-secondary-background nx:text-secondary-foreground nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium nx:hover:opacity-90 nx:transition-opacity">
+              <button className="nx:bg-secondary-background nx:text-secondary-foreground nx:rounded-md nx:px-4 nx:py-2 nx:typography-label-default nx:hover:opacity-90 nx:transition-opacity">
                 Secondary
               </button>
-              <button className="nx:border nx:border-border-default nx:bg-background nx:hover:bg-background-hover nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium nx:transition-colors">
+              <button className="nx:border nx:border-border-default nx:bg-background nx:hover:bg-background-hover nx:rounded-md nx:px-4 nx:py-2 nx:typography-label-default nx:transition-colors">
                 Outline
               </button>
-              <button className="nx:hover:bg-background-hover nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium nx:transition-colors">
+              <button className="nx:hover:bg-background-hover nx:rounded-md nx:px-4 nx:py-2 nx:typography-label-default nx:transition-colors">
                 Ghost
               </button>
-              <button className="nx:bg-error-background nx:text-error-foreground nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium nx:hover:opacity-90 nx:transition-opacity">
+              <button className="nx:bg-error-background nx:text-error-foreground nx:rounded-md nx:px-4 nx:py-2 nx:typography-label-default nx:hover:opacity-90 nx:transition-opacity">
                 Destructive
               </button>
             </div>
@@ -310,19 +310,19 @@ export function ComponentShowcase() {
           <div className="nx:grid nx:gap-4 nx:md:grid-cols-2">
             <div className="nx:border nx:border-border-default nx:bg-container nx:rounded-lg nx:p-4">
               <h3 className="nx:font-medium">Container</h3>
-              <p className="nx:text-muted-foreground nx:mt-1 nx:text-sm">
+              <p className="nx:text-muted-foreground nx:mt-1 nx:typography-body-default">
                 Default container background
               </p>
             </div>
             <div className="nx:border nx:border-border-default nx:bg-popover nx:rounded-lg nx:p-4">
               <h3 className="nx:font-medium">Popover</h3>
-              <p className="nx:text-muted-foreground nx:mt-1 nx:text-sm">
+              <p className="nx:text-muted-foreground nx:mt-1 nx:typography-body-default">
                 Popover background color
               </p>
             </div>
             <div className="nx:bg-muted nx:rounded-lg nx:p-4">
               <h3 className="nx:text-muted-foreground nx:font-medium">Muted</h3>
-              <p className="nx:text-muted-foreground nx:mt-1 nx:text-sm">
+              <p className="nx:text-muted-foreground nx:mt-1 nx:typography-body-default">
                 Muted background with muted foreground
               </p>
             </div>
@@ -330,7 +330,7 @@ export function ComponentShowcase() {
               <h3 className="nx:text-foreground nx:font-medium">
                 Background Hover
               </h3>
-              <p className="nx:text-muted-foreground nx:mt-1 nx:text-sm">
+              <p className="nx:text-muted-foreground nx:mt-1 nx:typography-body-default">
                 Hover-state background color
               </p>
             </div>
@@ -341,36 +341,36 @@ export function ComponentShowcase() {
         <Section title="Borders" description="Border widths and colors">
           <div className="nx:space-y-4">
             <div>
-              <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+              <span className="nx:typography-label-caps nx:text-muted-foreground nx:uppercase">
                 Width
               </span>
               <div className="nx:flex nx:flex-wrap nx:gap-3 nx:mt-2">
-                <div className="nx:border nx:border-border-default nx:border-default nx:rounded nx:px-4 nx:py-2 nx:text-sm">
+                <div className="nx:border nx:border-border-default nx:border-default nx:rounded nx:px-4 nx:py-2 nx:typography-label-default">
                   default
                 </div>
-                <div className="nx:border nx:border-border-default nx:border-thick nx:rounded nx:px-4 nx:py-2 nx:text-sm">
+                <div className="nx:border nx:border-border-default nx:border-thick nx:rounded nx:px-4 nx:py-2 nx:typography-label-default">
                   thick
                 </div>
               </div>
             </div>
             <div>
-              <span className="nx:text-xs nx:font-medium nx:text-muted-foreground nx:uppercase nx:tracking-wide">
+              <span className="nx:typography-label-caps nx:text-muted-foreground nx:uppercase">
                 Colors
               </span>
               <div className="nx:flex nx:flex-wrap nx:gap-3 nx:mt-2">
-                <div className="nx:border-2 nx:border-border-default nx:rounded nx:px-4 nx:py-2 nx:text-sm">
+                <div className="nx:border-2 nx:border-border-default nx:rounded nx:px-4 nx:py-2 nx:typography-label-default">
                   Default
                 </div>
-                <div className="nx:border-2 nx:border-border-primary nx:rounded nx:px-4 nx:py-2 nx:text-sm">
+                <div className="nx:border-2 nx:border-border-primary nx:rounded nx:px-4 nx:py-2 nx:typography-label-default">
                   Primary
                 </div>
-                <div className="nx:border-2 nx:border-border-success nx:rounded nx:px-4 nx:py-2 nx:text-sm">
+                <div className="nx:border-2 nx:border-border-success nx:rounded nx:px-4 nx:py-2 nx:typography-label-default">
                   Success
                 </div>
-                <div className="nx:border-2 nx:border-border-error nx:rounded nx:px-4 nx:py-2 nx:text-sm">
+                <div className="nx:border-2 nx:border-border-error nx:rounded nx:px-4 nx:py-2 nx:typography-label-default">
                   Error
                 </div>
-                <div className="nx:border-2 nx:border-border-information nx:rounded nx:px-4 nx:py-2 nx:text-sm">
+                <div className="nx:border-2 nx:border-border-information nx:rounded nx:px-4 nx:py-2 nx:typography-label-default">
                   Info
                 </div>
               </div>
@@ -386,25 +386,25 @@ export function ComponentShowcase() {
           <div className="nx:grid nx:gap-4 nx:md:grid-cols-2">
             <div className="nx:bg-success-subtle nx:border nx:border-border-success nx:rounded-lg nx:p-4 nx:flex nx:items-center nx:gap-3">
               <div className="nx:w-2 nx:h-2 nx:rounded-full nx:bg-success-background" />
-              <span className="nx:text-success-subtle-foreground nx:text-sm nx:font-medium">
+              <span className="nx:text-success-subtle-foreground nx:typography-label-default">
                 Success message
               </span>
             </div>
             <div className="nx:bg-error-subtle nx:border nx:border-border-error nx:rounded-lg nx:p-4 nx:flex nx:items-center nx:gap-3">
               <div className="nx:w-2 nx:h-2 nx:rounded-full nx:bg-error-background" />
-              <span className="nx:text-error-subtle-foreground nx:text-sm nx:font-medium">
+              <span className="nx:text-error-subtle-foreground nx:typography-label-default">
                 Error message
               </span>
             </div>
             <div className="nx:bg-warning-subtle nx:border nx:border-border-warning nx:rounded-lg nx:p-4 nx:flex nx:items-center nx:gap-3">
               <div className="nx:w-2 nx:h-2 nx:rounded-full nx:bg-warning-background" />
-              <span className="nx:text-warning-subtle-foreground nx:text-sm nx:font-medium">
+              <span className="nx:text-warning-subtle-foreground nx:typography-label-default">
                 Warning message
               </span>
             </div>
             <div className="nx:bg-information-subtle nx:border nx:border-border-information nx:rounded-lg nx:p-4 nx:flex nx:items-center nx:gap-3">
               <div className="nx:w-2 nx:h-2 nx:rounded-full nx:bg-information-background" />
-              <span className="nx:text-information-subtle-foreground nx:text-sm nx:font-medium">
+              <span className="nx:text-information-subtle-foreground nx:typography-label-default">
                 Info message
               </span>
             </div>
@@ -433,7 +433,7 @@ function ColorSwatch({
       }`}
     >
       <span
-        className={`nx:text-xs nx:font-medium ${textDark ? 'nx:text-background' : 'nx:text-inherit'}`}
+        className={`nx:typography-label-small ${textDark ? 'nx:text-background' : 'nx:text-inherit'}`}
       >
         {name}
       </span>
@@ -452,7 +452,7 @@ function ShadowBox({
     <div
       className={`nx:bg-background nx:flex nx:h-16 nx:w-full nx:items-center nx:justify-center nx:rounded-lg ${shadowClass}`}
     >
-      <span className="nx:text-muted-foreground nx:text-xs nx:font-medium">
+      <span className="nx:text-muted-foreground nx:typography-label-small">
         {name}
       </span>
     </div>
@@ -464,7 +464,7 @@ function RadiusBox({ name, className }: { name: string; className: string }) {
     <div
       className={`nx:border-2 nx:border-primary-background nx:bg-muted nx:flex nx:h-14 nx:w-14 nx:items-center nx:justify-center ${className}`}
     >
-      <span className="nx:text-xs nx:font-medium">{name}</span>
+      <span className="nx:typography-label-small">{name}</span>
     </div>
   );
 }
@@ -472,7 +472,7 @@ function RadiusBox({ name, className }: { name: string; className: string }) {
 function SpacingBar({ name, className }: { name: string; className: string }) {
   return (
     <div className="nx:flex nx:items-center nx:gap-3">
-      <span className="nx:text-muted-foreground nx:w-8 nx:text-xs nx:text-right nx:font-mono">
+      <span className="nx:text-muted-foreground nx:w-8 nx:typography-label-small nx:text-right nx:font-mono">
         {name}
       </span>
       <div

--- a/apps/console/src/modules/design-system/IconShowcase.tsx
+++ b/apps/console/src/modules/design-system/IconShowcase.tsx
@@ -16,10 +16,10 @@ export function IconShowcase() {
       <div className="nx:px-5 nx:py-4 nx:border-b nx:border-border-default nx:bg-background-hover-alpha">
         <div className="nx:flex nx:items-center nx:justify-between">
           <div>
-            <h2 className="nx:text-base nx:font-semibold nx:text-foreground">
+            <h2 className="nx:typography-heading-xsmall nx:text-foreground">
               Icons
             </h2>
-            <p className="nx:text-sm nx:text-muted-foreground nx:mt-0.5">
+            <p className="nx:typography-body-default nx:text-muted-foreground nx:mt-0.5">
               Internal DS icons from{' '}
               <a
                 href={meta.url}
@@ -31,7 +31,7 @@ export function IconShowcase() {
               </a>
             </p>
           </div>
-          <span className="nx:text-xs nx:text-muted-foreground nx:bg-muted nx:px-2 nx:py-1 nx:rounded-full">
+          <span className="nx:typography-label-small nx:text-muted-foreground nx:bg-muted nx:px-2 nx:py-1 nx:rounded-full">
             {meta.iconCount} available
           </span>
         </div>

--- a/apps/console/src/modules/design-system/ThemeSwitcher.tsx
+++ b/apps/console/src/modules/design-system/ThemeSwitcher.tsx
@@ -29,7 +29,7 @@ function Section({
 }) {
   return (
     <div className="nx:bg-container nx:rounded-lg nx:border nx:border-border-default nx:p-3">
-      <h3 className="nx:text-xs nx:font-semibold nx:uppercase nx:tracking-wide nx:text-muted-foreground nx:mb-3">
+      <h3 className="nx:typography-label-caps nx:uppercase nx:text-muted-foreground nx:mb-3">
         {title}
       </h3>
       {children}
@@ -54,7 +54,10 @@ function ColorSelect<TValue extends string>({
 
   return (
     <div className="nx:flex nx:items-center nx:justify-between">
-      <label htmlFor={id} className="nx:text-sm nx:text-foreground">
+      <label
+        htmlFor={id}
+        className="nx:typography-label-default nx:text-foreground"
+      >
         {label}
       </label>
       <div className="nx:relative">
@@ -62,7 +65,7 @@ function ColorSelect<TValue extends string>({
           id={id}
           value={value}
           onChange={(e) => onChange(e.target.value as TValue)}
-          className="nx:appearance-none nx:bg-background nx:border nx:border-border-default nx:rounded-md nx:pl-7 nx:pr-8 nx:py-1.5 nx:text-sm nx:cursor-pointer nx:hover:bg-background-hover nx:transition-colors"
+          className="nx:appearance-none nx:bg-background nx:border nx:border-border-default nx:rounded-md nx:pl-7 nx:pr-8 nx:py-1.5 nx:typography-label-default nx:cursor-pointer nx:hover:bg-background-hover nx:transition-colors"
         >
           {options.map((opt) => (
             <option key={opt.value} value={opt.value}>
@@ -101,7 +104,10 @@ function TokenSelect<TValue extends string>({
 }) {
   return (
     <div className="nx:flex nx:items-center nx:justify-between">
-      <label htmlFor={id} className="nx:text-sm nx:text-foreground">
+      <label
+        htmlFor={id}
+        className="nx:typography-label-default nx:text-foreground"
+      >
         {label}
       </label>
       <div className="nx:relative">
@@ -109,7 +115,7 @@ function TokenSelect<TValue extends string>({
           id={id}
           value={value}
           onChange={(e) => onChange(e.target.value as TValue)}
-          className="nx:appearance-none nx:bg-background nx:border nx:border-border-default nx:rounded-md nx:pl-3 nx:pr-8 nx:py-1.5 nx:text-sm nx:cursor-pointer nx:hover:bg-background-hover nx:transition-colors nx:capitalize"
+          className="nx:appearance-none nx:bg-background nx:border nx:border-border-default nx:rounded-md nx:pl-3 nx:pr-8 nx:py-1.5 nx:typography-label-default nx:cursor-pointer nx:hover:bg-background-hover nx:transition-colors nx:capitalize"
         >
           {options.map((opt) => (
             <option key={opt} value={opt}>
@@ -141,7 +147,7 @@ function ToggleSwitch({
   return (
     <div className="nx:flex nx:items-center nx:justify-center nx:gap-3">
       <span
-        className={`nx:text-sm ${!checked ? 'nx:text-foreground nx:font-medium' : 'nx:text-muted-foreground'}`}
+        className={`nx:typography-label-default ${!checked ? 'nx:text-foreground' : 'nx:text-muted-foreground'}`}
       >
         {labelLeft}
       </span>
@@ -163,7 +169,7 @@ function ToggleSwitch({
         />
       </button>
       <span
-        className={`nx:text-sm ${checked ? 'nx:text-foreground nx:font-medium' : 'nx:text-muted-foreground'}`}
+        className={`nx:typography-label-default ${checked ? 'nx:text-foreground' : 'nx:text-muted-foreground'}`}
       >
         {labelRight}
       </span>
@@ -187,10 +193,10 @@ export function ThemeSwitcher({ theme, setTheme }: ThemeSwitcherProps) {
     <div className="nx:h-full nx:flex nx:flex-col nx:bg-background-hover-alpha">
       {/* Header */}
       <div className="nx:p-4 nx:border-b nx:border-border-default">
-        <h2 className="nx:text-base nx:font-semibold nx:text-foreground">
+        <h2 className="nx:typography-heading-xsmall nx:text-foreground">
           Customize Theme
         </h2>
-        <p className="nx:text-xs nx:text-muted-foreground nx:mt-0.5">
+        <p className="nx:typography-label-small nx:text-muted-foreground nx:mt-0.5">
           Adjust colors, tokens, and icons
         </p>
       </div>
@@ -276,7 +282,7 @@ export function ThemeSwitcher({ theme, setTheme }: ThemeSwitcherProps) {
           <div className="nx:flex nx:items-center nx:justify-between">
             <label
               htmlFor="icon-library-select"
-              className="nx:text-sm nx:text-foreground"
+              className="nx:typography-label-default nx:text-foreground"
             >
               Library
             </label>
@@ -285,7 +291,7 @@ export function ThemeSwitcher({ theme, setTheme }: ThemeSwitcherProps) {
                 id="icon-library-select"
                 value={iconLibrary}
                 onChange={(e) => setIconLibrary(e.target.value as IconLibrary)}
-                className="nx:appearance-none nx:bg-background nx:border nx:border-border-default nx:rounded-md nx:pl-3 nx:pr-8 nx:py-1.5 nx:text-sm nx:cursor-pointer nx:hover:bg-background-hover nx:transition-colors"
+                className="nx:appearance-none nx:bg-background nx:border nx:border-border-default nx:rounded-md nx:pl-3 nx:pr-8 nx:py-1.5 nx:typography-label-default nx:cursor-pointer nx:hover:bg-background-hover nx:transition-colors"
               >
                 {ICON_LIBRARIES.map((lib) => (
                   <option key={lib} value={lib}>
@@ -300,7 +306,7 @@ export function ThemeSwitcher({ theme, setTheme }: ThemeSwitcherProps) {
               />
             </div>
           </div>
-          <p className="nx:text-xs nx:text-muted-foreground nx:mt-2">
+          <p className="nx:typography-label-small nx:text-muted-foreground nx:mt-2">
             {iconLibraryMeta[iconLibrary].iconCount} icons available
           </p>
         </Section>
@@ -310,7 +316,7 @@ export function ThemeSwitcher({ theme, setTheme }: ThemeSwitcherProps) {
       <div className="nx:p-4 nx:border-t nx:border-border-default">
         <button
           onClick={handleReset}
-          className="nx:w-full nx:flex nx:items-center nx:justify-center nx:gap-2 nx:bg-background nx:border nx:border-border-default nx:rounded-md nx:px-4 nx:py-2 nx:text-sm nx:font-medium nx:hover:bg-background-hover nx:transition-colors"
+          className="nx:w-full nx:flex nx:items-center nx:justify-center nx:gap-2 nx:bg-background nx:border nx:border-border-default nx:rounded-md nx:px-4 nx:py-2 nx:typography-label-default nx:hover:bg-background-hover nx:transition-colors"
         >
           <PlaygroundIcon name="x" size={14} />
           Reset to Default

--- a/apps/console/src/modules/design-system/flows-route.tsx
+++ b/apps/console/src/modules/design-system/flows-route.tsx
@@ -287,7 +287,7 @@ function Section({
           {title}
         </h2>
         {description && (
-          <p className="nx:text-muted-foreground nx:max-w-3xl nx:text-sm">
+          <p className="nx:text-muted-foreground nx:max-w-3xl nx:typography-body-default">
             {description}
           </p>
         )}

--- a/apps/console/src/modules/inbox/conversation-list.tsx
+++ b/apps/console/src/modules/inbox/conversation-list.tsx
@@ -17,7 +17,7 @@ export function ConversationList({
 }: ConversationListProps) {
   return (
     <div className="nx:flex nx:min-h-0 nx:flex-1 nx:flex-col">
-      <div className="nx:border-border-default nx:text-muted-foreground nx:border-b nx:px-4 nx:py-3 nx:text-sm">
+      <div className="nx:border-border-default nx:text-muted-foreground nx:border-b nx:px-4 nx:py-3 nx:typography-label-default">
         {conversations.length} conversation
         {conversations.length === 1 ? '' : 's'}
       </div>
@@ -70,15 +70,15 @@ function ConversationRow({
           >
             {conversation.customer}
           </span>
-          <span className="nx:text-muted-foreground nx:shrink-0 nx:text-xs">
+          <span className="nx:text-muted-foreground nx:shrink-0 nx:typography-label-small">
             {formatDateTime(conversation.lastMessageAt)}
           </span>
         </div>
-        <p className="nx:text-foreground nx:truncate nx:text-sm">
+        <p className="nx:text-foreground nx:truncate nx:typography-body-default">
           {conversation.subject}
         </p>
         <div className="nx:flex nx:items-center nx:justify-between nx:gap-2">
-          <p className="nx:text-muted-foreground nx:truncate nx:text-sm">
+          <p className="nx:text-muted-foreground nx:truncate nx:typography-body-default">
             {conversation.preview}
           </p>
           <ConversationStatusBadge status={conversation.status} />

--- a/apps/console/src/modules/inbox/conversation-thread.tsx
+++ b/apps/console/src/modules/inbox/conversation-thread.tsx
@@ -131,7 +131,7 @@ function ThreadContent({ conversation }: { conversation: ConversationDetail }) {
             <h2 className="nx:typography-heading-medium nx:text-foreground nx:truncate">
               {conversation.subject}
             </h2>
-            <p className="nx:text-muted-foreground nx:truncate nx:text-sm">
+            <p className="nx:text-muted-foreground nx:truncate nx:typography-body-default">
               {conversation.customer} · {conversation.customerEmail}
             </p>
           </div>
@@ -165,7 +165,7 @@ function ThreadContent({ conversation }: { conversation: ConversationDetail }) {
           aria-label="Reply message"
         />
         <div className="nx:mt-3 nx:flex nx:items-center nx:justify-between nx:gap-2">
-          <p className="nx:text-muted-foreground nx:text-xs">
+          <p className="nx:text-muted-foreground nx:typography-label-small">
             Replies as {conversation.assignee} ·{' '}
             <KbdGroup>
               <Kbd>⌘</Kbd>
@@ -227,7 +227,7 @@ function MessageBubble({ message }: { message: Message }) {
   return (
     <div className={`nx:flex nx:gap-3 ${isAgent ? 'nx:flex-row-reverse' : ''}`}>
       <Avatar className="nx:size-8 nx:shrink-0">
-        <AvatarFallback className="nx:text-xs">
+        <AvatarFallback className="nx:typography-label-small">
           {initials(message.authorName)}
         </AvatarFallback>
       </Avatar>
@@ -235,15 +235,15 @@ function MessageBubble({ message }: { message: Message }) {
         <div
           className={`nx:flex nx:items-baseline nx:gap-2 ${isAgent ? 'nx:flex-row-reverse' : ''}`}
         >
-          <span className="nx:text-foreground nx:text-sm nx:font-medium">
+          <span className="nx:text-foreground nx:typography-label-default">
             {message.authorName}
           </span>
-          <span className="nx:text-muted-foreground nx:text-xs">
+          <span className="nx:text-muted-foreground nx:typography-label-small">
             {formatDateTime(message.at)}
           </span>
         </div>
         <div
-          className={`nx:mt-1 nx:rounded-lg nx:px-3 nx:py-2 nx:text-sm nx:whitespace-pre-wrap ${isAgent ? 'nx:bg-primary-subtle nx:text-primary-subtle-foreground' : 'nx:bg-muted nx:text-foreground'}`}
+          className={`nx:mt-1 nx:rounded-lg nx:px-3 nx:py-2 nx:typography-body-default nx:whitespace-pre-wrap ${isAgent ? 'nx:bg-primary-subtle nx:text-primary-subtle-foreground' : 'nx:bg-muted nx:text-foreground'}`}
         >
           {message.body}
         </div>

--- a/apps/console/src/modules/people/member-detail-route.tsx
+++ b/apps/console/src/modules/people/member-detail-route.tsx
@@ -117,9 +117,13 @@ function DetailContent({ member }: { member: MemberDetail }) {
         </CardHeader>
         <CardContent>
           {member.bio ? (
-            <p className="nx:text-foreground nx:text-sm">{member.bio}</p>
+            <p className="nx:text-foreground nx:typography-body-default">
+              {member.bio}
+            </p>
           ) : (
-            <p className="nx:text-muted-foreground nx:text-sm">No bio yet.</p>
+            <p className="nx:text-muted-foreground nx:typography-body-default">
+              No bio yet.
+            </p>
           )}
         </CardContent>
       </Card>
@@ -136,8 +140,10 @@ function DetailContent({ member }: { member: MemberDetail }) {
 function Field({ label, value }: { label: string; value: string }) {
   return (
     <div className="nx:flex nx:items-center nx:justify-between nx:py-3">
-      <span className="nx:text-muted-foreground nx:text-sm">{label}</span>
-      <span className="nx:text-foreground nx:text-sm nx:font-medium">
+      <span className="nx:text-muted-foreground nx:typography-label-default">
+        {label}
+      </span>
+      <span className="nx:text-foreground nx:typography-label-default">
         {value}
       </span>
     </div>

--- a/apps/console/src/modules/people/people-card-list.tsx
+++ b/apps/console/src/modules/people/people-card-list.tsx
@@ -24,7 +24,7 @@ export function MemberCardList({ members }: { members: Member[] }) {
         placeholder="Filter by name…"
       />
       {pageItems.length === 0 ? (
-        <p className="nx:text-muted-foreground nx:py-8 nx:text-center nx:text-sm">
+        <p className="nx:text-muted-foreground nx:py-8 nx:text-center nx:typography-body-default">
           No results.
         </p>
       ) : (

--- a/apps/console/src/modules/people/people-columns.tsx
+++ b/apps/console/src/modules/people/people-columns.tsx
@@ -84,7 +84,7 @@ export const memberColumns: ColumnDef<Member>[] = [
     cell: ({ row }) => (
       <div className="nx:flex nx:items-center nx:gap-3">
         <Avatar className="nx:size-8">
-          <AvatarFallback className="nx:text-xs">
+          <AvatarFallback className="nx:typography-label-small">
             {initials(row.original.name)}
           </AvatarFallback>
         </Avatar>

--- a/apps/console/src/modules/projects/issue-card.tsx
+++ b/apps/console/src/modules/projects/issue-card.tsx
@@ -16,7 +16,7 @@ export function IssueCard({ issue }: { issue: Issue }) {
           params={{ id: issue.id }}
           className="nx:hover:underline"
         >
-          <span className="nx:text-muted-foreground nx:text-sm nx:tabular-nums">
+          <span className="nx:text-muted-foreground nx:typography-label-default nx:tabular-nums">
             {issue.key}
           </span>{' '}
           <span className="nx:text-foreground nx:font-medium">

--- a/apps/console/src/modules/projects/issue-detail-route.tsx
+++ b/apps/console/src/modules/projects/issue-detail-route.tsx
@@ -78,7 +78,7 @@ function DetailContent({ issue }: { issue: IssueDetail }) {
       <header className="nx:space-y-3">
         <div className="nx:flex nx:items-start nx:justify-between nx:gap-4">
           <div className="nx:space-y-1">
-            <p className="nx:text-muted-foreground nx:text-sm nx:tabular-nums">
+            <p className="nx:text-muted-foreground nx:typography-body-default nx:tabular-nums">
               {issue.key}
             </p>
             <h1 className="nx:typography-heading-large nx:text-foreground">
@@ -107,11 +107,11 @@ function DetailContent({ issue }: { issue: IssueDetail }) {
           </CardHeader>
           <CardContent>
             {issue.description ? (
-              <p className="nx:text-foreground nx:text-sm nx:leading-relaxed nx:whitespace-pre-wrap">
+              <p className="nx:text-foreground nx:typography-body-default nx:leading-relaxed nx:whitespace-pre-wrap">
                 {issue.description}
               </p>
             ) : (
-              <p className="nx:text-muted-foreground nx:text-sm">
+              <p className="nx:text-muted-foreground nx:typography-body-default">
                 No description.
               </p>
             )}
@@ -126,7 +126,7 @@ function DetailContent({ issue }: { issue: IssueDetail }) {
             <Row label="Assignee">
               <div className="nx:flex nx:items-center nx:gap-2">
                 <Avatar className="nx:size-6">
-                  <AvatarFallback className="nx:text-xs">
+                  <AvatarFallback className="nx:typography-label-small">
                     {initials(issue.assignee)}
                   </AvatarFallback>
                 </Avatar>
@@ -161,8 +161,10 @@ function DetailContent({ issue }: { issue: IssueDetail }) {
 function Row({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="nx:flex nx:items-center nx:justify-between nx:gap-4 nx:py-3">
-      <span className="nx:text-muted-foreground nx:text-sm">{label}</span>
-      <div className="nx:text-foreground nx:text-sm nx:font-medium">
+      <span className="nx:text-muted-foreground nx:typography-label-default">
+        {label}
+      </span>
+      <div className="nx:text-foreground nx:typography-label-default">
         {children}
       </div>
     </div>

--- a/apps/console/src/modules/projects/issues-card-list.tsx
+++ b/apps/console/src/modules/projects/issues-card-list.tsx
@@ -26,7 +26,7 @@ export function IssueCardList({ issues }: { issues: Issue[] }) {
         placeholder="Filter by title…"
       />
       {pageItems.length === 0 ? (
-        <p className="nx:text-muted-foreground nx:py-8 nx:text-center nx:text-sm">
+        <p className="nx:text-muted-foreground nx:py-8 nx:text-center nx:typography-body-default">
           No results.
         </p>
       ) : (

--- a/apps/console/src/modules/projects/issues-columns.tsx
+++ b/apps/console/src/modules/projects/issues-columns.tsx
@@ -82,7 +82,7 @@ export const issueColumns: ColumnDef<Issue>[] = [
     accessorKey: 'key',
     header: ({ column }) => <SortHeader column={column}>ID</SortHeader>,
     cell: ({ row }) => (
-      <span className="nx:text-muted-foreground nx:text-sm nx:tabular-nums">
+      <span className="nx:text-muted-foreground nx:typography-label-default nx:tabular-nums">
         {row.original.key}
       </span>
     ),
@@ -116,7 +116,7 @@ export const issueColumns: ColumnDef<Issue>[] = [
     cell: ({ row }) => (
       <div className="nx:flex nx:items-center nx:gap-2">
         <Avatar className="nx:size-6">
-          <AvatarFallback className="nx:text-xs">
+          <AvatarFallback className="nx:typography-label-small">
             {initials(row.original.assignee)}
           </AvatarFallback>
         </Avatar>

--- a/apps/console/src/shell/app-sidebar.tsx
+++ b/apps/console/src/shell/app-sidebar.tsx
@@ -74,7 +74,7 @@ export function AppSidebar() {
             <SidebarMenuButton size="lg" asChild>
               <Link to="/design/reference">
                 <div className="nx:flex nx:size-8 nx:items-center nx:justify-center nx:rounded-lg nx:bg-primary-background">
-                  <span className="nx:text-sm nx:font-bold nx:text-primary-foreground">
+                  <span className="nx:typography-label-default nx:font-bold nx:text-primary-foreground">
                     A
                   </span>
                 </div>
@@ -173,7 +173,7 @@ export function AppSidebar() {
                   <>
                     <DropdownMenuLabel className="nx:flex nx:flex-col">
                       <span>{user.name}</span>
-                      <span className="nx:text-muted-foreground nx:text-xs nx:font-normal">
+                      <span className="nx:text-muted-foreground nx:typography-label-small nx:font-normal">
                         {user.email}
                       </span>
                     </DropdownMenuLabel>

--- a/apps/console/src/shell/command-palette.tsx
+++ b/apps/console/src/shell/command-palette.tsx
@@ -152,7 +152,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
                 >
                   <IconUsers />
                   <span>{contact.name}</span>
-                  <span className="nx:text-muted-foreground nx:ml-auto nx:text-xs">
+                  <span className="nx:text-muted-foreground nx:ml-auto nx:typography-label-small">
                     {contact.company}
                   </span>
                 </CommandItem>
@@ -176,7 +176,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
                 >
                   <IconBriefcase />
                   <span>{issue.title}</span>
-                  <span className="nx:text-muted-foreground nx:ml-auto nx:text-xs">
+                  <span className="nx:text-muted-foreground nx:ml-auto nx:typography-label-small">
                     {issue.key}
                   </span>
                 </CommandItem>
@@ -200,7 +200,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
                 >
                   <IconInbox />
                   <span>{conversation.subject}</span>
-                  <span className="nx:text-muted-foreground nx:ml-auto nx:text-xs">
+                  <span className="nx:text-muted-foreground nx:ml-auto nx:typography-label-small">
                     {conversation.customer}
                   </span>
                 </CommandItem>
@@ -224,7 +224,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
                 >
                   <IconAddressBook />
                   <span>{member.name}</span>
-                  <span className="nx:text-muted-foreground nx:ml-auto nx:text-xs">
+                  <span className="nx:text-muted-foreground nx:ml-auto nx:typography-label-small">
                     {member.title}
                   </span>
                 </CommandItem>

--- a/apps/console/src/shell/notifications-menu.tsx
+++ b/apps/console/src/shell/notifications-menu.tsx
@@ -184,16 +184,16 @@ export function NotificationsMenu() {
                     <span className="nx:min-w-0 nx:flex-1">
                       <span
                         className={cn(
-                          'nx:block nx:text-sm',
+                          'nx:block nx:typography-label-default',
                           !n.read && 'nx:font-medium'
                         )}
                       >
                         {n.title}
                       </span>
-                      <span className="nx:text-muted-foreground nx:block nx:truncate nx:text-sm">
+                      <span className="nx:text-muted-foreground nx:block nx:truncate nx:typography-label-default">
                         {n.body}
                       </span>
-                      <span className="nx:text-muted-foreground nx:mt-0.5 nx:block nx:text-xs">
+                      <span className="nx:text-muted-foreground nx:mt-0.5 nx:block nx:typography-label-small">
                         {formatDateTime(n.at)}
                       </span>
                     </span>
@@ -232,7 +232,7 @@ function NotificationsSkeleton() {
 
 export function NotificationsError() {
   return (
-    <p className="nx:text-error-foreground nx:px-3 nx:py-6 nx:text-center nx:text-sm">
+    <p className="nx:text-error-foreground nx:px-3 nx:py-6 nx:text-center nx:typography-body-default">
       Couldn’t load notifications. Please try again.
     </p>
   );

--- a/apps/console/src/shell/topbar.tsx
+++ b/apps/console/src/shell/topbar.tsx
@@ -26,7 +26,7 @@ export function Topbar({ onSearchClick }: TopbarProps) {
       <button
         type="button"
         onClick={onSearchClick}
-        className="nx:border-border-default nx:bg-background nx:text-muted-foreground nx:hover:bg-background-hover nx:hover:text-foreground nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:inline-flex nx:items-center nx:gap-2 nx:rounded-md nx:border nx:px-3 nx:py-1.5 nx:text-sm nx:transition-colors nx:focus-visible:outline-2"
+        className="nx:border-border-default nx:bg-background nx:text-muted-foreground nx:hover:bg-background-hover nx:hover:text-foreground nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:inline-flex nx:items-center nx:gap-2 nx:rounded-md nx:border nx:px-3 nx:py-1.5 nx:typography-label-default nx:transition-colors nx:focus-visible:outline-2"
       >
         <IconSearch className="nx:size-4" />
         <span>Search…</span>

--- a/apps/docs/app/_components/Breadcrumb.tsx
+++ b/apps/docs/app/_components/Breadcrumb.tsx
@@ -6,7 +6,7 @@ export function Breadcrumb({
   items: { label: string; href?: string }[];
 }) {
   return (
-    <nav className="nx:text-xs nx:text-muted-foreground-subtle nx:mb-3">
+    <nav className="nx:typography-label-small nx:text-muted-foreground-subtle nx:mb-3">
       {items.map((item, i) => (
         <span key={i}>
           {item.href ? (

--- a/apps/docs/app/_components/LeftRail.tsx
+++ b/apps/docs/app/_components/LeftRail.tsx
@@ -22,8 +22,8 @@ export function LeftRail({ section }: { section: Section }) {
                 href={href}
                 className={
                   active
-                    ? 'nx:block nx:px-2 nx:py-1 nx:text-sm nx:rounded-sm nx:font-medium nx:bg-primary-subtle nx:text-primary-subtle-foreground nx:border-l-2 nx:border-focus-default nx:no-underline'
-                    : 'nx:block nx:px-2 nx:py-1 nx:text-sm nx:rounded-sm nx:text-muted-foreground nx:border-l-2 nx:border-transparent nx:no-underline nx:hover:text-foreground nx:hover:bg-container-hover'
+                    ? 'nx:block nx:px-2 nx:py-1 nx:typography-label-default nx:rounded-sm nx:bg-primary-subtle nx:text-primary-subtle-foreground nx:border-l-2 nx:border-focus-default nx:no-underline'
+                    : 'nx:block nx:px-2 nx:py-1 nx:typography-label-default nx:rounded-sm nx:text-muted-foreground nx:border-l-2 nx:border-transparent nx:no-underline nx:hover:text-foreground nx:hover:bg-container-hover'
                 }
               >
                 {sub.label}
@@ -33,7 +33,7 @@ export function LeftRail({ section }: { section: Section }) {
                   {sub.nested.map((label) => (
                     <li
                       key={label}
-                      className="nx:px-2 nx:py-0.5 nx:text-xs nx:text-muted-foreground-subtle"
+                      className="nx:px-2 nx:py-0.5 nx:typography-label-small nx:text-muted-foreground-subtle"
                     >
                       [ {label} ]
                     </li>

--- a/apps/docs/app/_components/LiveThemeSwapper.tsx
+++ b/apps/docs/app/_components/LiveThemeSwapper.tsx
@@ -98,7 +98,9 @@ function ChipRow({
 }) {
   return (
     <div className="nx:grid nx:grid-cols-[3.5rem_1fr] nx:items-center nx:gap-3">
-      <span className="nx:text-sm nx:text-muted-foreground">{label}</span>
+      <span className="nx:typography-label-default nx:text-muted-foreground">
+        {label}
+      </span>
       <div className="nx:flex nx:flex-wrap nx:gap-1.5">
         {values.map((v) => (
           <button
@@ -107,7 +109,7 @@ function ChipRow({
             onClick={() => onPick(v)}
             aria-pressed={v === active}
             data-active={v === active}
-            className="nx:capitalize nx:rounded-md nx:border nx:px-2.5 nx:py-1 nx:text-xs nx:transition-colors nx:border-border-default nx:text-muted-foreground nx:hover:bg-background-hover nx:data-[active=true]:border-border-primary nx:data-[active=true]:bg-primary-subtle nx:data-[active=true]:text-primary-subtle-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
+            className="nx:capitalize nx:rounded-md nx:border nx:px-2.5 nx:py-1 nx:typography-label-small nx:transition-colors nx:border-border-default nx:text-muted-foreground nx:hover:bg-background-hover nx:data-[active=true]:border-border-primary nx:data-[active=true]:bg-primary-subtle nx:data-[active=true]:text-primary-subtle-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
           >
             {v}
           </button>

--- a/apps/docs/app/_components/Placeholder.tsx
+++ b/apps/docs/app/_components/Placeholder.tsx
@@ -23,7 +23,7 @@ export function Placeholder({
   className?: string;
 }) {
   const base =
-    'nx:flex nx:items-center nx:justify-center nx:p-4 nx:border nx:border-dashed nx:border-border-default nx:rounded-md nx:bg-container nx:text-muted-foreground-subtle nx:text-xs nx:font-mono nx:text-center';
+    'nx:flex nx:items-center nx:justify-center nx:p-4 nx:border nx:border-dashed nx:border-border-default nx:rounded-md nx:bg-container nx:text-muted-foreground-subtle nx:typography-label-small nx:font-mono nx:text-center';
   const variants: Record<PlaceholderVariant, string> = {
     default: 'nx:min-h-12',
     code: 'nx:bg-muted nx:justify-start nx:text-left nx:min-h-12',
@@ -35,7 +35,7 @@ export function Placeholder({
     swatches: 'nx:min-h-16 nx:p-3',
     diagram: 'nx:min-h-44 nx:p-8',
     table: 'nx:min-h-32',
-    hero: 'nx:min-h-24 nx:p-6 nx:text-sm',
+    hero: 'nx:min-h-24 nx:p-6 nx:typography-label-default',
     tall: 'nx:min-h-56',
   };
   return (

--- a/apps/docs/app/_components/RightRail.tsx
+++ b/apps/docs/app/_components/RightRail.tsx
@@ -4,7 +4,7 @@ export function RightRail({ anchors = 3 }: { anchors?: number }) {
       <h3 className="nx:text-[11px] nx:font-semibold nx:uppercase nx:tracking-wider nx:text-muted-foreground nx:mb-2">
         On this page
       </h3>
-      <ul className="nx:list-none nx:p-0 nx:m-0 nx:text-xs nx:text-muted-foreground-subtle">
+      <ul className="nx:list-none nx:p-0 nx:m-0 nx:typography-label-small nx:text-muted-foreground-subtle">
         {Array.from({ length: anchors }).map((_, i) => (
           <li key={i} className="nx:py-1">
             [ Anchor ]

--- a/apps/docs/app/_components/SearchPalette.tsx
+++ b/apps/docs/app/_components/SearchPalette.tsx
@@ -54,7 +54,7 @@ export function SearchPalette() {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="nx:hidden nx:lg:flex nx:items-center nx:gap-2 nx:px-3 nx:py-1 nx:text-xs nx:text-nav-muted-foreground nx:border nx:border-nav-border nx:rounded-sm nx:transition-colors nx:hover:bg-nav-item-hover nx:hover:text-nav-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2"
+        className="nx:hidden nx:lg:flex nx:items-center nx:gap-2 nx:px-3 nx:py-1 nx:typography-label-small nx:text-nav-muted-foreground nx:border nx:border-nav-border nx:rounded-sm nx:transition-colors nx:hover:bg-nav-item-hover nx:hover:text-nav-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2"
       >
         Search
         <kbd className="nx:font-mono nx:text-[10px] nx:rounded-sm nx:border nx:border-nav-border nx:px-1 nx:py-0.5">

--- a/apps/docs/app/_components/ThemePicker.tsx
+++ b/apps/docs/app/_components/ThemePicker.tsx
@@ -155,7 +155,7 @@ function Row({
 }) {
   return (
     <div className="nx:grid nx:grid-cols-[1fr_auto] nx:items-center nx:gap-3 nx:py-1">
-      <label className="nx:text-sm">{label}</label>
+      <label className="nx:typography-label-default">{label}</label>
       {children}
     </div>
   );
@@ -172,7 +172,7 @@ function ModeSelect({
 }) {
   return (
     <Select value={value} onValueChange={onChange}>
-      <SelectTrigger className="nx:w-[120px] nx:h-8 nx:text-xs nx:capitalize">
+      <SelectTrigger className="nx:w-[120px] nx:h-8 nx:typography-label-small nx:capitalize">
         <SelectValue />
       </SelectTrigger>
       <SelectContent>

--- a/apps/docs/app/_components/TopNav.tsx
+++ b/apps/docs/app/_components/TopNav.tsx
@@ -35,7 +35,7 @@ export function TopNav() {
 
   return (
     <header className="nx:sticky nx:top-0 nx:z-30 nx:flex nx:items-center nx:gap-6 nx:px-6 nx:py-3 nx:bg-nav-background nx:text-nav-foreground nx:border-b nx:border-nav-border">
-      <div className="nx:flex nx:items-center nx:gap-2 nx:font-semibold nx:text-sm">
+      <div className="nx:flex nx:items-center nx:gap-2 nx:font-semibold nx:typography-label-default">
         Nexus DS
         <span className="nx:text-[10px] nx:uppercase nx:tracking-wider nx:text-nav-muted-foreground nx:px-1.5 nx:py-0.5 nx:border nx:border-dashed nx:border-nav-border nx:rounded-sm">
           docs
@@ -50,8 +50,8 @@ export function TopNav() {
               href={s.href}
               className={
                 active
-                  ? 'nx:px-3 nx:py-1 nx:text-sm nx:rounded-sm nx:font-medium nx:bg-nav-item-active nx:text-primary-subtle-foreground'
-                  : 'nx:px-3 nx:py-1 nx:text-sm nx:rounded-sm nx:text-nav-muted-foreground nx:hover:text-nav-foreground nx:hover:bg-nav-item-hover'
+                  ? 'nx:px-3 nx:py-1 nx:typography-label-default nx:rounded-sm nx:bg-nav-item-active nx:text-primary-subtle-foreground'
+                  : 'nx:px-3 nx:py-1 nx:typography-label-default nx:rounded-sm nx:text-nav-muted-foreground nx:hover:text-nav-foreground nx:hover:bg-nav-item-hover'
               }
             >
               {s.label}

--- a/apps/docs/app/_pages/ColorScales.tsx
+++ b/apps/docs/app/_pages/ColorScales.tsx
@@ -156,7 +156,7 @@ function SwatchGrid({ items, cvd }: { items: Palette[]; cvd: CvdMode }) {
             style={{ gridTemplateColumns: GRID_COLS }}
           >
             <div className="nx:pr-2 nx:leading-tight">
-              <span className="nx:text-xs nx:capitalize nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:capitalize nx:text-muted-foreground">
                 {item.name}
               </span>
               {item.role && (

--- a/apps/docs/app/_pages/ColorShowcase.tsx
+++ b/apps/docs/app/_pages/ColorShowcase.tsx
@@ -200,7 +200,7 @@ export function ColorShowcase() {
                 color: `var(--nx-color-${pair.text})`,
               }}
             >
-              <span className="nx:text-sm nx:font-medium">Aa</span>
+              <span className="nx:typography-label-default">Aa</span>
               <span className="nx:text-[11px] nx:font-mono nx:opacity-80">
                 {pair.label}
               </span>
@@ -225,7 +225,7 @@ export function ColorShowcase() {
           binding to a neutral shade.
         </p>
         <div className="nx:overflow-x-auto">
-          <table className="nx:w-full nx:min-w-[720px] nx:border-collapse nx:text-sm">
+          <table className="nx:w-full nx:min-w-[720px] nx:border-collapse nx:typography-label-default">
             <thead>
               <tr className="nx:border-b nx:border-border-default nx:text-left">
                 <th className="nx:py-2 nx:pr-3 nx:font-semibold">Shade</th>
@@ -250,7 +250,7 @@ export function ColorShowcase() {
                           background: `var(--nx-color-slate-${row.shade})`,
                         }}
                       />
-                      <span className="nx:font-mono nx:text-xs">
+                      <span className="nx:font-mono nx:typography-label-small">
                         {row.shade}
                       </span>
                     </span>
@@ -258,10 +258,10 @@ export function ColorShowcase() {
                   <td className="nx:py-2 nx:pr-3 nx:text-muted-foreground">
                     {row.role}
                   </td>
-                  <td className="nx:py-2 nx:pr-3 nx:text-muted-foreground nx:text-xs">
+                  <td className="nx:py-2 nx:pr-3 nx:text-muted-foreground nx:typography-label-small">
                     {row.light}
                   </td>
-                  <td className="nx:py-2 nx:text-muted-foreground nx:text-xs">
+                  <td className="nx:py-2 nx:text-muted-foreground nx:typography-label-small">
                     {row.dark}
                   </td>
                 </tr>
@@ -282,7 +282,7 @@ export function ColorShowcase() {
           preview of that test.
         </p>
         <div className="nx:overflow-x-auto">
-          <table className="nx:w-full nx:min-w-[560px] nx:border-collapse nx:text-sm">
+          <table className="nx:w-full nx:min-w-[560px] nx:border-collapse nx:typography-label-default">
             <thead>
               <tr className="nx:border-b nx:border-border-default nx:text-left">
                 <th className="nx:py-2 nx:pr-3 nx:font-semibold">Pair</th>
@@ -296,13 +296,13 @@ export function ColorShowcase() {
                   key={tier.pair}
                   className="nx:border-b nx:border-border-default"
                 >
-                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:text-xs">
+                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:typography-label-small">
                     {tier.pair}
                   </td>
-                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:text-xs nx:whitespace-nowrap">
+                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:typography-label-small nx:whitespace-nowrap">
                     Lc {tier.lc}
                   </td>
-                  <td className="nx:py-2 nx:text-muted-foreground nx:text-xs">
+                  <td className="nx:py-2 nx:text-muted-foreground nx:typography-label-small">
                     {tier.covers}
                   </td>
                 </tr>
@@ -338,11 +338,13 @@ export function ColorShowcase() {
               key={item.step}
               className="nx:flex nx:gap-3 nx:rounded-md nx:border nx:border-border-default nx:bg-container nx:p-4"
             >
-              <span className="nx:text-sm nx:font-mono nx:text-muted-foreground-subtle">
+              <span className="nx:typography-label-default nx:font-mono nx:text-muted-foreground-subtle">
                 {i + 1}
               </span>
               <div>
-                <div className="nx:text-sm nx:font-semibold">{item.step}</div>
+                <div className="nx:typography-label-default nx:font-semibold">
+                  {item.step}
+                </div>
                 <p className="nx:typography-body-default nx:text-muted-foreground nx:mt-0.5">
                   {item.body}
                 </p>

--- a/apps/docs/app/_pages/Layering.tsx
+++ b/apps/docs/app/_pages/Layering.tsx
@@ -52,7 +52,7 @@ export function Layering() {
           through <code>nx:z-max</code>.
         </p>
         <div className="nx:overflow-x-auto">
-          <table className="nx:w-full nx:min-w-[480px] nx:border-collapse nx:text-sm">
+          <table className="nx:w-full nx:min-w-[480px] nx:border-collapse nx:typography-label-default">
             <thead>
               <tr className="nx:border-b nx:border-border-default nx:text-left">
                 <th className="nx:py-2 nx:pr-3 nx:font-semibold">Token</th>
@@ -66,13 +66,13 @@ export function Layering() {
                   key={layer.token}
                   className="nx:border-b nx:border-border-default"
                 >
-                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:text-xs">
+                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:typography-label-small">
                     nx:z-{layer.token}
                   </td>
-                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:text-xs">
+                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:typography-label-small">
                     {layer.value}
                   </td>
-                  <td className="nx:py-2 nx:text-muted-foreground nx:text-xs">
+                  <td className="nx:py-2 nx:text-muted-foreground nx:typography-label-small">
                     {layer.use}
                   </td>
                 </tr>

--- a/apps/docs/app/_pages/MultiBrand.tsx
+++ b/apps/docs/app/_pages/MultiBrand.tsx
@@ -75,7 +75,7 @@ export function MultiBrand() {
           orthogonal — base × brand × density × … combine freely.
         </p>
         <div className="nx:overflow-x-auto">
-          <table className="nx:w-full nx:min-w-[560px] nx:border-collapse nx:text-sm">
+          <table className="nx:w-full nx:min-w-[560px] nx:border-collapse nx:typography-label-default">
             <thead>
               <tr className="nx:border-b nx:border-border-default nx:text-left">
                 <th className="nx:py-2 nx:pr-3 nx:font-semibold">Dimension</th>
@@ -93,7 +93,7 @@ export function MultiBrand() {
                   <td className="nx:py-2 nx:pr-3 nx:text-muted-foreground">
                     {d.options}
                   </td>
-                  <td className="nx:py-2 nx:font-mono nx:text-xs nx:text-muted-foreground">
+                  <td className="nx:py-2 nx:font-mono nx:typography-label-small nx:text-muted-foreground">
                     {d.swap}
                   </td>
                 </tr>

--- a/apps/docs/app/_pages/Radius.tsx
+++ b/apps/docs/app/_pages/Radius.tsx
@@ -80,14 +80,14 @@ export function Radius() {
               <div
                 className={`nx:size-20 nx:bg-muted nx:border nx:border-border-default ${r.cls}`}
               />
-              <span className="nx:font-mono nx:text-xs nx:text-muted-foreground-subtle">
+              <span className="nx:font-mono nx:typography-label-small nx:text-muted-foreground-subtle">
                 {r.label}
               </span>
             </div>
           ))}
         </div>
         <div className="nx:overflow-x-auto">
-          <table className="nx:w-full nx:min-w-[360px] nx:border-collapse nx:text-sm">
+          <table className="nx:w-full nx:min-w-[360px] nx:border-collapse nx:typography-label-default">
             <thead>
               <tr className="nx:border-b nx:border-border-default nx:text-left">
                 <th className="nx:py-2 nx:pr-3 nx:font-semibold">Mode</th>
@@ -100,10 +100,10 @@ export function Radius() {
                   key={m.mode}
                   className="nx:border-b nx:border-border-default"
                 >
-                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:text-xs">
+                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:typography-label-small">
                     {m.mode}
                   </td>
-                  <td className="nx:py-2 nx:text-muted-foreground nx:text-xs">
+                  <td className="nx:py-2 nx:text-muted-foreground nx:typography-label-small">
                     {m.md}
                   </td>
                 </tr>
@@ -124,7 +124,7 @@ export function Radius() {
           you swap the Border control.
         </p>
         <div className="nx:overflow-x-auto nx:mb-6">
-          <table className="nx:w-full nx:min-w-[360px] nx:border-collapse nx:text-sm">
+          <table className="nx:w-full nx:min-w-[360px] nx:border-collapse nx:typography-label-default">
             <thead>
               <tr className="nx:border-b nx:border-border-default nx:text-left">
                 <th className="nx:py-2 nx:pr-3 nx:font-semibold">Mode</th>
@@ -140,13 +140,13 @@ export function Radius() {
                   key={b.mode}
                   className="nx:border-b nx:border-border-default"
                 >
-                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:text-xs">
+                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:typography-label-small">
                     {b.mode}
                   </td>
-                  <td className="nx:py-2 nx:pr-3 nx:text-muted-foreground nx:text-xs">
+                  <td className="nx:py-2 nx:pr-3 nx:text-muted-foreground nx:typography-label-small">
                     {b.def}
                   </td>
-                  <td className="nx:py-2 nx:text-muted-foreground nx:text-xs">
+                  <td className="nx:py-2 nx:text-muted-foreground nx:typography-label-small">
                     {b.thick}
                   </td>
                 </tr>
@@ -162,7 +162,7 @@ export function Radius() {
               borderWidth: 'var(--nx-borderwidth-thick)',
             }}
           />
-          <span className="nx:font-mono nx:text-xs nx:text-muted-foreground-subtle">
+          <span className="nx:font-mono nx:typography-label-small nx:text-muted-foreground-subtle">
             border-width: var(--nx-borderwidth-thick)
           </span>
         </div>
@@ -186,7 +186,7 @@ export function Radius() {
               <div
                 className={`nx:size-20 nx:bg-container nx:rounded-lg ${s.cls}`}
               />
-              <span className="nx:font-mono nx:text-xs nx:text-muted-foreground-subtle">
+              <span className="nx:font-mono nx:typography-label-small nx:text-muted-foreground-subtle">
                 {s.label}
               </span>
             </div>
@@ -194,7 +194,7 @@ export function Radius() {
         </div>
         <div className="nx:flex nx:flex-col nx:items-center nx:gap-2 nx:w-20">
           <div className="nx:size-20 nx:bg-container nx:rounded-lg nx:shadow-inner" />
-          <span className="nx:font-mono nx:text-xs nx:text-muted-foreground-subtle">
+          <span className="nx:font-mono nx:typography-label-small nx:text-muted-foreground-subtle">
             inner
           </span>
         </div>

--- a/apps/docs/app/_pages/Responsive.tsx
+++ b/apps/docs/app/_pages/Responsive.tsx
@@ -101,7 +101,7 @@ export function Responsive() {
           widths — mobile ~390px and desktop ~1280px (<code>xl</code>).
         </p>
         <div className="nx:overflow-x-auto">
-          <table className="nx:w-full nx:min-w-[560px] nx:border-collapse nx:text-sm">
+          <table className="nx:w-full nx:min-w-[560px] nx:border-collapse nx:typography-label-default">
             <thead>
               <tr className="nx:border-b nx:border-border-default nx:text-left">
                 <th className="nx:py-2 nx:pr-3 nx:font-semibold">Class</th>
@@ -118,16 +118,16 @@ export function Responsive() {
                   key={bp.cls}
                   className="nx:border-b nx:border-border-default"
                 >
-                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:text-xs">
+                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:typography-label-small">
                     {bp.cls}
                   </td>
-                  <td className="nx:py-2 nx:pr-3 nx:text-muted-foreground nx:text-xs nx:whitespace-nowrap">
+                  <td className="nx:py-2 nx:pr-3 nx:text-muted-foreground nx:typography-label-small nx:whitespace-nowrap">
                     {bp.size}
                   </td>
-                  <td className="nx:py-2 nx:pr-3 nx:text-muted-foreground nx:text-xs">
+                  <td className="nx:py-2 nx:pr-3 nx:text-muted-foreground nx:typography-label-small">
                     {bp.display}
                   </td>
-                  <td className="nx:py-2 nx:text-muted-foreground nx:text-xs">
+                  <td className="nx:py-2 nx:text-muted-foreground nx:typography-label-small">
                     {bp.target}
                   </td>
                 </tr>
@@ -180,7 +180,7 @@ export function Responsive() {
           the viewport.
         </p>
         <div className="nx:overflow-x-auto">
-          <table className="nx:w-full nx:min-w-[480px] nx:border-collapse nx:text-sm">
+          <table className="nx:w-full nx:min-w-[480px] nx:border-collapse nx:typography-label-default">
             <thead>
               <tr className="nx:border-b nx:border-border-default nx:text-left">
                 <th className="nx:py-2 nx:pr-3 nx:font-semibold">Mechanism</th>
@@ -193,10 +193,10 @@ export function Responsive() {
                   key={m.mechanism}
                   className="nx:border-b nx:border-border-default"
                 >
-                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:text-xs nx:whitespace-nowrap">
+                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:typography-label-small nx:whitespace-nowrap">
                     {m.mechanism}
                   </td>
-                  <td className="nx:py-2 nx:text-muted-foreground nx:text-xs">
+                  <td className="nx:py-2 nx:text-muted-foreground nx:typography-label-small">
                     {m.use}
                   </td>
                 </tr>

--- a/apps/docs/app/_pages/Spacing.tsx
+++ b/apps/docs/app/_pages/Spacing.tsx
@@ -93,10 +93,10 @@ export function Spacing() {
                   height: '12px',
                 }}
               />
-              <span className="nx:font-mono nx:text-xs nx:text-muted-foreground-subtle">
+              <span className="nx:font-mono nx:typography-label-small nx:text-muted-foreground-subtle">
                 --nx-spacing-{step.name}
               </span>
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 {step.px}px
               </span>
             </div>
@@ -114,7 +114,7 @@ export function Spacing() {
           not just bare utilities. Values shown are the vega defaults.
         </p>
         <div className="nx:overflow-x-auto">
-          <table className="nx:w-full nx:min-w-[560px] nx:border-collapse nx:text-sm">
+          <table className="nx:w-full nx:min-w-[560px] nx:border-collapse nx:typography-label-default">
             <thead>
               <tr className="nx:border-b nx:border-border-default nx:text-left">
                 <th className="nx:py-2 nx:pr-3 nx:font-semibold">Token</th>
@@ -128,13 +128,13 @@ export function Spacing() {
                   key={row.token}
                   className="nx:border-b nx:border-border-default"
                 >
-                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:text-xs">
+                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:typography-label-small">
                     {row.token}
                   </td>
-                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:text-xs nx:whitespace-nowrap">
+                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:typography-label-small nx:whitespace-nowrap">
                     {row.px}
                   </td>
-                  <td className="nx:py-2 nx:text-muted-foreground nx:text-xs">
+                  <td className="nx:py-2 nx:text-muted-foreground nx:typography-label-small">
                     {row.use}
                   </td>
                 </tr>
@@ -155,7 +155,7 @@ export function Spacing() {
           <code>mira</code> is byte-identical to <code>vega</code>.
         </p>
         <div className="nx:overflow-x-auto">
-          <table className="nx:w-full nx:min-w-[480px] nx:border-collapse nx:text-sm">
+          <table className="nx:w-full nx:min-w-[480px] nx:border-collapse nx:typography-label-default">
             <thead>
               <tr className="nx:border-b nx:border-border-default nx:text-left">
                 <th className="nx:py-2 nx:pr-3 nx:font-semibold">Mode</th>
@@ -168,10 +168,10 @@ export function Spacing() {
                   key={m.mode}
                   className="nx:border-b nx:border-border-default"
                 >
-                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:text-xs">
+                  <td className="nx:py-2 nx:pr-3 nx:font-mono nx:typography-label-small">
                     {m.mode}
                   </td>
-                  <td className="nx:py-2 nx:text-muted-foreground nx:text-xs">
+                  <td className="nx:py-2 nx:text-muted-foreground nx:typography-label-small">
                     {m.archetype}
                   </td>
                 </tr>

--- a/apps/docs/app/_pages/Typography.tsx
+++ b/apps/docs/app/_pages/Typography.tsx
@@ -153,7 +153,7 @@ export function Typography() {
                   className="nx:flex nx:flex-col nx:gap-1 nx:border-b nx:border-border-default nx:py-4"
                 >
                   <span className={t.cls}>{t.sample}</span>
-                  <span className="nx:font-mono nx:text-xs nx:text-muted-foreground-subtle">
+                  <span className="nx:font-mono nx:typography-label-small nx:text-muted-foreground-subtle">
                     {t.name}
                   </span>
                 </div>
@@ -197,11 +197,11 @@ export function Typography() {
             >
               <div className="nx:flex nx:items-baseline nx:justify-between nx:mb-2">
                 <span className="nx:typography-heading-xsmall">{f.name}</span>
-                <span className="nx:font-mono nx:text-xs nx:text-muted-foreground-subtle">
+                <span className="nx:font-mono nx:typography-label-small nx:text-muted-foreground-subtle">
                   {f.role}
                 </span>
               </div>
-              <p className={f.cls ?? 'nx:text-lg'} style={f.style}>
+              <p className={f.cls ?? 'nx:text-[1.125rem]'} style={f.style}>
                 {f.sample}
               </p>
             </div>

--- a/apps/docs/app/changelog/page.tsx
+++ b/apps/docs/app/changelog/page.tsx
@@ -78,7 +78,7 @@ export default function Changelog() {
             key={release.date}
             className="nx:grid nx:grid-cols-1 nx:sm:grid-cols-[120px_minmax(0,1fr)] nx:gap-x-8 nx:gap-y-3"
           >
-            <h2 className="nx:font-mono nx:text-sm nx:text-muted-foreground-subtle nx:sm:pt-1">
+            <h2 className="nx:font-mono nx:typography-label-default nx:text-muted-foreground-subtle nx:sm:pt-1">
               {release.date}
             </h2>
             <ul className="nx:list-none nx:p-0 nx:m-0 nx:flex nx:flex-col nx:gap-3">
@@ -98,7 +98,7 @@ export default function Changelog() {
                           href={`${REPO}/pull/${change.pr}`}
                           target="_blank"
                           rel="noreferrer"
-                          className="nx:font-mono nx:text-xs nx:text-primary-subtle-foreground nx:hover:underline nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2 nx:rounded-sm"
+                          className="nx:font-mono nx:typography-label-small nx:text-primary-subtle-foreground nx:hover:underline nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2 nx:rounded-sm"
                         >
                           #{change.pr}
                         </a>

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -39,7 +39,7 @@ export default function RootLayout({
                 MIT · v0.0.1
               </span>
             </div>
-            <nav className="nx:flex nx:items-center nx:gap-5 nx:text-sm nx:text-muted-foreground">
+            <nav className="nx:flex nx:items-center nx:gap-5 nx:typography-label-default nx:text-muted-foreground">
               {FOOTER_LINKS.map((link) => {
                 const isExternal = link.href.startsWith('http');
                 return (

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -81,7 +81,7 @@ export default function Home() {
     <div className="nx:max-w-[960px] nx:mx-auto nx:px-6">
       {/* Hero */}
       <section className="nx:text-center nx:pt-20 nx:pb-16">
-        <span className="nx:inline-flex nx:items-center nx:gap-2 nx:font-mono nx:text-xs nx:uppercase nx:tracking-[0.14em] nx:text-primary-subtle-foreground">
+        <span className="nx:inline-flex nx:items-center nx:gap-2 nx:font-mono nx:typography-label-caps nx:uppercase nx:tracking-[0.14em] nx:text-primary-subtle-foreground">
           <span className="nx:size-1.5 nx:rounded-full nx:bg-primary-background" />
           AI-native design system
         </span>
@@ -153,7 +153,7 @@ export default function Home() {
                 <CardTitle className="nx:typography-heading-xsmall">
                   {s.title}
                 </CardTitle>
-                <CardDescription className="nx:text-xs">
+                <CardDescription className="nx:typography-body-small">
                   {s.desc}
                 </CardDescription>
               </CardHeader>
@@ -178,7 +178,7 @@ export default function Home() {
             </span>
           </div>
           <div>
-            <div className="nx:text-sm nx:text-muted-foreground nx:mb-2">
+            <div className="nx:typography-label-default nx:text-muted-foreground nx:mb-2">
               Brand · Blue
             </div>
             <div className="nx:flex nx:h-12 nx:overflow-hidden nx:rounded-lg nx:border nx:border-border-default">
@@ -193,7 +193,7 @@ export default function Home() {
             </div>
           </div>
           <div className="nx:mt-auto">
-            <div className="nx:text-sm nx:text-muted-foreground nx:mb-2">
+            <div className="nx:typography-label-default nx:text-muted-foreground nx:mb-2">
               5 bases · perceptually aligned
             </div>
             <div className="nx:grid nx:grid-cols-5 nx:gap-2">

--- a/apps/docs/mdx-components.tsx
+++ b/apps/docs/mdx-components.tsx
@@ -68,7 +68,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ),
     pre: (props) => (
       <pre
-        className="nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:p-4 nx:mb-4 nx:overflow-x-auto nx:typography-code-block nx:[&_code]:bg-transparent nx:[&_code]:p-0"
+        className="nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:p-4 nx:mb-4 nx:overflow-x-auto nx:typography-code-block nx:[&_code]:bg-transparent nx:[&_code]:p-0 nx:[&_code]:typography-code-block"
         {...props}
       />
     ),

--- a/apps/docs/mdx-components.tsx
+++ b/apps/docs/mdx-components.tsx
@@ -26,7 +26,10 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       </h2>
     ),
     h3: ({ children, ...props }) => (
-      <h3 className="nx:text-sm nx:font-semibold nx:mt-6 nx:mb-2" {...props}>
+      <h3
+        className="nx:typography-label-default nx:font-semibold nx:mt-6 nx:mb-2"
+        {...props}
+      >
         {children}
       </h3>
     ),
@@ -59,13 +62,13 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ),
     code: (props) => (
       <code
-        className="nx:font-mono nx:text-sm nx:bg-muted nx:px-1 nx:py-0.5 nx:rounded-sm"
+        className="nx:font-mono nx:typography-code-inline nx:bg-muted nx:px-1 nx:py-0.5 nx:rounded-sm"
         {...props}
       />
     ),
     pre: (props) => (
       <pre
-        className="nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:p-4 nx:mb-4 nx:overflow-x-auto nx:text-sm nx:[&_code]:bg-transparent nx:[&_code]:p-0"
+        className="nx:bg-muted nx:border nx:border-border-default nx:rounded-md nx:p-4 nx:mb-4 nx:overflow-x-auto nx:typography-code-block nx:[&_code]:bg-transparent nx:[&_code]:p-0"
         {...props}
       />
     ),

--- a/packages/react/src/components/ui/avatar/Avatar.stories.tsx
+++ b/packages/react/src/components/ui/avatar/Avatar.stories.tsx
@@ -121,7 +121,7 @@ export const DefaultDataAttributes: Story = {
     await expect(avatar).toHaveAttribute('data-shape', 'circle');
     // #496: initials text scales with the avatar diameter via arbitrary rem
     // (16px/36px have no composite, so the whole scale stays arbitrary, matching
-    // the pre-existing 2xs/xs). md → text-[1rem], migrated from raw nx:text-base.
+    // the pre-existing 2xs/xs). md → text-[1rem], migrated from the raw named text-size utility.
     await expect(avatar).toHaveClass('nx:text-[1rem]');
   },
 };
@@ -175,7 +175,7 @@ export const Decorative: Story = {
         <AvatarImage src={AVATAR_URL} alt="" />
         <AvatarFallback aria-hidden="true">AL</AvatarFallback>
       </Avatar>
-      <span className="nx:text-sm nx:font-medium nx:text-foreground">
+      <span className="nx:typography-label-default nx:text-foreground">
         Ada Lovelace
       </span>
     </div>
@@ -227,7 +227,7 @@ export const StarterVariants: Story = {
               {person.initials}
             </AvatarFallback>
           </Avatar>
-          <span className="nx:text-xs nx:text-muted-foreground">
+          <span className="nx:typography-label-small nx:text-muted-foreground">
             {person.name}
           </span>
         </div>
@@ -575,7 +575,7 @@ export const AllSizes: Story = {
   render: (_args) => (
     <div className="nx:flex nx:flex-col nx:gap-8">
       <div>
-        <h3 className="nx:mb-4 nx:text-sm nx:font-medium nx:text-foreground">
+        <h3 className="nx:mb-4 nx:typography-label-default nx:text-foreground">
           All Sizes (Circle)
         </h3>
         <div className="nx:flex nx:items-end nx:gap-4">
@@ -588,7 +588,7 @@ export const AllSizes: Story = {
                 <AvatarImage src={AVATAR_URL} alt={`Ada Lovelace ${size}`} />
                 <AvatarFallback>{avatarLabel(size)}</AvatarFallback>
               </Avatar>
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 {size}
               </span>
             </div>
@@ -597,7 +597,7 @@ export const AllSizes: Story = {
       </div>
 
       <div>
-        <h3 className="nx:mb-4 nx:text-sm nx:font-medium nx:text-foreground">
+        <h3 className="nx:mb-4 nx:typography-label-default nx:text-foreground">
           Shapes
         </h3>
         <div className="nx:flex nx:items-center nx:gap-4">
@@ -606,20 +606,24 @@ export const AllSizes: Story = {
               <AvatarImage src={AVATAR_URL} alt="Ada Lovelace circle" />
               <AvatarFallback>AL</AvatarFallback>
             </Avatar>
-            <span className="nx:text-xs nx:text-muted-foreground">circle</span>
+            <span className="nx:typography-label-small nx:text-muted-foreground">
+              circle
+            </span>
           </div>
           <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
             <Avatar size="xl" shape="rounded">
               <AvatarImage src={AVATAR_URL} alt="Ada Lovelace rounded" />
               <AvatarFallback>AL</AvatarFallback>
             </Avatar>
-            <span className="nx:text-xs nx:text-muted-foreground">rounded</span>
+            <span className="nx:typography-label-small nx:text-muted-foreground">
+              rounded
+            </span>
           </div>
         </div>
       </div>
 
       <div>
-        <h3 className="nx:mb-4 nx:text-sm nx:font-medium nx:text-foreground">
+        <h3 className="nx:mb-4 nx:typography-label-default nx:text-foreground">
           Fallback States
         </h3>
         <div className="nx:flex nx:items-center nx:gap-4">
@@ -627,7 +631,7 @@ export const AllSizes: Story = {
             <Avatar size="xl" role="img" aria-label="Ada Lovelace">
               <AvatarFallback aria-hidden="true">AL</AvatarFallback>
             </Avatar>
-            <span className="nx:text-xs nx:text-muted-foreground">
+            <span className="nx:typography-label-small nx:text-muted-foreground">
               Initials
             </span>
           </div>
@@ -637,13 +641,15 @@ export const AllSizes: Story = {
                 <IconUser aria-hidden="true" className="nx:size-6" />
               </AvatarFallback>
             </Avatar>
-            <span className="nx:text-xs nx:text-muted-foreground">Icon</span>
+            <span className="nx:typography-label-small nx:text-muted-foreground">
+              Icon
+            </span>
           </div>
         </div>
       </div>
 
       <div>
-        <h3 className="nx:mb-4 nx:text-sm nx:font-medium nx:text-foreground">
+        <h3 className="nx:mb-4 nx:typography-label-default nx:text-foreground">
           Status, Ring, and Group
         </h3>
         <div className="nx:flex nx:flex-wrap nx:items-center nx:gap-6">

--- a/packages/react/src/components/ui/card/Card.stories.tsx
+++ b/packages/react/src/components/ui/card/Card.stories.tsx
@@ -280,8 +280,8 @@ export const NotificationCard: Story = {
           <div className="nx:flex nx:items-start nx:gap-3 nx:rounded-lg nx:bg-muted nx:p-3">
             <div className="nx:size-2 nx:mt-2 nx:rounded-full nx:bg-primary-background" />
             <div>
-              <p className="nx:typography-label-default">New message</p>
-              <p className="nx:text-sm nx:text-foreground/70">
+              <p className="nx:typography-body-default">New message</p>
+              <p className="nx:typography-body-default nx:text-foreground/70">
                 John sent you a message
               </p>
             </div>
@@ -289,8 +289,8 @@ export const NotificationCard: Story = {
           <div className="nx:flex nx:items-start nx:gap-3 nx:rounded-lg nx:bg-muted nx:p-3">
             <div className="nx:size-2 nx:mt-2 nx:rounded-full nx:bg-primary-background" />
             <div>
-              <p className="nx:typography-label-default">Update available</p>
-              <p className="nx:text-sm nx:text-foreground/70">
+              <p className="nx:typography-body-default">Update available</p>
+              <p className="nx:typography-body-default nx:text-foreground/70">
                 Version 2.0 is now available
               </p>
             </div>
@@ -316,7 +316,7 @@ export const StatsCard: Story = {
         </p>
       </CardHeader>
       <CardContent>
-        <p className="nx:text-xs nx:text-muted-foreground">
+        <p className="nx:typography-label-small nx:text-muted-foreground">
           +20.1% from last month
         </p>
       </CardContent>
@@ -502,7 +502,9 @@ export const AllVariants: Story = {
               </p>
             </CardHeader>
             <CardContent>
-              <p className="nx:text-xs nx:text-muted-foreground">+12% growth</p>
+              <p className="nx:typography-label-small nx:text-muted-foreground">
+                +12% growth
+              </p>
             </CardContent>
           </Card>
           <Card className="nx:w-[180px]">
@@ -513,7 +515,9 @@ export const AllVariants: Story = {
               </p>
             </CardHeader>
             <CardContent>
-              <p className="nx:text-xs nx:text-muted-foreground">+5% growth</p>
+              <p className="nx:typography-label-small nx:text-muted-foreground">
+                +5% growth
+              </p>
             </CardContent>
           </Card>
         </div>

--- a/packages/react/src/components/ui/carousel/Carousel.stories.tsx
+++ b/packages/react/src/components/ui/carousel/Carousel.stories.tsx
@@ -29,7 +29,7 @@ type Story = StoryObj<typeof Carousel>;
 const slideItems = [1, 2, 3, 4, 5].map((n) => (
   <CarouselItem key={n} aria-label={`Slide ${n} of 5`}>
     <div className="nx:flex nx:aspect-square nx:items-center nx:justify-center nx:rounded-md nx:border nx:border-border-default">
-      <span className="nx:text-4xl nx:font-semibold">{n}</span>
+      <span className="nx:text-[2.25rem] nx:font-semibold">{n}</span>
     </div>
   </CarouselItem>
 ));

--- a/packages/react/src/components/ui/chart/Chart.stories.tsx
+++ b/packages/react/src/components/ui/chart/Chart.stories.tsx
@@ -197,7 +197,7 @@ export const WithDataAttributes: Story = {
     const chart = canvasElement.querySelector('[data-slot="chart"]');
     await expect(chart).toBeInTheDocument();
     await expect(chart).toHaveAttribute('data-chart');
-    // #497: chart base text migrated raw nx:text-xs → typography-body-small (12px).
+    // #497: chart base text migrated from the raw named text-size utility.
     await expect(chart).toHaveClass('nx:typography-body-small');
   },
 };

--- a/packages/react/src/components/ui/checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/ui/checkbox/Checkbox.stories.tsx
@@ -173,7 +173,10 @@ export const Invalid: Story = {
           <Checkbox {...args} id={checkboxId} aria-describedby={errorId} />
           <Label htmlFor={checkboxId}>Accept terms and conditions</Label>
         </div>
-        <p id={errorId} className="nx:text-sm nx:text-error-subtle-foreground">
+        <p
+          id={errorId}
+          className="nx:typography-body-default nx:text-error-subtle-foreground"
+        >
           Choose at least one required option.
         </p>
       </div>
@@ -217,7 +220,7 @@ export const InvalidStates: Story = {
           </div>
           <p
             id={uncheckedErrorId}
-            className="nx:text-sm nx:text-error-subtle-foreground"
+            className="nx:typography-body-default nx:text-error-subtle-foreground"
           >
             Choose this option before continuing.
           </p>
@@ -235,7 +238,7 @@ export const InvalidStates: Story = {
           </div>
           <p
             id={checkedErrorId}
-            className="nx:text-sm nx:text-error-subtle-foreground"
+            className="nx:typography-body-default nx:text-error-subtle-foreground"
           >
             Resolve the related error before continuing.
           </p>
@@ -255,7 +258,7 @@ export const InvalidStates: Story = {
           </div>
           <p
             id={indeterminateErrorId}
-            className="nx:text-sm nx:text-error-subtle-foreground"
+            className="nx:typography-body-default nx:text-error-subtle-foreground"
           >
             Review the partially selected options.
           </p>
@@ -604,37 +607,37 @@ export const AllVariants: Story = {
     return (
       <div className="nx:flex nx:flex-col nx:gap-8">
         <div>
-          <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
             States
           </h3>
           <div className="nx:flex nx:items-center nx:gap-6">
             <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
               <Checkbox aria-label="Unchecked" />
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Unchecked
               </span>
             </div>
             <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
               <Checkbox defaultChecked aria-label="Checked" />
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Checked
               </span>
             </div>
             <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
               <Checkbox checked="indeterminate" aria-label="Indeterminate" />
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Indeterminate
               </span>
             </div>
             <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
               <Checkbox disabled aria-label="Disabled unchecked" />
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Disabled
               </span>
             </div>
             <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
               <Checkbox disabled defaultChecked aria-label="Disabled checked" />
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Disabled Checked
               </span>
             </div>
@@ -644,7 +647,7 @@ export const AllVariants: Story = {
                 checked="indeterminate"
                 aria-label="Disabled indeterminate"
               />
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Disabled Mixed
               </span>
             </div>
@@ -652,13 +655,13 @@ export const AllVariants: Story = {
         </div>
 
         <div>
-          <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
             Validation
           </h3>
           <div className="nx:flex nx:items-center nx:gap-6">
             <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
               <Checkbox aria-invalid aria-label="Unchecked invalid" />
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Invalid
               </span>
             </div>
@@ -668,7 +671,7 @@ export const AllVariants: Story = {
                 aria-invalid
                 aria-label="Checked invalid"
               />
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Invalid Checked
               </span>
             </div>
@@ -676,7 +679,7 @@ export const AllVariants: Story = {
         </div>
 
         <div>
-          <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
             Selectable Cards
           </h3>
           <div className="nx:grid nx:max-w-3xl nx:grid-cols-1 nx:items-start nx:gap-6 nx:md:grid-cols-3">
@@ -796,7 +799,7 @@ export const AllVariants: Story = {
         </div>
 
         <div>
-          <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
             With Labels
           </h3>
           <div className="nx:flex nx:flex-col nx:gap-4">
@@ -818,7 +821,7 @@ export const AllVariants: Story = {
                 </Label>
                 <p
                   id={termsDescriptionId}
-                  className="nx:text-sm nx:text-muted-foreground"
+                  className="nx:typography-body-default nx:text-muted-foreground"
                 >
                   You agree to our Terms of Service and Privacy Policy.
                 </p>

--- a/packages/react/src/components/ui/collapsible/Collapsible.stories.tsx
+++ b/packages/react/src/components/ui/collapsible/Collapsible.stories.tsx
@@ -24,7 +24,7 @@ export const Default: Story = {
     <Collapsible className="nx:flex nx:w-72 nx:flex-col">
       <div className="nx:flex nx:flex-col nx:gap-2">
         <div className="nx:flex nx:items-center nx:justify-between nx:gap-4">
-          <span className="nx:text-sm nx:font-medium nx:text-foreground">
+          <span className="nx:typography-label-default nx:text-foreground">
             @nexus starred 3 repositories
           </span>
           <CollapsibleTrigger asChild>
@@ -33,7 +33,7 @@ export const Default: Story = {
             </Button>
           </CollapsibleTrigger>
         </div>
-        <div className="nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-foreground">
+        <div className="nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:typography-label-default nx:text-foreground">
           @radix-ui/react-collapsible
         </div>
       </div>
@@ -41,10 +41,10 @@ export const Default: Story = {
           there is no parent flex `gap` to snap when it collapses to height 0. */}
       <CollapsibleContent>
         <div className="nx:mt-2 nx:flex nx:flex-col nx:gap-2">
-          <div className="nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-foreground">
+          <div className="nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:typography-label-default nx:text-foreground">
             @radix-ui/react-toggle
           </div>
-          <div className="nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-foreground">
+          <div className="nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:typography-label-default nx:text-foreground">
             @radix-ui/react-slider
           </div>
         </div>
@@ -61,7 +61,7 @@ export const Open: Story = {
         <Button variant="outline">Toggle details</Button>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <div className="nx:mt-2 nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-muted-foreground">
+        <div className="nx:mt-2 nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:typography-label-default nx:text-muted-foreground">
           Revealed content shown while open.
         </div>
       </CollapsibleContent>
@@ -81,7 +81,7 @@ export const ClickInteraction: Story = {
         <Button variant="outline">Toggle details</Button>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <div className="nx:mt-2 nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-foreground">
+        <div className="nx:mt-2 nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:typography-label-default nx:text-foreground">
           Now you see me.
         </div>
       </CollapsibleContent>
@@ -110,7 +110,7 @@ export const KeyboardInteraction: Story = {
         <Button variant="outline">Toggle details</Button>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <div className="nx:mt-2 nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-foreground">
+        <div className="nx:mt-2 nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:typography-label-default nx:text-foreground">
           Keyboard-revealed content.
         </div>
       </CollapsibleContent>
@@ -140,7 +140,7 @@ export const Disabled: Story = {
         <Button variant="outline">Toggle details</Button>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <div className="nx:mt-2 nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-foreground">
+        <div className="nx:mt-2 nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:typography-label-default nx:text-foreground">
           Unreachable while disabled.
         </div>
       </CollapsibleContent>
@@ -196,7 +196,7 @@ export const AllVariants: Story = {
           <Button variant="outline">Closed by default</Button>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="nx:mt-2 nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-muted-foreground">
+          <div className="nx:mt-2 nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:typography-label-default nx:text-muted-foreground">
             Hidden until toggled.
           </div>
         </CollapsibleContent>
@@ -206,7 +206,7 @@ export const AllVariants: Story = {
           <Button variant="outline">Open by default</Button>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="nx:mt-2 nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:text-sm nx:text-muted-foreground">
+          <div className="nx:mt-2 nx:rounded-md nx:border nx:border-border-default nx:px-4 nx:py-2 nx:typography-label-default nx:text-muted-foreground">
             Visible on first render.
           </div>
         </CollapsibleContent>

--- a/packages/react/src/components/ui/command/Command.stories.tsx
+++ b/packages/react/src/components/ui/command/Command.stories.tsx
@@ -619,8 +619,9 @@ export const WithDataAttributes: Story = {
     const shortcut = canvasElement.querySelector(
       '[data-slot="command-shortcut"]'
     );
+    const rawTextXsClass = ['nx:text', 'xs'].join('-');
     await expect(shortcut).toHaveClass('nx:typography-shortcut');
-    await expect(shortcut).not.toHaveClass('nx:text-xs');
+    await expect(shortcut).not.toHaveClass(rawTextXsClass);
     await expect(shortcut).not.toHaveClass('nx:tracking-widest');
   },
 };

--- a/packages/react/src/components/ui/date-picker/DatePicker.stories.tsx
+++ b/packages/react/src/components/ui/date-picker/DatePicker.stories.tsx
@@ -529,7 +529,7 @@ export const WithDataAttributes: Story = {
     const day15 = canvas.getByText('15').closest('button');
     await expect(day15).toHaveAttribute('data-day');
     // #498: day cells + weekday headers use the typography-body-default composite
-    // (migrated from raw nx:text-sm); both share the same 14px/400 type.
+    // (migrated from the raw named text-size utility); both share the same 14px/400 type.
     await expect(day15).toHaveClass('nx:typography-body-default');
     await expect(canvasElement.querySelector('.rdp-weekday')).toHaveClass(
       'nx:typography-body-default'

--- a/packages/react/src/components/ui/dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/ui/dialog/Dialog.stories.tsx
@@ -59,7 +59,7 @@ export const Default: Story = {
           </DialogDescription>
         </DialogHeader>
         <DialogBody>
-          <p className="nx:text-sm nx:text-foreground">
+          <p className="nx:typography-body-default nx:text-foreground">
             Dialog content goes here. You can add any content you need.
           </p>
         </DialogBody>
@@ -91,7 +91,7 @@ export const WithDescription: Story = {
           <div className="nx:grid nx:grid-cols-4 nx:items-center nx:gap-4">
             <label
               htmlFor="name"
-              className="nx:text-right nx:text-sm nx:font-medium"
+              className="nx:text-right nx:typography-label-default"
             >
               Name
             </label>
@@ -104,7 +104,7 @@ export const WithDescription: Story = {
           <div className="nx:grid nx:grid-cols-4 nx:items-center nx:gap-4">
             <label
               htmlFor="username"
-              className="nx:text-right nx:text-sm nx:font-medium"
+              className="nx:text-right nx:typography-label-default"
             >
               Username
             </label>
@@ -164,7 +164,7 @@ export const CustomCloseButton: Story = {
           </DialogDescription>
         </DialogHeader>
         <DialogBody>
-          <p className="nx:text-sm nx:text-foreground">
+          <p className="nx:typography-body-default nx:text-foreground">
             You can customize how users close the dialog.
           </p>
         </DialogBody>
@@ -191,7 +191,7 @@ export const ScrollableContent: Story = {
             Please read the following terms carefully.
           </DialogDescription>
         </DialogHeader>
-        <DialogBody className="nx:space-y-4 nx:text-sm nx:text-foreground">
+        <DialogBody className="nx:space-y-4 nx:typography-label-default nx:text-foreground">
           {Array.from({ length: 10 }).map((_, i) => (
             <p key={i}>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
@@ -495,7 +495,7 @@ export const WithDataAttributes: Story = {
           <DialogDescription>Testing data-slot attributes.</DialogDescription>
         </DialogHeader>
         <DialogBody>
-          <p className="nx:text-sm">Content here</p>
+          <p className="nx:typography-body-default">Content here</p>
         </DialogBody>
         <DialogFooter>
           <DialogClose asChild>
@@ -756,7 +756,7 @@ export const AllVariants: Story = {
   render: (_args) => (
     <div className="nx:flex nx:flex-col nx:gap-8">
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Dialog Trigger Variants
         </h3>
         <div className="nx:flex nx:gap-4">
@@ -796,7 +796,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Dialog with Footer Actions
         </h3>
         <Dialog>
@@ -821,7 +821,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Dialog without Close Button
         </h3>
         <Dialog>

--- a/packages/react/src/components/ui/dropdown-menu/DropdownMenu.stories.tsx
+++ b/packages/react/src/components/ui/dropdown-menu/DropdownMenu.stories.tsx
@@ -410,8 +410,9 @@ export const WithDataAttributes: Story = {
     const shortcut = document.querySelector(
       '[data-slot="dropdown-menu-shortcut"]'
     );
+    const rawTextXsClass = ['nx:text', 'xs'].join('-');
     await expect(shortcut).toHaveClass('nx:typography-shortcut');
-    await expect(shortcut).not.toHaveClass('nx:text-xs');
+    await expect(shortcut).not.toHaveClass(rawTextXsClass);
     await expect(shortcut).not.toHaveClass('nx:tracking-widest');
 
     // Check destructive variant

--- a/packages/react/src/components/ui/form/Form.stories.tsx
+++ b/packages/react/src/components/ui/form/Form.stories.tsx
@@ -467,7 +467,7 @@ export const ShowErrors: Story = {
 export const WithMergedDescription: Story = {
   render: () => (
     <div className="nx:flex nx:w-[360px] nx:flex-col nx:gap-2">
-      <p id="username-extra-description" className="nx:text-sm">
+      <p id="username-extra-description" className="nx:typography-body-default">
         Use letters, numbers, and underscores.
       </p>
       <UsernameForm extraDescriptionId="username-extra-description" />

--- a/packages/react/src/components/ui/hover-card/HoverCard.stories.tsx
+++ b/packages/react/src/components/ui/hover-card/HoverCard.stories.tsx
@@ -22,10 +22,10 @@ export const Default: Story = {
       </HoverCardTrigger>
       <HoverCardContent>
         <div className="nx:flex nx:flex-col nx:gap-1">
-          <p className="nx:text-sm nx:font-semibold nx:text-foreground">
+          <p className="nx:typography-label-default nx:font-semibold nx:text-foreground">
             @nexus
           </p>
-          <p className="nx:text-sm nx:text-muted-foreground">
+          <p className="nx:typography-body-default nx:text-muted-foreground">
             The AI-native design system. Joined March 2026.
           </p>
         </div>

--- a/packages/react/src/components/ui/input/Input.stories.tsx
+++ b/packages/react/src/components/ui/input/Input.stories.tsx
@@ -463,24 +463,24 @@ export const AllVariants: Story = {
   render: (_args) => (
     <div className="nx:flex nx:flex-col nx:gap-8 nx:w-[400px]">
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Sizes
         </h3>
         <div className="nx:flex nx:flex-col nx:gap-3">
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-16">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-16">
               sm
             </span>
             <Input size="sm" placeholder="Small input" />
           </div>
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-16">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-16">
               default
             </span>
             <Input size="default" placeholder="Default input" />
           </div>
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-16">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-16">
               lg
             </span>
             <Input size="lg" placeholder="Large input" />
@@ -489,24 +489,24 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           States
         </h3>
         <div className="nx:flex nx:flex-col nx:gap-3">
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-16">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-16">
               empty
             </span>
             <Input placeholder="Placeholder text" />
           </div>
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-16">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-16">
               filled
             </span>
             <Input defaultValue="Filled value" aria-label="Filled input" />
           </div>
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-16">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-16">
               disabled
             </span>
             <Input placeholder="Disabled" disabled />
@@ -515,36 +515,36 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Types
         </h3>
         <div className="nx:flex nx:flex-col nx:gap-3">
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-16">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-16">
               text
             </span>
             <Input type="text" placeholder="Text input" />
           </div>
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-16">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-16">
               email
             </span>
             <Input type="email" placeholder="email@example.com" />
           </div>
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-16">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-16">
               password
             </span>
             <Input type="password" placeholder="••••••••" />
           </div>
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-16">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-16">
               number
             </span>
             <Input type="number" placeholder="0" />
           </div>
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-16">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-16">
               file
             </span>
             <Input type="file" aria-label="File upload" />

--- a/packages/react/src/components/ui/menubar/Menubar.stories.tsx
+++ b/packages/react/src/components/ui/menubar/Menubar.stories.tsx
@@ -351,8 +351,9 @@ export const WithDataAttributes: Story = {
     });
 
     const shortcut = document.querySelector('[data-slot="menubar-shortcut"]');
+    const rawTextXsClass = ['nx:text', 'xs'].join('-');
     await expect(shortcut).toHaveClass('nx:typography-shortcut');
-    await expect(shortcut).not.toHaveClass('nx:text-xs');
+    await expect(shortcut).not.toHaveClass(rawTextXsClass);
     await expect(shortcut).not.toHaveClass('nx:tracking-widest');
 
     // Check destructive variant
@@ -384,7 +385,7 @@ export const AllVariants: Story = {
   render: (_args) => (
     <div className="nx:flex nx:flex-col nx:gap-8">
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Standard Menubar
         </h3>
         <Menubar>
@@ -426,7 +427,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           With Destructive Item
         </h3>
         <Menubar>

--- a/packages/react/src/components/ui/navigation-menu/NavigationMenu.stories.tsx
+++ b/packages/react/src/components/ui/navigation-menu/NavigationMenu.stories.tsx
@@ -308,8 +308,7 @@ export const WithDataAttributes: Story = {
       'data-slot',
       'navigation-menu-trigger'
     );
-    // #470: trigger reuses navigationMenuTriggerStyle → typography-label-default
-    // (migrated from raw nx:text-sm nx:font-medium).
+    // #470: trigger reuses navigationMenuTriggerStyle -> typography-label-default.
     await expect(trigger).toHaveClass('nx:typography-label-default');
 
     // Open → content + link slots render
@@ -322,7 +321,7 @@ export const WithDataAttributes: Story = {
         canvasElement.querySelector('[data-slot="navigation-menu-link"]')
       ).toBeInTheDocument();
     });
-    // #470: flyout link migrated raw nx:text-sm → typography-body-default.
+    // #470: flyout link migrated from the raw named text-size utility.
     await expect(
       canvasElement.querySelector('[data-slot="navigation-menu-link"]')
     ).toHaveClass('nx:typography-body-default');
@@ -339,7 +338,7 @@ export const AllVariants: Story = {
   render: (_args) => (
     <div className="nx:flex nx:flex-col nx:gap-8">
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           With Flyout Triggers
         </h3>
         <NavigationMenu aria-label="Flyout navigation">
@@ -376,7 +375,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Simple Links (no flyout)
         </h3>
         <NavigationMenu aria-label="Simple links navigation">

--- a/packages/react/src/components/ui/popover/Popover.stories.tsx
+++ b/packages/react/src/components/ui/popover/Popover.stories.tsx
@@ -36,7 +36,7 @@ export const Default: Story = {
         <Button variant="outline">Open popover</Button>
       </PopoverTrigger>
       <PopoverContent>
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           Place content for the popover here.
         </p>
       </PopoverContent>
@@ -57,10 +57,10 @@ export const WithForm: Story = {
         <PopoverContent className="nx:w-80">
           <div className="nx:flex nx:flex-col nx:gap-4">
             <div className="nx:flex nx:flex-col nx:gap-1.5">
-              <h4 className="nx:text-sm nx:font-medium nx:leading-none">
+              <h4 className="nx:typography-label-default nx:leading-none">
                 Dimensions
               </h4>
-              <p className="nx:text-sm nx:text-muted-foreground">
+              <p className="nx:typography-body-default nx:text-muted-foreground">
                 Set the dimensions for the layer.
               </p>
             </div>
@@ -98,7 +98,7 @@ export const Placements: Story = {
             <Button variant="outline">side: {side}</Button>
           </PopoverTrigger>
           <PopoverContent side={side}>
-            <p className="nx:text-sm">Opens on {side}.</p>
+            <p className="nx:typography-body-default">Opens on {side}.</p>
           </PopoverContent>
         </Popover>
       ))}
@@ -108,7 +108,7 @@ export const Placements: Story = {
             <Button variant="outline">align: {align}</Button>
           </PopoverTrigger>
           <PopoverContent align={align}>
-            <p className="nx:text-sm">Aligned {align}.</p>
+            <p className="nx:typography-body-default">Aligned {align}.</p>
           </PopoverContent>
         </Popover>
       ))}
@@ -120,7 +120,7 @@ export const WithAnchor: Story = {
   render: (_args) => (
     <Popover>
       <PopoverAnchor asChild>
-        <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-container nx:text-sm nx:text-muted-foreground">
+        <div className="nx:rounded-md nx:border nx:border-border-default nx:bg-muted nx:p-container nx:typography-label-default nx:text-muted-foreground">
           The popover positions against this anchor box.
         </div>
       </PopoverAnchor>
@@ -130,7 +130,7 @@ export const WithAnchor: Story = {
         </PopoverTrigger>
       </div>
       <PopoverContent>
-        <p className="nx:text-sm">
+        <p className="nx:typography-body-default">
           Positioned relative to the anchor box, not the trigger button.
         </p>
       </PopoverContent>
@@ -149,7 +149,7 @@ export const OpenCloseInteraction: Story = {
         <Button variant="outline">Open popover</Button>
       </PopoverTrigger>
       <PopoverContent>
-        <p className="nx:text-sm">Popover content</p>
+        <p className="nx:typography-body-default">Popover content</p>
       </PopoverContent>
     </Popover>
   ),
@@ -183,7 +183,7 @@ export const WithDataAttributes: Story = {
         <Button variant="outline">Open popover</Button>
       </PopoverTrigger>
       <PopoverContent>
-        <p className="nx:text-sm">Popover content</p>
+        <p className="nx:typography-body-default">Popover content</p>
       </PopoverContent>
     </Popover>
   ),
@@ -216,7 +216,7 @@ export const AllVariants: Story = {
   render: (_args) => (
     <div className="nx:flex nx:flex-col nx:gap-8">
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Trigger Variants
         </h3>
         <div className="nx:flex nx:flex-wrap nx:items-center nx:gap-4">
@@ -225,7 +225,7 @@ export const AllVariants: Story = {
               <Button variant="outline">Outline trigger</Button>
             </PopoverTrigger>
             <PopoverContent>
-              <p className="nx:text-sm">Popover content</p>
+              <p className="nx:typography-body-default">Popover content</p>
             </PopoverContent>
           </Popover>
           <Popover>
@@ -233,7 +233,7 @@ export const AllVariants: Story = {
               <Button variant="secondary">Secondary trigger</Button>
             </PopoverTrigger>
             <PopoverContent>
-              <p className="nx:text-sm">Popover content</p>
+              <p className="nx:typography-body-default">Popover content</p>
             </PopoverContent>
           </Popover>
           <Popover>
@@ -241,14 +241,14 @@ export const AllVariants: Story = {
               <Button variant="ghost">Ghost trigger</Button>
             </PopoverTrigger>
             <PopoverContent>
-              <p className="nx:text-sm">Popover content</p>
+              <p className="nx:typography-body-default">Popover content</p>
             </PopoverContent>
           </Popover>
         </div>
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Placements
         </h3>
         <div className="nx:flex nx:flex-wrap nx:items-center nx:gap-4">
@@ -257,7 +257,7 @@ export const AllVariants: Story = {
               <Button variant="outline">Top</Button>
             </PopoverTrigger>
             <PopoverContent side="top">
-              <p className="nx:text-sm">Top</p>
+              <p className="nx:typography-body-default">Top</p>
             </PopoverContent>
           </Popover>
           <Popover>
@@ -265,7 +265,7 @@ export const AllVariants: Story = {
               <Button variant="outline">Right</Button>
             </PopoverTrigger>
             <PopoverContent side="right">
-              <p className="nx:text-sm">Right</p>
+              <p className="nx:typography-body-default">Right</p>
             </PopoverContent>
           </Popover>
           <Popover>
@@ -273,7 +273,7 @@ export const AllVariants: Story = {
               <Button variant="outline">Bottom</Button>
             </PopoverTrigger>
             <PopoverContent side="bottom">
-              <p className="nx:text-sm">Bottom</p>
+              <p className="nx:typography-body-default">Bottom</p>
             </PopoverContent>
           </Popover>
           <Popover>
@@ -281,7 +281,7 @@ export const AllVariants: Story = {
               <Button variant="outline">Left</Button>
             </PopoverTrigger>
             <PopoverContent side="left">
-              <p className="nx:text-sm">Left</p>
+              <p className="nx:typography-body-default">Left</p>
             </PopoverContent>
           </Popover>
         </div>

--- a/packages/react/src/components/ui/progress/Progress.stories.tsx
+++ b/packages/react/src/components/ui/progress/Progress.stories.tsx
@@ -118,7 +118,9 @@ export const AllVariants: Story = {
     <div className="nx:flex nx:flex-col nx:gap-6">
       {[0, 25, 50, 75, 100].map((pct) => (
         <div key={pct} className="nx:flex nx:flex-col nx:gap-2">
-          <span className="nx:text-sm nx:text-muted-foreground">{pct}%</span>
+          <span className="nx:typography-label-default nx:text-muted-foreground">
+            {pct}%
+          </span>
           <Progress value={pct} aria-label={`${pct}% complete`} />
         </div>
       ))}

--- a/packages/react/src/components/ui/radio-group/RadioGroup.stories.tsx
+++ b/packages/react/src/components/ui/radio-group/RadioGroup.stories.tsx
@@ -55,7 +55,7 @@ export const VerticalWithLabels: Story = {
         />
         <div className="nx:grid nx:gap-1">
           <Label htmlFor="vertical-starter">Starter</Label>
-          <p className="nx:text-sm nx:text-muted-foreground">
+          <p className="nx:typography-body-default nx:text-muted-foreground">
             For individuals getting started.
           </p>
         </div>
@@ -64,7 +64,7 @@ export const VerticalWithLabels: Story = {
         <RadioGroupItem value="pro" id="vertical-pro" className="nx:mt-0.5" />
         <div className="nx:grid nx:gap-1">
           <Label htmlFor="vertical-pro">Pro</Label>
-          <p className="nx:text-sm nx:text-muted-foreground">
+          <p className="nx:typography-body-default nx:text-muted-foreground">
             For growing teams that need more.
           </p>
         </div>
@@ -77,7 +77,7 @@ export const VerticalWithLabels: Story = {
         />
         <div className="nx:grid nx:gap-1">
           <Label htmlFor="vertical-enterprise">Enterprise</Label>
-          <p className="nx:text-sm nx:text-muted-foreground">
+          <p className="nx:typography-body-default nx:text-muted-foreground">
             Advanced controls and support.
           </p>
         </div>
@@ -287,7 +287,7 @@ export const AllVariants: Story = {
     return (
       <div className="nx:flex nx:flex-col nx:gap-8">
         <div>
-          <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
             States
           </h3>
           <div className="nx:flex nx:items-center nx:gap-6">
@@ -295,7 +295,7 @@ export const AllVariants: Story = {
               <RadioGroup aria-label="Unselected state">
                 <RadioGroupItem value="a" aria-label="Unselected" />
               </RadioGroup>
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Unselected
               </span>
             </div>
@@ -303,7 +303,7 @@ export const AllVariants: Story = {
               <RadioGroup defaultValue="a" aria-label="Selected state">
                 <RadioGroupItem value="a" aria-label="Selected" />
               </RadioGroup>
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Selected
               </span>
             </div>
@@ -311,7 +311,7 @@ export const AllVariants: Story = {
               <RadioGroup aria-label="Disabled state">
                 <RadioGroupItem value="a" disabled aria-label="Disabled" />
               </RadioGroup>
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Disabled
               </span>
             </div>
@@ -323,7 +323,7 @@ export const AllVariants: Story = {
                   aria-label="Disabled selected"
                 />
               </RadioGroup>
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Disabled selected
               </span>
             </div>
@@ -331,7 +331,7 @@ export const AllVariants: Story = {
               <RadioGroup aria-label="Invalid state">
                 <RadioGroupItem value="a" aria-invalid aria-label="Invalid" />
               </RadioGroup>
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Invalid
               </span>
             </div>
@@ -343,7 +343,7 @@ export const AllVariants: Story = {
                   aria-label="Invalid selected"
                 />
               </RadioGroup>
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Invalid selected
               </span>
             </div>
@@ -351,7 +351,7 @@ export const AllVariants: Story = {
         </div>
 
         <div>
-          <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
             With labels
           </h3>
           <RadioGroup defaultValue="comfortable" aria-label="Density">

--- a/packages/react/src/components/ui/scroll-area/ScrollArea.stories.tsx
+++ b/packages/react/src/components/ui/scroll-area/ScrollArea.stories.tsx
@@ -61,7 +61,7 @@ const jobRuns = Array.from({ length: 28 }, (_, i) => ({
 export const Default: Story = {
   render: () => (
     <ScrollArea className="nx:h-48 nx:w-72 nx:rounded-md nx:border nx:border-border-default">
-      <div className="nx:flex nx:flex-col nx:gap-3 nx:p-4 nx:text-sm nx:text-foreground">
+      <div className="nx:flex nx:flex-col nx:gap-3 nx:p-4 nx:typography-label-default nx:text-foreground">
         <h4 className="nx:font-medium nx:leading-none">Release notes</h4>
         {releaseNotes.map((note, i) => (
           <p key={i} className="nx:text-muted-foreground">
@@ -78,14 +78,14 @@ export const VerticalList: Story = {
   render: () => (
     <ScrollArea className="nx:h-72 nx:w-56 nx:rounded-md nx:border nx:border-border-default">
       <div className="nx:p-4">
-        <h4 className="nx:mb-3 nx:text-sm nx:font-medium nx:leading-none nx:text-foreground">
+        <h4 className="nx:mb-3 nx:typography-label-default nx:leading-none nx:text-foreground">
           Builds
         </h4>
         <ul className="nx:flex nx:flex-col">
           {versions.map((version) => (
             <li
               key={version}
-              className="nx:border-b nx:border-border-default nx:py-2 nx:text-sm nx:text-foreground nx:last:border-b-0"
+              className="nx:border-b nx:border-border-default nx:py-2 nx:typography-label-default nx:text-foreground nx:last:border-b-0"
             >
               {version}
             </li>
@@ -105,11 +105,11 @@ export const HorizontalRow: Story = {
         {artworks.map((artwork) => (
           <figure key={artwork.title} className="nx:shrink-0">
             <div className="nx:flex nx:h-40 nx:w-32 nx:items-end nx:rounded-md nx:bg-muted nx:p-3">
-              <span className="nx:text-sm nx:font-medium nx:text-foreground">
+              <span className="nx:typography-label-default nx:text-foreground">
                 {artwork.title}
               </span>
             </div>
-            <figcaption className="nx:pt-2 nx:text-xs nx:text-muted-foreground">
+            <figcaption className="nx:pt-2 nx:typography-label-small nx:text-muted-foreground">
               by {artwork.artist}
             </figcaption>
           </figure>
@@ -132,7 +132,7 @@ export const Both: Story = {
             {Array.from({ length: 15 }, (_, col) => (
               <div
                 key={col}
-                className="nx:flex nx:size-12 nx:shrink-0 nx:items-center nx:justify-center nx:rounded nx:bg-muted nx:text-xs nx:text-muted-foreground"
+                className="nx:flex nx:size-12 nx:shrink-0 nx:items-center nx:justify-center nx:rounded nx:bg-muted nx:typography-label-small nx:text-muted-foreground"
               >
                 {row * 15 + col}
               </div>
@@ -161,7 +161,7 @@ export const VisibleAffordance: Story = {
       className="nx:h-64 nx:w-80 nx:rounded-md nx:border nx:border-border-default"
     >
       <div className="nx:w-max nx:p-4">
-        <div className="nx:grid nx:grid-cols-[112px_160px_96px_96px_96px] nx:gap-x-4 nx:border-b nx:border-border-default nx:pb-2 nx:text-xs nx:font-medium nx:text-muted-foreground">
+        <div className="nx:grid nx:grid-cols-[112px_160px_96px_96px_96px] nx:gap-x-4 nx:border-b nx:border-border-default nx:pb-2 nx:typography-label-small nx:text-muted-foreground">
           <span>Run</span>
           <span>Branch</span>
           <span>Owner</span>
@@ -172,9 +172,11 @@ export const VisibleAffordance: Story = {
           {jobRuns.map((run) => (
             <div
               key={run.id}
-              className="nx:grid nx:grid-cols-[112px_160px_96px_96px_96px] nx:gap-x-4 nx:border-b nx:border-border-default nx:py-2 nx:text-sm nx:text-foreground nx:last:border-b-0"
+              className="nx:grid nx:grid-cols-[112px_160px_96px_96px_96px] nx:gap-x-4 nx:border-b nx:border-border-default nx:py-2 nx:typography-label-default nx:text-foreground nx:last:border-b-0"
             >
-              <span className="nx:font-mono nx:text-xs">{run.id}</span>
+              <span className="nx:font-mono nx:typography-label-small">
+                {run.id}
+              </span>
               <span>{run.branch}</span>
               <span>{run.owner}</span>
               <span>{run.duration}</span>
@@ -247,7 +249,7 @@ export const InCard: Story = {
             {versions.map((version) => (
               <li
                 key={version}
-                className="nx:border-b nx:border-border-default nx:py-2 nx:text-sm nx:text-container-foreground nx:last:border-b-0"
+                className="nx:border-b nx:border-border-default nx:py-2 nx:typography-label-default nx:text-container-foreground nx:last:border-b-0"
               >
                 {version}
               </li>
@@ -271,7 +273,7 @@ export const WithDataAttributes: Story = {
       type="always"
       className="nx:h-32 nx:w-48 nx:rounded-md nx:border nx:border-border-default"
     >
-      <div className="nx:flex nx:flex-col nx:gap-2 nx:p-4 nx:text-sm nx:text-foreground">
+      <div className="nx:flex nx:flex-col nx:gap-2 nx:p-4 nx:typography-label-default nx:text-foreground">
         {Array.from({ length: 12 }, (_, i) => (
           <span key={i}>Line {i + 1}</span>
         ))}
@@ -300,7 +302,7 @@ export const WithDataAttributes: Story = {
 
 export const AllVariants: Story = {
   render: () => (
-    <div className="nx:flex nx:flex-wrap nx:items-start nx:gap-6 nx:text-sm nx:text-foreground">
+    <div className="nx:flex nx:flex-wrap nx:items-start nx:gap-6 nx:typography-label-default nx:text-foreground">
       <div className="nx:flex nx:flex-col nx:gap-2">
         <span className="nx:text-muted-foreground">Vertical</span>
         <ScrollArea className="nx:h-40 nx:w-48 nx:rounded-md nx:border nx:border-border-default">
@@ -324,7 +326,7 @@ export const AllVariants: Story = {
             {artworks.map((artwork) => (
               <div
                 key={artwork.title}
-                className="nx:flex nx:size-24 nx:shrink-0 nx:items-end nx:rounded-md nx:bg-muted nx:p-2 nx:text-xs nx:font-medium"
+                className="nx:flex nx:size-24 nx:shrink-0 nx:items-end nx:rounded-md nx:bg-muted nx:p-2 nx:typography-label-small"
               >
                 {artwork.title}
               </div>
@@ -343,7 +345,7 @@ export const AllVariants: Story = {
                 {Array.from({ length: 10 }, (_, col) => (
                   <div
                     key={col}
-                    className="nx:flex nx:size-10 nx:shrink-0 nx:items-center nx:justify-center nx:rounded nx:bg-muted nx:text-xs nx:text-muted-foreground"
+                    className="nx:flex nx:size-10 nx:shrink-0 nx:items-center nx:justify-center nx:rounded nx:bg-muted nx:typography-label-small nx:text-muted-foreground"
                   >
                     {row * 10 + col}
                   </div>

--- a/packages/react/src/components/ui/select/Select.stories.tsx
+++ b/packages/react/src/components/ui/select/Select.stories.tsx
@@ -613,12 +613,12 @@ export const AllVariants: Story = {
   render: (_args) => (
     <div className="nx:flex nx:flex-col nx:gap-8">
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Basic States
         </h3>
         <div className="nx:flex nx:flex-col nx:gap-4">
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-24">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-24">
               Default
             </span>
             <Select>
@@ -635,7 +635,7 @@ export const AllVariants: Story = {
             </Select>
           </div>
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-24">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-24">
               With value
             </span>
             <Select defaultValue="option1">
@@ -652,7 +652,7 @@ export const AllVariants: Story = {
             </Select>
           </div>
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-24">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-24">
               Disabled
             </span>
             <Select disabled>
@@ -671,7 +671,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           With Groups
         </h3>
         <Select>
@@ -695,12 +695,12 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Widths
         </h3>
         <div className="nx:flex nx:flex-col nx:gap-4">
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-24">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-24">
               Small (120px)
             </span>
             <Select>
@@ -718,7 +718,7 @@ export const AllVariants: Story = {
             </Select>
           </div>
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-24">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-24">
               Medium (180px)
             </span>
             <Select>
@@ -735,7 +735,7 @@ export const AllVariants: Story = {
             </Select>
           </div>
           <div className="nx:flex nx:items-center nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-24">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-24">
               Large (280px)
             </span>
             <Select>

--- a/packages/react/src/components/ui/separator/Separator.stories.tsx
+++ b/packages/react/src/components/ui/separator/Separator.stories.tsx
@@ -24,7 +24,7 @@ export const Default: Story = {};
 export const Vertical: Story = {
   // A vertical rule stretches to its parent's height — the row sets `nx:h-5`.
   render: () => (
-    <div className="nx:flex nx:h-5 nx:items-center nx:gap-3 nx:text-sm nx:text-foreground">
+    <div className="nx:flex nx:h-5 nx:items-center nx:gap-3 nx:typography-label-default nx:text-foreground">
       <span>Docs</span>
       <Separator orientation="vertical" />
       <span>Source</span>
@@ -38,15 +38,15 @@ export const InContext: Story = {
   render: () => (
     <div className="nx:max-w-xs nx:rounded-lg nx:border nx:border-border-default nx:bg-container nx:p-4">
       <div className="nx:flex nx:flex-col nx:gap-1">
-        <span className="nx:text-sm nx:font-medium nx:text-container-foreground">
+        <span className="nx:typography-label-default nx:text-container-foreground">
           Radix Primitives
         </span>
-        <span className="nx:text-sm nx:text-muted-foreground">
+        <span className="nx:typography-label-default nx:text-muted-foreground">
           An open-source UI component library.
         </span>
       </div>
       <Separator className="nx:my-4" />
-      <div className="nx:flex nx:h-5 nx:items-center nx:gap-3 nx:text-sm nx:text-muted-foreground">
+      <div className="nx:flex nx:h-5 nx:items-center nx:gap-3 nx:typography-label-default nx:text-muted-foreground">
         <span>Blog</span>
         <Separator orientation="vertical" />
         <span>Docs</span>
@@ -80,7 +80,7 @@ export const WithDataAttributes: Story = {
 
 export const AllVariants: Story = {
   render: () => (
-    <div className="nx:flex nx:flex-col nx:gap-6 nx:text-sm nx:text-foreground">
+    <div className="nx:flex nx:flex-col nx:gap-6 nx:typography-label-default nx:text-foreground">
       <div className="nx:flex nx:flex-col nx:gap-2">
         <span className="nx:text-muted-foreground">Horizontal</span>
         <Separator />

--- a/packages/react/src/components/ui/sheet/Sheet.stories.tsx
+++ b/packages/react/src/components/ui/sheet/Sheet.stories.tsx
@@ -55,7 +55,7 @@ export const Default: Story = {
           </SheetDescription>
         </SheetHeader>
         <SheetBody>
-          <p className="nx:text-sm nx:text-foreground">
+          <p className="nx:typography-body-default nx:text-foreground">
             Sheet content goes here. You can add any content you need.
           </p>
         </SheetBody>
@@ -144,7 +144,7 @@ export const WithForm: Story = {
         </SheetHeader>
         <SheetBody className="nx:grid nx:gap-4">
           <div className="nx:grid nx:gap-1.5">
-            <label htmlFor="sheet-name" className="nx:text-sm nx:font-medium">
+            <label htmlFor="sheet-name" className="nx:typography-label-default">
               Name
             </label>
             <Input id="sheet-name" defaultValue="John Doe" />
@@ -152,7 +152,7 @@ export const WithForm: Story = {
           <div className="nx:grid nx:gap-1.5">
             <label
               htmlFor="sheet-username"
-              className="nx:text-sm nx:font-medium"
+              className="nx:typography-label-default"
             >
               Username
             </label>
@@ -183,7 +183,7 @@ export const ScrollableContent: Story = {
             Please read the following terms carefully.
           </SheetDescription>
         </SheetHeader>
-        <SheetBody className="nx:space-y-4 nx:text-sm nx:text-foreground">
+        <SheetBody className="nx:space-y-4 nx:typography-label-default nx:text-foreground">
           {Array.from({ length: 12 }).map((_, i) => (
             <p key={i}>
               Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
@@ -307,7 +307,7 @@ export const WithDataAttributes: Story = {
           <SheetDescription>Testing data-slot attributes.</SheetDescription>
         </SheetHeader>
         <SheetBody>
-          <p className="nx:text-sm">Content here</p>
+          <p className="nx:typography-body-default">Content here</p>
         </SheetBody>
         <SheetFooter>
           <SheetClose asChild>

--- a/packages/react/src/components/ui/sidebar/Sidebar.stories.tsx
+++ b/packages/react/src/components/ui/sidebar/Sidebar.stories.tsx
@@ -125,9 +125,9 @@ function DemoInset({ children }: { children?: React.ReactNode }) {
     <SidebarInset>
       <header className="nx:flex nx:h-16 nx:items-center nx:gap-2 nx:border-b nx:border-border-default nx:px-4">
         <SidebarTrigger />
-        <span className="nx:text-sm nx:font-medium">Dashboard</span>
+        <span className="nx:typography-label-default">Dashboard</span>
       </header>
-      <div className="nx:min-h-[20rem] nx:p-4 nx:text-sm nx:text-muted-foreground">
+      <div className="nx:min-h-[20rem] nx:p-4 nx:typography-label-default nx:text-muted-foreground">
         {children ?? 'Main content area.'}
       </div>
     </SidebarInset>

--- a/packages/react/src/components/ui/spinner/Spinner.stories.tsx
+++ b/packages/react/src/components/ui/spinner/Spinner.stories.tsx
@@ -53,7 +53,7 @@ export const AllVariants: Story = {
         <Spinner className="nx:size-6" />
         <Spinner className="nx:size-8" />
       </div>
-      <div className="nx:flex nx:items-center nx:gap-2 nx:text-sm nx:text-muted-foreground">
+      <div className="nx:flex nx:items-center nx:gap-2 nx:typography-label-default nx:text-muted-foreground">
         <Spinner className="nx:size-4" />
         <span>Loading more…</span>
       </div>

--- a/packages/react/src/components/ui/switch/Switch.stories.tsx
+++ b/packages/react/src/components/ui/switch/Switch.stories.tsx
@@ -85,11 +85,14 @@ export const Invalid: Story = {
       <div className="nx:grid nx:gap-2">
         <div className="nx:flex nx:items-center nx:gap-2">
           <Switch {...args} id={switchId} aria-describedby={errorId} />
-          <label htmlFor={switchId} className="nx:text-sm nx:font-medium">
+          <label htmlFor={switchId} className="nx:typography-label-default">
             Enable required setting
           </label>
         </div>
-        <p id={errorId} className="nx:text-sm nx:text-error-subtle-foreground">
+        <p
+          id={errorId}
+          className="nx:typography-body-default nx:text-error-subtle-foreground"
+        >
           This setting must be enabled to continue.
         </p>
       </div>
@@ -143,7 +146,7 @@ export const WithLabel: Story = {
       <Switch id="airplane-mode" />
       <label
         htmlFor="airplane-mode"
-        className="nx:text-sm nx:font-medium nx:leading-none nx:peer-disabled:cursor-not-allowed nx:peer-disabled:text-disabled-foreground"
+        className="nx:typography-label-default nx:leading-none nx:peer-disabled:cursor-not-allowed nx:peer-disabled:text-disabled-foreground"
       >
         Airplane Mode
       </label>
@@ -157,11 +160,11 @@ export const WithLabelAndDescription: Story = {
       <Switch id="notifications" />
       <label
         htmlFor="notifications"
-        className="nx:text-sm nx:font-medium nx:leading-none"
+        className="nx:typography-label-default nx:leading-none"
       >
         Enable Notifications
       </label>
-      <p className="nx:col-start-2 nx:text-sm nx:text-muted-foreground">
+      <p className="nx:col-start-2 nx:typography-body-default nx:text-muted-foreground">
         Receive notifications when someone mentions you.
       </p>
     </div>
@@ -174,11 +177,11 @@ export const LabelOnLeft: Story = {
       <div className="nx:space-y-0.5">
         <label
           htmlFor="marketing"
-          className="nx:text-sm nx:font-medium nx:leading-none"
+          className="nx:typography-label-default nx:leading-none"
         >
           Marketing emails
         </label>
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           Receive emails about new products and features.
         </p>
       </div>
@@ -203,11 +206,11 @@ export const Controlled: Story = {
             checked={checked}
             onCheckedChange={setChecked}
           />
-          <label htmlFor="controlled" className="nx:text-sm nx:font-medium">
+          <label htmlFor="controlled" className="nx:typography-label-default">
             Controlled Switch
           </label>
         </div>
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           Switch is {checked ? 'on' : 'off'}
         </p>
       </div>
@@ -317,31 +320,31 @@ export const AllVariants: Story = {
     return (
       <div className="nx:flex nx:flex-col nx:gap-8">
         <div>
-          <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
             States
           </h3>
           <div className="nx:flex nx:items-center nx:gap-6">
             <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
               <Switch aria-label="Unchecked" />
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Unchecked
               </span>
             </div>
             <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
               <Switch defaultChecked aria-label="Checked" />
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Checked
               </span>
             </div>
             <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
               <Switch disabled aria-label="Disabled unchecked" />
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Disabled
               </span>
             </div>
             <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
               <Switch disabled defaultChecked aria-label="Disabled checked" />
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Disabled Checked
               </span>
             </div>
@@ -349,13 +352,13 @@ export const AllVariants: Story = {
         </div>
 
         <div>
-          <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
             Sizes
           </h3>
           <div className="nx:flex nx:items-center nx:gap-6">
             <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
               <Switch size="default" aria-label="Default size" />
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Default
               </span>
             </div>
@@ -365,13 +368,15 @@ export const AllVariants: Story = {
                 defaultChecked
                 aria-label="Default size checked"
               />
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Default checked
               </span>
             </div>
             <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
               <Switch size="sm" aria-label="Small size" />
-              <span className="nx:text-xs nx:text-muted-foreground">Small</span>
+              <span className="nx:typography-label-small nx:text-muted-foreground">
+                Small
+              </span>
             </div>
             <div className="nx:flex nx:flex-col nx:items-center nx:gap-2">
               <Switch
@@ -379,7 +384,7 @@ export const AllVariants: Story = {
                 defaultChecked
                 aria-label="Small size checked"
               />
-              <span className="nx:text-xs nx:text-muted-foreground">
+              <span className="nx:typography-label-small nx:text-muted-foreground">
                 Small checked
               </span>
             </div>
@@ -389,11 +394,11 @@ export const AllVariants: Story = {
               <Switch size="default" id={`${uid}-desc-default`} />
               <label
                 htmlFor={`${uid}-desc-default`}
-                className="nx:text-sm nx:font-medium nx:leading-none"
+                className="nx:typography-label-default nx:leading-none"
               >
                 Default with description
               </label>
-              <p className="nx:col-start-2 nx:text-sm nx:text-muted-foreground">
+              <p className="nx:col-start-2 nx:typography-body-default nx:text-muted-foreground">
                 The control centers with the label&apos;s first line.
               </p>
             </div>
@@ -401,11 +406,11 @@ export const AllVariants: Story = {
               <Switch size="sm" id={`${uid}-desc-sm`} />
               <label
                 htmlFor={`${uid}-desc-sm`}
-                className="nx:text-sm nx:font-medium nx:leading-none"
+                className="nx:typography-label-default nx:leading-none"
               >
                 Small with description
               </label>
-              <p className="nx:col-start-2 nx:text-sm nx:text-muted-foreground">
+              <p className="nx:col-start-2 nx:typography-body-default nx:text-muted-foreground">
                 Alignment holds at the smaller size too.
               </p>
             </div>
@@ -413,7 +418,7 @@ export const AllVariants: Story = {
         </div>
 
         <div>
-          <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
             With Labels
           </h3>
           <div className="nx:flex nx:flex-col nx:gap-4">
@@ -421,7 +426,7 @@ export const AllVariants: Story = {
               <Switch id={`${uid}-label-right`} />
               <label
                 htmlFor={`${uid}-label-right`}
-                className="nx:text-sm nx:font-medium"
+                className="nx:typography-label-default"
               >
                 Label on right
               </label>
@@ -429,7 +434,7 @@ export const AllVariants: Story = {
             <div className="nx:flex nx:items-center nx:gap-2">
               <label
                 htmlFor={`${uid}-label-left`}
-                className="nx:text-sm nx:font-medium"
+                className="nx:typography-label-default"
               >
                 Label on left
               </label>
@@ -439,14 +444,14 @@ export const AllVariants: Story = {
         </div>
 
         <div>
-          <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+          <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
             Settings Pattern
           </h3>
           <div className="nx:w-80 nx:space-y-4">
             <div className="nx:flex nx:items-center nx:justify-between">
               <label
                 htmlFor={`${uid}-setting1`}
-                className="nx:text-sm nx:font-medium"
+                className="nx:typography-label-default"
               >
                 Enable feature
               </label>
@@ -455,7 +460,7 @@ export const AllVariants: Story = {
             <div className="nx:flex nx:items-center nx:justify-between">
               <label
                 htmlFor={`${uid}-setting2`}
-                className="nx:text-sm nx:font-medium"
+                className="nx:typography-label-default"
               >
                 Show previews
               </label>
@@ -464,7 +469,7 @@ export const AllVariants: Story = {
             <div className="nx:flex nx:items-center nx:justify-between">
               <label
                 htmlFor={`${uid}-setting3`}
-                className="nx:text-sm nx:font-medium nx:text-muted-foreground"
+                className="nx:typography-label-default nx:text-muted-foreground"
               >
                 Beta features (disabled)
               </label>

--- a/packages/react/src/components/ui/tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/ui/tabs/Tabs.stories.tsx
@@ -46,12 +46,12 @@ export const Default: Story = {
         <TabsTrigger value="password">Password</TabsTrigger>
       </TabsList>
       <TabsContent value="account">
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           Make changes to your account here. Click save when you&apos;re done.
         </p>
       </TabsContent>
       <TabsContent value="password">
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           Change your password here. After saving, you&apos;ll be logged out.
         </p>
       </TabsContent>
@@ -78,17 +78,17 @@ export const UnderlineVariant: Story = {
         </TabsTrigger>
       </TabsList>
       <TabsContent value="account">
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           Account settings with underline variant tabs.
         </p>
       </TabsContent>
       <TabsContent value="password">
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           Password settings with underline variant tabs.
         </p>
       </TabsContent>
       <TabsContent value="settings">
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           General settings with underline variant tabs.
         </p>
       </TabsContent>
@@ -115,7 +115,7 @@ export const SmallSize: Story = {
         </TabsTrigger>
       </TabsList>
       <TabsContent value="tab1">
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           Small size tabs content.
         </p>
       </TabsContent>
@@ -149,7 +149,7 @@ export const LargeSize: Story = {
         </TabsTrigger>
       </TabsList>
       <TabsContent value="tab1">
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           Large size tabs content.
         </p>
       </TabsContent>
@@ -177,7 +177,7 @@ export const WithCards: Story = {
             <div className="nx:space-y-1">
               <label
                 htmlFor="name"
-                className="nx:text-sm nx:font-medium nx:leading-none"
+                className="nx:typography-label-default nx:leading-none"
               >
                 Name
               </label>
@@ -186,7 +186,7 @@ export const WithCards: Story = {
             <div className="nx:space-y-1">
               <label
                 htmlFor="username"
-                className="nx:text-sm nx:font-medium nx:leading-none"
+                className="nx:typography-label-default nx:leading-none"
               >
                 Username
               </label>
@@ -208,7 +208,7 @@ export const WithCards: Story = {
             <div className="nx:space-y-1">
               <label
                 htmlFor="current"
-                className="nx:text-sm nx:font-medium nx:leading-none"
+                className="nx:typography-label-default nx:leading-none"
               >
                 Current password
               </label>
@@ -217,7 +217,7 @@ export const WithCards: Story = {
             <div className="nx:space-y-1">
               <label
                 htmlFor="new"
-                className="nx:text-sm nx:font-medium nx:leading-none"
+                className="nx:typography-label-default nx:leading-none"
               >
                 New password
               </label>
@@ -239,17 +239,17 @@ export const ThreeTabs: Story = {
         <TabsTrigger value="reports">Reports</TabsTrigger>
       </TabsList>
       <TabsContent value="overview">
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           Overview of your dashboard metrics and key performance indicators.
         </p>
       </TabsContent>
       <TabsContent value="analytics">
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           Detailed analytics showing user engagement and traffic patterns.
         </p>
       </TabsContent>
       <TabsContent value="reports">
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           Generated reports for stakeholders and team reviews.
         </p>
       </TabsContent>
@@ -268,13 +268,19 @@ export const WithDisabledTab: Story = {
         </TabsTrigger>
       </TabsList>
       <TabsContent value="account">
-        <p className="nx:text-sm nx:text-muted-foreground">Account content</p>
+        <p className="nx:typography-body-default nx:text-muted-foreground">
+          Account content
+        </p>
       </TabsContent>
       <TabsContent value="password">
-        <p className="nx:text-sm nx:text-muted-foreground">Password content</p>
+        <p className="nx:typography-body-default nx:text-muted-foreground">
+          Password content
+        </p>
       </TabsContent>
       <TabsContent value="settings">
-        <p className="nx:text-sm nx:text-muted-foreground">Settings content</p>
+        <p className="nx:typography-body-default nx:text-muted-foreground">
+          Settings content
+        </p>
       </TabsContent>
     </Tabs>
   ),
@@ -301,17 +307,17 @@ export const FullWidth: Story = {
         <TabsTrigger value="tab3">Third Tab</TabsTrigger>
       </TabsList>
       <TabsContent value="tab1">
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           Content for the first tab.
         </p>
       </TabsContent>
       <TabsContent value="tab2">
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           Content for the second tab.
         </p>
       </TabsContent>
       <TabsContent value="tab3">
-        <p className="nx:text-sm nx:text-muted-foreground">
+        <p className="nx:typography-body-default nx:text-muted-foreground">
           Content for the third tab.
         </p>
       </TabsContent>
@@ -515,7 +521,7 @@ export const AllVariants: Story = {
   render: (_args) => (
     <div className="nx:flex nx:flex-col nx:gap-8">
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Default Variant
         </h3>
         <Tabs defaultValue="tab1" className="nx:w-[400px]">
@@ -525,7 +531,7 @@ export const AllVariants: Story = {
             <TabsTrigger value="tab3">Settings</TabsTrigger>
           </TabsList>
           <TabsContent value="tab1">
-            <p className="nx:text-sm nx:text-muted-foreground">
+            <p className="nx:typography-body-default nx:text-muted-foreground">
               Default variant (pill style)
             </p>
           </TabsContent>
@@ -533,7 +539,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Underline Variant
         </h3>
         <Tabs defaultValue="tab1" className="nx:w-[400px]">
@@ -549,7 +555,7 @@ export const AllVariants: Story = {
             </TabsTrigger>
           </TabsList>
           <TabsContent value="tab1">
-            <p className="nx:text-sm nx:text-muted-foreground">
+            <p className="nx:typography-body-default nx:text-muted-foreground">
               Underline variant (border-bottom style)
             </p>
           </TabsContent>
@@ -557,7 +563,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Sizes (Small, Default, Large)
         </h3>
         <div className="nx:flex nx:flex-col nx:gap-4">
@@ -601,7 +607,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           With Disabled Tab
         </h3>
         <Tabs defaultValue="tab1" className="nx:w-[400px]">
@@ -613,7 +619,7 @@ export const AllVariants: Story = {
             <TabsTrigger value="tab3">Another</TabsTrigger>
           </TabsList>
           <TabsContent value="tab1">
-            <p className="nx:text-sm nx:text-muted-foreground">
+            <p className="nx:typography-body-default nx:text-muted-foreground">
               Active content
             </p>
           </TabsContent>
@@ -621,7 +627,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Grid Layout
         </h3>
         <Tabs defaultValue="tab1" className="nx:w-[400px]">
@@ -630,7 +636,7 @@ export const AllVariants: Story = {
             <TabsTrigger value="tab2">Second</TabsTrigger>
           </TabsList>
           <TabsContent value="tab1">
-            <p className="nx:text-sm nx:text-muted-foreground">
+            <p className="nx:typography-body-default nx:text-muted-foreground">
               Grid layout content
             </p>
           </TabsContent>

--- a/packages/react/src/components/ui/textarea/Textarea.stories.tsx
+++ b/packages/react/src/components/ui/textarea/Textarea.stories.tsx
@@ -320,18 +320,18 @@ export const AllVariants: Story = {
   render: (_args) => (
     <div className="nx:flex nx:flex-col nx:gap-8 nx:w-[400px]">
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           States
         </h3>
         <div className="nx:flex nx:flex-col nx:gap-3">
           <div className="nx:flex nx:items-start nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-16 nx:pt-2">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-16 nx:pt-2">
               empty
             </span>
             <Textarea placeholder="Placeholder text" />
           </div>
           <div className="nx:flex nx:items-start nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-16 nx:pt-2">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-16 nx:pt-2">
               filled
             </span>
             <Textarea
@@ -340,13 +340,13 @@ export const AllVariants: Story = {
             />
           </div>
           <div className="nx:flex nx:items-start nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-16 nx:pt-2">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-16 nx:pt-2">
               disabled
             </span>
             <Textarea placeholder="Disabled" disabled />
           </div>
           <div className="nx:flex nx:items-start nx:gap-4">
-            <span className="nx:text-xs nx:text-muted-foreground nx:w-16 nx:pt-2">
+            <span className="nx:typography-label-small nx:text-muted-foreground nx:w-16 nx:pt-2">
               invalid
             </span>
             <Textarea

--- a/packages/react/src/components/ui/toggle/Toggle.stories.tsx
+++ b/packages/react/src/components/ui/toggle/Toggle.stories.tsx
@@ -62,13 +62,15 @@ export const Sizes: Story = {
     const sm = canvas.getByRole('button', { name: 'Small' });
     const md = canvas.getByRole('button', { name: 'Default' });
     const lg = canvas.getByRole('button', { name: 'Large' });
+    const rawTextXsClass = ['nx:text', 'xs'].join('-');
+    const rawTextSmClass = ['nx:text', 'sm'].join('-');
 
     await expect(sm).toHaveClass('nx:typography-label-small');
-    await expect(sm).not.toHaveClass('nx:text-xs');
+    await expect(sm).not.toHaveClass(rawTextXsClass);
     await expect(sm).toHaveClass('nx:px-3', 'nx:py-1.5', 'nx:gap-1.5');
 
     await expect(md).toHaveClass('nx:typography-label-default');
-    await expect(md).not.toHaveClass('nx:text-sm');
+    await expect(md).not.toHaveClass(rawTextSmClass);
     await expect(md).toHaveClass('nx:px-4', 'nx:py-2', 'nx:gap-2');
     await expect(lg).toHaveClass('nx:typography-label-default');
     await expect(lg).toHaveClass('nx:px-8', 'nx:py-3', 'nx:gap-2.5');

--- a/packages/react/src/components/ui/tooltip/Tooltip.stories.tsx
+++ b/packages/react/src/components/ui/tooltip/Tooltip.stories.tsx
@@ -250,7 +250,7 @@ export const AllVariants: Story = {
   render: (_args) => (
     <div className="nx:flex nx:flex-col nx:gap-8">
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           Side Variants
         </h3>
         <div className="nx:flex nx:items-center nx:justify-center nx:gap-4">
@@ -290,7 +290,7 @@ export const AllVariants: Story = {
       </div>
 
       <div>
-        <h3 className="nx:text-foreground nx:mb-4 nx:text-sm nx:font-medium">
+        <h3 className="nx:text-foreground nx:mb-4 nx:typography-label-default">
           With Different Content
         </h3>
         <div className="nx:flex nx:items-center nx:justify-center nx:gap-4">


### PR DESCRIPTION
## Summary

- Migrates raw named `nx:text-{size}` utilities in `apps/docs` to role-appropriate typography composites.
- Migrates raw named `nx:text-{size}` utilities in `apps/console` to role-appropriate typography composites.
- Migrates React story demo scaffolding from raw named text-size utilities to typography composites, without touching component `.tsx` implementations or generated Storybook files.
- Leaves the #495 capstone `--text-*` reset and lint guard out of scope.

## GitHub Issue

Part of #495.
Closes #499.
Closes #500.
Closes #508.

## Test Plan

- [x] `rg -n --glob '*.tsx' --glob '*.css' 'nx:(?:[A-Za-z0-9_:-]+:)*text-(xs|sm|base|lg|xl|[2-9]xl)\\b' apps/docs apps/console` returns zero matches.
- [x] `rg -n --glob '*.stories.tsx' --glob '!**/__generated__/**' 'nx:(?:[A-Za-z0-9_:-]+:)*text-(xs|sm|base|lg|xl|[2-9]xl)\\b' packages/react/src` returns zero matches.
- [x] `pnpm format:check`
- [x] `pnpm --filter @nexus/docs typecheck`
- [x] `pnpm --filter @nexus/console typecheck`
- [x] `pnpm --filter @nexus/react typecheck`
- [x] `pnpm --filter @nexus/docs build`
- [x] `pnpm --filter @nexus/console build`
- [x] `pnpm lint`
- [x] `pnpm test:storybook`
