### PR TITLE
feat(sidebar): Tier-A audit — colour-only active, type tokens, spacing, stories

### DIFF
--- a/packages/react/src/components/ui/sidebar/Sidebar.stories.tsx
+++ b/packages/react/src/components/ui/sidebar/Sidebar.stories.tsx
@@ -537,8 +537,6 @@ export const StylingContracts: Story = {
     );
 
     await expect(defaultButton).toHaveClass('nx:typography-body-default');
-    // Active is colour-only (no weight/size change): text brightens to the
-    // full nav foreground; it must not re-introduce a label/weight composite.
     await expect(defaultButton).toHaveClass(
       'nx:data-[active=true]:text-nav-foreground'
     );
@@ -614,6 +612,12 @@ export const StylingContracts: Story = {
     );
     await expect(defaultSubButton).toHaveClass('nx:typography-body-default');
     await expect(defaultSubButton).not.toHaveClass('nx:text-sm');
+    await expect(defaultSubButton).not.toHaveClass(
+      'nx:[&>svg]:text-nav-muted-foreground'
+    );
+    await expect(defaultSubButton).not.toHaveClass(
+      'nx:data-[active=true]:[&>svg]:text-nav-foreground'
+    );
     await expect(smallSubButton).toHaveClass('nx:typography-body-small');
     await expect(smallSubButton).not.toHaveClass('nx:text-xs');
 

--- a/packages/react/src/components/ui/sidebar/Sidebar.stories.tsx
+++ b/packages/react/src/components/ui/sidebar/Sidebar.stories.tsx
@@ -537,25 +537,36 @@ export const StylingContracts: Story = {
     );
 
     await expect(defaultButton).toHaveClass('nx:typography-body-default');
+    // Active is colour-only (no weight/size change): text brightens to the
+    // full nav foreground; it must not re-introduce a label/weight composite.
     await expect(defaultButton).toHaveClass(
-      'nx:data-[active=true]:typography-label-default'
+      'nx:data-[active=true]:text-nav-foreground'
     );
     await expect(defaultButton).not.toHaveClass('nx:text-sm');
+    await expect(defaultButton).not.toHaveClass(
+      'nx:data-[active=true]:typography-label-default'
+    );
     await expect(defaultButton).not.toHaveClass(
       'nx:data-[active=true]:font-medium'
     );
 
     await expect(smallButton).toHaveClass('nx:typography-body-small');
     await expect(smallButton).toHaveClass(
-      'nx:data-[active=true]:typography-label-small'
+      'nx:data-[active=true]:text-nav-foreground'
     );
     await expect(smallButton).not.toHaveClass('nx:text-xs');
+    await expect(smallButton).not.toHaveClass(
+      'nx:data-[active=true]:typography-label-small'
+    );
 
     await expect(largeButton).toHaveClass('nx:typography-body-default');
     await expect(largeButton).toHaveClass(
-      'nx:data-[active=true]:typography-label-default'
+      'nx:data-[active=true]:text-nav-foreground'
     );
     await expect(largeButton).not.toHaveClass('nx:text-sm');
+    await expect(largeButton).not.toHaveClass(
+      'nx:data-[active=true]:typography-label-default'
+    );
 
     for (const button of [defaultButton, smallButton, largeButton]) {
       await expect(button).toHaveClass(

--- a/packages/react/src/components/ui/sidebar/Sidebar.stories.tsx
+++ b/packages/react/src/components/ui/sidebar/Sidebar.stories.tsx
@@ -921,3 +921,45 @@ export const Compact: Story = {
     </SidebarProvider>
   ),
 };
+
+/**
+ * The minimal shape: a flat `SidebarMenu` of buttons with no group wrapper or
+ * label. `SidebarGroup`/`-Label`/`-Content` are dropped; the `SidebarMenu` /
+ * `SidebarMenuItem` list stays (accessibility + badge/action anchoring). The
+ * `p-2` that `SidebarGroup` normally supplies is moved onto `SidebarContent`.
+ */
+export const Flat: Story = {
+  name: 'Flat (no groups)',
+  render: () => (
+    <SidebarProvider>
+      <Sidebar>
+        <SidebarContent className="nx:p-2">
+          <SidebarMenu>
+            {NAV_ITEMS.map((item) => {
+              const Icon = item.icon;
+              return (
+                <SidebarMenuItem key={item.title}>
+                  <SidebarMenuButton
+                    tooltip={item.title}
+                    isActive={item.title === 'Home'}
+                  >
+                    <Icon />
+                    <span>{item.title}</span>
+                  </SidebarMenuButton>
+                  {item.badge && (
+                    <SidebarMenuBadge>{item.badge}</SidebarMenuBadge>
+                  )}
+                </SidebarMenuItem>
+              );
+            })}
+          </SidebarMenu>
+        </SidebarContent>
+        <SidebarRail />
+      </Sidebar>
+      <DemoInset>
+        Flat structure — no SidebarGroup/-Label/-Content, just a SidebarMenu of
+        buttons.
+      </DemoInset>
+    </SidebarProvider>
+  ),
+};

--- a/packages/react/src/components/ui/sidebar/Sidebar.stories.tsx
+++ b/packages/react/src/components/ui/sidebar/Sidebar.stories.tsx
@@ -3,15 +3,20 @@ import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import {
   IconCalendar,
+  IconChartBar,
   IconChevronRight,
+  IconDots,
   IconFolder,
   IconHome,
   IconInbox,
   IconLayoutGrid,
+  IconPlus,
   IconSearch,
   IconSettings,
   IconUser,
+  IconUsers,
 } from '@tabler/icons-react';
+import { useArgs } from 'storybook/preview-api';
 import { expect, userEvent, within } from 'storybook/test';
 
 import {
@@ -19,12 +24,14 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
+  SidebarGroupAction,
   SidebarGroupContent,
   SidebarGroupLabel,
   SidebarHeader,
   SidebarInput,
   SidebarInset,
   SidebarMenu,
+  SidebarMenuAction,
   SidebarMenuBadge,
   SidebarMenuButton,
   SidebarMenuItem,
@@ -48,6 +55,23 @@ const meta: Meta<typeof Sidebar> = {
 
 export default meta;
 type Story = StoryObj<typeof Sidebar>;
+type SidebarControlsArgs = Pick<
+  React.ComponentProps<typeof Sidebar>,
+  'collapsible' | 'side' | 'variant'
+> & {
+  open: boolean;
+};
+
+type ControlsStory = StoryObj<SidebarControlsArgs>;
+
+function getRequiredElement<T extends HTMLElement>(
+  root: ParentNode,
+  selector: string
+) {
+  const element = root.querySelector<T>(selector);
+  if (!element) throw new Error(`Missing element for selector: ${selector}`);
+  return element;
+}
 
 const NAV_ITEMS = [
   { title: 'Home', icon: IconHome },
@@ -141,6 +165,55 @@ export const Default: Story = {
       <DemoInset />
     </SidebarProvider>
   ),
+};
+
+export const InteractiveControls: ControlsStory = {
+  name: 'Interactive Controls',
+  args: {
+    open: true,
+    collapsible: 'offcanvas',
+    variant: 'sidebar',
+    side: 'left',
+  },
+  argTypes: {
+    open: {
+      control: 'boolean',
+    },
+    collapsible: {
+      control: 'inline-radio',
+      options: ['offcanvas', 'icon', 'none'],
+    },
+    variant: {
+      control: 'inline-radio',
+      options: ['sidebar', 'floating', 'inset'],
+    },
+    side: {
+      control: 'inline-radio',
+      options: ['left', 'right'],
+    },
+  },
+  parameters: {
+    controls: {
+      include: ['open', 'collapsible', 'variant', 'side'],
+    },
+  },
+  render: function Render(args) {
+    const [, updateArgs] = useArgs<SidebarControlsArgs>();
+
+    return (
+      <SidebarProvider
+        open={args.open}
+        onOpenChange={(open) => updateArgs({ open })}
+      >
+        <DemoSidebar
+          collapsible={args.collapsible}
+          side={args.side}
+          variant={args.variant}
+        />
+        <DemoInset />
+      </SidebarProvider>
+    );
+  },
 };
 
 export const Expanded: Story = {
@@ -380,6 +453,178 @@ export const Disabled: Story = {
   },
 };
 
+export const StylingContracts: Story = {
+  render: () => (
+    <SidebarProvider defaultOpen={false}>
+      <Sidebar collapsible="icon">
+        <SidebarHeader>
+          <SidebarInput aria-label="Search" placeholder="Search" />
+        </SidebarHeader>
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel>Platform</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton isActive>
+                    <IconHome />
+                    <span>Active</span>
+                  </SidebarMenuButton>
+                  <SidebarMenuBadge>4</SidebarMenuBadge>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton size="sm">
+                    <IconCalendar />
+                    <span>Small</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton size="lg">
+                    <IconSettings />
+                    <span>Large</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuSub>
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton href="#default-sub">
+                        Default sub
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton href="#small-sub" size="sm">
+                        Small sub
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                  </SidebarMenuSub>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+        <SidebarRail />
+      </Sidebar>
+      <DemoInset />
+    </SidebarProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const groupLabel = getRequiredElement(
+      canvasElement,
+      '[data-slot="sidebar-group-label"]'
+    );
+    await expect(groupLabel).toHaveClass('nx:typography-label-small');
+    await expect(groupLabel).not.toHaveClass('nx:text-xs');
+    await expect(groupLabel).not.toHaveClass('nx:font-medium');
+
+    const groupContent = getRequiredElement(
+      canvasElement,
+      '[data-slot="sidebar-group-content"]'
+    );
+    await expect(groupContent).toHaveClass('nx:typography-body-default');
+    await expect(groupContent).not.toHaveClass('nx:text-sm');
+
+    const defaultButton = getRequiredElement(
+      canvasElement,
+      '[data-slot="sidebar-menu-button"][data-size="default"]'
+    );
+    const smallButton = getRequiredElement(
+      canvasElement,
+      '[data-slot="sidebar-menu-button"][data-size="sm"]'
+    );
+    const largeButton = getRequiredElement(
+      canvasElement,
+      '[data-slot="sidebar-menu-button"][data-size="lg"]'
+    );
+
+    await expect(defaultButton).toHaveClass('nx:typography-body-default');
+    await expect(defaultButton).toHaveClass(
+      'nx:data-[active=true]:typography-label-default'
+    );
+    await expect(defaultButton).not.toHaveClass('nx:text-sm');
+    await expect(defaultButton).not.toHaveClass(
+      'nx:data-[active=true]:font-medium'
+    );
+
+    await expect(smallButton).toHaveClass('nx:typography-body-small');
+    await expect(smallButton).toHaveClass(
+      'nx:data-[active=true]:typography-label-small'
+    );
+    await expect(smallButton).not.toHaveClass('nx:text-xs');
+
+    await expect(largeButton).toHaveClass('nx:typography-body-default');
+    await expect(largeButton).toHaveClass(
+      'nx:data-[active=true]:typography-label-default'
+    );
+    await expect(largeButton).not.toHaveClass('nx:text-sm');
+
+    for (const button of [defaultButton, smallButton, largeButton]) {
+      await expect(button).toHaveClass(
+        'nx:group-data-[collapsible=icon]:size-8'
+      );
+      await expect(button).not.toHaveClass(
+        'nx:group-data-[collapsible=icon]:size-8!'
+      );
+      await expect(button).not.toHaveClass(
+        'nx:group-data-[collapsible=icon]:p-2!'
+      );
+      await expect(button).not.toHaveClass(
+        'nx:group-data-[collapsible=icon]:p-0!'
+      );
+    }
+
+    await expect(defaultButton).toHaveClass(
+      'nx:group-data-[collapsible=icon]:p-2'
+    );
+    await expect(smallButton).toHaveClass(
+      'nx:group-data-[collapsible=icon]:p-2'
+    );
+    await expect(largeButton).toHaveClass(
+      'nx:group-data-[collapsible=icon]:p-0'
+    );
+    await expect(largeButton).not.toHaveClass(
+      'nx:group-data-[collapsible=icon]:p-2'
+    );
+
+    const badge = getRequiredElement(
+      canvasElement,
+      '[data-slot="sidebar-menu-badge"]'
+    );
+    await expect(badge).toHaveClass('nx:typography-label-small');
+    await expect(badge).not.toHaveClass('nx:text-xs');
+    await expect(badge).not.toHaveClass('nx:font-medium');
+
+    const defaultSubButton = getRequiredElement(
+      canvasElement,
+      '[data-slot="sidebar-menu-sub-button"][data-size="md"]'
+    );
+    const smallSubButton = getRequiredElement(
+      canvasElement,
+      '[data-slot="sidebar-menu-sub-button"][data-size="sm"]'
+    );
+    await expect(defaultSubButton).toHaveClass('nx:typography-body-default');
+    await expect(defaultSubButton).not.toHaveClass('nx:text-sm');
+    await expect(smallSubButton).toHaveClass('nx:typography-body-small');
+    await expect(smallSubButton).not.toHaveClass('nx:text-xs');
+
+    const trigger = getRequiredElement(
+      canvasElement,
+      '[data-slot="sidebar-trigger"]'
+    );
+    await expect(trigger).toHaveClass('nx:size-7');
+    await expect(trigger).toHaveClass('nx:relative');
+    await expect(trigger).toHaveClass('nx:pointer-coarse:after:absolute');
+    await expect(trigger).toHaveClass('nx:pointer-coarse:after:-inset-2');
+    await expect(trigger).not.toHaveClass('nx:pointer-coarse:after:-inset-0.5');
+
+    const input = getRequiredElement(
+      canvasElement,
+      '[data-slot="sidebar-input"]'
+    );
+    await expect(input).toHaveClass('nx:h-8');
+    await expect(input).toHaveClass('nx:pointer-coarse:min-h-11');
+  },
+};
+
 /**
  * Visual grid reference for every `SidebarMenuButton` variant, size, and the
  * `asChild` composition. Uses `collapsible="none"` and a bounded height so the
@@ -440,5 +685,224 @@ export const AllVariants: Story = {
         <DemoInset />
       </SidebarProvider>
     </div>
+  ),
+};
+
+/**
+ * The kitchen-sink view: a workspace switcher + search in the header, two
+ * labelled groups with a group action, menu items carrying badges, a row
+ * action, two nested sub-menus (each with an active child), a separator, and
+ * an account footer — most of the sidebar's parts in one tree.
+ */
+export const Complex: Story = {
+  name: 'Complex (kitchen sink)',
+  render: () => (
+    <SidebarProvider>
+      <Sidebar>
+        <SidebarHeader>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton size="lg" tooltip="Acme Inc">
+                <IconLayoutGrid />
+                <span>Acme Inc</span>
+                <IconChevronRight className="nx:ml-auto" />
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+          <SidebarInput aria-label="Search" placeholder="Search…" />
+        </SidebarHeader>
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel>Platform</SidebarGroupLabel>
+            <SidebarGroupAction aria-label="Add project">
+              <IconPlus />
+            </SidebarGroupAction>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton isActive tooltip="Dashboard">
+                    <IconHome />
+                    <span>Dashboard</span>
+                  </SidebarMenuButton>
+                  <SidebarMenuBadge>3</SidebarMenuBadge>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton tooltip="Inbox">
+                    <IconInbox />
+                    <span>Inbox</span>
+                  </SidebarMenuButton>
+                  <SidebarMenuBadge>12</SidebarMenuBadge>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton tooltip="Projects">
+                    <IconFolder />
+                    <span>Projects</span>
+                    <IconChevronRight className="nx:ml-auto" />
+                  </SidebarMenuButton>
+                  <SidebarMenuSub>
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton href="#overview">
+                        Overview
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton href="#mobile" isActive>
+                        Mobile App
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton href="#marketing">
+                        Marketing Site
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                  </SidebarMenuSub>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton tooltip="Tasks">
+                    <IconCalendar />
+                    <span>Tasks</span>
+                  </SidebarMenuButton>
+                  <SidebarMenuAction aria-label="Task options">
+                    <IconDots />
+                  </SidebarMenuAction>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+          <SidebarSeparator />
+          <SidebarGroup>
+            <SidebarGroupLabel>Workspace</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                <SidebarMenuItem>
+                  <SidebarMenuButton tooltip="Members">
+                    <IconUsers />
+                    <span>Members</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton tooltip="Reports">
+                    <IconChartBar />
+                    <span>Reports</span>
+                  </SidebarMenuButton>
+                  <SidebarMenuBadge>New</SidebarMenuBadge>
+                </SidebarMenuItem>
+                <SidebarMenuItem>
+                  <SidebarMenuButton tooltip="Settings">
+                    <IconSettings />
+                    <span>Settings</span>
+                    <IconChevronRight className="nx:ml-auto" />
+                  </SidebarMenuButton>
+                  <SidebarMenuSub>
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton href="#general">
+                        General
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton href="#billing">
+                        Billing
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                  </SidebarMenuSub>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+        <SidebarFooter>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton size="lg" tooltip="Jane Doe">
+                <IconUser />
+                <span>Jane Doe</span>
+                <IconChevronRight className="nx:ml-auto" />
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarFooter>
+        <SidebarRail />
+      </Sidebar>
+      <DemoInset />
+    </SidebarProvider>
+  ),
+};
+
+/**
+ * Every row at `size="sm"` — the compact option, rendering text at
+ * `body-small` (12px) for information-dense sidebars. Sub-items use the small
+ * size too.
+ */
+export const Compact: Story = {
+  name: 'Compact (small size)',
+  render: () => (
+    <SidebarProvider>
+      <Sidebar>
+        <SidebarHeader>
+          <SidebarInput aria-label="Search" placeholder="Search…" />
+        </SidebarHeader>
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel>Platform</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {NAV_ITEMS.map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <SidebarMenuItem key={item.title}>
+                      <SidebarMenuButton
+                        size="sm"
+                        tooltip={item.title}
+                        isActive={item.title === 'Home'}
+                      >
+                        <Icon />
+                        <span>{item.title}</span>
+                      </SidebarMenuButton>
+                      {item.badge && (
+                        <SidebarMenuBadge>{item.badge}</SidebarMenuBadge>
+                      )}
+                    </SidebarMenuItem>
+                  );
+                })}
+                <SidebarMenuItem>
+                  <SidebarMenuButton size="sm" tooltip="Projects">
+                    <IconFolder />
+                    <span>Projects</span>
+                    <IconChevronRight className="nx:ml-auto" />
+                  </SidebarMenuButton>
+                  <SidebarMenuSub>
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton href="#overview" size="sm">
+                        Overview
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton href="#mobile" size="sm" isActive>
+                        Mobile App
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                  </SidebarMenuSub>
+                </SidebarMenuItem>
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        </SidebarContent>
+        <SidebarFooter>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton size="sm" tooltip="Account">
+                <IconUser />
+                <span>Account</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarFooter>
+        <SidebarRail />
+      </Sidebar>
+      <DemoInset>
+        Compact rows use the small size (12px body-small) for denser,
+        information-heavy sidebars.
+      </DemoInset>
+    </SidebarProvider>
   ),
 };

--- a/packages/react/src/components/ui/sidebar/Sidebar.stories.tsx
+++ b/packages/react/src/components/ui/sidebar/Sidebar.stories.tsx
@@ -784,7 +784,6 @@ export const Complex: Story = {
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
-          <SidebarSeparator />
           <SidebarGroup>
             <SidebarGroupLabel>Workspace</SidebarGroupLabel>
             <SidebarGroupContent>

--- a/packages/react/src/components/ui/sidebar/sidebar.tsx
+++ b/packages/react/src/components/ui/sidebar/sidebar.tsx
@@ -390,7 +390,7 @@ function SidebarTrigger({ className, onClick, ...props }: SidebarTriggerProps) {
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon"
-      className={cn('nx:size-7', className)}
+      className={cn('nx:size-7 nx:pointer-coarse:after:-inset-2', className)}
       onClick={handleClick}
       {...props}
     >
@@ -482,7 +482,10 @@ function SidebarInput({ className, ...props }: SidebarInputProps) {
   return (
     <Input
       data-slot="sidebar-input"
-      className={cn('nx:h-8 nx:w-full nx:bg-background', className)}
+      className={cn(
+        'nx:h-8 nx:w-full nx:bg-background nx:pointer-coarse:min-h-11',
+        className
+      )}
       {...props}
     />
   );
@@ -651,7 +654,7 @@ function SidebarGroupLabel({
     <Comp
       data-slot="sidebar-group-label"
       className={cn(
-        'nx:flex nx:h-8 nx:shrink-0 nx:items-center nx:rounded-md nx:px-2 nx:text-xs nx:font-medium nx:text-nav-muted-foreground nx:transition-[margin,opacity] nx:duration-200 nx:ease-linear nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&>svg]:size-4 nx:[&>svg]:shrink-0',
+        'nx:flex nx:h-8 nx:shrink-0 nx:items-center nx:rounded-md nx:px-2 nx:typography-label-small nx:text-nav-muted-foreground nx:transition-[margin,opacity] nx:duration-200 nx:ease-linear nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&>svg]:size-4 nx:[&>svg]:shrink-0',
         'nx:group-data-[collapsible=icon]:-mt-8 nx:group-data-[collapsible=icon]:opacity-0',
         className
       )}
@@ -720,7 +723,7 @@ function SidebarGroupContent({
   return (
     <div
       data-slot="sidebar-group-content"
-      className={cn('nx:w-full nx:text-sm', className)}
+      className={cn('nx:w-full nx:typography-body-default', className)}
       {...props}
     />
   );
@@ -743,7 +746,7 @@ function SidebarMenu({ className, ...props }: SidebarMenuProps) {
     <ul
       data-slot="sidebar-menu"
       className={cn(
-        'nx:flex nx:w-full nx:min-w-0 nx:flex-col nx:gap-1',
+        'nx:flex nx:w-full nx:min-w-0 nx:flex-col nx:gap-px',
         className
       )}
       {...props}
@@ -776,12 +779,12 @@ function SidebarMenuItem({ className, ...props }: SidebarMenuItemProps) {
 
 const sidebarMenuButtonVariants = cva(
   cn(
-    'nx:peer/menu-button nx:flex nx:w-full nx:items-center nx:gap-2 nx:overflow-hidden nx:rounded-md nx:p-2 nx:text-left nx:text-sm nx:transition-[width,height,padding]',
-    'nx:group-has-data-[slot=sidebar-menu-action]/menu-item:pr-8 nx:group-data-[collapsible=icon]:size-8! nx:group-data-[collapsible=icon]:p-2!',
+    'nx:peer/menu-button nx:flex nx:w-full nx:items-center nx:gap-2 nx:overflow-hidden nx:rounded-md nx:p-2 nx:text-left nx:text-nav-muted-foreground nx:transition-[width,height,padding]',
+    'nx:group-has-data-[slot=sidebar-menu-action]/menu-item:pr-8 nx:group-data-[collapsible=icon]:size-8',
     'nx:hover:bg-nav-item-hover nx:active:bg-nav-item-active',
     'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
     'nx:disabled:pointer-events-none nx:disabled:text-disabled-foreground nx:aria-disabled:pointer-events-none nx:aria-disabled:text-disabled-foreground',
-    'nx:data-[active=true]:bg-nav-item-active nx:data-[active=true]:font-medium',
+    'nx:data-[active=true]:bg-nav-item-active nx:data-[active=true]:text-nav-foreground',
     'nx:data-[state=open]:hover:bg-nav-item-hover',
     'nx:[&>span:last-child]:truncate nx:[&>svg]:size-4 nx:[&>svg]:shrink-0'
   ),
@@ -793,9 +796,10 @@ const sidebarMenuButtonVariants = cva(
           'nx:border nx:border-nav-border nx:bg-background nx:hover:bg-nav-item-hover',
       },
       size: {
-        default: 'nx:h-8 nx:text-sm',
-        sm: 'nx:h-7 nx:text-xs',
-        lg: 'nx:h-12 nx:text-sm nx:group-data-[collapsible=icon]:p-0!',
+        default:
+          'nx:h-8 nx:typography-body-default nx:group-data-[collapsible=icon]:p-2',
+        sm: 'nx:h-7 nx:typography-body-small nx:group-data-[collapsible=icon]:p-2',
+        lg: 'nx:h-12 nx:typography-body-default nx:group-data-[collapsible=icon]:p-0',
       },
     },
     defaultVariants: {
@@ -955,7 +959,7 @@ function SidebarMenuBadge({ className, ...props }: SidebarMenuBadgeProps) {
     <div
       data-slot="sidebar-menu-badge"
       className={cn(
-        'nx:pointer-events-none nx:absolute nx:right-1 nx:flex nx:h-5 nx:min-w-5 nx:items-center nx:justify-center nx:rounded-md nx:px-1 nx:text-xs nx:font-medium nx:text-nav-foreground nx:tabular-nums nx:select-none',
+        'nx:pointer-events-none nx:absolute nx:right-1 nx:flex nx:h-5 nx:min-w-5 nx:items-center nx:justify-center nx:rounded-md nx:px-1 nx:typography-label-small nx:text-nav-foreground nx:tabular-nums nx:select-none',
         'nx:peer-data-[size=sm]/menu-button:top-1',
         'nx:peer-data-[size=default]/menu-button:top-1.5',
         'nx:peer-data-[size=lg]/menu-button:top-2.5',
@@ -1043,7 +1047,7 @@ function SidebarMenuSub({ className, ...props }: SidebarMenuSubProps) {
     <ul
       data-slot="sidebar-menu-sub"
       className={cn(
-        'nx:mx-3.5 nx:flex nx:min-w-0 nx:translate-x-px nx:flex-col nx:gap-1 nx:border-l nx:border-nav-border nx:px-2.5 nx:py-0.5',
+        'nx:ml-3.5 nx:flex nx:min-w-0 nx:translate-x-px nx:flex-col nx:gap-px nx:border-l nx:border-nav-border nx:pl-2.5 nx:py-0.5',
         'nx:group-data-[collapsible=icon]:hidden',
         className
       )}
@@ -1117,10 +1121,10 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        'nx:flex nx:h-7 nx:min-w-0 nx:-translate-x-px nx:items-center nx:gap-2 nx:overflow-hidden nx:rounded-md nx:px-2 nx:text-nav-foreground nx:outline-hidden nx:hover:bg-nav-item-hover nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:active:bg-nav-item-active nx:disabled:pointer-events-none nx:disabled:text-disabled-foreground nx:aria-disabled:pointer-events-none nx:aria-disabled:text-disabled-foreground nx:[&>span:last-child]:truncate nx:[&>svg]:size-4 nx:[&>svg]:shrink-0 nx:[&>svg]:text-nav-foreground nx:disabled:[&>svg]:text-disabled-foreground nx:aria-disabled:[&>svg]:text-disabled-foreground',
-        'nx:data-[active=true]:bg-nav-item-active',
-        size === 'sm' && 'nx:text-xs',
-        size === 'md' && 'nx:text-sm',
+        'nx:flex nx:h-7 nx:min-w-0 nx:-translate-x-px nx:items-center nx:gap-2 nx:overflow-hidden nx:rounded-md nx:px-2 nx:text-nav-muted-foreground nx:outline-hidden nx:hover:bg-nav-item-hover nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:active:bg-nav-item-active nx:disabled:pointer-events-none nx:disabled:text-disabled-foreground nx:aria-disabled:pointer-events-none nx:aria-disabled:text-disabled-foreground nx:[&>span:last-child]:truncate nx:[&>svg]:size-4 nx:[&>svg]:shrink-0 nx:[&>svg]:text-nav-muted-foreground nx:disabled:[&>svg]:text-disabled-foreground nx:aria-disabled:[&>svg]:text-disabled-foreground',
+        'nx:data-[active=true]:bg-nav-item-active nx:data-[active=true]:text-nav-foreground nx:data-[active=true]:[&>svg]:text-nav-foreground',
+        size === 'sm' && 'nx:typography-body-small',
+        size === 'md' && 'nx:typography-body-default',
         'nx:group-data-[collapsible=icon]:hidden',
         className
       )}

--- a/packages/react/src/components/ui/sidebar/sidebar.tsx
+++ b/packages/react/src/components/ui/sidebar/sidebar.tsx
@@ -1121,8 +1121,8 @@ function SidebarMenuSubButton({
       data-size={size}
       data-active={isActive}
       className={cn(
-        'nx:flex nx:h-7 nx:min-w-0 nx:-translate-x-px nx:items-center nx:gap-2 nx:overflow-hidden nx:rounded-md nx:px-2 nx:text-nav-muted-foreground nx:outline-hidden nx:hover:bg-nav-item-hover nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:active:bg-nav-item-active nx:disabled:pointer-events-none nx:disabled:text-disabled-foreground nx:aria-disabled:pointer-events-none nx:aria-disabled:text-disabled-foreground nx:[&>span:last-child]:truncate nx:[&>svg]:size-4 nx:[&>svg]:shrink-0 nx:[&>svg]:text-nav-muted-foreground nx:disabled:[&>svg]:text-disabled-foreground nx:aria-disabled:[&>svg]:text-disabled-foreground',
-        'nx:data-[active=true]:bg-nav-item-active nx:data-[active=true]:text-nav-foreground nx:data-[active=true]:[&>svg]:text-nav-foreground',
+        'nx:flex nx:h-7 nx:min-w-0 nx:-translate-x-px nx:items-center nx:gap-2 nx:overflow-hidden nx:rounded-md nx:px-2 nx:text-nav-muted-foreground nx:outline-hidden nx:hover:bg-nav-item-hover nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:active:bg-nav-item-active nx:disabled:pointer-events-none nx:disabled:text-disabled-foreground nx:aria-disabled:pointer-events-none nx:aria-disabled:text-disabled-foreground nx:[&>span:last-child]:truncate nx:[&>svg]:size-4 nx:[&>svg]:shrink-0',
+        'nx:data-[active=true]:bg-nav-item-active nx:data-[active=true]:text-nav-foreground',
         size === 'sm' && 'nx:typography-body-small',
         size === 'md' && 'nx:typography-body-default',
         'nx:group-data-[collapsible=icon]:hidden',

--- a/packages/react/src/components/ui/sidebar/sidebar.tsx
+++ b/packages/react/src/components/ui/sidebar/sidebar.tsx
@@ -781,6 +781,7 @@ const sidebarMenuButtonVariants = cva(
   cn(
     'nx:peer/menu-button nx:flex nx:w-full nx:items-center nx:gap-2 nx:overflow-hidden nx:rounded-md nx:p-2 nx:text-left nx:text-nav-muted-foreground nx:transition-[width,height,padding]',
     'nx:group-has-data-[slot=sidebar-menu-action]/menu-item:pr-8 nx:group-data-[collapsible=icon]:size-8',
+    'nx:group-data-[collapsible=icon]:justify-center nx:group-data-[collapsible=icon]:[&>span]:sr-only nx:group-data-[collapsible=icon]:[&>svg:not(:first-child)]:hidden',
     'nx:hover:bg-nav-item-hover nx:active:bg-nav-item-active',
     'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
     'nx:disabled:pointer-events-none nx:disabled:text-disabled-foreground nx:aria-disabled:pointer-events-none nx:aria-disabled:text-disabled-foreground',


### PR DESCRIPTION
## Summary

Sidebar polish from a Tier-A benchmark pass (measured against the logged-in product UIs of Stripe, Notion, and Linear):

- **Active = colour only.** Active nav items now read by colour (muted rest → full `nav-foreground`) instead of a weight bump — matching Notion/Linear. Icons follow the text colour through every state. Resolves the old "active looks like hover" overlap and the double-emphasis (bolder + darker) that read as heavy.
- **Typography tokens.** Migrated raw `text-*`/`font-medium` to composites (`body-default`/`-small`, `label-small`) across menu button, sub-button, group label, badge, and group content.
- **Spacing.** Item gap tightened to **1px** (`gap-px`). Sub-menu uses **left-only** inset (`ml-3.5` + `pl-2.5`) so sub-item fills align with the top-level items on the right (the symmetric `mx`/`px` was insetting the right edge by 24px for no reason).
- **Touch targets.** `pointer-coarse` hit-area on the trigger + input.
- **Stories.** Added **Complex (kitchen sink)** — workspace switcher, search, two groups, group/row actions, badges, nested sub-menus, separator, footer — and **Compact (small size)** to show the dense `size="sm"` option.

## GitHub Issue

Closes #474

Part of the typography-migration umbrella (#495) — sidebar slice.

## Test Plan

- [x] `pnpm --filter @nexus/react typecheck`
- [x] `pnpm exec eslint` on the changed files
- [x] `pnpm exec prettier --check` on the changed files
- [ ] `pnpm --filter @nexus/react audit:storybook-coverage --component sidebar`
- [ ] `pnpm test:storybook` (full vitest + a11y)
- [ ] Visual: Sidebar → Complex / Compact render; active reads by colour, 1px gap, sub-menu right-aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)
