### PR TITLE
fix(typography): close raw text-size leak

### DIFF
--- a/apps/console/public/themes/globals.css
+++ b/apps/console/public/themes/globals.css
@@ -23,6 +23,7 @@
   /* Reset default Tailwind namespaces to enforce semantic tokens only */
   --color-*: initial;
   --spacing-*: initial;
+  --text-*: initial;
   --radius-*: initial;
   --shadow-*: initial;
   --breakpoint-*: initial;

--- a/apps/console/src/styles/globals.css
+++ b/apps/console/src/styles/globals.css
@@ -23,6 +23,7 @@
   /* Reset default Tailwind namespaces to enforce semantic tokens only */
   --color-*: initial;
   --spacing-*: initial;
+  --text-*: initial;
   --radius-*: initial;
   --shadow-*: initial;
   --breakpoint-*: initial;

--- a/apps/docs/public/themes/globals.css
+++ b/apps/docs/public/themes/globals.css
@@ -23,6 +23,7 @@
   /* Reset default Tailwind namespaces to enforce semantic tokens only */
   --color-*: initial;
   --spacing-*: initial;
+  --text-*: initial;
   --radius-*: initial;
   --shadow-*: initial;
   --breakpoint-*: initial;

--- a/packages/core/scripts/__tests__/generate-modular.test.js
+++ b/packages/core/scripts/__tests__/generate-modular.test.js
@@ -73,6 +73,11 @@ describe('generateModular', () => {
     expect(globals).toMatch(/--breakpoint-2xl: 96rem;/);
   });
 
+  it('emits the --text-*: initial reset in globals.css', () => {
+    const globals = fs.readFileSync(path.join(distDir, 'globals.css'), 'utf8');
+    expect(globals).toMatch(/--text-\*:\s*initial;/);
+  });
+
   it('emits the native browser UI theme policy in globals.css', () => {
     const globals = fs.readFileSync(path.join(distDir, 'globals.css'), 'utf8');
     expect(globals).toMatch(/:root \{\n\s*color-scheme:\s*light dark;\n\s*\}/);

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -303,6 +303,13 @@ describe('generateTailwindPackage', () => {
     expect(themeBlock).toMatch(/--spacing-\*:\s*initial;/);
   });
 
+  it('preserves the --text-*: initial reset in @theme', () => {
+    // Raw named Tailwind font-size utilities must not leak around the
+    // typography composites that own type sizing.
+    const themeBlock = extractBlock(nexusCSS, '@theme');
+    expect(themeBlock).toMatch(/--text-\*:\s*initial;/);
+  });
+
   it('registers numeric --spacing-N in @theme with direct px (not var() refs)', () => {
     // The numeric subset seeds @theme so Tailwind codegens nx:p-N / nx:m-N /
     // nx:h-N / nx:gap-N. After migration these are direct px values, not

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -1449,6 +1449,7 @@ export function generateThemeCSS(config) {
   css += `  /* Reset default Tailwind namespaces to enforce semantic tokens only */\n`;
   css += `  --color-*: initial;\n`;
   css += `  --spacing-*: initial;\n`;
+  css += `  --text-*: initial;\n`;
   css += `  --radius-*: initial;\n`;
   css += `  --shadow-*: initial;\n`;
   css += `  --breakpoint-*: initial;\n\n`;

--- a/packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js
+++ b/packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js
@@ -40,6 +40,15 @@ ruleTester.run('nx-class-conventions', rule, {
     "const c = 'nx:typography-code-block';",
     // Shortcut hint typography is a live one-level composite.
     "const c = 'nx:ml-auto nx:typography-shortcut nx:text-muted-foreground';",
+    // Text alignment, wrapping, arbitrary values, and colours are not font-size
+    // utilities and must stay legal.
+    "const c = 'nx:text-center';",
+    "const c = 'nx:text-wrap';",
+    "const c = 'nx:text-balance';",
+    "const c = 'nx:text-ellipsis';",
+    "const c = 'nx:text-[clamp(1rem,2vw,3rem)]';",
+    "const c = 'nx:text-muted-foreground';",
+    "const c = 'nx:text-foreground';",
   ],
   invalid: [
     {
@@ -69,6 +78,18 @@ ruleTester.run('nx-class-conventions', rule, {
     {
       code: "const c = 'nx:hover:bg-slate-100';",
       errors: [{ messageId: 'rawPrimitive' }],
+    },
+    {
+      code: "const c = 'nx:text-sm nx:text-muted-foreground';",
+      errors: [{ messageId: 'rawFontSize' }],
+    },
+    {
+      code: "const c = 'nx:group-hover:text-2xl';",
+      errors: [{ messageId: 'rawFontSize' }],
+    },
+    {
+      code: "const c = 'nx:text-sm nx:bg-primary';",
+      errors: [{ messageId: 'incompletePath' }, { messageId: 'rawFontSize' }],
     },
     // Modifiers beyond hover/active/focus must not evade the checks.
     {

--- a/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
+++ b/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
@@ -43,6 +43,10 @@ const CHECKS = [
     re: /nx:(?:[\w-]+:)*(?:bg|text|border)-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d{2,3}/,
   },
   {
+    messageId: 'rawFontSize',
+    re: /nx:(?:[\w-]+:)*text-(?:xs|sm|base|lg|xl|[2-9]xl)\b/,
+  },
+  {
     messageId: 'deadTypography',
     re: new RegExp(
       `nx:(?:[\\w-]+:)*typography-(?!(?:${LIVE_TYPOGRAPHY.join('|')})\\b)[\\w-]+`
@@ -77,6 +81,8 @@ export default {
         'Incomplete semantic token path — add a `-background`, `-foreground`, or `-subtle` suffix (e.g. `nx:bg-primary-background`).',
       rawPrimitive:
         'Raw Tailwind primitive color — use a semantic token instead (e.g. `nx:bg-primary-background`, not `nx:bg-blue-500`).',
+      rawFontSize:
+        'Raw Tailwind font-size utility — use a typography composite instead (e.g. `nx:typography-body-default`, not `nx:text-sm`).',
       deadTypography:
         'Unknown typography composite — this `nx:typography-*` utility is not emitted by typography-utilities.css and renders nothing. Use a live tier (e.g. `nx:typography-body-default`, `nx:typography-label-default`).',
     },

--- a/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
+++ b/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
@@ -69,7 +69,7 @@ export default {
     type: 'problem',
     docs: {
       description:
-        'Enforce nx: Tailwind class conventions — correct prefix order, no banned `accent` token, complete semantic token paths, and no raw primitive colors.',
+        'Enforce nx: Tailwind class conventions — correct prefix order, no banned `accent` token, complete semantic token paths, no raw primitive colors, and no raw named font-size utilities.',
     },
     schema: [],
     messages: {

--- a/packages/react/.storybook/preview.css
+++ b/packages/react/.storybook/preview.css
@@ -7,3 +7,5 @@
  * @nexus/tailwind, whose package entry is a .css. */
 @import '@nexus/tailwind';
 @import '../src/index.css';
+
+@source inline('nx:text-xs');

--- a/packages/react/src/components/ui/sidebar/Sidebar.stories.tsx
+++ b/packages/react/src/components/ui/sidebar/Sidebar.stories.tsx
@@ -513,7 +513,6 @@ export const StylingContracts: Story = {
       '[data-slot="sidebar-group-label"]'
     );
     await expect(groupLabel).toHaveClass('nx:typography-label-small');
-    await expect(groupLabel).not.toHaveClass('nx:text-xs');
     await expect(groupLabel).not.toHaveClass('nx:font-medium');
 
     const groupContent = getRequiredElement(
@@ -521,7 +520,6 @@ export const StylingContracts: Story = {
       '[data-slot="sidebar-group-content"]'
     );
     await expect(groupContent).toHaveClass('nx:typography-body-default');
-    await expect(groupContent).not.toHaveClass('nx:text-sm');
 
     const defaultButton = getRequiredElement(
       canvasElement,
@@ -540,7 +538,6 @@ export const StylingContracts: Story = {
     await expect(defaultButton).toHaveClass(
       'nx:data-[active=true]:text-nav-foreground'
     );
-    await expect(defaultButton).not.toHaveClass('nx:text-sm');
     await expect(defaultButton).not.toHaveClass(
       'nx:data-[active=true]:typography-label-default'
     );
@@ -552,7 +549,6 @@ export const StylingContracts: Story = {
     await expect(smallButton).toHaveClass(
       'nx:data-[active=true]:text-nav-foreground'
     );
-    await expect(smallButton).not.toHaveClass('nx:text-xs');
     await expect(smallButton).not.toHaveClass(
       'nx:data-[active=true]:typography-label-small'
     );
@@ -561,7 +557,6 @@ export const StylingContracts: Story = {
     await expect(largeButton).toHaveClass(
       'nx:data-[active=true]:text-nav-foreground'
     );
-    await expect(largeButton).not.toHaveClass('nx:text-sm');
     await expect(largeButton).not.toHaveClass(
       'nx:data-[active=true]:typography-label-default'
     );
@@ -599,7 +594,6 @@ export const StylingContracts: Story = {
       '[data-slot="sidebar-menu-badge"]'
     );
     await expect(badge).toHaveClass('nx:typography-label-small');
-    await expect(badge).not.toHaveClass('nx:text-xs');
     await expect(badge).not.toHaveClass('nx:font-medium');
 
     const defaultSubButton = getRequiredElement(
@@ -611,7 +605,6 @@ export const StylingContracts: Story = {
       '[data-slot="sidebar-menu-sub-button"][data-size="sm"]'
     );
     await expect(defaultSubButton).toHaveClass('nx:typography-body-default');
-    await expect(defaultSubButton).not.toHaveClass('nx:text-sm');
     await expect(defaultSubButton).not.toHaveClass(
       'nx:[&>svg]:text-nav-muted-foreground'
     );
@@ -619,7 +612,6 @@ export const StylingContracts: Story = {
       'nx:data-[active=true]:[&>svg]:text-nav-foreground'
     );
     await expect(smallSubButton).toHaveClass('nx:typography-body-small');
-    await expect(smallSubButton).not.toHaveClass('nx:text-xs');
 
     const trigger = getRequiredElement(
       canvasElement,

--- a/packages/react/src/components/ui/table/Table.stories.tsx
+++ b/packages/react/src/components/ui/table/Table.stories.tsx
@@ -33,6 +33,8 @@ const meta: Meta<typeof Table> = {
 export default meta;
 type Story = StoryObj<typeof Table>;
 
+const rawTextSizeSentinelClass = ['nx', 'text-xs'].join(':');
+
 // Representative fixture: a list of invoices with status, payment method, and
 // amount — the shape a real billing table renders.
 const invoices = [
@@ -324,11 +326,9 @@ export const TokenizedTypography: Story = {
 
     await expect(table).toBeInTheDocument();
     await expect(table).toHaveClass('nx:typography-body-default');
-    await expect(table).not.toHaveClass('nx:text-sm');
 
     await expect(caption).toBeInTheDocument();
     await expect(caption).toHaveClass('nx:typography-body-small');
-    await expect(caption).not.toHaveClass('nx:text-sm');
 
     await expect(head).toBeInTheDocument();
     await expect(head).toHaveClass('nx:typography-label-default');
@@ -337,6 +337,47 @@ export const TokenizedTypography: Story = {
     await expect(footer).toBeInTheDocument();
     await expect(footer).toHaveClass('nx:typography-label-default');
     await expect(footer).not.toHaveClass('nx:font-medium');
+  },
+};
+
+export const RawTextSizeReset: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Regression sentinel: a runtime raw named text-size utility no longer applies font-size, while a typography composite still resolves its intended size.',
+      },
+    },
+  },
+  render: () => (
+    <div style={{ fontSize: '18px' }}>
+      <span data-testid="raw-text-size" className={rawTextSizeSentinelClass}>
+        Raw text size
+      </span>
+      <span
+        data-testid="typography-composite"
+        className="nx:typography-body-small"
+      >
+        Typography composite
+      </span>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    await document.fonts.ready;
+
+    const raw = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="raw-text-size"]'
+    );
+    const composite = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="typography-composite"]'
+    );
+
+    if (!raw || !composite) {
+      throw new Error('Raw text-size reset sentinel elements are missing');
+    }
+
+    await expect(getComputedStyle(raw).fontSize).toBe('18px');
+    await expect(getComputedStyle(composite).fontSize).toBe('12px');
   },
 };
 

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -18,6 +18,7 @@
   /* Reset default Tailwind namespaces to enforce semantic tokens only */
   --color-*: initial;
   --spacing-*: initial;
+  --text-*: initial;
   --radius-*: initial;
   --shadow-*: initial;
   --breakpoint-*: initial;


### PR DESCRIPTION
## Summary
- reset Tailwind's `--text-*` namespace in generated Nexus theme CSS and synced console/docs theme copies
- add `@nexus/nx-class-conventions` coverage for raw named `nx:text-{size}` utilities
- add generator, lint, and Storybook regression coverage for the raw font-size leak

## GitHub Issue
Closes #495

## Test Plan
- [x] `grep -rEn 'nx:(?:[\w-]+:)*text-(xs|sm|base|lg|xl|[2-9]xl)\b' packages/react/src apps/docs apps/console | grep -v __generated__`
- [x] `pnpm tokens:tailwind`
- [x] `pnpm tokens:modular`
- [x] `pnpm test:unit -- packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js packages/core/scripts/__tests__/generate-tailwind-package.test.js packages/core/scripts/__tests__/generate-modular.test.js`
- [x] `pnpm test:storybook`
- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component table`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm --filter @nexus/console build`
- [x] `pnpm --filter @nexus/docs build`
- [x] built CSS grep: no raw named `.nx\:text-{size}` selectors; text color utilities and typography utilities still present
