### PR TITLE
feat(react): add shortcut typography utility

### DIFF
--- a/apps/console/public/themes/typography-utilities.css
+++ b/apps/console/public/themes/typography-utilities.css
@@ -50,6 +50,14 @@
   text-wrap: pretty;
 }
 
+@utility typography-shortcut {
+  font-family: var(--nx-typography-family-font-sans);
+  font-size: var(--nx-typography-size-xs);
+  font-weight: var(--nx-typography-weight-normal);
+  line-height: var(--nx-typography-line-height-xs);
+  letter-spacing: var(--nx-typography-letterspacing-widest);
+}
+
 @utility typography-label-default {
   font-family: var(--nx-typography-family-font-sans);
   font-size: var(--nx-typography-size-sm);

--- a/apps/console/src/styles/typography-utilities.css
+++ b/apps/console/src/styles/typography-utilities.css
@@ -50,6 +50,14 @@
   text-wrap: pretty;
 }
 
+@utility typography-shortcut {
+  font-family: var(--nx-typography-family-font-sans);
+  font-size: var(--nx-typography-size-xs);
+  font-weight: var(--nx-typography-weight-normal);
+  line-height: var(--nx-typography-line-height-xs);
+  letter-spacing: var(--nx-typography-letterspacing-widest);
+}
+
 @utility typography-label-default {
   font-family: var(--nx-typography-family-font-sans);
   font-size: var(--nx-typography-size-sm);

--- a/apps/docs/app/_pages/Typography.tsx
+++ b/apps/docs/app/_pages/Typography.tsx
@@ -77,6 +77,16 @@ const SCALE: {
       },
     ],
   },
+  {
+    group: 'Shortcut',
+    tiers: [
+      {
+        cls: 'nx:typography-shortcut',
+        name: 'shortcut',
+        sample: '⌘⇧P',
+      },
+    ],
+  },
 ];
 
 const FAMILIES: {
@@ -127,9 +137,9 @@ export function Typography() {
       <section className="nx:mb-12">
         <h2 className="nx:typography-heading-small nx:mb-1">The scale</h2>
         <p className="nx:typography-body-small nx:text-muted-foreground nx:mb-6 nx:max-w-[64ch]">
-          Eleven tiers across four groups, every one at normal (0)
-          letter-spacing — the lone exception is label-caps, which adds +0.8px
-          for all-caps legibility.
+          Twelve composite tiers across five groups. Most use normal (0)
+          letter-spacing; label-caps adds +0.8px for all-caps legibility, and
+          shortcut adds +1.6px for compact key-command hints.
         </p>
         {SCALE.map((group) => (
           <div key={group.group} className="nx:mb-8">

--- a/apps/docs/public/themes/typography-utilities.css
+++ b/apps/docs/public/themes/typography-utilities.css
@@ -50,6 +50,14 @@
   text-wrap: pretty;
 }
 
+@utility typography-shortcut {
+  font-family: var(--nx-typography-family-font-sans);
+  font-size: var(--nx-typography-size-xs);
+  font-weight: var(--nx-typography-weight-normal);
+  line-height: var(--nx-typography-line-height-xs);
+  letter-spacing: var(--nx-typography-letterspacing-widest);
+}
+
 @utility typography-label-default {
   font-family: var(--nx-typography-family-font-sans);
   font-size: var(--nx-typography-size-sm);

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -243,6 +243,21 @@ describe('generateTailwindPackage', () => {
     expect(typographyCSS).not.toMatch(/line-height: auto/);
   });
 
+  it('emits typography-shortcut from the shortcut composite token', () => {
+    const block = extractBlock(typographyCSS, '@utility typography-shortcut');
+    expect(block).toMatch(
+      /font-family: var\(--nx-typography-family-font-sans\);/
+    );
+    expect(block).toMatch(/font-size: var\(--nx-typography-size-xs\);/);
+    expect(block).toMatch(/font-weight: var\(--nx-typography-weight-normal\);/);
+    expect(block).toMatch(
+      /line-height: var\(--nx-typography-line-height-xs\);/
+    );
+    expect(block).toMatch(
+      /letter-spacing: var\(--nx-typography-letterspacing-widest\);/
+    );
+  });
+
   // Regenerating tokens used to produce a noisy whitespace diff against the
   // committed CSS because the generator emitted raw output but the committed
   // files were prettier-formatted. The generator now formats every emitted

--- a/packages/core/tokens/styles/typography.json
+++ b/packages/core/tokens/styles/typography.json
@@ -69,6 +69,17 @@
       "$description": "12"
     }
   },
+  "shortcut": {
+    "$type": "typography",
+    "$value": {
+      "fontFamily": "{family.font-sans}",
+      "fontSize": "{size.xs}",
+      "fontWeight": "{weight.normal}",
+      "lineHeight": "{line-height.xs}",
+      "letterSpacing": "{letterspacing.widest}"
+    },
+    "$description": "Keyboard shortcut hint text in command palettes, menus, and menubars"
+  },
   "label": {
     "default": {
       "$type": "typography",

--- a/packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js
+++ b/packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js
@@ -38,6 +38,8 @@ ruleTester.run('nx-class-conventions', rule, {
     "const c = 'nx:focus:typography-label-default';",
     // The code-* family is live too.
     "const c = 'nx:typography-code-block';",
+    // Shortcut hint typography is a live one-level composite.
+    "const c = 'nx:ml-auto nx:typography-shortcut nx:text-muted-foreground';",
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
+++ b/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
@@ -5,7 +5,7 @@
 // `pnpm lint` and the pre-commit hook for every contributor — not only on
 // in-session Claude edits.
 
-// The 11 live typography composites emitted as `@utility typography-*` by
+// The 12 live typography composites emitted as `@utility typography-*` by
 // packages/tailwind/typography-utilities.css; any other `nx:…typography-*` is
 // dead — it renders nothing (e.g. the `label-large` / `body-xsmall` tiers dropped
 // by the #459 trim). A drift guard in the rule's test fails if this list and the
@@ -22,6 +22,7 @@ export const LIVE_TYPOGRAPHY = [
   'label-caps',
   'label-default',
   'label-small',
+  'shortcut',
 ];
 
 const CHECKS = [

--- a/packages/react/src/components/ui/command/Command.stories.tsx
+++ b/packages/react/src/components/ui/command/Command.stories.tsx
@@ -615,6 +615,13 @@ export const WithDataAttributes: Story = {
     await expect(
       canvasElement.querySelector('[data-slot="command-shortcut"]')
     ).toBeInTheDocument();
+
+    const shortcut = canvasElement.querySelector(
+      '[data-slot="command-shortcut"]'
+    );
+    await expect(shortcut).toHaveClass('nx:typography-shortcut');
+    await expect(shortcut).not.toHaveClass('nx:text-xs');
+    await expect(shortcut).not.toHaveClass('nx:tracking-widest');
   },
 };
 

--- a/packages/react/src/components/ui/command/command.tsx
+++ b/packages/react/src/components/ui/command/command.tsx
@@ -383,7 +383,7 @@ function CommandShortcut({ className, ...props }: CommandShortcutProps) {
     <span
       data-slot="command-shortcut"
       className={cn(
-        'nx:ml-auto nx:text-xs nx:tracking-widest nx:text-muted-foreground',
+        'nx:ml-auto nx:typography-shortcut nx:text-muted-foreground',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/context-menu/ContextMenu.stories.tsx
+++ b/packages/react/src/components/ui/context-menu/ContextMenu.stories.tsx
@@ -355,7 +355,10 @@ export const WithDataAttributes: Story = {
       <ContextMenuContent>
         <ContextMenuLabel>Label</ContextMenuLabel>
         <ContextMenuSeparator />
-        <ContextMenuItem>Item</ContextMenuItem>
+        <ContextMenuItem>
+          Item
+          <ContextMenuShortcut>⌘I</ContextMenuShortcut>
+        </ContextMenuItem>
         <ContextMenuItem variant="destructive">Destructive</ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>
@@ -384,7 +387,17 @@ export const WithDataAttributes: Story = {
       expect(
         document.querySelector('[data-slot="context-menu-item"]')
       ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="context-menu-shortcut"]')
+      ).toBeInTheDocument();
     });
+
+    const shortcut = document.querySelector(
+      '[data-slot="context-menu-shortcut"]'
+    );
+    await expect(shortcut).toHaveClass('nx:typography-shortcut');
+    await expect(shortcut).not.toHaveClass('nx:typography-body-small');
+    await expect(shortcut).not.toHaveClass('nx:tracking-widest');
 
     // Check destructive variant
     const destructiveItem = document.querySelector(

--- a/packages/react/src/components/ui/context-menu/context-menu.tsx
+++ b/packages/react/src/components/ui/context-menu/context-menu.tsx
@@ -460,7 +460,7 @@ function ContextMenuShortcut({
     <span
       data-slot="context-menu-shortcut"
       className={cn(
-        'nx:ml-auto nx:typography-body-small nx:tracking-widest nx:text-muted-foreground',
+        'nx:ml-auto nx:typography-shortcut nx:text-muted-foreground',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/dropdown-menu/DropdownMenu.stories.tsx
+++ b/packages/react/src/components/ui/dropdown-menu/DropdownMenu.stories.tsx
@@ -370,7 +370,10 @@ export const WithDataAttributes: Story = {
       <DropdownMenuContent>
         <DropdownMenuLabel>Label</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem>Item</DropdownMenuItem>
+        <DropdownMenuItem>
+          Item
+          <DropdownMenuShortcut>⌘I</DropdownMenuShortcut>
+        </DropdownMenuItem>
         <DropdownMenuItem variant="destructive">Destructive</DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
@@ -399,7 +402,17 @@ export const WithDataAttributes: Story = {
       expect(
         document.querySelector('[data-slot="dropdown-menu-item"]')
       ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="dropdown-menu-shortcut"]')
+      ).toBeInTheDocument();
     });
+
+    const shortcut = document.querySelector(
+      '[data-slot="dropdown-menu-shortcut"]'
+    );
+    await expect(shortcut).toHaveClass('nx:typography-shortcut');
+    await expect(shortcut).not.toHaveClass('nx:text-xs');
+    await expect(shortcut).not.toHaveClass('nx:tracking-widest');
 
     // Check destructive variant
     const destructiveItem = document.querySelector(

--- a/packages/react/src/components/ui/dropdown-menu/dropdown-menu.tsx
+++ b/packages/react/src/components/ui/dropdown-menu/dropdown-menu.tsx
@@ -465,7 +465,7 @@ function DropdownMenuShortcut({
     <span
       data-slot="dropdown-menu-shortcut"
       className={cn(
-        'nx:ml-auto nx:text-xs nx:tracking-widest nx:text-muted-foreground',
+        'nx:ml-auto nx:typography-shortcut nx:text-muted-foreground',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/menubar/Menubar.stories.tsx
+++ b/packages/react/src/components/ui/menubar/Menubar.stories.tsx
@@ -312,7 +312,10 @@ export const WithDataAttributes: Story = {
         <MenubarContent>
           <MenubarLabel>Actions</MenubarLabel>
           <MenubarSeparator />
-          <MenubarItem>Open</MenubarItem>
+          <MenubarItem>
+            Open
+            <MenubarShortcut>⌘O</MenubarShortcut>
+          </MenubarItem>
           <MenubarItem variant="destructive">Delete</MenubarItem>
         </MenubarContent>
       </MenubarMenu>
@@ -342,7 +345,15 @@ export const WithDataAttributes: Story = {
       expect(
         document.querySelector('[data-slot="menubar-item"]')
       ).toBeInTheDocument();
+      expect(
+        document.querySelector('[data-slot="menubar-shortcut"]')
+      ).toBeInTheDocument();
     });
+
+    const shortcut = document.querySelector('[data-slot="menubar-shortcut"]');
+    await expect(shortcut).toHaveClass('nx:typography-shortcut');
+    await expect(shortcut).not.toHaveClass('nx:text-xs');
+    await expect(shortcut).not.toHaveClass('nx:tracking-widest');
 
     // Check destructive variant
     const destructiveItem = document.querySelector(

--- a/packages/react/src/components/ui/menubar/menubar.tsx
+++ b/packages/react/src/components/ui/menubar/menubar.tsx
@@ -506,7 +506,7 @@ function MenubarShortcut({ className, ...props }: MenubarShortcutProps) {
     <span
       data-slot="menubar-shortcut"
       className={cn(
-        'nx:ml-auto nx:text-xs nx:tracking-widest nx:text-muted-foreground',
+        'nx:ml-auto nx:typography-shortcut nx:text-muted-foreground',
         className
       )}
       {...props}

--- a/packages/react/src/stories/Typography.stories.tsx
+++ b/packages/react/src/stories/Typography.stories.tsx
@@ -103,6 +103,10 @@ const COMPOSITE_UTILITIES: {
     ],
   },
   {
+    group: 'Shortcut',
+    items: [{ cls: 'nx:typography-shortcut', sample: '⌘⇧P' }],
+  },
+  {
     group: 'Code',
     items: [
       {
@@ -120,16 +124,27 @@ const COMPOSITE_UTILITIES: {
 // truth. Derive the expected set from that source and assert parity in the
 // CompositeUtilities play function below, so a token add/rename can't silently
 // desync the specimen.
-const EXPECTED_UTILITY_CLASSES = Object.entries(
-  typographyStyles as Record<string, Record<string, unknown>>
-)
-  .filter(([tier]) => !tier.startsWith('$'))
-  .flatMap(([tier, group]) =>
-    Object.keys(group)
-      .filter((name) => !name.startsWith('$'))
-      .map((name) => `nx:typography-${tier}-${name}`)
-  )
-  .sort();
+function collectTypographyUtilityClasses(
+  node: Record<string, unknown>,
+  path: string[] = []
+): string[] {
+  return Object.entries(node).flatMap(([key, value]) => {
+    if (key.startsWith('$') || !value || typeof value !== 'object') return [];
+
+    const child = value as Record<string, unknown>;
+    const nextPath = [...path, key];
+
+    if (child.$type === 'typography') {
+      return [`nx:typography-${nextPath.join('-')}`];
+    }
+
+    return collectTypographyUtilityClasses(child, nextPath);
+  });
+}
+
+const EXPECTED_UTILITY_CLASSES = collectTypographyUtilityClasses(
+  typographyStyles as Record<string, unknown>
+).sort();
 
 const SCALE_SAMPLE = 'Aa Bb 12';
 const WEIGHT_SAMPLE = 'The quick brown fox';
@@ -367,10 +382,10 @@ export const CompositeUtilities: Story = {
           Composite Utilities
         </h2>
         <p className="nx:text-muted-foreground nx:typography-body-small nx:max-w-2xl">
-          The 11 ready-to-use `nx:typography-*` classes — each bundles
-          font-family, size, weight, line-height, and letter-spacing (body tiers
-          also get `text-wrap: pretty`). Prefer these over composing raw
-          size/weight utilities so every consumer stays consistent.
+          The ready-to-use `nx:typography-*` classes — each bundles font-family,
+          size, weight, line-height, and letter-spacing (body tiers also get
+          `text-wrap: pretty`). Prefer these over composing raw size/weight
+          utilities so every consumer stays consistent.
         </p>
       </div>
       {COMPOSITE_UTILITIES.map(({ group, items }) => (

--- a/packages/tailwind/typography-utilities.css
+++ b/packages/tailwind/typography-utilities.css
@@ -50,6 +50,14 @@
   text-wrap: pretty;
 }
 
+@utility typography-shortcut {
+  font-family: var(--nx-typography-family-font-sans);
+  font-size: var(--nx-typography-size-xs);
+  font-weight: var(--nx-typography-weight-normal);
+  line-height: var(--nx-typography-line-height-xs);
+  letter-spacing: var(--nx-typography-letterspacing-widest);
+}
+
 @utility typography-label-default {
   font-family: var(--nx-typography-family-font-sans);
   font-size: var(--nx-typography-size-sm);


### PR DESCRIPTION
## Summary
- Add the shared `typography-shortcut` typography recipe through the Nexus token generation path.
- Replace raw shortcut text utilities in Command, DropdownMenu, ContextMenu, and Menubar shortcut components.
- Add story/test coverage so the generated utility and visible shortcut examples stay covered.

## GitHub Issue
Closes #440

## Test Plan
- `pnpm --filter @nexus/react audit:storybook-coverage --component command`
- `pnpm --filter @nexus/react audit:storybook-coverage --component dropdown-menu`
- `pnpm --filter @nexus/react audit:storybook-coverage --component context-menu`
- `pnpm --filter @nexus/react audit:storybook-coverage --component menubar`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test:unit -- packages/core/scripts/__tests__/generate-tailwind-package.test.js packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js`
- `git diff --check`

Storybook verification: http://localhost:6007/?path=/story/tokens-typography--composite-utilities