### PR TITLE
feat(dialog): add prop-driven content API

### DIFF
--- a/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
+++ b/packages/react/src/components/ui/alert-dialog/alert-dialog.tsx
@@ -1,70 +1,25 @@
 import * as React from 'react';
 
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
-import { cva, type VariantProps } from 'class-variance-authority';
+import type { VariantProps } from 'class-variance-authority';
 
 import { buttonVariants } from '@/components/ui/button';
+import {
+  defaultOverlayLayout,
+  overlayContentVariants,
+  overlayFooterVariants,
+  overlayHeaderVariants,
+  type OverlayLayoutContextValue,
+  type OverlayVariant,
+  resolveOverlayButtonOrientation,
+} from '@/components/ui/overlay-layout/overlay-layout';
 import { cn } from '@/lib/utils';
 
-const alertDialogContentVariants = cva(
-  [
-    'nx:fixed nx:left-1/2 nx:top-1/2 nx:z-modal nx:grid nx:w-full nx:max-w-lg',
-    'nx:-translate-x-1/2 nx:-translate-y-1/2',
-    'nx:gap-4 nx:border nx:border-border-default nx:bg-container nx:py-6 nx:shadow-lg',
-    'nx:data-[state=open]:duration-300 nx:data-[state=closed]:duration-150',
-    'nx:data-[state=open]:ease-out nx:data-[state=closed]:ease-in',
-    'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
-    'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
-    'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',
-    'nx:motion-reduce:duration-0 nx:motion-reduce:data-[state=open]:animate-none nx:motion-reduce:data-[state=closed]:animate-none',
-    'nx:sm:rounded-lg',
-  ].join(' ')
-);
-
-const alertDialogHeaderVariants = cva('nx:flex nx:flex-col nx:gap-1 nx:px-6', {
-  variants: {
-    variant: {
-      default: 'nx:text-center nx:sm:text-left',
-      center: 'nx:items-center nx:text-center',
-    },
-  },
-  defaultVariants: {
-    variant: 'default',
-  },
-});
-
-const alertDialogFooterVariants = cva('nx:flex nx:gap-2 nx:px-6', {
-  variants: {
-    orientation: {
-      horizontal:
-        'nx:flex-col nx:sm:flex-row nx:sm:items-center nx:sm:justify-end',
-      vertical: 'nx:flex-col nx:items-stretch nx:*:w-full',
-    },
-  },
-  defaultVariants: {
-    orientation: 'horizontal',
-  },
-});
-
-type AlertDialogVariant = NonNullable<
-  VariantProps<typeof alertDialogHeaderVariants>['variant']
->;
-type AlertDialogButtonOrientation = NonNullable<
-  VariantProps<typeof alertDialogFooterVariants>['orientation']
->;
-
-type AlertDialogLayoutContextValue = {
-  variant: AlertDialogVariant;
-  buttonOrientation: AlertDialogButtonOrientation;
-};
-
-const defaultAlertDialogLayout: AlertDialogLayoutContextValue = {
-  variant: 'default',
-  buttonOrientation: 'horizontal',
-};
+type AlertDialogVariant = OverlayVariant;
+type AlertDialogLayoutContextValue = OverlayLayoutContextValue;
 
 const AlertDialogLayoutContext =
-  React.createContext<AlertDialogLayoutContextValue>(defaultAlertDialogLayout);
+  React.createContext<AlertDialogLayoutContextValue>(defaultOverlayLayout);
 
 /**
  * AlertDialog
@@ -184,7 +139,7 @@ function AlertDialogContent({
   variant = 'default',
   ...props
 }: AlertDialogContentProps) {
-  const buttonOrientation = variant === 'center' ? 'vertical' : 'horizontal';
+  const buttonOrientation = resolveOverlayButtonOrientation(variant);
 
   return (
     <AlertDialogPortal>
@@ -195,7 +150,7 @@ function AlertDialogContent({
           data-variant={variant}
           data-orientation={buttonOrientation}
           className={cn(
-            alertDialogContentVariants(),
+            overlayContentVariants(),
             variant === 'center' && 'nx:max-w-xs',
             className
           )}
@@ -214,7 +169,7 @@ function AlertDialogContent({
 interface AlertDialogHeaderProps
   extends
     React.ComponentProps<'div'>,
-    VariantProps<typeof alertDialogHeaderVariants> {}
+    VariantProps<typeof overlayHeaderVariants> {}
 
 /**
  * AlertDialogHeader
@@ -242,7 +197,7 @@ function AlertDialogHeader({
       data-slot="alert-dialog-header"
       data-variant={resolvedVariant}
       className={cn(
-        alertDialogHeaderVariants({ variant: resolvedVariant }),
+        overlayHeaderVariants({ variant: resolvedVariant }),
         className
       )}
       {...props}
@@ -308,7 +263,7 @@ function AlertDialogFooter({ className, ...props }: AlertDialogFooterProps) {
       data-slot="alert-dialog-footer"
       data-orientation={layout.buttonOrientation}
       className={cn(
-        alertDialogFooterVariants({ orientation: layout.buttonOrientation }),
+        overlayFooterVariants({ orientation: layout.buttonOrientation }),
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/ui/dialog/Dialog.stories.tsx
@@ -212,6 +212,180 @@ export const ScrollableContent: Story = {
   ),
 };
 
+export const PropDrivenContent: Story = {
+  render: (_args) => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline">Open invite dialog</Button>
+      </DialogTrigger>
+      <DialogContent
+        title="Invite teammate"
+        description="Send an invitation to a teammate and assign their first workspace role."
+        body={
+          <p className="nx:typography-body-default nx:text-foreground">
+            The invitation expires in seven days and can be revoked from team
+            settings.
+          </p>
+        }
+      >
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button>Send invite</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Open invite dialog' })
+    );
+
+    const dialog = await within(document.body).findByRole('dialog', {
+      name: 'Invite teammate',
+    });
+    await expect(dialog).toHaveAttribute('data-variant', 'default');
+    await expect(dialog).toHaveAttribute('data-orientation', 'horizontal');
+
+    await expect(
+      document.querySelector('[data-slot="dialog-header"]')
+    ).toHaveAttribute('data-variant', 'default');
+    await expect(
+      document.querySelector('[data-slot="dialog-title"]')
+    ).toHaveTextContent('Invite teammate');
+    await expect(
+      document.querySelector('[data-slot="dialog-description"]')
+    ).toHaveTextContent('Send an invitation to a teammate');
+    await expect(
+      document.querySelector('[data-slot="dialog-body"]')
+    ).toHaveClass('nx:px-6');
+    await expect(dialog).toHaveTextContent(
+      'The invitation expires in seven days'
+    );
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(document.querySelector('[role="dialog"]')).toBeNull();
+    });
+  },
+};
+
+export const ComposedHeaderPrecedence: Story = {
+  render: (_args) => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline">Open precedence dialog</Button>
+      </DialogTrigger>
+      <DialogContent
+        title="Prop title"
+        description="Prop description"
+        body="Prop body"
+      >
+        <>
+          <DialogHeader>
+            <DialogTitle>Composed title</DialogTitle>
+            <DialogDescription>
+              The composed header takes precedence over generated title props.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogBody>
+            <p className="nx:typography-body-default">
+              The composed body takes precedence over the body prop.
+            </p>
+          </DialogBody>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button>Close</Button>
+            </DialogClose>
+          </DialogFooter>
+        </>
+      </DialogContent>
+    </Dialog>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Open precedence dialog' })
+    );
+
+    const dialog = await within(document.body).findByRole('dialog', {
+      name: 'Composed title',
+    });
+    const titles = document.querySelectorAll('[data-slot="dialog-title"]');
+    const bodies = document.querySelectorAll('[data-slot="dialog-body"]');
+
+    await expect(titles).toHaveLength(1);
+    await expect(titles[0]).toHaveTextContent('Composed title');
+    await expect(bodies).toHaveLength(1);
+    await expect(dialog).not.toHaveTextContent('Prop title');
+    await expect(dialog).not.toHaveTextContent('Prop description');
+    await expect(dialog).not.toHaveTextContent('Prop body');
+    await expect(dialog).toHaveTextContent(
+      'The composed body takes precedence over the body prop.'
+    );
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(document.querySelector('[role="dialog"]')).toBeNull();
+    });
+  },
+};
+
+export const ComposedUsageCompatibility: Story = {
+  render: (_args) => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline">Open composed dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Composed API</DialogTitle>
+          <DialogDescription>
+            Existing composed Dialog usage continues to render without prop
+            shorthands.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogBody>
+          <p className="nx:typography-body-default">
+            This body is authored with DialogBody.
+          </p>
+        </DialogBody>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button>Done</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Open composed dialog' })
+    );
+
+    const dialog = await within(document.body).findByRole('dialog', {
+      name: 'Composed API',
+    });
+    await expect(dialog).toHaveTextContent(
+      'Existing composed Dialog usage continues to render'
+    );
+    await expect(
+      document.querySelector('[data-slot="dialog-body"]')
+    ).toHaveTextContent('This body is authored with DialogBody.');
+
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Done' }));
+    await waitFor(() => {
+      expect(document.querySelector('[role="dialog"]')).toBeNull();
+    });
+  },
+};
+
 // ============================================
 // INTERACTION TESTS
 // ============================================
@@ -370,14 +544,22 @@ export const WithDataAttributes: Story = {
     });
 
     const content = document.querySelector('[data-slot="dialog-content"]');
+    await expect(content).toHaveAttribute('data-variant', 'default');
+    await expect(content).toHaveAttribute('data-orientation', 'horizontal');
     await expect(content).toHaveClass('nx:py-6', 'nx:gap-4');
     await expect(content).not.toHaveClass('nx:p-6');
     await expect(
       document.querySelector('[data-slot="dialog-header"]')
     ).toHaveClass('nx:px-6');
     await expect(
+      document.querySelector('[data-slot="dialog-header"]')
+    ).toHaveAttribute('data-variant', 'default');
+    await expect(
       document.querySelector('[data-slot="dialog-footer"]')
     ).toHaveClass('nx:px-6');
+    await expect(
+      document.querySelector('[data-slot="dialog-footer"]')
+    ).toHaveAttribute('data-orientation', 'horizontal');
     await expect(
       document.querySelector('[data-slot="dialog-body"]')
     ).toHaveClass('nx:px-6');

--- a/packages/react/src/components/ui/dialog/dialog.tsx
+++ b/packages/react/src/components/ui/dialog/dialog.tsx
@@ -2,8 +2,23 @@ import * as React from 'react';
 
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 
+import {
+  containsComposedSlot,
+  defaultOverlayLayout,
+  overlayContentVariants,
+  overlayHeaderVariants,
+  type OverlayLayoutContextValue,
+} from '@/components/ui/overlay-layout/overlay-layout';
 import { IconX } from '@/lib/icons';
 import { cn } from '@/lib/utils';
+
+type DialogLayoutContextValue = Pick<
+  OverlayLayoutContextValue,
+  'variant' | 'buttonOrientation'
+>;
+
+const DialogLayoutContext =
+  React.createContext<DialogLayoutContextValue>(defaultOverlayLayout);
 
 /**
  * Dialog
@@ -87,14 +102,35 @@ function DialogOverlay({ className, ...props }: DialogOverlayProps) {
  *
  * Props for the DialogContent component.
  */
-interface DialogContentProps extends React.ComponentProps<
-  typeof DialogPrimitive.Content
+interface DialogContentProps extends Omit<
+  React.ComponentProps<typeof DialogPrimitive.Content>,
+  'title'
 > {
   /**
    * Whether to show the close button in the top-right corner.
    * @default true
    */
   showCloseButton?: boolean;
+
+  /**
+   * Optional title for a prop-driven header, rendered before `children`.
+   * Ignored when a composed `DialogHeader` child is present. Detection covers
+   * a direct child or a Fragment-wrapped header; a header nested inside another
+   * element is not detected.
+   */
+  title?: React.ReactNode;
+
+  /**
+   * Optional description for a prop-driven header, rendered before `children`.
+   * Ignored when a composed `DialogHeader` child is present.
+   */
+  description?: React.ReactNode;
+
+  /**
+   * Optional body content rendered in a generated `DialogBody` before
+   * `children`. Ignored when a composed `DialogBody` child is present.
+   */
+  body?: React.ReactNode;
 }
 
 /**
@@ -115,49 +151,59 @@ interface DialogContentProps extends React.ComponentProps<
 function DialogContent({
   className,
   children,
+  title,
+  description,
+  body,
   showCloseButton = true,
   ...props
 }: DialogContentProps) {
+  const showGeneratedHeader =
+    !containsComposedSlot(children, DialogHeader) &&
+    (title != null || description != null);
+  const showGeneratedBody =
+    !containsComposedSlot(children, DialogBody) && body != null;
+
   return (
     <DialogPortal>
       <DialogOverlay />
-      <DialogPrimitive.Content
-        data-slot="dialog-content"
-        className={cn(
-          'nx:fixed nx:left-1/2 nx:top-1/2 nx:z-modal nx:grid nx:w-full nx:max-w-lg',
-          'nx:-translate-x-1/2 nx:-translate-y-1/2',
-          'nx:gap-4 nx:border nx:border-border-default nx:bg-container nx:py-6 nx:shadow-lg',
-          'nx:data-[state=open]:duration-300 nx:data-[state=closed]:duration-150',
-          'nx:data-[state=open]:ease-out nx:data-[state=closed]:ease-in',
-          'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
-          'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
-          'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',
-          'nx:motion-reduce:duration-0 nx:motion-reduce:data-[state=open]:animate-none nx:motion-reduce:data-[state=closed]:animate-none',
-          'nx:sm:rounded-lg',
-          className
-        )}
-        {...props}
-      >
-        {children}
-        {showCloseButton && (
-          <DialogPrimitive.Close
-            data-slot="dialog-close-button"
-            className={cn(
-              'nx:absolute nx:right-4 nx:top-4 nx:rounded-sm nx:p-1 nx:text-muted-foreground-subtle',
-              'nx:after:absolute nx:after:-inset-2.5 nx:lg:after:hidden',
-              'nx:transition-colors',
-              'nx:motion-reduce:transition-none',
-              'nx:hover:bg-background-hover nx:hover:text-foreground',
-              'nx:focus-visible:bg-background-hover nx:focus-visible:text-foreground',
-              'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
-              'nx:disabled:pointer-events-none'
-            )}
-          >
-            <IconX className="nx:size-4" />
-            <span className="nx:sr-only">Close</span>
-          </DialogPrimitive.Close>
-        )}
-      </DialogPrimitive.Content>
+      <DialogLayoutContext.Provider value={defaultOverlayLayout}>
+        <DialogPrimitive.Content
+          data-slot="dialog-content"
+          data-variant={defaultOverlayLayout.variant}
+          data-orientation={defaultOverlayLayout.buttonOrientation}
+          className={cn(overlayContentVariants(), className)}
+          {...props}
+        >
+          {showGeneratedHeader && (
+            <DialogHeader>
+              {title != null && <DialogTitle>{title}</DialogTitle>}
+              {description != null && (
+                <DialogDescription>{description}</DialogDescription>
+              )}
+            </DialogHeader>
+          )}
+          {showGeneratedBody && <DialogBody>{body}</DialogBody>}
+          {children}
+          {showCloseButton && (
+            <DialogPrimitive.Close
+              data-slot="dialog-close-button"
+              className={cn(
+                'nx:absolute nx:right-4 nx:top-4 nx:rounded-sm nx:p-1 nx:text-muted-foreground-subtle',
+                'nx:after:absolute nx:after:-inset-2.5 nx:lg:after:hidden',
+                'nx:transition-colors',
+                'nx:motion-reduce:transition-none',
+                'nx:hover:bg-background-hover nx:hover:text-foreground',
+                'nx:focus-visible:bg-background-hover nx:focus-visible:text-foreground',
+                'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
+                'nx:disabled:pointer-events-none'
+              )}
+            >
+              <IconX className="nx:size-4" />
+              <span className="nx:sr-only">Close</span>
+            </DialogPrimitive.Close>
+          )}
+        </DialogPrimitive.Content>
+      </DialogLayoutContext.Provider>
     </DialogPortal>
   );
 }
@@ -183,11 +229,14 @@ interface DialogHeaderProps extends React.ComponentProps<'div'> {}
  * ```
  */
 function DialogHeader({ className, ...props }: DialogHeaderProps) {
+  const layout = React.useContext(DialogLayoutContext);
+
   return (
     <div
       data-slot="dialog-header"
+      data-variant={layout.variant}
       className={cn(
-        'nx:flex nx:flex-col nx:gap-1 nx:px-6 nx:text-center nx:sm:text-left',
+        overlayHeaderVariants({ variant: layout.variant }),
         className
       )}
       {...props}
@@ -246,9 +295,12 @@ interface DialogFooterProps extends React.ComponentProps<'div'> {}
  * ```
  */
 function DialogFooter({ className, ...props }: DialogFooterProps) {
+  const layout = React.useContext(DialogLayoutContext);
+
   return (
     <div
       data-slot="dialog-footer"
+      data-orientation={layout.buttonOrientation}
       className={cn(
         'nx:flex nx:flex-col-reverse nx:px-6 nx:sm:flex-row nx:sm:justify-end nx:sm:gap-2',
         className

--- a/packages/react/src/components/ui/overlay-layout/overlay-layout.ts
+++ b/packages/react/src/components/ui/overlay-layout/overlay-layout.ts
@@ -1,0 +1,96 @@
+import * as React from 'react';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+const overlayContentVariants = cva(
+  [
+    'nx:fixed nx:left-1/2 nx:top-1/2 nx:z-modal nx:grid nx:w-full nx:max-w-lg',
+    'nx:-translate-x-1/2 nx:-translate-y-1/2',
+    'nx:gap-4 nx:border nx:border-border-default nx:bg-container nx:py-6 nx:shadow-lg',
+    'nx:data-[state=open]:duration-300 nx:data-[state=closed]:duration-150',
+    'nx:data-[state=open]:ease-out nx:data-[state=closed]:ease-in',
+    'nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out',
+    'nx:data-[state=closed]:fade-out-0 nx:data-[state=open]:fade-in-0',
+    'nx:data-[state=closed]:zoom-out-95 nx:data-[state=open]:zoom-in-95',
+    'nx:motion-reduce:duration-0 nx:motion-reduce:data-[state=open]:animate-none nx:motion-reduce:data-[state=closed]:animate-none',
+    'nx:sm:rounded-lg',
+  ].join(' ')
+);
+
+const overlayHeaderVariants = cva('nx:flex nx:flex-col nx:gap-1 nx:px-6', {
+  variants: {
+    variant: {
+      default: 'nx:text-center nx:sm:text-left',
+      center: 'nx:items-center nx:text-center',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
+
+const overlayFooterVariants = cva('nx:flex nx:gap-2 nx:px-6', {
+  variants: {
+    orientation: {
+      horizontal:
+        'nx:flex-col nx:sm:flex-row nx:sm:items-center nx:sm:justify-end',
+      vertical: 'nx:flex-col nx:items-stretch nx:*:w-full',
+    },
+  },
+  defaultVariants: {
+    orientation: 'horizontal',
+  },
+});
+
+type OverlayVariant = NonNullable<
+  VariantProps<typeof overlayHeaderVariants>['variant']
+>;
+
+type OverlayButtonOrientation = NonNullable<
+  VariantProps<typeof overlayFooterVariants>['orientation']
+>;
+
+type OverlayLayoutContextValue = {
+  variant: OverlayVariant;
+  buttonOrientation: OverlayButtonOrientation;
+};
+
+const defaultOverlayLayout: OverlayLayoutContextValue = {
+  variant: 'default',
+  buttonOrientation: 'horizontal',
+};
+
+function resolveOverlayButtonOrientation(
+  variant: OverlayVariant
+): OverlayButtonOrientation {
+  return variant === 'center' ? 'vertical' : 'horizontal';
+}
+
+function containsComposedSlot(
+  children: React.ReactNode,
+  slot: React.ElementType
+): boolean {
+  return React.Children.toArray(children).some((child) => {
+    if (!React.isValidElement(child)) return false;
+    if (child.type === slot) return true;
+    if (child.type === React.Fragment) {
+      const fragment = child as React.ReactElement<{
+        children?: React.ReactNode;
+      }>;
+      return containsComposedSlot(fragment.props.children, slot);
+    }
+    return false;
+  });
+}
+
+export {
+  containsComposedSlot,
+  defaultOverlayLayout,
+  type OverlayButtonOrientation,
+  overlayContentVariants,
+  overlayFooterVariants,
+  overlayHeaderVariants,
+  type OverlayLayoutContextValue,
+  type OverlayVariant,
+  resolveOverlayButtonOrientation,
+};


### PR DESCRIPTION
## Summary

- Add prop-driven title, description, and body support to DialogContent while preserving composed DialogHeader/DialogBody precedence.
- Share overlay layout helpers between Dialog and AlertDialog without adding a Dialog center variant.
- Add Dialog Storybook coverage for prop-driven usage, composed precedence, body slot behavior, data attributes, and backward-compatible composition.

## GitHub Issue

Closes #426

## Test Plan

- [x] pnpm --filter @nexus/react audit:storybook-coverage --component dialog
- [x] pnpm --filter @nexus/react audit:storybook-coverage --component alert-dialog
- [x] pnpm test:storybook -- Dialog.stories.tsx AlertDialog.stories.tsx
- [x] pnpm typecheck
- [x] pnpm lint
- [x] pnpm format:check
- [x] git diff --check