### PR TITLE
[codex] Add raw typography lint guard

### DIFF
--- a/apps/console/src/app/auth-layout.tsx
+++ b/apps/console/src/app/auth-layout.tsx
@@ -17,14 +17,14 @@ export function AuthLayout() {
       <aside className="nx:bg-primary-background nx:text-primary-foreground nx:hidden nx:w-1/2 nx:flex-col nx:justify-between nx:p-12 nx:lg:flex">
         <div className="nx:flex nx:items-center nx:gap-2">
           <div className="nx:bg-primary-foreground nx:flex nx:size-8 nx:items-center nx:justify-center nx:rounded-lg">
-            <span className="nx:text-primary-background nx:typography-label-default nx:font-bold">
+            <span className="nx:text-primary-background nx:typography-label-caps">
               A
             </span>
           </div>
           <span className="nx:typography-heading-xsmall">Atlas</span>
         </div>
         <div className="nx:space-y-3">
-          <p className="nx:typography-heading-medium nx:leading-snug">
+          <p className="nx:typography-heading-medium">
             The operating system for your whole company.
           </p>
           <p className="nx:text-primary-foreground/80 nx:typography-body-default">

--- a/apps/console/src/app/not-found.tsx
+++ b/apps/console/src/app/not-found.tsx
@@ -10,7 +10,7 @@ import { Link } from '@tanstack/react-router';
 export function NotFound() {
   return (
     <div className="nx:bg-background nx:text-foreground nx:flex nx:min-h-svh nx:flex-col nx:items-center nx:justify-center nx:gap-3 nx:p-6 nx:text-center">
-      <p className="nx:typography-label-small nx:text-muted-foreground-subtle nx:uppercase nx:tracking-wide">
+      <p className="nx:typography-label-caps nx:text-muted-foreground-subtle nx:uppercase">
         404
       </p>
       <h1 className="nx:typography-heading-large">Page not found</h1>

--- a/apps/console/src/modules/analytics/analytics-route.tsx
+++ b/apps/console/src/modules/analytics/analytics-route.tsx
@@ -182,7 +182,7 @@ function SourcesCard({ sources }: { sources: TrafficSource[] }) {
           <TableBody>
             {sources.map((source) => (
               <TableRow key={source.source}>
-                <TableCell className="nx:text-foreground nx:font-medium">
+                <TableCell className="nx:text-foreground nx:typography-label-default">
                   {source.source}
                 </TableCell>
                 <TableCell className="nx:text-right nx:tabular-nums">

--- a/apps/console/src/modules/auth/verify-route.tsx
+++ b/apps/console/src/modules/auth/verify-route.tsx
@@ -55,7 +55,10 @@ export function VerifyRoute() {
         <CardTitle>Check your email</CardTitle>
         <CardDescription>
           Enter the 6-digit code we sent to {email}. Demo code:{' '}
-          <span className="nx:text-foreground nx:font-medium">123456</span>.
+          <span className="nx:text-foreground nx:typography-label-default">
+            123456
+          </span>
+          .
         </CardDescription>
       </CardHeader>
       <CardContent className="nx:flex nx:flex-col nx:items-center nx:gap-5">

--- a/apps/console/src/modules/billing/billing-route.tsx
+++ b/apps/console/src/modules/billing/billing-route.tsx
@@ -239,7 +239,7 @@ function PaymentCard({ method }: { method: PaymentMethod }) {
             <IconCreditCard />
           </div>
           <div className="nx:min-w-0">
-            <p className="nx:text-foreground nx:font-medium">
+            <p className="nx:text-foreground nx:typography-label-default">
               {method.brand} ···· {method.last4}
             </p>
             <p className="nx:text-muted-foreground nx:typography-body-default nx:tabular-nums">

--- a/apps/console/src/modules/billing/plan-sheet.tsx
+++ b/apps/console/src/modules/billing/plan-sheet.tsx
@@ -120,7 +120,7 @@ export function PlanSheet({
                   />
                   <div className="nx:flex-1 nx:space-y-1">
                     <div className="nx:flex nx:items-baseline nx:justify-between nx:gap-2">
-                      <span className="nx:text-foreground nx:font-medium">
+                      <span className="nx:text-foreground nx:typography-label-default">
                         {plan.name}
                       </span>
                       <span className="nx:text-foreground nx:typography-label-default">

--- a/apps/console/src/modules/crm/contact-card.tsx
+++ b/apps/console/src/modules/crm/contact-card.tsx
@@ -14,7 +14,7 @@ export function ContactCard({ contact }: { contact: Contact }) {
         <Link
           to="/m/crm/$id"
           params={{ id: contact.id }}
-          className="nx:text-foreground nx:font-medium nx:hover:underline"
+          className="nx:text-foreground nx:typography-label-default nx:hover:underline"
         >
           {contact.name}
         </Link>

--- a/apps/console/src/modules/crm/contacts-board.tsx
+++ b/apps/console/src/modules/crm/contacts-board.tsx
@@ -154,7 +154,9 @@ function BoardCard({ contact }: { contact: Contact }) {
         isDragging ? 'nx:opacity-50' : ''
       }`}
     >
-      <div className="nx:text-foreground nx:font-medium">{contact.name}</div>
+      <div className="nx:text-foreground nx:typography-label-default">
+        {contact.name}
+      </div>
       <div className="nx:text-muted-foreground nx:typography-label-default">
         {contact.company}
       </div>

--- a/apps/console/src/modules/crm/contacts-columns.tsx
+++ b/apps/console/src/modules/crm/contacts-columns.tsx
@@ -85,7 +85,7 @@ export const contactColumns: ColumnDef<Contact>[] = [
       <Link
         to="/m/crm/$id"
         params={{ id: row.original.id }}
-        className="nx:text-foreground nx:font-medium nx:hover:underline"
+        className="nx:text-foreground nx:typography-label-default nx:hover:underline"
       >
         {row.original.name}
       </Link>

--- a/apps/console/src/modules/design-system/ComponentShowcase.tsx
+++ b/apps/console/src/modules/design-system/ComponentShowcase.tsx
@@ -231,7 +231,7 @@ export function ComponentShowcase() {
                 Container — p-container, gap-container
               </span>
               <div className="nx:bg-container nx:border nx:border-border-default nx:rounded-lg nx:flex nx:flex-col nx:p-container nx:gap-container">
-                <h4 className="nx:text-foreground nx:font-medium">
+                <h4 className="nx:text-foreground nx:typography-label-default">
                   Card header
                 </h4>
                 <p className="nx:typography-body-default nx:text-muted-foreground">
@@ -260,7 +260,7 @@ export function ComponentShowcase() {
                     key={label}
                     className="nx:flex nx:flex-col nx:gap-layout-stack"
                   >
-                    <span className="nx:typography-label-small nx:font-semibold nx:text-foreground">
+                    <span className="nx:typography-label-caps nx:text-foreground">
                       {label}
                     </span>
                     <span className="nx:typography-label-default nx:text-muted-foreground">
@@ -309,25 +309,27 @@ export function ComponentShowcase() {
         >
           <div className="nx:grid nx:gap-4 nx:md:grid-cols-2">
             <div className="nx:border nx:border-border-default nx:bg-container nx:rounded-lg nx:p-4">
-              <h3 className="nx:font-medium">Container</h3>
+              <h3 className="nx:typography-label-default">Container</h3>
               <p className="nx:text-muted-foreground nx:mt-1 nx:typography-body-default">
                 Default container background
               </p>
             </div>
             <div className="nx:border nx:border-border-default nx:bg-popover nx:rounded-lg nx:p-4">
-              <h3 className="nx:font-medium">Popover</h3>
+              <h3 className="nx:typography-label-default">Popover</h3>
               <p className="nx:text-muted-foreground nx:mt-1 nx:typography-body-default">
                 Popover background color
               </p>
             </div>
             <div className="nx:bg-muted nx:rounded-lg nx:p-4">
-              <h3 className="nx:text-muted-foreground nx:font-medium">Muted</h3>
+              <h3 className="nx:text-muted-foreground nx:typography-label-default">
+                Muted
+              </h3>
               <p className="nx:text-muted-foreground nx:mt-1 nx:typography-body-default">
                 Muted background with muted foreground
               </p>
             </div>
             <div className="nx:bg-background-hover nx:rounded-lg nx:p-4">
-              <h3 className="nx:text-foreground nx:font-medium">
+              <h3 className="nx:text-foreground nx:typography-label-default">
                 Background Hover
               </h3>
               <p className="nx:text-muted-foreground nx:mt-1 nx:typography-body-default">

--- a/apps/console/src/modules/design-system/IconShowcase.tsx
+++ b/apps/console/src/modules/design-system/IconShowcase.tsx
@@ -48,7 +48,7 @@ export function IconShowcase() {
                 size={20}
                 className="nx:text-foreground"
               />
-              <span className="nx:text-muted-foreground nx:text-[10px] nx:text-center nx:leading-tight">
+              <span className="nx:text-muted-foreground nx:text-[10px] nx:text-center">
                 {name}
               </span>
             </div>

--- a/apps/console/src/modules/inbox/conversation-list.tsx
+++ b/apps/console/src/modules/inbox/conversation-list.tsx
@@ -65,9 +65,7 @@ function ConversationRow({
       </div>
       <div className="nx:min-w-0 nx:flex-1 nx:space-y-1">
         <div className="nx:flex nx:items-baseline nx:justify-between nx:gap-2">
-          <span
-            className={`nx:text-foreground nx:truncate ${conversation.unread ? 'nx:font-semibold' : 'nx:font-medium'}`}
-          >
+          <span className="nx:text-foreground nx:truncate nx:typography-label-default">
             {conversation.customer}
           </span>
           <span className="nx:text-muted-foreground nx:shrink-0 nx:typography-label-small">

--- a/apps/console/src/modules/people/member-card.tsx
+++ b/apps/console/src/modules/people/member-card.tsx
@@ -14,7 +14,7 @@ export function MemberCard({ member }: { member: Member }) {
         <Link
           to="/m/people/$id"
           params={{ id: member.id }}
-          className="nx:text-foreground nx:font-medium nx:hover:underline"
+          className="nx:text-foreground nx:typography-label-default nx:hover:underline"
         >
           {member.name}
         </Link>

--- a/apps/console/src/modules/people/people-columns.tsx
+++ b/apps/console/src/modules/people/people-columns.tsx
@@ -91,7 +91,7 @@ export const memberColumns: ColumnDef<Member>[] = [
         <Link
           to="/m/people/$id"
           params={{ id: row.original.id }}
-          className="nx:text-foreground nx:font-medium nx:hover:underline"
+          className="nx:text-foreground nx:typography-label-default nx:hover:underline"
         >
           {row.original.name}
         </Link>

--- a/apps/console/src/modules/projects/issue-card.tsx
+++ b/apps/console/src/modules/projects/issue-card.tsx
@@ -19,7 +19,7 @@ export function IssueCard({ issue }: { issue: Issue }) {
           <span className="nx:text-muted-foreground nx:typography-label-default nx:tabular-nums">
             {issue.key}
           </span>{' '}
-          <span className="nx:text-foreground nx:font-medium">
+          <span className="nx:text-foreground nx:typography-label-default">
             {issue.title}
           </span>
         </Link>

--- a/apps/console/src/modules/projects/issue-detail-route.tsx
+++ b/apps/console/src/modules/projects/issue-detail-route.tsx
@@ -107,7 +107,7 @@ function DetailContent({ issue }: { issue: IssueDetail }) {
           </CardHeader>
           <CardContent>
             {issue.description ? (
-              <p className="nx:text-foreground nx:typography-body-default nx:leading-relaxed nx:whitespace-pre-wrap">
+              <p className="nx:text-foreground nx:typography-body-default nx:whitespace-pre-wrap">
                 {issue.description}
               </p>
             ) : (

--- a/apps/console/src/modules/projects/issues-columns.tsx
+++ b/apps/console/src/modules/projects/issues-columns.tsx
@@ -94,7 +94,7 @@ export const issueColumns: ColumnDef<Issue>[] = [
       <Link
         to="/m/projects/$id"
         params={{ id: row.original.id }}
-        className="nx:text-foreground nx:font-medium nx:hover:underline"
+        className="nx:text-foreground nx:typography-label-default nx:hover:underline"
       >
         {row.original.title}
       </Link>

--- a/apps/console/src/shell/app-sidebar.tsx
+++ b/apps/console/src/shell/app-sidebar.tsx
@@ -74,11 +74,11 @@ export function AppSidebar() {
             <SidebarMenuButton size="lg" asChild>
               <Link to="/design/reference">
                 <div className="nx:flex nx:size-8 nx:items-center nx:justify-center nx:rounded-lg nx:bg-primary-background">
-                  <span className="nx:typography-label-default nx:font-bold nx:text-primary-foreground">
+                  <span className="nx:typography-label-caps nx:text-primary-foreground">
                     A
                   </span>
                 </div>
-                <span className="nx:font-semibold">Atlas</span>
+                <span className="nx:typography-label-default">Atlas</span>
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>
@@ -173,7 +173,7 @@ export function AppSidebar() {
                   <>
                     <DropdownMenuLabel className="nx:flex nx:flex-col">
                       <span>{user.name}</span>
-                      <span className="nx:text-muted-foreground nx:typography-label-small nx:font-normal">
+                      <span className="nx:text-muted-foreground nx:typography-body-small">
                         {user.email}
                       </span>
                     </DropdownMenuLabel>

--- a/apps/console/src/shell/notifications-menu.tsx
+++ b/apps/console/src/shell/notifications-menu.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react';
 import {
   Badge,
   Button,
-  cn,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -182,12 +181,7 @@ export function NotificationsMenu() {
                   >
                     <KindIcon className="nx:text-muted-foreground nx:mt-0.5 nx:size-4 nx:shrink-0" />
                     <span className="nx:min-w-0 nx:flex-1">
-                      <span
-                        className={cn(
-                          'nx:block nx:typography-label-default',
-                          !n.read && 'nx:font-medium'
-                        )}
-                      >
+                      <span className="nx:block nx:typography-label-default">
                         {n.title}
                       </span>
                       <span className="nx:text-muted-foreground nx:block nx:truncate nx:typography-label-default">

--- a/packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js
+++ b/packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js
@@ -141,6 +141,18 @@ ruleTester.run('nx-class-conventions', rule, {
       errors: [{ messageId: 'rawFontWeight' }],
     },
     {
+      code: "const c = 'nx:has-[[role=checkbox]]:font-medium';",
+      errors: [{ messageId: 'rawFontWeight' }],
+    },
+    {
+      code: "const c = 'nx:group-has-[[role=checkbox]]:font-semibold';",
+      errors: [{ messageId: 'rawFontWeight' }],
+    },
+    {
+      code: "const c = 'nx:@md/field-group:font-medium';",
+      errors: [{ messageId: 'rawFontWeight' }],
+    },
+    {
       code: "const c = 'nx:leading-none';",
       errors: [{ messageId: 'rawLineHeight' }],
     },
@@ -149,11 +161,19 @@ ruleTester.run('nx-class-conventions', rule, {
       errors: [{ messageId: 'rawLineHeight' }],
     },
     {
+      code: "const c = 'nx:not-has-[>[data-align^=block]]:leading-tight';",
+      errors: [{ messageId: 'rawLineHeight' }],
+    },
+    {
       code: "const c = 'nx:tracking-wide';",
       errors: [{ messageId: 'rawLetterSpacing' }],
     },
     {
       code: 'const c = `nx:tracking-[0.14em] ${x}`;',
+      errors: [{ messageId: 'rawLetterSpacing' }],
+    },
+    {
+      code: "const c = 'nx:has-[[data-slot=input-group-control]:focus-visible]:tracking-wide';",
       errors: [{ messageId: 'rawLetterSpacing' }],
     },
     {

--- a/packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js
+++ b/packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js
@@ -5,7 +5,11 @@ import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 
 import plugin from '../src/index.js';
-import { LIVE_TYPOGRAPHY } from '../src/rules/nx-class-conventions.js';
+import {
+  LIVE_TYPOGRAPHY,
+  RAW_FONT_WEIGHTS,
+  RAW_LETTER_SPACINGS,
+} from '../src/rules/nx-class-conventions.js';
 
 RuleTester.describe = describe;
 RuleTester.it = it;
@@ -49,6 +53,31 @@ ruleTester.run('nx-class-conventions', rule, {
     "const c = 'nx:text-[clamp(1rem,2vw,3rem)]';",
     "const c = 'nx:text-muted-foreground';",
     "const c = 'nx:text-foreground';",
+    // Font families are still legal; the raw typography guard targets weight,
+    // line-height, and tracking utilities that bypass the composite scale.
+    "const c = 'nx:font-mono nx:tabular-nums';",
+    // The raw typography guard is runtime-scoped. Stories and docs remain useful
+    // demo surfaces, but are not part of this hard gate.
+    {
+      code: "const c = 'nx:font-medium nx:leading-none nx:tracking-wide';",
+      filename:
+        '/repo/packages/react/src/components/ui/table/Table.stories.tsx',
+    },
+    {
+      code: "const c = 'nx:font-semibold nx:tracking-wider';",
+      filename: '/repo/apps/docs/app/page.tsx',
+    },
+    // Avatar initials inherit diameter-driven text size from the root variant;
+    // this stays a narrow exception until there is an Avatar-specific typography
+    // token that preserves that relationship.
+    {
+      code: "const c = 'nx:flex nx:size-full nx:items-center nx:justify-center nx:rounded-[inherit] nx:bg-muted nx:text-foreground nx:font-medium nx:leading-none';",
+      filename: '/repo/packages/react/src/components/ui/avatar/avatar.tsx',
+    },
+    {
+      code: "const c = 'nx:text-foreground nx:font-mono nx:font-medium nx:tabular-nums';",
+      filename: '/repo/packages/react/src/components/ui/chart/chart.tsx',
+    },
   ],
   invalid: [
     {
@@ -90,6 +119,38 @@ ruleTester.run('nx-class-conventions', rule, {
     {
       code: "const c = 'nx:text-sm nx:bg-primary';",
       errors: [{ messageId: 'incompletePath' }, { messageId: 'rawFontSize' }],
+    },
+    {
+      code: "const c = 'nx:font-medium';",
+      errors: [{ messageId: 'rawFontWeight' }],
+    },
+    {
+      code: "const c = 'nx:data-[today=true]:font-semibold';",
+      errors: [{ messageId: 'rawFontWeight' }],
+    },
+    {
+      code: "const c = 'nx:leading-none';",
+      errors: [{ messageId: 'rawLineHeight' }],
+    },
+    {
+      code: "const c = 'nx:group-hover:leading-[1.1]';",
+      errors: [{ messageId: 'rawLineHeight' }],
+    },
+    {
+      code: "const c = 'nx:tracking-wide';",
+      errors: [{ messageId: 'rawLetterSpacing' }],
+    },
+    {
+      code: 'const c = `nx:tracking-[0.14em] ${x}`;',
+      errors: [{ messageId: 'rawLetterSpacing' }],
+    },
+    {
+      code: "const c = 'nx:text-sm nx:font-medium nx:leading-tight';",
+      errors: [
+        { messageId: 'rawFontSize' },
+        { messageId: 'rawFontWeight' },
+        { messageId: 'rawLineHeight' },
+      ],
     },
     // Modifiers beyond hover/active/focus must not evade the checks.
     {
@@ -140,5 +201,41 @@ describe('LIVE_TYPOGRAPHY drift guard', () => {
     );
 
     expect([...emitted].sort()).toEqual([...LIVE_TYPOGRAPHY].sort());
+  });
+});
+
+describe('raw typography guard drift checks', () => {
+  it('keeps raw font-weight names aligned with the typography primitive tokens', () => {
+    const dir = path.dirname(fileURLToPath(import.meta.url));
+    const tokens = JSON.parse(
+      fs.readFileSync(
+        path.resolve(
+          dir,
+          '../../core/tokens/primitives/typography/typography-vega.json'
+        ),
+        'utf8'
+      )
+    );
+
+    expect([...Object.keys(tokens.weight)].sort()).toEqual(
+      [...RAW_FONT_WEIGHTS].sort()
+    );
+  });
+
+  it('keeps raw letter-spacing names aligned with the typography primitive tokens', () => {
+    const dir = path.dirname(fileURLToPath(import.meta.url));
+    const tokens = JSON.parse(
+      fs.readFileSync(
+        path.resolve(
+          dir,
+          '../../core/tokens/primitives/typography/typography-vega.json'
+        ),
+        'utf8'
+      )
+    );
+
+    expect([...Object.keys(tokens.letterspacing)].sort()).toEqual(
+      [...RAW_LETTER_SPACINGS].sort()
+    );
   });
 });

--- a/packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js
+++ b/packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js
@@ -129,6 +129,18 @@ ruleTester.run('nx-class-conventions', rule, {
       errors: [{ messageId: 'rawFontWeight' }],
     },
     {
+      code: "const c = 'nx:**:font-medium';",
+      errors: [{ messageId: 'rawFontWeight' }],
+    },
+    {
+      code: "const c = 'nx:**:[[cmdk-group-heading]]:font-semibold';",
+      errors: [{ messageId: 'rawFontWeight' }],
+    },
+    {
+      code: "const c = 'nx:[&[data-state=open]]:font-bold';",
+      errors: [{ messageId: 'rawFontWeight' }],
+    },
+    {
       code: "const c = 'nx:leading-none';",
       errors: [{ messageId: 'rawLineHeight' }],
     },
@@ -143,6 +155,23 @@ ruleTester.run('nx-class-conventions', rule, {
     {
       code: 'const c = `nx:tracking-[0.14em] ${x}`;',
       errors: [{ messageId: 'rawLetterSpacing' }],
+    },
+    {
+      code: "const c = 'nx:flex nx:size-full nx:items-center nx:justify-center nx:rounded-[inherit] nx:bg-muted nx:text-foreground nx:font-medium nx:leading-none nx:tracking-wide';",
+      filename: '/repo/packages/react/src/components/ui/avatar/avatar.tsx',
+      errors: [
+        { messageId: 'rawFontWeight' },
+        { messageId: 'rawLineHeight' },
+        { messageId: 'rawLetterSpacing' },
+      ],
+    },
+    {
+      code: "const c = 'nx:text-foreground nx:font-mono nx:font-medium nx:tabular-nums nx:tracking-wide';",
+      filename: '/repo/packages/react/src/components/ui/chart/chart.tsx',
+      errors: [
+        { messageId: 'rawFontWeight' },
+        { messageId: 'rawLetterSpacing' },
+      ],
     },
     {
       code: "const c = 'nx:text-sm nx:font-medium nx:leading-tight';",

--- a/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
+++ b/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
@@ -55,7 +55,10 @@ export const RAW_LETTER_SPACINGS = [
   'widest',
 ];
 
-const NX_MODIFIER_CHAIN = String.raw`(?:[\w-]+(?:\[[^\]]+\])?(?:\/[\w-]+)?:|\[[^\]]+\]:|\*:)*`;
+const NAMED_VARIANT = String.raw`[\w-]+(?:\[[^\]]+\])?(?:\/[\w-]+)?:`;
+const ARBITRARY_VARIANT = String.raw`\[[^\s]+?\]:`;
+const CHILD_VARIANT = String.raw`\*{1,2}:`;
+const NX_MODIFIER_CHAIN = String.raw`(?:${NAMED_VARIANT}|${ARBITRARY_VARIANT}|${CHILD_VARIANT})*`;
 
 const CHECKS = [
   {
@@ -121,24 +124,34 @@ function isDocsFile(filename) {
   return /(?:^|[/\\])apps[/\\]docs[/\\]/.test(filename);
 }
 
-function isRawTypographyException(filename, raw) {
-  const isAvatarFallback =
-    /(?:^|[/\\])packages[/\\]react[/\\]src[/\\]components[/\\]ui[/\\]avatar[/\\]avatar\.tsx$/.test(
-      filename
-    ) &&
-    raw.includes('nx:size-full') &&
-    raw.includes('nx:font-medium') &&
-    raw.includes('nx:leading-none');
+const RAW_TYPOGRAPHY_EXCEPTIONS = [
+  {
+    filename:
+      /(?:^|[/\\])packages[/\\]react[/\\]src[/\\]components[/\\]ui[/\\]avatar[/\\]avatar\.tsx$/,
+    className:
+      'nx:flex nx:size-full nx:items-center nx:justify-center nx:rounded-[inherit] nx:bg-muted nx:text-foreground nx:font-medium nx:leading-none',
+    messageIds: new Set(['rawFontWeight', 'rawLineHeight']),
+  },
+  {
+    filename:
+      /(?:^|[/\\])packages[/\\]react[/\\]src[/\\]components[/\\]ui[/\\]chart[/\\]chart\.tsx$/,
+    className: 'nx:text-foreground nx:font-mono nx:font-medium nx:tabular-nums',
+    messageIds: new Set(['rawFontWeight']),
+  },
+];
 
-  const isChartMonospaceValue =
-    /(?:^|[/\\])packages[/\\]react[/\\]src[/\\]components[/\\]ui[/\\]chart[/\\]chart\.tsx$/.test(
-      filename
-    ) &&
-    raw.includes('nx:font-mono') &&
-    raw.includes('nx:font-medium') &&
-    raw.includes('nx:tabular-nums');
+function normalizeClassName(raw) {
+  return raw.trim().replace(/\s+/g, ' ');
+}
 
-  return isAvatarFallback || isChartMonospaceValue;
+function isRawTypographyException(check, filename, raw) {
+  const normalized = normalizeClassName(raw);
+  return RAW_TYPOGRAPHY_EXCEPTIONS.some(
+    (exception) =>
+      exception.filename.test(filename) &&
+      exception.className === normalized &&
+      exception.messageIds.has(check.messageId)
+  );
 }
 
 function shouldRunCheck(check, filename, raw) {
@@ -148,7 +161,7 @@ function shouldRunCheck(check, filename, raw) {
   if (isStoryFile(filename) || isDocsFile(filename)) {
     return false;
   }
-  return !isRawTypographyException(filename, raw);
+  return !isRawTypographyException(check, filename, raw);
 }
 
 function matchedMessageIds(raw, filename) {

--- a/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
+++ b/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
@@ -55,7 +55,7 @@ export const RAW_LETTER_SPACINGS = [
   'widest',
 ];
 
-const NAMED_VARIANT = String.raw`[\w-]+(?:\[[^\]]+\])?(?:\/[\w-]+)?:`;
+const NAMED_VARIANT = String.raw`@?[\w-]+(?:\[[^\s]+?\])?(?:\/[\w-]+)?:`;
 const ARBITRARY_VARIANT = String.raw`\[[^\s]+?\]:`;
 const CHILD_VARIANT = String.raw`\*{1,2}:`;
 const NX_MODIFIER_CHAIN = String.raw`(?:${NAMED_VARIANT}|${ARBITRARY_VARIANT}|${CHILD_VARIANT})*`;

--- a/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
+++ b/packages/eslint-plugin-nexus/src/rules/nx-class-conventions.js
@@ -25,6 +25,38 @@ export const LIVE_TYPOGRAPHY = [
   'shortcut',
 ];
 
+export const RAW_FONT_WEIGHTS = [
+  'thin',
+  'extralight',
+  'light',
+  'normal',
+  'medium',
+  'semibold',
+  'bold',
+  'extrabold',
+  'black',
+];
+
+export const RAW_LINE_HEIGHTS = [
+  'none',
+  'tight',
+  'snug',
+  'normal',
+  'relaxed',
+  'loose',
+];
+
+export const RAW_LETTER_SPACINGS = [
+  'tighter',
+  'tight',
+  'normal',
+  'wide',
+  'wider',
+  'widest',
+];
+
+const NX_MODIFIER_CHAIN = String.raw`(?:[\w-]+(?:\[[^\]]+\])?(?:\/[\w-]+)?:|\[[^\]]+\]:|\*:)*`;
+
 const CHECKS = [
   {
     messageId: 'prefixOrder',
@@ -32,31 +64,100 @@ const CHECKS = [
   },
   {
     messageId: 'bannedAccent',
-    re: /nx:(?:[\w-]+:)*(?:bg|text)-accent\b/,
+    re: new RegExp(`nx:${NX_MODIFIER_CHAIN}(?:bg|text)-accent\\b`),
   },
   {
     messageId: 'incompletePath',
-    re: /nx:(?:[\w-]+:)*(?:bg|text|border)-(?:primary|secondary|error|success|warning|information|destructive)(?![\w-])/,
+    re: new RegExp(
+      `nx:${NX_MODIFIER_CHAIN}(?:bg|text|border)-(?:primary|secondary|error|success|warning|information|destructive)(?![\\w-])`
+    ),
   },
   {
     messageId: 'rawPrimitive',
-    re: /nx:(?:[\w-]+:)*(?:bg|text|border)-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\d{2,3}/,
+    re: new RegExp(
+      `nx:${NX_MODIFIER_CHAIN}(?:bg|text|border)-(?:slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-\\d{2,3}`
+    ),
   },
   {
     messageId: 'rawFontSize',
-    re: /nx:(?:[\w-]+:)*text-(?:xs|sm|base|lg|xl|[2-9]xl)\b/,
+    re: new RegExp(
+      `nx:${NX_MODIFIER_CHAIN}text-(?:xs|sm|base|lg|xl|[2-9]xl)\\b`
+    ),
+  },
+  {
+    messageId: 'rawFontWeight',
+    re: new RegExp(
+      `nx:${NX_MODIFIER_CHAIN}font-(?:${RAW_FONT_WEIGHTS.join('|')})\\b`
+    ),
+    runtimeOnly: true,
+  },
+  {
+    messageId: 'rawLineHeight',
+    re: new RegExp(
+      `nx:${NX_MODIFIER_CHAIN}leading-(?:${RAW_LINE_HEIGHTS.join('|')}|\\d+|\\[)`
+    ),
+    runtimeOnly: true,
+  },
+  {
+    messageId: 'rawLetterSpacing',
+    re: new RegExp(
+      `nx:${NX_MODIFIER_CHAIN}tracking-(?:${RAW_LETTER_SPACINGS.join('|')}|\\[)`
+    ),
+    runtimeOnly: true,
   },
   {
     messageId: 'deadTypography',
     re: new RegExp(
-      `nx:(?:[\\w-]+:)*typography-(?!(?:${LIVE_TYPOGRAPHY.join('|')})\\b)[\\w-]+`
+      `nx:${NX_MODIFIER_CHAIN}typography-(?!(?:${LIVE_TYPOGRAPHY.join('|')})\\b)[\\w-]+`
     ),
   },
 ];
 
-function matchedMessageIds(raw) {
+function isStoryFile(filename) {
+  return /\.stories\.[jt]sx?$/.test(filename);
+}
+
+function isDocsFile(filename) {
+  return /(?:^|[/\\])apps[/\\]docs[/\\]/.test(filename);
+}
+
+function isRawTypographyException(filename, raw) {
+  const isAvatarFallback =
+    /(?:^|[/\\])packages[/\\]react[/\\]src[/\\]components[/\\]ui[/\\]avatar[/\\]avatar\.tsx$/.test(
+      filename
+    ) &&
+    raw.includes('nx:size-full') &&
+    raw.includes('nx:font-medium') &&
+    raw.includes('nx:leading-none');
+
+  const isChartMonospaceValue =
+    /(?:^|[/\\])packages[/\\]react[/\\]src[/\\]components[/\\]ui[/\\]chart[/\\]chart\.tsx$/.test(
+      filename
+    ) &&
+    raw.includes('nx:font-mono') &&
+    raw.includes('nx:font-medium') &&
+    raw.includes('nx:tabular-nums');
+
+  return isAvatarFallback || isChartMonospaceValue;
+}
+
+function shouldRunCheck(check, filename, raw) {
+  if (!check.runtimeOnly) {
+    return true;
+  }
+  if (isStoryFile(filename) || isDocsFile(filename)) {
+    return false;
+  }
+  return !isRawTypographyException(filename, raw);
+}
+
+function matchedMessageIds(raw, filename) {
   const matched = new Set();
-  for (const { messageId, re } of CHECKS) {
+  for (const check of CHECKS) {
+    const { messageId, re } = check;
+    if (!shouldRunCheck(check, filename, raw)) {
+      continue;
+    }
     if (re.test(raw)) {
       matched.add(messageId);
     }
@@ -83,13 +184,19 @@ export default {
         'Raw Tailwind primitive color — use a semantic token instead (e.g. `nx:bg-primary-background`, not `nx:bg-blue-500`).',
       rawFontSize:
         'Raw Tailwind font-size utility — use a typography composite instead (e.g. `nx:typography-body-default`, not `nx:text-sm`).',
+      rawFontWeight:
+        'Raw Tailwind font-weight utility — use a typography composite instead (e.g. `nx:typography-label-default`, not `nx:font-medium`).',
+      rawLineHeight:
+        'Raw Tailwind line-height utility — let a typography composite own line-height instead of `nx:leading-*`.',
+      rawLetterSpacing:
+        'Raw Tailwind letter-spacing utility — use a typography composite such as `nx:typography-label-caps` instead of `nx:tracking-*`.',
       deadTypography:
         'Unknown typography composite — this `nx:typography-*` utility is not emitted by typography-utilities.css and renders nothing. Use a live tier (e.g. `nx:typography-body-default`, `nx:typography-label-default`).',
     },
   },
   create(context) {
     function report(node, raw) {
-      for (const messageId of matchedMessageIds(raw)) {
+      for (const messageId of matchedMessageIds(raw, context.filename ?? '')) {
         context.report({ node, messageId });
       }
     }
@@ -105,7 +212,7 @@ export default {
         const matched = new Set();
         for (const quasi of node.quasis) {
           const raw = quasi.value.cooked ?? quasi.value.raw;
-          for (const id of matchedMessageIds(raw)) {
+          for (const id of matchedMessageIds(raw, context.filename ?? '')) {
             matched.add(id);
           }
         }

--- a/packages/react/src/components/ui/chart/chart.tsx
+++ b/packages/react/src/components/ui/chart/chart.tsx
@@ -171,13 +171,17 @@ function ChartTooltipLabel({
 
   if (labelFormatter) {
     return (
-      <div className={cn('nx:font-medium', labelClassName)}>
+      <div className={cn('nx:typography-label-default', labelClassName)}>
         {labelFormatter(value, payload)}
       </div>
     );
   }
   if (!value) return null;
-  return <div className={cn('nx:font-medium', labelClassName)}>{value}</div>;
+  return (
+    <div className={cn('nx:typography-label-default', labelClassName)}>
+      {value}
+    </div>
+  );
 }
 
 function ChartTooltipContent({
@@ -324,7 +328,7 @@ function ChartTooltipItem({
       />
       <div
         className={cn(
-          'nx:flex nx:flex-1 nx:justify-between nx:leading-none',
+          'nx:flex nx:flex-1 nx:justify-between',
           nestLabel ? 'nx:items-end' : 'nx:items-center'
         )}
       >

--- a/packages/react/src/components/ui/date-picker/date-picker.tsx
+++ b/packages/react/src/components/ui/date-picker/date-picker.tsx
@@ -336,13 +336,13 @@ function DatePickerDayButton({
       data-today={isToday}
       data-outside={isOutside || undefined}
       className={cn(
-        'nx:flex nx:aspect-square nx:size-(--cell-size) nx:min-w-(--cell-size) nx:typography-body-default nx:leading-none',
+        'nx:flex nx:aspect-square nx:size-(--cell-size) nx:min-w-(--cell-size) nx:typography-body-default',
         'nx:disabled:text-disabled-foreground nx:aria-disabled:text-disabled-foreground',
         isOutside && 'nx:text-muted-foreground-subtle',
         // Keyboard-focus ring on the focused day (modality-independent — paints above neighbours).
         'nx:group-data-[focused=true]/day:relative nx:group-data-[focused=true]/day:z-10 nx:group-data-[focused=true]/day:outline-2 nx:group-data-[focused=true]/day:outline-focus-default nx:group-data-[focused=true]/day:outline-offset-(--focus-offset)',
         // Today → inner error circle while keeping the button target at cell size.
-        'nx:data-[today=true]:relative nx:data-[today=true]:bg-transparent nx:data-[today=true]:font-medium nx:data-[today=true]:text-error-foreground nx:data-[today=true]:hover:bg-transparent nx:data-[today=true]:hover:text-error-foreground',
+        'nx:data-[today=true]:relative nx:data-[today=true]:bg-transparent nx:data-[today=true]:typography-label-default nx:data-[today=true]:text-error-foreground nx:data-[today=true]:hover:bg-transparent nx:data-[today=true]:hover:text-error-foreground',
         'nx:data-[today=true]:before:absolute nx:data-[today=true]:before:top-1/2 nx:data-[today=true]:before:left-1/2 nx:data-[today=true]:before:size-(--today-marker-size) nx:data-[today=true]:before:-translate-x-1/2 nx:data-[today=true]:before:-translate-y-1/2 nx:data-[today=true]:before:rounded-full nx:data-[today=true]:before:bg-error-background nx:data-[today=true]:hover:before:bg-error-background-hover',
         "nx:data-[today=true]:before:content-['']",
         // Selected single + range endpoints → solid primary fill.

--- a/packages/react/src/components/ui/field/field.tsx
+++ b/packages/react/src/components/ui/field/field.tsx
@@ -147,7 +147,7 @@ function FieldContent({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="field-content"
       className={cn(
-        'nx:group/field-content nx:flex nx:flex-1 nx:flex-col nx:gap-1.5 nx:leading-snug',
+        'nx:group/field-content nx:flex nx:flex-1 nx:flex-col nx:gap-1.5',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/table/table.tsx
+++ b/packages/react/src/components/ui/table/table.tsx
@@ -376,7 +376,7 @@ function TableRowHeader({ className, ...props }: TableRowHeaderProps) {
       data-slot="table-row-header"
       className={cn(
         tableCellVariants({ variant, density }),
-        'nx:font-medium',
+        'nx:typography-label-default',
         className
       )}
       {...props}

--- a/reports/nexus-style-token-audit.md
+++ b/reports/nexus-style-token-audit.md
@@ -1,0 +1,445 @@
+# Nexus Style-Token Leak Audit
+
+## Baseline Proof
+
+| Field | Value |
+| --- | --- |
+| Worktree | `/Users/temp/.codex/worktrees/3d2a/nexus` |
+| Branch | detached HEAD; `git name-rev HEAD` resolves to `main` |
+| HEAD | `644eb78535566d498edd33fb833ebb1afe3fbb8a` |
+| Base checked | `main` at `644eb78535566d498edd33fb833ebb1afe3fbb8a` |
+| Merge-base | `644eb78535566d498edd33fb833ebb1afe3fbb8a` |
+| Initial diff state | clean by `git diff --quiet`, `git diff --cached --quiet`, and `git diff main...HEAD` |
+| Untracked files | none by `git ls-files --others --exclude-standard` |
+
+Tracked scope used for the primary audit:
+
+| Tree | Files | LOC |
+| --- | ---: | ---: |
+| `packages/react/src` | 189 | 41,712 |
+| `packages/core` | 89 | 21,576 |
+| `packages/tailwind` | 6 | 1,309 |
+| `apps/console` | 148 | 16,681 |
+| Primary plus secondary total | 432 | 81,278 |
+
+Related but non-finding context:
+
+| Tree | Files | LOC | Use |
+| --- | ---: | ---: | --- |
+| `packages/eslint-plugin-nexus` | 14 | 1,062 | Existing guard inspection and plug proposal target |
+| `apps/docs` | 78 | 7,246 | Excluded marketing/docs consumer; appendix count only |
+
+## Scope And Method
+
+Findings are classified into these buckets:
+
+| Bucket | Meaning |
+| --- | --- |
+| leak | Raw or arbitrary styling escapes an existing token/composite surface and has a plausible token-backed target. |
+| convention | Valid utility, but violates a repo convention such as padding-based control sizing. |
+| sanctioned-exception | Existing documented or verified exception; do not migrate without a separate design decision. |
+| allowed-one-off | Arbitrary/system value is locally meaningful and not replaceable by the current scale. |
+| needs-new-token | A design-system concept exists, but no current token/composite names it. |
+| needs-decision | The scan found a real seam, but the correct policy is not yet settled. |
+| non-runtime | Story, docs, token source, generated token output, or guard code; not counted as runtime source leakage. |
+
+Mechanical inventory used these families:
+
+| Family | Pattern seed |
+| --- | --- |
+| Typography weight | `nx:(...:)font-(thin|extralight|light|normal|medium|semibold|bold|extrabold|black)` |
+| Typography leading | `nx:(...:)leading-(none|tight|snug|normal|relaxed|loose|<number>|[...])` |
+| Typography tracking | `nx:(...:)tracking-(tighter|tight|normal|wide|wider|widest|[...])` |
+| Typography size | named `text-*`, arbitrary `text-[...]`, and inline `fontSize/fontWeight/lineHeight/letterSpacing` |
+| Color | raw primitive fill/stroke/ring/gradient utilities plus color literals |
+| Spacing/sizing | arbitrary `p/m/gap/size/w/h/min/max/inset/top/right/bottom/left/translate-*` |
+| Fixed-height convention | `h-*` inside `packages/react/src/components/ui` |
+| Radius/border | arbitrary `rounded-[...]`, `rounded-*-[...]`, and `border-[...]` |
+| Z-index | `z-*` minus `z-overlay`, `z-sticky`, `z-modal`, `z-popover`, `z-toast`, `z-max` |
+| Focus/ring | non-focus `ring-*` utilities |
+| Motion | arbitrary `duration/ease/delay/animate-[...]` |
+| Responsive | viewport prefixes inside component internals and raw `vh` |
+
+Modern Web Guidance CSS guidance was checked before writing conclusions. Relevant points: prefer token/custom-property architecture for nontrivial values, use `outline` for focus visibility, preserve forced-colors behavior with system colors where needed, and prefer `svh/lvh/dvh` over raw `vh`. The repo browser floor remains Chrome 111+, Edge 111+, Firefox 113+, Safari 15.4+, Samsung Internet 22+, with OKLCH treated as the floor feature.
+
+## Executive Summary
+
+This is not a #495-scale migration. The primary React runtime has a concentrated set of open seams:
+
+| Rank | Finding | Count | Classification |
+| ---: | --- | ---: | --- |
+| 1 | Typography non-size utilities (`font-*`, `leading-*`) still bypass both reset and lint. | 10 primary hits, plus 28 console hits | leak / needs-new-token / needs-decision |
+| 2 | Raw numeric z-index appears in local stacking contexts. | 6 primary hits | needs-decision before linting |
+| 3 | Chart uses arbitrary radius and border width where token or chart-specific policy should exist. | 3 primary leak hits | leak |
+| 4 | Avatar initials arbitrary text sizes are sanctioned by issue #496, but related weight/leading/ring geometry still needs policy. | 9 sanctioned size hits, 1 weight/leading line, 3 ring lines | sanctioned-exception / needs-decision |
+| 5 | Input and Switch fixed geometry are convention issues, not token leaks. | Input 3 `h-*`; Switch 4 arbitrary geometry tokens plus `h-5` | convention |
+| 6 | `apps/console` contains raw typography and color swatch literals. | 47 runtime candidates | secondary consumer exposure |
+
+Clean or guarded areas:
+
+| Area | Status |
+| --- | --- |
+| Raw named font size | Guarded by `--text-*` reset and `rawFontSize` lint. No primary runtime named `text-xs/sm/base/...` hits found. |
+| Raw primitive `bg/text/border` colors | Guarded by `nx-class-conventions` `rawPrimitive`. No open primary runtime hits found in the scanned set. |
+| Raw primitive `fill/stroke/ring/from/via/to` colors | No current primary runtime primitive-color hits found, but the lint gap remains open. |
+| Shadow | `--shadow-*` reset is present; no arbitrary shadow or focusable-shadow leak found by this scan. |
+| Motion | No arbitrary motion utility hits found in primary or console runtime. |
+| Raw `vh` | No raw `vh` hits found in primary or console runtime; current arbitrary viewport heights use `svh`. |
+
+## Defense Coverage Matrix
+
+| Family | Reset in `packages/tailwind/nexus.css` | Lint guard | Audit script | Net status |
+| --- | --- | --- | --- | --- |
+| Color primitives: `bg/text/border` | `--color-*` reset | `rawPrimitive` | `audit-class-refs` for semantic refs | Guarded. |
+| Color primitives: `fill/stroke/ring/gradient` | `--color-*` reset | none | none | Currently clean in runtime, but future seam is open. |
+| Color literals | n/a | none | none | Runtime literals are mostly selector/system/app data, not direct token leaks. |
+| Typography size: named | `--text-*` reset | `rawFontSize` | none | Guarded. |
+| Typography size: arbitrary | bypasses reset | none | none | Avatar exception is sanctioned; console/icon candidates remain. |
+| Typography weight/leading/tracking | not reset | none | none | Open. Primary component leaks exist. |
+| Typography composites | n/a | `deadTypography` | drift test | Guarded by hardcoded live list plus test. |
+| Spacing/sizing named | `--spacing-*` reset plus Nexus scale | token JSON spacing guard only | none | Reset-only for source classes; arbitrary values bypass. |
+| Radius | `--radius-*` reset | none | none | Reset-only; Chart has arbitrary radius hits. |
+| Border width | custom `--border-*` utilities | none | none | Chart has arbitrary `border-[1.5px]`. |
+| Shadow | `--shadow-*` reset | none | none | Source clean in this scan. |
+| Z-index | token keys exist, but namespace is not reset | none | none | Open; 6 primary numeric hits. |
+| Focus | n/a | none | component review only | Presence audit candidate; Avatar non-focus rings need decision. |
+| Motion | custom imports / Tailwind defaults | none | none | Source clean in this scan. |
+| Responsive | `--breakpoint-*` reset | none | responsive rule docs | Viewport-prefix exceptions need a clearer allowlist. |
+
+Current reset block verified at `packages/tailwind/nexus.css:19-24`:
+
+```css
+--color-*: initial;
+--spacing-*: initial;
+--text-*: initial;
+--radius-*: initial;
+--shadow-*: initial;
+--breakpoint-*: initial;
+```
+
+Notably absent from that reset block: `--font-weight-*`, `--leading-*`, `--tracking-*`, and `--z-index-*`.
+
+## Per-Family Findings
+
+### Color
+
+Closed/blocked:
+
+| Surface | Evidence | Status |
+| --- | --- | --- |
+| Raw primitive `bg/text/border` | `nx-class-conventions.js` has `rawPrimitive`; `nexus.css` resets `--color-*`. | Guarded. |
+| Semantic color refs | `packages/core/scripts/audit-class-refs.js` validates semantic refs against emitted `--color-*`. | Guarded for the prefixes it owns. |
+| Runtime raw primitive `fill/stroke/ring/from/via/to` | Mechanical scan found 0 raw primitive runtime hits. | Source clean, guard gap remains. |
+
+Still-possible/open:
+
+| Location | Pattern | Bucket | Recommendation |
+| --- | --- | --- | --- |
+| `packages/react/src/components/ui/chart/chart.tsx:75` | `#ccc`, `#fff` inside arbitrary selectors matching Recharts generated attributes | allowed-one-off | Keep out of primitive-color lint or require a documented selector-literal allowlist. These literals identify third-party SVG attributes; they do not apply raw colors. |
+| `packages/react/src/components/ui/native-select/native-select.tsx:97,115` | `nx:bg-[Canvas]`, `nx:text-[CanvasText]` | allowed-one-off | Forced-colors/system-color values are deliberate browser UI integration. Do not classify as arbitrary font-size/color leak. |
+| `apps/console/src/hooks/useTheme.ts:4-17` | 11 hex swatch values | needs-decision | Secondary consumer app stores palette swatch metadata. Prefer deriving from token data if this is meant to stay design-system-authored. |
+
+False positives subtracted: issue references in comments such as `#281`, `#418`, `#119`, and `#118`.
+
+### Typography
+
+Closed/blocked:
+
+| Surface | Evidence | Status |
+| --- | --- | --- |
+| Raw named sizes | `--text-*` reset plus `rawFontSize` lint. | Guarded; no primary runtime named-size hits. |
+| Dead composites | `LIVE_TYPOGRAPHY` in `nx-class-conventions.js` plus drift test comment. | Guarded, but list is hardcoded. |
+
+Primary runtime findings:
+
+| Location | Pattern | Bucket | Recommendation |
+| --- | --- | --- | --- |
+| `packages/react/src/components/ui/avatar/avatar.tsx:11-19` | 9 `nx:text-[...]` sizes | sanctioned-exception | Verified by issue #496. Avatar initials scale with avatar diameter, not semantic role. Keep allowed unless a new avatar-initials token is designed. |
+| `packages/react/src/components/ui/avatar/avatar.tsx:199` | `nx:font-medium`, `nx:leading-none` | needs-decision | Decide whether Avatar fallback initials get a local token/policy alongside the #496 arbitrary-size exception. |
+| `packages/react/src/components/ui/chart/chart.tsx:174,180` | `nx:font-medium` | leak | Use a typography composite or add a chart tooltip label token. |
+| `packages/react/src/components/ui/chart/chart.tsx:327` | `nx:leading-none` | leak | Composite-swap trap required: likely delete redundant line-height if the composite already owns it. |
+| `packages/react/src/components/ui/chart/chart.tsx:338` | `nx:font-mono nx:font-medium` | needs-new-token | Existing `code-inline` may not be right for chart numeric values; decide on a chart value typography token/composite. |
+| `packages/react/src/components/ui/date-picker/date-picker.tsx:339` | `nx:leading-none` | leak | Composite-swap trap required. |
+| `packages/react/src/components/ui/date-picker/date-picker.tsx:345` | `nx:data-[today=true]:font-medium` | leak | Prefer token/composite ownership for emphasized day text. |
+| `packages/react/src/components/ui/field/field.tsx:150` | `nx:leading-snug` | leak | Confirm whether the field content composite should own this line-height. |
+| `packages/react/src/components/ui/table/table.tsx:379` | `nx:font-medium` | leak | Prefer label/body composite or token-backed table header/body role. |
+
+Secondary console findings:
+
+| Family | Count | Locations |
+| --- | ---: | --- |
+| `font-*` | 24 | `apps/console/src/app/auth-layout.tsx:20`; `analytics-route.tsx:185`; `verify-route.tsx:58`; `billing-route.tsx:242`; `plan-sheet.tsx:123`; `crm/contact-card.tsx:17`; `crm/contacts-board.tsx:157`; `crm/contacts-columns.tsx:88`; `design-system/ComponentShowcase.tsx:234,263,312,318,324,330`; `inbox/conversation-list.tsx:69` x2; `people/member-card.tsx:17`; `people/people-columns.tsx:94`; `projects/issue-card.tsx:22`; `projects/issues-columns.tsx:97`; `shell/app-sidebar.tsx:77,81,176`; `shell/notifications-menu.tsx:188` |
+| `leading-*` | 3 | `apps/console/src/app/auth-layout.tsx:27`; `design-system/IconShowcase.tsx:51`; `projects/issue-detail-route.tsx:110` |
+| `tracking-*` | 1 | `apps/console/src/app/not-found.tsx:13` |
+| arbitrary `text-[...]` | 1 | `apps/console/src/modules/design-system/IconShowcase.tsx:51` |
+
+### Spacing And Sizing
+
+Closed/blocked:
+
+| Surface | Evidence | Status |
+| --- | --- | --- |
+| Named spacing scale | `--spacing-*` reset, then Nexus scale in `nexus.css`. | Off-scale named utilities should no-op. |
+| Token JSON spacing values | `canonical-spacing-steps.js` validates spacing mode JSON values against `canonical-step-set.json`. | Token-source guard only. |
+
+Open convention surface:
+
+| Location | Pattern | Bucket | Recommendation |
+| --- | --- | --- | --- |
+| `packages/react/src/components/ui/input/input.tsx:20-22` | `nx:h-10`, `nx:h-8`, `nx:h-12` | convention | Defer to Input-specific cleanup. This is not a token leak; it is a sizing convention question. |
+| `packages/react/src/components/ui/switch/switch.tsx:23-24,44` | `nx:h-5`, `nx:h-[18px]`, `nx:w-[32px]`, `nx:size-[14px]`, `nx:translate-x-[14px]` | convention | Likely intrinsic switch geometry, but should be documented or migrated in a Switch-specific pass. |
+
+Arbitrary spacing/size candidates that are not automatic leaks:
+
+| Location | Pattern | Bucket |
+| --- | --- | --- |
+| `packages/react/src/components/ui/avatar/avatar.tsx:209` | `right-[0.04em]`, `bottom-[0.04em]`, `size-[0.6em]` | allowed-one-off candidate |
+| `packages/react/src/components/ui/breadcrumb/breadcrumb.tsx:127,154` | `max-w-[150px]` | needs-decision |
+| `packages/react/src/components/ui/command/command.tsx:184` | `max-h-[300px]` | needs-decision |
+| `packages/react/src/components/ui/drawer/drawer.tsx:101,102,111` | `max-h-[80svh]`, `w-[100px]` | needs-decision |
+| `packages/react/src/components/ui/navigation-menu/navigation-menu.tsx:301` | `top-[60%]` | needs-decision |
+| `packages/react/src/components/ui/sidebar/sidebar.tsx:334,349` | `w-[calc(...)]` | needs-decision |
+| `apps/console/src/modules/analytics/analytics-charts.tsx:25` | `h-[260px]` | secondary consumer |
+| `apps/console/src/modules/coming-soon.tsx:26` | `min-h-[60svh]` | secondary consumer, uses `svh` |
+| `apps/console/src/modules/inbox/conversation-thread.tsx:234` | `max-w-[75%]` | secondary consumer |
+| `apps/console/src/modules/inbox/inbox-route.tsx:57` | `h-[calc(100svh-3.5rem)]` | secondary consumer, uses `svh` |
+
+Policy note: keep arbitrary values when no exact Nexus scale utility exists. Do not snap to a nearby token and change approved geometry.
+
+### Radius And Border Width
+
+Closed/blocked:
+
+| Surface | Evidence | Status |
+| --- | --- | --- |
+| Named radius scale | `--radius-*` reset and semantic radius tokens in `nexus.css`. | Off-scale named radius should no-op. |
+| Named border widths | `--border-default` and `--border-thick` emitted by `borderwidth-utilities.css`. | Token surface exists, but lint does not protect arbitrary border widths. |
+
+Primary runtime findings:
+
+| Location | Pattern | Bucket | Recommendation |
+| --- | --- | --- | --- |
+| `packages/react/src/components/ui/chart/chart.tsx:272` | `nx:rounded-[2px]` | leak | Add/use a chart marker radius token or choose an existing radius if exact. |
+| `packages/react/src/components/ui/chart/chart.tsx:276` | `nx:border-[1.5px]` | leak | Add/use a border-width token if 1.5px is intentional. |
+| `packages/react/src/components/ui/chart/chart.tsx:393` | `nx:rounded-[2px]` | leak | Same chart marker radius decision as line 272. |
+| `packages/react/src/components/ui/avatar/avatar.tsx:165,199`; `scroll-area.tsx:65` | `nx:rounded-[inherit]` | allowed-one-off | Inheritance keyword, not a raw numeric design token. Allowlist if arbitrary-radius lint is added. |
+| `packages/react/src/components/ui/scroll-area/scroll-area.tsx:74` | `nx:forced-colors:border-[ButtonBorder]` | allowed-one-off | Forced-colors system keyword; preserve accessibility behavior. |
+
+### Shadow
+
+No runtime arbitrary shadow candidates were found. The current source uses tokenized `shadow-*` utilities where present, and `--shadow-*` is reset in `nexus.css`.
+
+### Z-Index
+
+Token source exists at `packages/core/tokens/semantic/z-index.json`: `overlay` 10, `sticky` 30, `modal` 50, `popover` 70, `toast` 100, `max` 9999. `nexus.css` emits token utilities, but does not reset `--z-index-*`.
+
+Primary runtime candidates:
+
+| Location | Pattern | Bucket | Recommendation |
+| --- | --- | --- | --- |
+| `packages/react/src/components/ui/button-group/button-group.tsx:15` | `nx:*:focus-visible:z-10` | needs-decision | Local focus overlap, not structural overlay layering. Decide whether local numeric z values are allowed. |
+| `packages/react/src/components/ui/date-picker/date-picker.tsx:343` | `nx:group-data-[focused=true]/day:z-10` | needs-decision | Local calendar focus stacking. Token scale may be semantically too broad. |
+| `packages/react/src/components/ui/date-picker/date-picker.tsx:361` | `nx:z-10` | needs-decision | Calendar caption local stacking. |
+| `packages/react/src/components/ui/input-otp/input-otp.tsx:125` | `nx:data-[active=true]:z-10` | needs-decision | Local active-cell stacking. |
+| `packages/react/src/components/ui/navigation-menu/navigation-menu.tsx:294` | `nx:z-1` | leak / needs-decision | Very low local arrow stacking; either local policy or token map needed. |
+| `packages/react/src/components/ui/resizable/resizable.tsx:76` | `nx:z-10` | leak / needs-decision | Resize handle local stacking. |
+
+Recommendation: do not blindly map all `z-10` to `z-overlay`; the existing token scale names structural layers, while several hits are local overlap inside one component.
+
+### Focus And Ring
+
+Closed/blocked:
+
+| Surface | Evidence | Status |
+| --- | --- | --- |
+| Canonical focus outline | `.claude/rules/components.md` defines `focus-visible:outline-2 outline-focus-default outline-offset-(--focus-offset)`. | Documented. |
+| Focus color token | `nexus.css` emits `--color-focus-default` and `--color-focus-error`. | Tokenized. |
+
+Open:
+
+| Location | Pattern | Bucket | Recommendation |
+| --- | --- | --- | --- |
+| `packages/react/src/components/ui/avatar/avatar.tsx:123` | selected/group `ring-*` | needs-decision | Non-focus visual emphasis; decide if Avatar gets a ring exception or should use border tokens. |
+| `packages/react/src/components/ui/avatar/avatar.tsx:209` | status marker `ring-[0.1em]` | needs-decision | Em-based geometry tied to avatar diameter; likely exception if documented. |
+| `packages/react/src/components/ui/avatar/avatar.tsx:335` | AvatarGroup overlap `ring-[0.1em]` | needs-decision | Same policy as status marker. |
+
+Separate presence audit proposal: a future guard should check that known focusable controls include the canonical outline token, but only after mapping components that intentionally use roving-focus background tints rather than outlines.
+
+### Motion
+
+No arbitrary `duration-[...]`, `ease-[...]`, `delay-[...]`, or `animate-[...]` runtime hits were found.
+
+### Responsive
+
+Closed/blocked:
+
+| Surface | Evidence | Status |
+| --- | --- | --- |
+| Raw `vh` | Scan found no raw `vh` in primary or console runtime. Current viewport arbitrary values use `svh`. | Clean. |
+| Breakpoint scale | `--breakpoint-*` reset and semantic breakpoint tokens in `nexus.css`. | Off-scale named breakpoints should no-op. |
+
+Viewport-prefix candidates inside component internals:
+
+| Location | Pattern | Bucket | Recommendation |
+| --- | --- | --- | --- |
+| `packages/react/src/components/ui/dialog/dialog.tsx:192,305` | `lg:` and `sm:` overlay behavior | sanctioned-exception | Explicitly named by `responsive.md`. |
+| `packages/react/src/components/ui/sheet/sheet.tsx:113,117,181` | `sm:`, `lg:` overlay behavior | sanctioned-exception | `responsive.md` names future Sheet as a viewport-driven overlay exception. |
+| `packages/react/src/components/ui/drawer/drawer.tsx:129` | `md:text-left` | needs-decision | Likely overlay exception; docs should name Drawer if accepted. |
+| `packages/react/src/components/ui/overlay-layout/overlay-layout.ts:16,23,36` | shared `sm:` overlay layout classes | needs-decision | Likely exception because it backs overlay layout; docs should name it if accepted. |
+| `packages/react/src/components/ui/sidebar/sidebar.tsx:319,341,427,461,698,932,938` | `lg:` page-shell/sidebar behavior | needs-decision | Sidebar is page-shell navigation, not a generic embedded component. If accepted, add it to the documented exception list. |
+
+## Runtime Raw Appendix
+
+This appendix groups the primary and secondary runtime candidates from the mechanical scan after generated files, token source/output, stories, and docs were excluded from findings. Rows with comma-separated lines or token lists are grouped duplicates from the same family and component area.
+
+### Primary React Runtime
+
+| Family | Bucket | Location | Token / pattern |
+| --- | --- | --- | --- |
+| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:11` | `nx:text-[0.625rem]` |
+| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:12` | `nx:text-[0.6875rem]` |
+| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:13` | `nx:text-[0.75rem]` |
+| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:14` | `nx:text-[1rem]` |
+| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:15` | `nx:text-[1.125rem]` |
+| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:16` | `nx:text-[1.25rem]` |
+| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:17` | `nx:text-[1.5rem]` |
+| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:18` | `nx:text-[1.875rem]` |
+| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:19` | `nx:text-[2.25rem]` |
+| focus-ring-utility | needs-decision | `packages/react/src/components/ui/avatar/avatar.tsx:123` | selected/group `ring-*` utilities |
+| radius-border-arbitrary | allowed-one-off | `packages/react/src/components/ui/avatar/avatar.tsx:165` | `nx:rounded-[inherit]` |
+| radius-border-arbitrary | allowed-one-off | `packages/react/src/components/ui/avatar/avatar.tsx:199` | `nx:rounded-[inherit]` |
+| typography-leading | needs-decision | `packages/react/src/components/ui/avatar/avatar.tsx:199` | `nx:leading-none` |
+| typography-weight | needs-decision | `packages/react/src/components/ui/avatar/avatar.tsx:199` | `nx:font-medium` |
+| focus-ring-utility | needs-decision | `packages/react/src/components/ui/avatar/avatar.tsx:209` | status marker `ring-*` |
+| spacing-arbitrary | allowed-one-off | `packages/react/src/components/ui/avatar/avatar.tsx:209` | `right-[0.04em]`, `bottom-[0.04em]`, `size-[0.6em]` |
+| focus-ring-utility | needs-decision | `packages/react/src/components/ui/avatar/avatar.tsx:335` | AvatarGroup `ring-*` |
+| fixed-height-control | convention | `packages/react/src/components/ui/badge/badge.tsx:145` | `nx:h-6` |
+| spacing-arbitrary | needs-decision | `packages/react/src/components/ui/breadcrumb/breadcrumb.tsx:127,154` | `nx:max-w-[150px]` |
+| z-index | needs-decision | `packages/react/src/components/ui/button-group/button-group.tsx:15` | `nx:*:focus-visible:z-10` |
+| fixed-height-control | convention | `packages/react/src/components/ui/button-group/button-group.tsx:36-38` | `nx:h-8`, `nx:h-10`, `nx:h-12` |
+| fixed-height-control | convention | `packages/react/src/components/ui/button/button.tsx:32-34` | `nx:h-8`, `nx:h-10`, `nx:h-12` |
+| color-literal | allowed-one-off | `packages/react/src/components/ui/chart/chart.tsx:75` | selector literals `#ccc`, `#fff` |
+| typography-weight | leak | `packages/react/src/components/ui/chart/chart.tsx:174,180` | `nx:font-medium` |
+| radius-border-arbitrary | leak | `packages/react/src/components/ui/chart/chart.tsx:272` | `nx:rounded-[2px]` |
+| radius-border-arbitrary | leak | `packages/react/src/components/ui/chart/chart.tsx:276` | `nx:border-[1.5px]` |
+| typography-leading | leak | `packages/react/src/components/ui/chart/chart.tsx:327` | `nx:leading-none` |
+| typography-weight | needs-new-token | `packages/react/src/components/ui/chart/chart.tsx:338` | `nx:font-mono nx:font-medium` |
+| radius-border-arbitrary | leak | `packages/react/src/components/ui/chart/chart.tsx:393` | `nx:rounded-[2px]` |
+| spacing-arbitrary | needs-decision | `packages/react/src/components/ui/command/command.tsx:184` | `nx:max-h-[300px]` |
+| fixed-height-control | convention | `packages/react/src/components/ui/date-picker/date-picker.tsx:211` | `nx:h-8` |
+| typography-leading | leak | `packages/react/src/components/ui/date-picker/date-picker.tsx:339` | `nx:leading-none` |
+| z-index | needs-decision | `packages/react/src/components/ui/date-picker/date-picker.tsx:343` | `nx:group-data-[focused=true]/day:z-10` |
+| typography-weight | leak | `packages/react/src/components/ui/date-picker/date-picker.tsx:345` | `nx:data-[today=true]:font-medium` |
+| z-index | needs-decision | `packages/react/src/components/ui/date-picker/date-picker.tsx:361` | `nx:z-10` |
+| responsive-viewport-prefix | sanctioned-exception | `packages/react/src/components/ui/dialog/dialog.tsx:192,305` | overlay `lg:` / `sm:` classes |
+| spacing-arbitrary | needs-decision | `packages/react/src/components/ui/drawer/drawer.tsx:101,102,111` | `max-h-[80svh]`, `w-[100px]` |
+| responsive-viewport-prefix | needs-decision | `packages/react/src/components/ui/drawer/drawer.tsx:129` | `nx:md:text-left` |
+| typography-leading | leak | `packages/react/src/components/ui/field/field.tsx:150` | `nx:leading-snug` |
+| fixed-height-control | convention | `packages/react/src/components/ui/field/field.tsx:236` | `nx:h-5` |
+| fixed-height-control | convention | `packages/react/src/components/ui/input-group/input-group.tsx:137,138` | `nx:h-6`, `nx:h-8` |
+| z-index | needs-decision | `packages/react/src/components/ui/input-otp/input-otp.tsx:125` | `nx:data-[active=true]:z-10` |
+| fixed-height-control | convention | `packages/react/src/components/ui/input-otp/input-otp.tsx:133` | `nx:h-4` |
+| fixed-height-control | convention | `packages/react/src/components/ui/input/input.tsx:20-22` | `nx:h-10`, `nx:h-8`, `nx:h-12` |
+| fixed-height-control | convention | `packages/react/src/components/ui/kbd/kbd.tsx:35` | `nx:h-5` |
+| color-system | allowed-one-off | `packages/react/src/components/ui/native-select/native-select.tsx:97,115` | `nx:bg-[Canvas]`, `nx:text-[CanvasText]` |
+| z-index | needs-decision | `packages/react/src/components/ui/navigation-menu/navigation-menu.tsx:294` | `nx:z-1` |
+| spacing-arbitrary | needs-decision | `packages/react/src/components/ui/navigation-menu/navigation-menu.tsx:301` | `nx:top-[60%]` |
+| responsive-viewport-prefix | needs-decision | `packages/react/src/components/ui/overlay-layout/overlay-layout.ts:16,23,36` | shared overlay `sm:` classes |
+| fixed-height-control | convention | `packages/react/src/components/ui/progress/progress.tsx:42` | `nx:h-2` |
+| fixed-height-control | convention | `packages/react/src/components/ui/resizable/resizable.tsx:69` | handle hit-area `h-*` |
+| z-index | needs-decision | `packages/react/src/components/ui/resizable/resizable.tsx:76` | `nx:z-10` |
+| fixed-height-control | convention | `packages/react/src/components/ui/resizable/resizable.tsx:76` | `nx:h-4` |
+| fixed-height-control | convention | `packages/react/src/components/ui/scroll-area/scroll-area.tsx:37,99` | `nx:h-72`, `nx:h-2.5` |
+| radius-border-arbitrary | allowed-one-off | `packages/react/src/components/ui/scroll-area/scroll-area.tsx:65` | `nx:rounded-[inherit]` |
+| radius-border-arbitrary | allowed-one-off | `packages/react/src/components/ui/scroll-area/scroll-area.tsx:74` | `nx:forced-colors:border-[ButtonBorder]` |
+| fixed-height-control | convention | `packages/react/src/components/ui/separator/separator.tsx:33` | `nx:h-5` |
+| responsive-viewport-prefix | sanctioned-exception | `packages/react/src/components/ui/sheet/sheet.tsx:113,117,181` | Sheet `sm:` / `lg:` overlay classes |
+| responsive-viewport-prefix | needs-decision | `packages/react/src/components/ui/sidebar/sidebar.tsx:319,341,427,461,698,932,938` | page-shell/sidebar `lg:` classes |
+| spacing-arbitrary | needs-decision | `packages/react/src/components/ui/sidebar/sidebar.tsx:334,349` | `w-[calc(...)]` |
+| fixed-height-control | convention | `packages/react/src/components/ui/sidebar/sidebar.tsx:486,657,801-803,963,1009,1022,1125` | sidebar `h-*` geometry |
+| fixed-height-control | convention | `packages/react/src/components/ui/skeleton/skeleton.tsx:22` | `nx:h-4` |
+| fixed-height-control | convention | `packages/react/src/components/ui/slider/slider.tsx:63` | `nx:data-[orientation=horizontal]:h-1.5` |
+| fixed-height-control | convention | `packages/react/src/components/ui/switch/switch.tsx:23,24` | `nx:h-5`, `nx:h-[18px]` |
+| spacing-arbitrary | convention | `packages/react/src/components/ui/switch/switch.tsx:24,44` | `w-[32px]`, `size-[14px]`, `translate-x-[14px]` |
+| typography-weight | leak | `packages/react/src/components/ui/table/table.tsx:379` | `nx:font-medium` |
+
+### Secondary Console Runtime
+
+| Family | Bucket | Location | Token / pattern |
+| --- | --- | --- | --- |
+| typography-weight | leak | `apps/console/src/app/auth-layout.tsx:20` | `nx:font-bold` |
+| typography-leading | leak | `apps/console/src/app/auth-layout.tsx:27` | `nx:leading-snug` |
+| typography-tracking | leak | `apps/console/src/app/not-found.tsx:13` | `nx:tracking-wide` |
+| color-literal | allowed-one-off / needs-decision | `apps/console/src/hooks/useTheme.ts:4-17` | 11 swatch hex values |
+| spacing-arbitrary | needs-decision | `apps/console/src/modules/analytics/analytics-charts.tsx:25` | `nx:h-[260px]` |
+| typography-weight | leak | `apps/console/src/modules/analytics/analytics-route.tsx:185` | `nx:font-medium` |
+| typography-weight | leak | `apps/console/src/modules/auth/verify-route.tsx:58` | `nx:font-medium` |
+| typography-weight | leak | `apps/console/src/modules/billing/billing-route.tsx:242` | `nx:font-medium` |
+| typography-weight | leak | `apps/console/src/modules/billing/plan-sheet.tsx:123` | `nx:font-medium` |
+| spacing-arbitrary | needs-decision | `apps/console/src/modules/coming-soon.tsx:26` | `nx:min-h-[60svh]` |
+| typography-weight | leak | `apps/console/src/modules/crm/contact-card.tsx:17` | `nx:font-medium` |
+| typography-weight | leak | `apps/console/src/modules/crm/contacts-board.tsx:157` | `nx:font-medium` |
+| typography-weight | leak | `apps/console/src/modules/crm/contacts-columns.tsx:88` | `nx:font-medium` |
+| typography-weight | leak | `apps/console/src/modules/design-system/ComponentShowcase.tsx:234,263,312,318,324,330` | `font-medium` / `font-semibold` |
+| typography-arbitrary-size | needs-decision | `apps/console/src/modules/design-system/IconShowcase.tsx:51` | `nx:text-[10px]` |
+| typography-leading | leak | `apps/console/src/modules/design-system/IconShowcase.tsx:51` | `nx:leading-tight` |
+| typography-weight | leak | `apps/console/src/modules/inbox/conversation-list.tsx:69` | `font-semibold` / `font-medium` |
+| spacing-arbitrary | needs-decision | `apps/console/src/modules/inbox/conversation-thread.tsx:234` | `nx:max-w-[75%]` |
+| spacing-arbitrary | needs-decision | `apps/console/src/modules/inbox/inbox-route.tsx:57` | `nx:h-[calc(100svh-3.5rem)]` |
+| typography-weight | leak | `apps/console/src/modules/people/member-card.tsx:17` | `nx:font-medium` |
+| typography-weight | leak | `apps/console/src/modules/people/people-columns.tsx:94` | `nx:font-medium` |
+| typography-weight | leak | `apps/console/src/modules/projects/issue-card.tsx:22` | `nx:font-medium` |
+| typography-leading | leak | `apps/console/src/modules/projects/issue-detail-route.tsx:110` | `nx:leading-relaxed` |
+| typography-weight | leak | `apps/console/src/modules/projects/issues-columns.tsx:97` | `nx:font-medium` |
+| typography-weight | leak | `apps/console/src/shell/app-sidebar.tsx:77,81,176` | `font-bold` / `font-semibold` / `font-normal` |
+| typography-weight | leak | `apps/console/src/shell/notifications-menu.tsx:188` | `nx:font-medium` |
+
+## Non-Runtime Appendix
+
+The scanner also saw these non-runtime candidates. They are intentionally excluded from source-leak counts:
+
+| Kind | Candidate count | Treatment |
+| --- | ---: | --- |
+| `story` | 258 | Story/demo sizing, literals, and assertions; useful for future story policy but not runtime leakage. |
+| `docs-out-of-scope` | 525 | Marketing/docs consumer; excluded by scope. |
+| `token-output` | 1,059 | Generated theme CSS and package token CSS; token values are expected here. |
+| `token-source` | 465 | DTCG token JSON; raw values are canonical source, not leaks. |
+| `token-infrastructure` | 108 | Scripts/tests manipulating token values; not class leakage. |
+| `guard-source` | 8 | Existing lint rule/test strings. |
+| `other` | 1 | Package metadata/non-runtime residue. |
+
+## Plug Proposal
+
+Ranked narrow plugs:
+
+| Rank | Plug | Why | Notes |
+| ---: | --- | --- | --- |
+| 1 | Add focused lint for typography non-size utilities: `font-*`, `leading-*`, `tracking-*`. | This is the biggest primary runtime leak family and has no reset/lint protection. | Derive allowlists from typography token/composite source or add a drift test. Avoid hardcoding a second live list without a guard. |
+| 2 | Add z-index numeric lint with a local-stacking policy. | Six primary numeric hits exist. | Do not blindly force `z-10` to `z-overlay`; tokens are structural layers, while several hits are local overlap. |
+| 3 | Add arbitrary radius/border lint for component runtime. | Chart has real arbitrary radius/border leaks. | Allowlist `rounded-[inherit]` and forced-colors system keywords such as `ButtonBorder`. |
+| 4 | Extend raw primitive color lint to `fill`, `stroke`, `ring`, `from`, `via`, `to`. | Current runtime is clean, but the seam remains open. | Keep system-color and selector-literal exceptions out of this rule. |
+| 5 | Add a documented exception list for arbitrary spacing/sizing. | Arbitrary values are not inherently bad; several are relative geometry or calc values with no exact scale equivalent. | Enforce exact scale replacement only when an exact Nexus scale value exists. |
+| 6 | Add a focus presence audit for known focusable controls. | Existing rules require outline focus tokens, but no automated presence guard exists. | Scope carefully around roving-focus overlay rows that intentionally use background tint instead of outline. |
+| 7 | Add docs to `responsive.md` for Drawer, OverlayLayout, and Sidebar if accepted as viewport exceptions. | Current local source uses viewport prefixes beyond the explicit Dialog and future Sheet text. | This is documentation/policy closure, not a class migration. |
+| 8 | Consider a console-only cleanup issue. | `apps/console` has 47 runtime candidates, mostly typography. | Keep separate from design-system package hard gates unless console is intended to be a strict consumer example. |
+
+## Validation And Rerun Checklist
+
+Completed in this pass:
+
+- Verified baseline commit and clean initial diff against `main`.
+- Read repo instructions, responsive/component rules, existing reset block, existing ESLint rule, spacing JSON guard, semantic color audit script, z-index tokens, typography composites, package browser floor, and issue #496.
+- Ran Modern Web Guidance CSS lookup and applied the repo browser-floor override.
+- Ran deterministic mechanical scans over primary, secondary, docs, stories, token source/output, and guard source, then classified runtime findings.
+
+Not run in this pass:
+
+- No source plugs were implemented, so `pnpm lint`, `pnpm typecheck`, app builds, reset-efficacy build grep, and per-app emission gates are deferred until a plug is approved.
+
+If plugs are approved, validation should include:
+
+1. Re-run the Phase 1 family patterns and confirm report counts remain intentional.
+2. Run `pnpm lint`, `pnpm typecheck`, and `pnpm format:check`.
+3. Run affected unit/Storybook checks for touched components.
+4. For reset changes, build generated CSS and grep for emitted defaults to prove the reset works at the CSS layer.
+5. For app emission gates, build each in-scope app separately and grep that app's built CSS, because Tailwind emission is tree-shaken per app.

--- a/reports/nexus-style-token-audit.md
+++ b/reports/nexus-style-token-audit.md
@@ -1,110 +1,111 @@
 # Nexus Style-Token Leak Audit
 
+This document keeps the baseline audit evidence first. The implementation
+follow-up section records changes made on this branch after that baseline scan.
+
 ## Baseline Proof
 
-| Field | Value |
-| --- | --- |
-| Worktree | `/Users/temp/.codex/worktrees/3d2a/nexus` |
-| Branch | detached HEAD; `git name-rev HEAD` resolves to `main` |
-| HEAD | `644eb78535566d498edd33fb833ebb1afe3fbb8a` |
-| Base checked | `main` at `644eb78535566d498edd33fb833ebb1afe3fbb8a` |
-| Merge-base | `644eb78535566d498edd33fb833ebb1afe3fbb8a` |
+| Field              | Value                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------ |
+| Worktree           | `/Users/temp/.codex/worktrees/3d2a/nexus`                                            |
+| Branch             | detached HEAD; `git name-rev HEAD` resolves to `main`                                |
+| HEAD               | `644eb78535566d498edd33fb833ebb1afe3fbb8a`                                           |
+| Base checked       | `main` at `644eb78535566d498edd33fb833ebb1afe3fbb8a`                                 |
+| Merge-base         | `644eb78535566d498edd33fb833ebb1afe3fbb8a`                                           |
 | Initial diff state | clean by `git diff --quiet`, `git diff --cached --quiet`, and `git diff main...HEAD` |
-| Untracked files | none by `git ls-files --others --exclude-standard` |
+| Untracked files    | none by `git ls-files --others --exclude-standard`                                   |
 
 Tracked scope used for the primary audit:
 
-| Tree | Files | LOC |
-| --- | ---: | ---: |
-| `packages/react/src` | 189 | 41,712 |
-| `packages/core` | 89 | 21,576 |
-| `packages/tailwind` | 6 | 1,309 |
-| `apps/console` | 148 | 16,681 |
-| Primary plus secondary total | 432 | 81,278 |
+| Tree                         | Files |    LOC |
+| ---------------------------- | ----: | -----: |
+| `packages/react/src`         |   189 | 41,712 |
+| `packages/core`              |    89 | 21,576 |
+| `packages/tailwind`          |     6 |  1,309 |
+| `apps/console`               |   148 | 16,681 |
+| Primary plus secondary total |   432 | 81,278 |
 
 Related but non-finding context:
 
-| Tree | Files | LOC | Use |
-| --- | ---: | ---: | --- |
-| `packages/eslint-plugin-nexus` | 14 | 1,062 | Existing guard inspection and plug proposal target |
-| `apps/docs` | 78 | 7,246 | Excluded marketing/docs consumer; appendix count only |
+| Tree                           | Files |   LOC | Use                                                   |
+| ------------------------------ | ----: | ----: | ----------------------------------------------------- |
+| `packages/eslint-plugin-nexus` |    14 | 1,062 | Existing guard inspection and plug proposal target    |
+| `apps/docs`                    |    78 | 7,246 | Excluded marketing/docs consumer; appendix count only |
 
 ## Scope And Method
 
 Findings are classified into these buckets:
 
-| Bucket | Meaning |
-| --- | --- |
-| leak | Raw or arbitrary styling escapes an existing token/composite surface and has a plausible token-backed target. |
-| convention | Valid utility, but violates a repo convention such as padding-based control sizing. |
-| sanctioned-exception | Existing documented or verified exception; do not migrate without a separate design decision. |
-| allowed-one-off | Arbitrary/system value is locally meaningful and not replaceable by the current scale. |
-| needs-new-token | A design-system concept exists, but no current token/composite names it. |
-| needs-decision | The scan found a real seam, but the correct policy is not yet settled. |
-| non-runtime | Story, docs, token source, generated token output, or guard code; not counted as runtime source leakage. |
+| Bucket               | Meaning                                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------------------- |
+| leak                 | Raw or arbitrary styling escapes an existing token/composite surface and has a plausible token-backed target. |
+| convention           | Valid utility, but violates a repo convention such as padding-based control sizing.                           |
+| sanctioned-exception | Existing documented or verified exception; do not migrate without a separate design decision.                 |
+| allowed-one-off      | Arbitrary/system value is locally meaningful and not replaceable by the current scale.                        |
+| needs-new-token      | A design-system concept exists, but no current token/composite names it.                                      |
+| needs-decision       | The scan found a real seam, but the correct policy is not yet settled.                                        |
+| non-runtime          | Story, docs, token source, generated token output, or guard code; not counted as runtime source leakage.      |
 
 Mechanical inventory used these families:
 
-| Family | Pattern seed |
-| --- | --- |
-| Typography weight | `nx:(...:)font-(thin|extralight|light|normal|medium|semibold|bold|extrabold|black)` |
-| Typography leading | `nx:(...:)leading-(none|tight|snug|normal|relaxed|loose|<number>|[...])` |
-| Typography tracking | `nx:(...:)tracking-(tighter|tight|normal|wide|wider|widest|[...])` |
-| Typography size | named `text-*`, arbitrary `text-[...]`, and inline `fontSize/fontWeight/lineHeight/letterSpacing` |
-| Color | raw primitive fill/stroke/ring/gradient utilities plus color literals |
-| Spacing/sizing | arbitrary `p/m/gap/size/w/h/min/max/inset/top/right/bottom/left/translate-*` |
-| Fixed-height convention | `h-*` inside `packages/react/src/components/ui` |
-| Radius/border | arbitrary `rounded-[...]`, `rounded-*-[...]`, and `border-[...]` |
-| Z-index | `z-*` minus `z-overlay`, `z-sticky`, `z-modal`, `z-popover`, `z-toast`, `z-max` |
-| Focus/ring | non-focus `ring-*` utilities |
-| Motion | arbitrary `duration/ease/delay/animate-[...]` |
-| Responsive | viewport prefixes inside component internals and raw `vh` |
+- Typography weight: `nx:(...:)font-(thin|extralight|light|normal|medium|semibold|bold|extrabold|black)`.
+- Typography leading: `nx:(...:)leading-(none|tight|snug|normal|relaxed|loose|<number>|[...])`.
+- Typography tracking: `nx:(...:)tracking-(tighter|tight|normal|wide|wider|widest|[...])`.
+- Typography size: named `text-*`, arbitrary `text-[...]`, and inline `fontSize/fontWeight/lineHeight/letterSpacing`.
+- Color: raw primitive fill/stroke/ring/gradient utilities plus color literals.
+- Spacing/sizing: arbitrary `p/m/gap/size/w/h/min/max/inset/top/right/bottom/left/translate-*`.
+- Fixed-height convention: `h-*` inside `packages/react/src/components/ui`.
+- Radius/border: arbitrary `rounded-[...]`, `rounded-*-[...]`, and `border-[...]`.
+- Z-index: `z-*` minus `z-overlay`, `z-sticky`, `z-modal`, `z-popover`, `z-toast`, `z-max`.
+- Focus/ring: non-focus `ring-*` utilities.
+- Motion: arbitrary `duration/ease/delay/animate-[...]`.
+- Responsive: viewport prefixes inside component internals and raw `vh`.
 
 Modern Web Guidance CSS guidance was checked before writing conclusions. Relevant points: prefer token/custom-property architecture for nontrivial values, use `outline` for focus visibility, preserve forced-colors behavior with system colors where needed, and prefer `svh/lvh/dvh` over raw `vh`. The repo browser floor remains Chrome 111+, Edge 111+, Firefox 113+, Safari 15.4+, Samsung Internet 22+, with OKLCH treated as the floor feature.
 
-## Executive Summary
+## Baseline Executive Summary
 
-This is not a #495-scale migration. The primary React runtime has a concentrated set of open seams:
+This is not a #495-scale migration. At baseline, the primary React runtime had a concentrated set of open seams:
 
-| Rank | Finding | Count | Classification |
-| ---: | --- | ---: | --- |
-| 1 | Typography non-size utilities (`font-*`, `leading-*`) still bypass both reset and lint. | 10 primary hits, plus 28 console hits | leak / needs-new-token / needs-decision |
-| 2 | Raw numeric z-index appears in local stacking contexts. | 6 primary hits | needs-decision before linting |
-| 3 | Chart uses arbitrary radius and border width where token or chart-specific policy should exist. | 3 primary leak hits | leak |
-| 4 | Avatar initials arbitrary text sizes are sanctioned by issue #496, but related weight/leading/ring geometry still needs policy. | 9 sanctioned size hits, 1 weight/leading line, 3 ring lines | sanctioned-exception / needs-decision |
-| 5 | Input and Switch fixed geometry are convention issues, not token leaks. | Input 3 `h-*`; Switch 4 arbitrary geometry tokens plus `h-5` | convention |
-| 6 | `apps/console` contains raw typography and color swatch literals. | 47 runtime candidates | secondary consumer exposure |
+| Rank | Finding                                                                                                                         |                                                        Count | Classification                          |
+| ---: | ------------------------------------------------------------------------------------------------------------------------------- | -----------------------------------------------------------: | --------------------------------------- |
+|    1 | Typography non-size utilities (`font-*`, `leading-*`) bypassed both reset and lint.                                             |                        10 primary hits, plus 28 console hits | leak / needs-new-token / needs-decision |
+|    2 | Raw numeric z-index appears in local stacking contexts.                                                                         |                                               6 primary hits | needs-decision before linting           |
+|    3 | Chart uses arbitrary radius and border width where token or chart-specific policy should exist.                                 |                                          3 primary leak hits | leak                                    |
+|    4 | Avatar initials arbitrary text sizes are sanctioned by issue #496, but related weight/leading/ring geometry still needs policy. |  9 sanctioned size hits, 1 weight/leading line, 3 ring lines | sanctioned-exception / needs-decision   |
+|    5 | Input and Switch fixed geometry are convention issues, not token leaks.                                                         | Input 3 `h-*`; Switch 4 arbitrary geometry tokens plus `h-5` | convention                              |
+|    6 | `apps/console` contains raw typography and color swatch literals.                                                               |                                        47 runtime candidates | secondary consumer exposure             |
 
 Clean or guarded areas:
 
-| Area | Status |
-| --- | --- |
-| Raw named font size | Guarded by `--text-*` reset and `rawFontSize` lint. No primary runtime named `text-xs/sm/base/...` hits found. |
-| Raw primitive `bg/text/border` colors | Guarded by `nx-class-conventions` `rawPrimitive`. No open primary runtime hits found in the scanned set. |
-| Raw primitive `fill/stroke/ring/from/via/to` colors | No current primary runtime primitive-color hits found, but the lint gap remains open. |
-| Shadow | `--shadow-*` reset is present; no arbitrary shadow or focusable-shadow leak found by this scan. |
-| Motion | No arbitrary motion utility hits found in primary or console runtime. |
-| Raw `vh` | No raw `vh` hits found in primary or console runtime; current arbitrary viewport heights use `svh`. |
+| Area                                                | Status                                                                                                         |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Raw named font size                                 | Guarded by `--text-*` reset and `rawFontSize` lint. No primary runtime named `text-xs/sm/base/...` hits found. |
+| Raw primitive `bg/text/border` colors               | Guarded by `nx-class-conventions` `rawPrimitive`. No open primary runtime hits found in the scanned set.       |
+| Raw primitive `fill/stroke/ring/from/via/to` colors | No current primary runtime primitive-color hits found, but the lint gap remains open.                          |
+| Shadow                                              | `--shadow-*` reset is present; no arbitrary shadow or focusable-shadow leak found by this scan.                |
+| Motion                                              | No arbitrary motion utility hits found in primary or console runtime.                                          |
+| Raw `vh`                                            | No raw `vh` hits found in primary or console runtime; current arbitrary viewport heights use `svh`.            |
 
 ## Defense Coverage Matrix
 
-| Family | Reset in `packages/tailwind/nexus.css` | Lint guard | Audit script | Net status |
-| --- | --- | --- | --- | --- |
-| Color primitives: `bg/text/border` | `--color-*` reset | `rawPrimitive` | `audit-class-refs` for semantic refs | Guarded. |
-| Color primitives: `fill/stroke/ring/gradient` | `--color-*` reset | none | none | Currently clean in runtime, but future seam is open. |
-| Color literals | n/a | none | none | Runtime literals are mostly selector/system/app data, not direct token leaks. |
-| Typography size: named | `--text-*` reset | `rawFontSize` | none | Guarded. |
-| Typography size: arbitrary | bypasses reset | none | none | Avatar exception is sanctioned; console/icon candidates remain. |
-| Typography weight/leading/tracking | not reset | none | none | Open. Primary component leaks exist. |
-| Typography composites | n/a | `deadTypography` | drift test | Guarded by hardcoded live list plus test. |
-| Spacing/sizing named | `--spacing-*` reset plus Nexus scale | token JSON spacing guard only | none | Reset-only for source classes; arbitrary values bypass. |
-| Radius | `--radius-*` reset | none | none | Reset-only; Chart has arbitrary radius hits. |
-| Border width | custom `--border-*` utilities | none | none | Chart has arbitrary `border-[1.5px]`. |
-| Shadow | `--shadow-*` reset | none | none | Source clean in this scan. |
-| Z-index | token keys exist, but namespace is not reset | none | none | Open; 6 primary numeric hits. |
-| Focus | n/a | none | component review only | Presence audit candidate; Avatar non-focus rings need decision. |
-| Motion | custom imports / Tailwind defaults | none | none | Source clean in this scan. |
-| Responsive | `--breakpoint-*` reset | none | responsive rule docs | Viewport-prefix exceptions need a clearer allowlist. |
+| Family                                        | Reset in `packages/tailwind/nexus.css`       | Lint guard                                                                                         | Audit script                         | Net status                                                                             |
+| --------------------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------- |
+| Color primitives: `bg/text/border`            | `--color-*` reset                            | `rawPrimitive`                                                                                     | `audit-class-refs` for semantic refs | Guarded.                                                                               |
+| Color primitives: `fill/stroke/ring/gradient` | `--color-*` reset                            | none                                                                                               | none                                 | Currently clean in runtime, but future seam is open.                                   |
+| Color literals                                | n/a                                          | none                                                                                               | none                                 | Runtime literals are mostly selector/system/app data, not direct token leaks.          |
+| Typography size: named                        | `--text-*` reset                             | `rawFontSize`                                                                                      | none                                 | Guarded.                                                                               |
+| Typography size: arbitrary                    | bypasses reset                               | none                                                                                               | none                                 | Avatar exception is sanctioned; console/icon candidates remain.                        |
+| Typography weight/leading/tracking            | not reset                                    | current branch adds runtime-scoped `rawFontWeight`, `rawLineHeight`, and `rawLetterSpacing` checks | none                                 | Baseline was open; current branch guards React/console runtime classes through ESLint. |
+| Typography composites                         | n/a                                          | `deadTypography`                                                                                   | drift test                           | Guarded by hardcoded live list plus test.                                              |
+| Spacing/sizing named                          | `--spacing-*` reset plus Nexus scale         | token JSON spacing guard only                                                                      | none                                 | Reset-only for source classes; arbitrary values bypass.                                |
+| Radius                                        | `--radius-*` reset                           | none                                                                                               | none                                 | Reset-only; Chart has arbitrary radius hits.                                           |
+| Border width                                  | custom `--border-*` utilities                | none                                                                                               | none                                 | Chart has arbitrary `border-[1.5px]`.                                                  |
+| Shadow                                        | `--shadow-*` reset                           | none                                                                                               | none                                 | Source clean in this scan.                                                             |
+| Z-index                                       | token keys exist, but namespace is not reset | none                                                                                               | none                                 | Open; 6 primary numeric hits.                                                          |
+| Focus                                         | n/a                                          | none                                                                                               | component review only                | Presence audit candidate; Avatar non-focus rings need decision.                        |
+| Motion                                        | custom imports / Tailwind defaults           | none                                                                                               | none                                 | Source clean in this scan.                                                             |
+| Responsive                                    | `--breakpoint-*` reset                       | none                                                                                               | responsive rule docs                 | Viewport-prefix exceptions need a clearer allowlist.                                   |
 
 Current reset block verified at `packages/tailwind/nexus.css:19-24`:
 
@@ -125,19 +126,19 @@ Notably absent from that reset block: `--font-weight-*`, `--leading-*`, `--track
 
 Closed/blocked:
 
-| Surface | Evidence | Status |
-| --- | --- | --- |
-| Raw primitive `bg/text/border` | `nx-class-conventions.js` has `rawPrimitive`; `nexus.css` resets `--color-*`. | Guarded. |
-| Semantic color refs | `packages/core/scripts/audit-class-refs.js` validates semantic refs against emitted `--color-*`. | Guarded for the prefixes it owns. |
-| Runtime raw primitive `fill/stroke/ring/from/via/to` | Mechanical scan found 0 raw primitive runtime hits. | Source clean, guard gap remains. |
+| Surface                                              | Evidence                                                                                         | Status                            |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------- |
+| Raw primitive `bg/text/border`                       | `nx-class-conventions.js` has `rawPrimitive`; `nexus.css` resets `--color-*`.                    | Guarded.                          |
+| Semantic color refs                                  | `packages/core/scripts/audit-class-refs.js` validates semantic refs against emitted `--color-*`. | Guarded for the prefixes it owns. |
+| Runtime raw primitive `fill/stroke/ring/from/via/to` | Mechanical scan found 0 raw primitive runtime hits.                                              | Source clean, guard gap remains.  |
 
 Still-possible/open:
 
-| Location | Pattern | Bucket | Recommendation |
-| --- | --- | --- | --- |
-| `packages/react/src/components/ui/chart/chart.tsx:75` | `#ccc`, `#fff` inside arbitrary selectors matching Recharts generated attributes | allowed-one-off | Keep out of primitive-color lint or require a documented selector-literal allowlist. These literals identify third-party SVG attributes; they do not apply raw colors. |
-| `packages/react/src/components/ui/native-select/native-select.tsx:97,115` | `nx:bg-[Canvas]`, `nx:text-[CanvasText]` | allowed-one-off | Forced-colors/system-color values are deliberate browser UI integration. Do not classify as arbitrary font-size/color leak. |
-| `apps/console/src/hooks/useTheme.ts:4-17` | 11 hex swatch values | needs-decision | Secondary consumer app stores palette swatch metadata. Prefer deriving from token data if this is meant to stay design-system-authored. |
+| Location                                                                  | Pattern                                                                          | Bucket          | Recommendation                                                                                                                                                         |
+| ------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/react/src/components/ui/chart/chart.tsx:75`                     | `#ccc`, `#fff` inside arbitrary selectors matching Recharts generated attributes | allowed-one-off | Keep out of primitive-color lint or require a documented selector-literal allowlist. These literals identify third-party SVG attributes; they do not apply raw colors. |
+| `packages/react/src/components/ui/native-select/native-select.tsx:97,115` | `nx:bg-[Canvas]`, `nx:text-[CanvasText]`                                         | allowed-one-off | Forced-colors/system-color values are deliberate browser UI integration. Do not classify as arbitrary font-size/color leak.                                            |
+| `apps/console/src/hooks/useTheme.ts:4-17`                                 | 11 hex swatch values                                                             | needs-decision  | Secondary consumer app stores palette swatch metadata. Prefer deriving from token data if this is meant to stay design-system-authored.                                |
 
 False positives subtracted: issue references in comments such as `#281`, `#418`, `#119`, and `#118`.
 
@@ -145,64 +146,64 @@ False positives subtracted: issue references in comments such as `#281`, `#418`,
 
 Closed/blocked:
 
-| Surface | Evidence | Status |
-| --- | --- | --- |
-| Raw named sizes | `--text-*` reset plus `rawFontSize` lint. | Guarded; no primary runtime named-size hits. |
-| Dead composites | `LIVE_TYPOGRAPHY` in `nx-class-conventions.js` plus drift test comment. | Guarded, but list is hardcoded. |
+| Surface         | Evidence                                                                | Status                                       |
+| --------------- | ----------------------------------------------------------------------- | -------------------------------------------- |
+| Raw named sizes | `--text-*` reset plus `rawFontSize` lint.                               | Guarded; no primary runtime named-size hits. |
+| Dead composites | `LIVE_TYPOGRAPHY` in `nx-class-conventions.js` plus drift test comment. | Guarded, but list is hardcoded.              |
 
 Primary runtime findings:
 
-| Location | Pattern | Bucket | Recommendation |
-| --- | --- | --- | --- |
-| `packages/react/src/components/ui/avatar/avatar.tsx:11-19` | 9 `nx:text-[...]` sizes | sanctioned-exception | Verified by issue #496. Avatar initials scale with avatar diameter, not semantic role. Keep allowed unless a new avatar-initials token is designed. |
-| `packages/react/src/components/ui/avatar/avatar.tsx:199` | `nx:font-medium`, `nx:leading-none` | needs-decision | Decide whether Avatar fallback initials get a local token/policy alongside the #496 arbitrary-size exception. |
-| `packages/react/src/components/ui/chart/chart.tsx:174,180` | `nx:font-medium` | leak | Use a typography composite or add a chart tooltip label token. |
-| `packages/react/src/components/ui/chart/chart.tsx:327` | `nx:leading-none` | leak | Composite-swap trap required: likely delete redundant line-height if the composite already owns it. |
-| `packages/react/src/components/ui/chart/chart.tsx:338` | `nx:font-mono nx:font-medium` | needs-new-token | Existing `code-inline` may not be right for chart numeric values; decide on a chart value typography token/composite. |
-| `packages/react/src/components/ui/date-picker/date-picker.tsx:339` | `nx:leading-none` | leak | Composite-swap trap required. |
-| `packages/react/src/components/ui/date-picker/date-picker.tsx:345` | `nx:data-[today=true]:font-medium` | leak | Prefer token/composite ownership for emphasized day text. |
-| `packages/react/src/components/ui/field/field.tsx:150` | `nx:leading-snug` | leak | Confirm whether the field content composite should own this line-height. |
-| `packages/react/src/components/ui/table/table.tsx:379` | `nx:font-medium` | leak | Prefer label/body composite or token-backed table header/body role. |
+| Location                                                           | Pattern                             | Bucket               | Recommendation                                                                                                                                      |
+| ------------------------------------------------------------------ | ----------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/react/src/components/ui/avatar/avatar.tsx:11-19`         | 9 `nx:text-[...]` sizes             | sanctioned-exception | Verified by issue #496. Avatar initials scale with avatar diameter, not semantic role. Keep allowed unless a new avatar-initials token is designed. |
+| `packages/react/src/components/ui/avatar/avatar.tsx:199`           | `nx:font-medium`, `nx:leading-none` | needs-decision       | Decide whether Avatar fallback initials get a local token/policy alongside the #496 arbitrary-size exception.                                       |
+| `packages/react/src/components/ui/chart/chart.tsx:174,180`         | `nx:font-medium`                    | leak                 | Use a typography composite or add a chart tooltip label token.                                                                                      |
+| `packages/react/src/components/ui/chart/chart.tsx:327`             | `nx:leading-none`                   | leak                 | Composite-swap trap required: likely delete redundant line-height if the composite already owns it.                                                 |
+| `packages/react/src/components/ui/chart/chart.tsx:338`             | `nx:font-mono nx:font-medium`       | needs-new-token      | Existing `code-inline` may not be right for chart numeric values; decide on a chart value typography token/composite.                               |
+| `packages/react/src/components/ui/date-picker/date-picker.tsx:339` | `nx:leading-none`                   | leak                 | Composite-swap trap required.                                                                                                                       |
+| `packages/react/src/components/ui/date-picker/date-picker.tsx:345` | `nx:data-[today=true]:font-medium`  | leak                 | Prefer token/composite ownership for emphasized day text.                                                                                           |
+| `packages/react/src/components/ui/field/field.tsx:150`             | `nx:leading-snug`                   | leak                 | Confirm whether the field content composite should own this line-height.                                                                            |
+| `packages/react/src/components/ui/table/table.tsx:379`             | `nx:font-medium`                    | leak                 | Prefer label/body composite or token-backed table header/body role.                                                                                 |
 
 Secondary console findings:
 
-| Family | Count | Locations |
-| --- | ---: | --- |
-| `font-*` | 24 | `apps/console/src/app/auth-layout.tsx:20`; `analytics-route.tsx:185`; `verify-route.tsx:58`; `billing-route.tsx:242`; `plan-sheet.tsx:123`; `crm/contact-card.tsx:17`; `crm/contacts-board.tsx:157`; `crm/contacts-columns.tsx:88`; `design-system/ComponentShowcase.tsx:234,263,312,318,324,330`; `inbox/conversation-list.tsx:69` x2; `people/member-card.tsx:17`; `people/people-columns.tsx:94`; `projects/issue-card.tsx:22`; `projects/issues-columns.tsx:97`; `shell/app-sidebar.tsx:77,81,176`; `shell/notifications-menu.tsx:188` |
-| `leading-*` | 3 | `apps/console/src/app/auth-layout.tsx:27`; `design-system/IconShowcase.tsx:51`; `projects/issue-detail-route.tsx:110` |
-| `tracking-*` | 1 | `apps/console/src/app/not-found.tsx:13` |
-| arbitrary `text-[...]` | 1 | `apps/console/src/modules/design-system/IconShowcase.tsx:51` |
+| Family                 | Count | Locations                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ---------------------- | ----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `font-*`               |    24 | `apps/console/src/app/auth-layout.tsx:20`; `analytics-route.tsx:185`; `verify-route.tsx:58`; `billing-route.tsx:242`; `plan-sheet.tsx:123`; `crm/contact-card.tsx:17`; `crm/contacts-board.tsx:157`; `crm/contacts-columns.tsx:88`; `design-system/ComponentShowcase.tsx:234,263,312,318,324,330`; `inbox/conversation-list.tsx:69` x2; `people/member-card.tsx:17`; `people/people-columns.tsx:94`; `projects/issue-card.tsx:22`; `projects/issues-columns.tsx:97`; `shell/app-sidebar.tsx:77,81,176`; `shell/notifications-menu.tsx:188` |
+| `leading-*`            |     3 | `apps/console/src/app/auth-layout.tsx:27`; `design-system/IconShowcase.tsx:51`; `projects/issue-detail-route.tsx:110`                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `tracking-*`           |     1 | `apps/console/src/app/not-found.tsx:13`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| arbitrary `text-[...]` |     1 | `apps/console/src/modules/design-system/IconShowcase.tsx:51`                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 
 ### Spacing And Sizing
 
 Closed/blocked:
 
-| Surface | Evidence | Status |
-| --- | --- | --- |
-| Named spacing scale | `--spacing-*` reset, then Nexus scale in `nexus.css`. | Off-scale named utilities should no-op. |
-| Token JSON spacing values | `canonical-spacing-steps.js` validates spacing mode JSON values against `canonical-step-set.json`. | Token-source guard only. |
+| Surface                   | Evidence                                                                                           | Status                                  |
+| ------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| Named spacing scale       | `--spacing-*` reset, then Nexus scale in `nexus.css`.                                              | Off-scale named utilities should no-op. |
+| Token JSON spacing values | `canonical-spacing-steps.js` validates spacing mode JSON values against `canonical-step-set.json`. | Token-source guard only.                |
 
 Open convention surface:
 
-| Location | Pattern | Bucket | Recommendation |
-| --- | --- | --- | --- |
-| `packages/react/src/components/ui/input/input.tsx:20-22` | `nx:h-10`, `nx:h-8`, `nx:h-12` | convention | Defer to Input-specific cleanup. This is not a token leak; it is a sizing convention question. |
+| Location                                                      | Pattern                                                                           | Bucket     | Recommendation                                                                                    |
+| ------------------------------------------------------------- | --------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------- |
+| `packages/react/src/components/ui/input/input.tsx:20-22`      | `nx:h-10`, `nx:h-8`, `nx:h-12`                                                    | convention | Defer to Input-specific cleanup. This is not a token leak; it is a sizing convention question.    |
 | `packages/react/src/components/ui/switch/switch.tsx:23-24,44` | `nx:h-5`, `nx:h-[18px]`, `nx:w-[32px]`, `nx:size-[14px]`, `nx:translate-x-[14px]` | convention | Likely intrinsic switch geometry, but should be documented or migrated in a Switch-specific pass. |
 
 Arbitrary spacing/size candidates that are not automatic leaks:
 
-| Location | Pattern | Bucket |
-| --- | --- | --- |
-| `packages/react/src/components/ui/avatar/avatar.tsx:209` | `right-[0.04em]`, `bottom-[0.04em]`, `size-[0.6em]` | allowed-one-off candidate |
-| `packages/react/src/components/ui/breadcrumb/breadcrumb.tsx:127,154` | `max-w-[150px]` | needs-decision |
-| `packages/react/src/components/ui/command/command.tsx:184` | `max-h-[300px]` | needs-decision |
-| `packages/react/src/components/ui/drawer/drawer.tsx:101,102,111` | `max-h-[80svh]`, `w-[100px]` | needs-decision |
-| `packages/react/src/components/ui/navigation-menu/navigation-menu.tsx:301` | `top-[60%]` | needs-decision |
-| `packages/react/src/components/ui/sidebar/sidebar.tsx:334,349` | `w-[calc(...)]` | needs-decision |
-| `apps/console/src/modules/analytics/analytics-charts.tsx:25` | `h-[260px]` | secondary consumer |
-| `apps/console/src/modules/coming-soon.tsx:26` | `min-h-[60svh]` | secondary consumer, uses `svh` |
-| `apps/console/src/modules/inbox/conversation-thread.tsx:234` | `max-w-[75%]` | secondary consumer |
-| `apps/console/src/modules/inbox/inbox-route.tsx:57` | `h-[calc(100svh-3.5rem)]` | secondary consumer, uses `svh` |
+| Location                                                                   | Pattern                                             | Bucket                         |
+| -------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------ |
+| `packages/react/src/components/ui/avatar/avatar.tsx:209`                   | `right-[0.04em]`, `bottom-[0.04em]`, `size-[0.6em]` | allowed-one-off candidate      |
+| `packages/react/src/components/ui/breadcrumb/breadcrumb.tsx:127,154`       | `max-w-[150px]`                                     | needs-decision                 |
+| `packages/react/src/components/ui/command/command.tsx:184`                 | `max-h-[300px]`                                     | needs-decision                 |
+| `packages/react/src/components/ui/drawer/drawer.tsx:101,102,111`           | `max-h-[80svh]`, `w-[100px]`                        | needs-decision                 |
+| `packages/react/src/components/ui/navigation-menu/navigation-menu.tsx:301` | `top-[60%]`                                         | needs-decision                 |
+| `packages/react/src/components/ui/sidebar/sidebar.tsx:334,349`             | `w-[calc(...)]`                                     | needs-decision                 |
+| `apps/console/src/modules/analytics/analytics-charts.tsx:25`               | `h-[260px]`                                         | secondary consumer             |
+| `apps/console/src/modules/coming-soon.tsx:26`                              | `min-h-[60svh]`                                     | secondary consumer, uses `svh` |
+| `apps/console/src/modules/inbox/conversation-thread.tsx:234`               | `max-w-[75%]`                                       | secondary consumer             |
+| `apps/console/src/modules/inbox/inbox-route.tsx:57`                        | `h-[calc(100svh-3.5rem)]`                           | secondary consumer, uses `svh` |
 
 Policy note: keep arbitrary values when no exact Nexus scale utility exists. Do not snap to a nearby token and change approved geometry.
 
@@ -210,20 +211,20 @@ Policy note: keep arbitrary values when no exact Nexus scale utility exists. Do 
 
 Closed/blocked:
 
-| Surface | Evidence | Status |
-| --- | --- | --- |
-| Named radius scale | `--radius-*` reset and semantic radius tokens in `nexus.css`. | Off-scale named radius should no-op. |
+| Surface             | Evidence                                                                        | Status                                                                   |
+| ------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Named radius scale  | `--radius-*` reset and semantic radius tokens in `nexus.css`.                   | Off-scale named radius should no-op.                                     |
 | Named border widths | `--border-default` and `--border-thick` emitted by `borderwidth-utilities.css`. | Token surface exists, but lint does not protect arbitrary border widths. |
 
 Primary runtime findings:
 
-| Location | Pattern | Bucket | Recommendation |
-| --- | --- | --- | --- |
-| `packages/react/src/components/ui/chart/chart.tsx:272` | `nx:rounded-[2px]` | leak | Add/use a chart marker radius token or choose an existing radius if exact. |
-| `packages/react/src/components/ui/chart/chart.tsx:276` | `nx:border-[1.5px]` | leak | Add/use a border-width token if 1.5px is intentional. |
-| `packages/react/src/components/ui/chart/chart.tsx:393` | `nx:rounded-[2px]` | leak | Same chart marker radius decision as line 272. |
-| `packages/react/src/components/ui/avatar/avatar.tsx:165,199`; `scroll-area.tsx:65` | `nx:rounded-[inherit]` | allowed-one-off | Inheritance keyword, not a raw numeric design token. Allowlist if arbitrary-radius lint is added. |
-| `packages/react/src/components/ui/scroll-area/scroll-area.tsx:74` | `nx:forced-colors:border-[ButtonBorder]` | allowed-one-off | Forced-colors system keyword; preserve accessibility behavior. |
+| Location                                                                           | Pattern                                  | Bucket          | Recommendation                                                                                    |
+| ---------------------------------------------------------------------------------- | ---------------------------------------- | --------------- | ------------------------------------------------------------------------------------------------- |
+| `packages/react/src/components/ui/chart/chart.tsx:272`                             | `nx:rounded-[2px]`                       | leak            | Add/use a chart marker radius token or choose an existing radius if exact.                        |
+| `packages/react/src/components/ui/chart/chart.tsx:276`                             | `nx:border-[1.5px]`                      | leak            | Add/use a border-width token if 1.5px is intentional.                                             |
+| `packages/react/src/components/ui/chart/chart.tsx:393`                             | `nx:rounded-[2px]`                       | leak            | Same chart marker radius decision as line 272.                                                    |
+| `packages/react/src/components/ui/avatar/avatar.tsx:165,199`; `scroll-area.tsx:65` | `nx:rounded-[inherit]`                   | allowed-one-off | Inheritance keyword, not a raw numeric design token. Allowlist if arbitrary-radius lint is added. |
+| `packages/react/src/components/ui/scroll-area/scroll-area.tsx:74`                  | `nx:forced-colors:border-[ButtonBorder]` | allowed-one-off | Forced-colors system keyword; preserve accessibility behavior.                                    |
 
 ### Shadow
 
@@ -235,14 +236,14 @@ Token source exists at `packages/core/tokens/semantic/z-index.json`: `overlay` 1
 
 Primary runtime candidates:
 
-| Location | Pattern | Bucket | Recommendation |
-| --- | --- | --- | --- |
-| `packages/react/src/components/ui/button-group/button-group.tsx:15` | `nx:*:focus-visible:z-10` | needs-decision | Local focus overlap, not structural overlay layering. Decide whether local numeric z values are allowed. |
-| `packages/react/src/components/ui/date-picker/date-picker.tsx:343` | `nx:group-data-[focused=true]/day:z-10` | needs-decision | Local calendar focus stacking. Token scale may be semantically too broad. |
-| `packages/react/src/components/ui/date-picker/date-picker.tsx:361` | `nx:z-10` | needs-decision | Calendar caption local stacking. |
-| `packages/react/src/components/ui/input-otp/input-otp.tsx:125` | `nx:data-[active=true]:z-10` | needs-decision | Local active-cell stacking. |
-| `packages/react/src/components/ui/navigation-menu/navigation-menu.tsx:294` | `nx:z-1` | leak / needs-decision | Very low local arrow stacking; either local policy or token map needed. |
-| `packages/react/src/components/ui/resizable/resizable.tsx:76` | `nx:z-10` | leak / needs-decision | Resize handle local stacking. |
+| Location                                                                   | Pattern                                 | Bucket                | Recommendation                                                                                           |
+| -------------------------------------------------------------------------- | --------------------------------------- | --------------------- | -------------------------------------------------------------------------------------------------------- |
+| `packages/react/src/components/ui/button-group/button-group.tsx:15`        | `nx:*:focus-visible:z-10`               | needs-decision        | Local focus overlap, not structural overlay layering. Decide whether local numeric z values are allowed. |
+| `packages/react/src/components/ui/date-picker/date-picker.tsx:343`         | `nx:group-data-[focused=true]/day:z-10` | needs-decision        | Local calendar focus stacking. Token scale may be semantically too broad.                                |
+| `packages/react/src/components/ui/date-picker/date-picker.tsx:361`         | `nx:z-10`                               | needs-decision        | Calendar caption local stacking.                                                                         |
+| `packages/react/src/components/ui/input-otp/input-otp.tsx:125`             | `nx:data-[active=true]:z-10`            | needs-decision        | Local active-cell stacking.                                                                              |
+| `packages/react/src/components/ui/navigation-menu/navigation-menu.tsx:294` | `nx:z-1`                                | leak / needs-decision | Very low local arrow stacking; either local policy or token map needed.                                  |
+| `packages/react/src/components/ui/resizable/resizable.tsx:76`              | `nx:z-10`                               | leak / needs-decision | Resize handle local stacking.                                                                            |
 
 Recommendation: do not blindly map all `z-10` to `z-overlay`; the existing token scale names structural layers, while several hits are local overlap inside one component.
 
@@ -250,18 +251,18 @@ Recommendation: do not blindly map all `z-10` to `z-overlay`; the existing token
 
 Closed/blocked:
 
-| Surface | Evidence | Status |
-| --- | --- | --- |
+| Surface                 | Evidence                                                                                                               | Status      |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------- | ----------- |
 | Canonical focus outline | `.claude/rules/components.md` defines `focus-visible:outline-2 outline-focus-default outline-offset-(--focus-offset)`. | Documented. |
-| Focus color token | `nexus.css` emits `--color-focus-default` and `--color-focus-error`. | Tokenized. |
+| Focus color token       | `nexus.css` emits `--color-focus-default` and `--color-focus-error`.                                                   | Tokenized.  |
 
 Open:
 
-| Location | Pattern | Bucket | Recommendation |
-| --- | --- | --- | --- |
-| `packages/react/src/components/ui/avatar/avatar.tsx:123` | selected/group `ring-*` | needs-decision | Non-focus visual emphasis; decide if Avatar gets a ring exception or should use border tokens. |
-| `packages/react/src/components/ui/avatar/avatar.tsx:209` | status marker `ring-[0.1em]` | needs-decision | Em-based geometry tied to avatar diameter; likely exception if documented. |
-| `packages/react/src/components/ui/avatar/avatar.tsx:335` | AvatarGroup overlap `ring-[0.1em]` | needs-decision | Same policy as status marker. |
+| Location                                                 | Pattern                            | Bucket         | Recommendation                                                                                 |
+| -------------------------------------------------------- | ---------------------------------- | -------------- | ---------------------------------------------------------------------------------------------- |
+| `packages/react/src/components/ui/avatar/avatar.tsx:123` | selected/group `ring-*`            | needs-decision | Non-focus visual emphasis; decide if Avatar gets a ring exception or should use border tokens. |
+| `packages/react/src/components/ui/avatar/avatar.tsx:209` | status marker `ring-[0.1em]`       | needs-decision | Em-based geometry tied to avatar diameter; likely exception if documented.                     |
+| `packages/react/src/components/ui/avatar/avatar.tsx:335` | AvatarGroup overlap `ring-[0.1em]` | needs-decision | Same policy as status marker.                                                                  |
 
 Separate presence audit proposal: a future guard should check that known focusable controls include the canonical outline token, but only after mapping components that intentionally use roving-focus background tints rather than outlines.
 
@@ -273,20 +274,20 @@ No arbitrary `duration-[...]`, `ease-[...]`, `delay-[...]`, or `animate-[...]` r
 
 Closed/blocked:
 
-| Surface | Evidence | Status |
-| --- | --- | --- |
-| Raw `vh` | Scan found no raw `vh` in primary or console runtime. Current viewport arbitrary values use `svh`. | Clean. |
-| Breakpoint scale | `--breakpoint-*` reset and semantic breakpoint tokens in `nexus.css`. | Off-scale named breakpoints should no-op. |
+| Surface          | Evidence                                                                                           | Status                                    |
+| ---------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| Raw `vh`         | Scan found no raw `vh` in primary or console runtime. Current viewport arbitrary values use `svh`. | Clean.                                    |
+| Breakpoint scale | `--breakpoint-*` reset and semantic breakpoint tokens in `nexus.css`.                              | Off-scale named breakpoints should no-op. |
 
 Viewport-prefix candidates inside component internals:
 
-| Location | Pattern | Bucket | Recommendation |
-| --- | --- | --- | --- |
-| `packages/react/src/components/ui/dialog/dialog.tsx:192,305` | `lg:` and `sm:` overlay behavior | sanctioned-exception | Explicitly named by `responsive.md`. |
-| `packages/react/src/components/ui/sheet/sheet.tsx:113,117,181` | `sm:`, `lg:` overlay behavior | sanctioned-exception | `responsive.md` names future Sheet as a viewport-driven overlay exception. |
-| `packages/react/src/components/ui/drawer/drawer.tsx:129` | `md:text-left` | needs-decision | Likely overlay exception; docs should name Drawer if accepted. |
-| `packages/react/src/components/ui/overlay-layout/overlay-layout.ts:16,23,36` | shared `sm:` overlay layout classes | needs-decision | Likely exception because it backs overlay layout; docs should name it if accepted. |
-| `packages/react/src/components/ui/sidebar/sidebar.tsx:319,341,427,461,698,932,938` | `lg:` page-shell/sidebar behavior | needs-decision | Sidebar is page-shell navigation, not a generic embedded component. If accepted, add it to the documented exception list. |
+| Location                                                                           | Pattern                             | Bucket               | Recommendation                                                                                                            |
+| ---------------------------------------------------------------------------------- | ----------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `packages/react/src/components/ui/dialog/dialog.tsx:192,305`                       | `lg:` and `sm:` overlay behavior    | sanctioned-exception | Explicitly named by `responsive.md`.                                                                                      |
+| `packages/react/src/components/ui/sheet/sheet.tsx:113,117,181`                     | `sm:`, `lg:` overlay behavior       | sanctioned-exception | `responsive.md` names future Sheet as a viewport-driven overlay exception.                                                |
+| `packages/react/src/components/ui/drawer/drawer.tsx:129`                           | `md:text-left`                      | needs-decision       | Likely overlay exception; docs should name Drawer if accepted.                                                            |
+| `packages/react/src/components/ui/overlay-layout/overlay-layout.ts:16,23,36`       | shared `sm:` overlay layout classes | needs-decision       | Likely exception because it backs overlay layout; docs should name it if accepted.                                        |
+| `packages/react/src/components/ui/sidebar/sidebar.tsx:319,341,427,461,698,932,938` | `lg:` page-shell/sidebar behavior   | needs-decision       | Sidebar is page-shell navigation, not a generic embedded component. If accepted, add it to the documented exception list. |
 
 ## Runtime Raw Appendix
 
@@ -294,134 +295,144 @@ This appendix groups the primary and secondary runtime candidates from the mecha
 
 ### Primary React Runtime
 
-| Family | Bucket | Location | Token / pattern |
-| --- | --- | --- | --- |
-| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:11` | `nx:text-[0.625rem]` |
-| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:12` | `nx:text-[0.6875rem]` |
-| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:13` | `nx:text-[0.75rem]` |
-| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:14` | `nx:text-[1rem]` |
-| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:15` | `nx:text-[1.125rem]` |
-| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:16` | `nx:text-[1.25rem]` |
-| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:17` | `nx:text-[1.5rem]` |
-| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:18` | `nx:text-[1.875rem]` |
-| typography-arbitrary-size | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:19` | `nx:text-[2.25rem]` |
-| focus-ring-utility | needs-decision | `packages/react/src/components/ui/avatar/avatar.tsx:123` | selected/group `ring-*` utilities |
-| radius-border-arbitrary | allowed-one-off | `packages/react/src/components/ui/avatar/avatar.tsx:165` | `nx:rounded-[inherit]` |
-| radius-border-arbitrary | allowed-one-off | `packages/react/src/components/ui/avatar/avatar.tsx:199` | `nx:rounded-[inherit]` |
-| typography-leading | needs-decision | `packages/react/src/components/ui/avatar/avatar.tsx:199` | `nx:leading-none` |
-| typography-weight | needs-decision | `packages/react/src/components/ui/avatar/avatar.tsx:199` | `nx:font-medium` |
-| focus-ring-utility | needs-decision | `packages/react/src/components/ui/avatar/avatar.tsx:209` | status marker `ring-*` |
-| spacing-arbitrary | allowed-one-off | `packages/react/src/components/ui/avatar/avatar.tsx:209` | `right-[0.04em]`, `bottom-[0.04em]`, `size-[0.6em]` |
-| focus-ring-utility | needs-decision | `packages/react/src/components/ui/avatar/avatar.tsx:335` | AvatarGroup `ring-*` |
-| fixed-height-control | convention | `packages/react/src/components/ui/badge/badge.tsx:145` | `nx:h-6` |
-| spacing-arbitrary | needs-decision | `packages/react/src/components/ui/breadcrumb/breadcrumb.tsx:127,154` | `nx:max-w-[150px]` |
-| z-index | needs-decision | `packages/react/src/components/ui/button-group/button-group.tsx:15` | `nx:*:focus-visible:z-10` |
-| fixed-height-control | convention | `packages/react/src/components/ui/button-group/button-group.tsx:36-38` | `nx:h-8`, `nx:h-10`, `nx:h-12` |
-| fixed-height-control | convention | `packages/react/src/components/ui/button/button.tsx:32-34` | `nx:h-8`, `nx:h-10`, `nx:h-12` |
-| color-literal | allowed-one-off | `packages/react/src/components/ui/chart/chart.tsx:75` | selector literals `#ccc`, `#fff` |
-| typography-weight | leak | `packages/react/src/components/ui/chart/chart.tsx:174,180` | `nx:font-medium` |
-| radius-border-arbitrary | leak | `packages/react/src/components/ui/chart/chart.tsx:272` | `nx:rounded-[2px]` |
-| radius-border-arbitrary | leak | `packages/react/src/components/ui/chart/chart.tsx:276` | `nx:border-[1.5px]` |
-| typography-leading | leak | `packages/react/src/components/ui/chart/chart.tsx:327` | `nx:leading-none` |
-| typography-weight | needs-new-token | `packages/react/src/components/ui/chart/chart.tsx:338` | `nx:font-mono nx:font-medium` |
-| radius-border-arbitrary | leak | `packages/react/src/components/ui/chart/chart.tsx:393` | `nx:rounded-[2px]` |
-| spacing-arbitrary | needs-decision | `packages/react/src/components/ui/command/command.tsx:184` | `nx:max-h-[300px]` |
-| fixed-height-control | convention | `packages/react/src/components/ui/date-picker/date-picker.tsx:211` | `nx:h-8` |
-| typography-leading | leak | `packages/react/src/components/ui/date-picker/date-picker.tsx:339` | `nx:leading-none` |
-| z-index | needs-decision | `packages/react/src/components/ui/date-picker/date-picker.tsx:343` | `nx:group-data-[focused=true]/day:z-10` |
-| typography-weight | leak | `packages/react/src/components/ui/date-picker/date-picker.tsx:345` | `nx:data-[today=true]:font-medium` |
-| z-index | needs-decision | `packages/react/src/components/ui/date-picker/date-picker.tsx:361` | `nx:z-10` |
-| responsive-viewport-prefix | sanctioned-exception | `packages/react/src/components/ui/dialog/dialog.tsx:192,305` | overlay `lg:` / `sm:` classes |
-| spacing-arbitrary | needs-decision | `packages/react/src/components/ui/drawer/drawer.tsx:101,102,111` | `max-h-[80svh]`, `w-[100px]` |
-| responsive-viewport-prefix | needs-decision | `packages/react/src/components/ui/drawer/drawer.tsx:129` | `nx:md:text-left` |
-| typography-leading | leak | `packages/react/src/components/ui/field/field.tsx:150` | `nx:leading-snug` |
-| fixed-height-control | convention | `packages/react/src/components/ui/field/field.tsx:236` | `nx:h-5` |
-| fixed-height-control | convention | `packages/react/src/components/ui/input-group/input-group.tsx:137,138` | `nx:h-6`, `nx:h-8` |
-| z-index | needs-decision | `packages/react/src/components/ui/input-otp/input-otp.tsx:125` | `nx:data-[active=true]:z-10` |
-| fixed-height-control | convention | `packages/react/src/components/ui/input-otp/input-otp.tsx:133` | `nx:h-4` |
-| fixed-height-control | convention | `packages/react/src/components/ui/input/input.tsx:20-22` | `nx:h-10`, `nx:h-8`, `nx:h-12` |
-| fixed-height-control | convention | `packages/react/src/components/ui/kbd/kbd.tsx:35` | `nx:h-5` |
-| color-system | allowed-one-off | `packages/react/src/components/ui/native-select/native-select.tsx:97,115` | `nx:bg-[Canvas]`, `nx:text-[CanvasText]` |
-| z-index | needs-decision | `packages/react/src/components/ui/navigation-menu/navigation-menu.tsx:294` | `nx:z-1` |
-| spacing-arbitrary | needs-decision | `packages/react/src/components/ui/navigation-menu/navigation-menu.tsx:301` | `nx:top-[60%]` |
-| responsive-viewport-prefix | needs-decision | `packages/react/src/components/ui/overlay-layout/overlay-layout.ts:16,23,36` | shared overlay `sm:` classes |
-| fixed-height-control | convention | `packages/react/src/components/ui/progress/progress.tsx:42` | `nx:h-2` |
-| fixed-height-control | convention | `packages/react/src/components/ui/resizable/resizable.tsx:69` | handle hit-area `h-*` |
-| z-index | needs-decision | `packages/react/src/components/ui/resizable/resizable.tsx:76` | `nx:z-10` |
-| fixed-height-control | convention | `packages/react/src/components/ui/resizable/resizable.tsx:76` | `nx:h-4` |
-| fixed-height-control | convention | `packages/react/src/components/ui/scroll-area/scroll-area.tsx:37,99` | `nx:h-72`, `nx:h-2.5` |
-| radius-border-arbitrary | allowed-one-off | `packages/react/src/components/ui/scroll-area/scroll-area.tsx:65` | `nx:rounded-[inherit]` |
-| radius-border-arbitrary | allowed-one-off | `packages/react/src/components/ui/scroll-area/scroll-area.tsx:74` | `nx:forced-colors:border-[ButtonBorder]` |
-| fixed-height-control | convention | `packages/react/src/components/ui/separator/separator.tsx:33` | `nx:h-5` |
-| responsive-viewport-prefix | sanctioned-exception | `packages/react/src/components/ui/sheet/sheet.tsx:113,117,181` | Sheet `sm:` / `lg:` overlay classes |
-| responsive-viewport-prefix | needs-decision | `packages/react/src/components/ui/sidebar/sidebar.tsx:319,341,427,461,698,932,938` | page-shell/sidebar `lg:` classes |
-| spacing-arbitrary | needs-decision | `packages/react/src/components/ui/sidebar/sidebar.tsx:334,349` | `w-[calc(...)]` |
-| fixed-height-control | convention | `packages/react/src/components/ui/sidebar/sidebar.tsx:486,657,801-803,963,1009,1022,1125` | sidebar `h-*` geometry |
-| fixed-height-control | convention | `packages/react/src/components/ui/skeleton/skeleton.tsx:22` | `nx:h-4` |
-| fixed-height-control | convention | `packages/react/src/components/ui/slider/slider.tsx:63` | `nx:data-[orientation=horizontal]:h-1.5` |
-| fixed-height-control | convention | `packages/react/src/components/ui/switch/switch.tsx:23,24` | `nx:h-5`, `nx:h-[18px]` |
-| spacing-arbitrary | convention | `packages/react/src/components/ui/switch/switch.tsx:24,44` | `w-[32px]`, `size-[14px]`, `translate-x-[14px]` |
-| typography-weight | leak | `packages/react/src/components/ui/table/table.tsx:379` | `nx:font-medium` |
+| Family                     | Bucket               | Location                                                                                  | Token / pattern                                     |
+| -------------------------- | -------------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| typography-arbitrary-size  | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:11`                                   | `nx:text-[0.625rem]`                                |
+| typography-arbitrary-size  | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:12`                                   | `nx:text-[0.6875rem]`                               |
+| typography-arbitrary-size  | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:13`                                   | `nx:text-[0.75rem]`                                 |
+| typography-arbitrary-size  | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:14`                                   | `nx:text-[1rem]`                                    |
+| typography-arbitrary-size  | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:15`                                   | `nx:text-[1.125rem]`                                |
+| typography-arbitrary-size  | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:16`                                   | `nx:text-[1.25rem]`                                 |
+| typography-arbitrary-size  | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:17`                                   | `nx:text-[1.5rem]`                                  |
+| typography-arbitrary-size  | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:18`                                   | `nx:text-[1.875rem]`                                |
+| typography-arbitrary-size  | sanctioned-exception | `packages/react/src/components/ui/avatar/avatar.tsx:19`                                   | `nx:text-[2.25rem]`                                 |
+| focus-ring-utility         | needs-decision       | `packages/react/src/components/ui/avatar/avatar.tsx:123`                                  | selected/group `ring-*` utilities                   |
+| radius-border-arbitrary    | allowed-one-off      | `packages/react/src/components/ui/avatar/avatar.tsx:165`                                  | `nx:rounded-[inherit]`                              |
+| radius-border-arbitrary    | allowed-one-off      | `packages/react/src/components/ui/avatar/avatar.tsx:199`                                  | `nx:rounded-[inherit]`                              |
+| typography-leading         | needs-decision       | `packages/react/src/components/ui/avatar/avatar.tsx:199`                                  | `nx:leading-none`                                   |
+| typography-weight          | needs-decision       | `packages/react/src/components/ui/avatar/avatar.tsx:199`                                  | `nx:font-medium`                                    |
+| focus-ring-utility         | needs-decision       | `packages/react/src/components/ui/avatar/avatar.tsx:209`                                  | status marker `ring-*`                              |
+| spacing-arbitrary          | allowed-one-off      | `packages/react/src/components/ui/avatar/avatar.tsx:209`                                  | `right-[0.04em]`, `bottom-[0.04em]`, `size-[0.6em]` |
+| focus-ring-utility         | needs-decision       | `packages/react/src/components/ui/avatar/avatar.tsx:335`                                  | AvatarGroup `ring-*`                                |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/badge/badge.tsx:145`                                    | `nx:h-6`                                            |
+| spacing-arbitrary          | needs-decision       | `packages/react/src/components/ui/breadcrumb/breadcrumb.tsx:127,154`                      | `nx:max-w-[150px]`                                  |
+| z-index                    | needs-decision       | `packages/react/src/components/ui/button-group/button-group.tsx:15`                       | `nx:*:focus-visible:z-10`                           |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/button-group/button-group.tsx:36-38`                    | `nx:h-8`, `nx:h-10`, `nx:h-12`                      |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/button/button.tsx:32-34`                                | `nx:h-8`, `nx:h-10`, `nx:h-12`                      |
+| color-literal              | allowed-one-off      | `packages/react/src/components/ui/chart/chart.tsx:75`                                     | selector literals `#ccc`, `#fff`                    |
+| typography-weight          | leak                 | `packages/react/src/components/ui/chart/chart.tsx:174,180`                                | `nx:font-medium`                                    |
+| radius-border-arbitrary    | leak                 | `packages/react/src/components/ui/chart/chart.tsx:272`                                    | `nx:rounded-[2px]`                                  |
+| radius-border-arbitrary    | leak                 | `packages/react/src/components/ui/chart/chart.tsx:276`                                    | `nx:border-[1.5px]`                                 |
+| typography-leading         | leak                 | `packages/react/src/components/ui/chart/chart.tsx:327`                                    | `nx:leading-none`                                   |
+| typography-weight          | needs-new-token      | `packages/react/src/components/ui/chart/chart.tsx:338`                                    | `nx:font-mono nx:font-medium`                       |
+| radius-border-arbitrary    | leak                 | `packages/react/src/components/ui/chart/chart.tsx:393`                                    | `nx:rounded-[2px]`                                  |
+| spacing-arbitrary          | needs-decision       | `packages/react/src/components/ui/command/command.tsx:184`                                | `nx:max-h-[300px]`                                  |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/date-picker/date-picker.tsx:211`                        | `nx:h-8`                                            |
+| typography-leading         | leak                 | `packages/react/src/components/ui/date-picker/date-picker.tsx:339`                        | `nx:leading-none`                                   |
+| z-index                    | needs-decision       | `packages/react/src/components/ui/date-picker/date-picker.tsx:343`                        | `nx:group-data-[focused=true]/day:z-10`             |
+| typography-weight          | leak                 | `packages/react/src/components/ui/date-picker/date-picker.tsx:345`                        | `nx:data-[today=true]:font-medium`                  |
+| z-index                    | needs-decision       | `packages/react/src/components/ui/date-picker/date-picker.tsx:361`                        | `nx:z-10`                                           |
+| responsive-viewport-prefix | sanctioned-exception | `packages/react/src/components/ui/dialog/dialog.tsx:192,305`                              | overlay `lg:` / `sm:` classes                       |
+| spacing-arbitrary          | needs-decision       | `packages/react/src/components/ui/drawer/drawer.tsx:101,102,111`                          | `max-h-[80svh]`, `w-[100px]`                        |
+| responsive-viewport-prefix | needs-decision       | `packages/react/src/components/ui/drawer/drawer.tsx:129`                                  | `nx:md:text-left`                                   |
+| typography-leading         | leak                 | `packages/react/src/components/ui/field/field.tsx:150`                                    | `nx:leading-snug`                                   |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/field/field.tsx:236`                                    | `nx:h-5`                                            |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/input-group/input-group.tsx:137,138`                    | `nx:h-6`, `nx:h-8`                                  |
+| z-index                    | needs-decision       | `packages/react/src/components/ui/input-otp/input-otp.tsx:125`                            | `nx:data-[active=true]:z-10`                        |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/input-otp/input-otp.tsx:133`                            | `nx:h-4`                                            |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/input/input.tsx:20-22`                                  | `nx:h-10`, `nx:h-8`, `nx:h-12`                      |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/kbd/kbd.tsx:35`                                         | `nx:h-5`                                            |
+| color-system               | allowed-one-off      | `packages/react/src/components/ui/native-select/native-select.tsx:97,115`                 | `nx:bg-[Canvas]`, `nx:text-[CanvasText]`            |
+| z-index                    | needs-decision       | `packages/react/src/components/ui/navigation-menu/navigation-menu.tsx:294`                | `nx:z-1`                                            |
+| spacing-arbitrary          | needs-decision       | `packages/react/src/components/ui/navigation-menu/navigation-menu.tsx:301`                | `nx:top-[60%]`                                      |
+| responsive-viewport-prefix | needs-decision       | `packages/react/src/components/ui/overlay-layout/overlay-layout.ts:16,23,36`              | shared overlay `sm:` classes                        |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/progress/progress.tsx:42`                               | `nx:h-2`                                            |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/resizable/resizable.tsx:69`                             | handle hit-area `h-*`                               |
+| z-index                    | needs-decision       | `packages/react/src/components/ui/resizable/resizable.tsx:76`                             | `nx:z-10`                                           |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/resizable/resizable.tsx:76`                             | `nx:h-4`                                            |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/scroll-area/scroll-area.tsx:37,99`                      | `nx:h-72`, `nx:h-2.5`                               |
+| radius-border-arbitrary    | allowed-one-off      | `packages/react/src/components/ui/scroll-area/scroll-area.tsx:65`                         | `nx:rounded-[inherit]`                              |
+| radius-border-arbitrary    | allowed-one-off      | `packages/react/src/components/ui/scroll-area/scroll-area.tsx:74`                         | `nx:forced-colors:border-[ButtonBorder]`            |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/separator/separator.tsx:33`                             | `nx:h-5`                                            |
+| responsive-viewport-prefix | sanctioned-exception | `packages/react/src/components/ui/sheet/sheet.tsx:113,117,181`                            | Sheet `sm:` / `lg:` overlay classes                 |
+| responsive-viewport-prefix | needs-decision       | `packages/react/src/components/ui/sidebar/sidebar.tsx:319,341,427,461,698,932,938`        | page-shell/sidebar `lg:` classes                    |
+| spacing-arbitrary          | needs-decision       | `packages/react/src/components/ui/sidebar/sidebar.tsx:334,349`                            | `w-[calc(...)]`                                     |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/sidebar/sidebar.tsx:486,657,801-803,963,1009,1022,1125` | sidebar `h-*` geometry                              |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/skeleton/skeleton.tsx:22`                               | `nx:h-4`                                            |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/slider/slider.tsx:63`                                   | `nx:data-[orientation=horizontal]:h-1.5`            |
+| fixed-height-control       | convention           | `packages/react/src/components/ui/switch/switch.tsx:23,24`                                | `nx:h-5`, `nx:h-[18px]`                             |
+| spacing-arbitrary          | convention           | `packages/react/src/components/ui/switch/switch.tsx:24,44`                                | `w-[32px]`, `size-[14px]`, `translate-x-[14px]`     |
+| typography-weight          | leak                 | `packages/react/src/components/ui/table/table.tsx:379`                                    | `nx:font-medium`                                    |
 
 ### Secondary Console Runtime
 
-| Family | Bucket | Location | Token / pattern |
-| --- | --- | --- | --- |
-| typography-weight | leak | `apps/console/src/app/auth-layout.tsx:20` | `nx:font-bold` |
-| typography-leading | leak | `apps/console/src/app/auth-layout.tsx:27` | `nx:leading-snug` |
-| typography-tracking | leak | `apps/console/src/app/not-found.tsx:13` | `nx:tracking-wide` |
-| color-literal | allowed-one-off / needs-decision | `apps/console/src/hooks/useTheme.ts:4-17` | 11 swatch hex values |
-| spacing-arbitrary | needs-decision | `apps/console/src/modules/analytics/analytics-charts.tsx:25` | `nx:h-[260px]` |
-| typography-weight | leak | `apps/console/src/modules/analytics/analytics-route.tsx:185` | `nx:font-medium` |
-| typography-weight | leak | `apps/console/src/modules/auth/verify-route.tsx:58` | `nx:font-medium` |
-| typography-weight | leak | `apps/console/src/modules/billing/billing-route.tsx:242` | `nx:font-medium` |
-| typography-weight | leak | `apps/console/src/modules/billing/plan-sheet.tsx:123` | `nx:font-medium` |
-| spacing-arbitrary | needs-decision | `apps/console/src/modules/coming-soon.tsx:26` | `nx:min-h-[60svh]` |
-| typography-weight | leak | `apps/console/src/modules/crm/contact-card.tsx:17` | `nx:font-medium` |
-| typography-weight | leak | `apps/console/src/modules/crm/contacts-board.tsx:157` | `nx:font-medium` |
-| typography-weight | leak | `apps/console/src/modules/crm/contacts-columns.tsx:88` | `nx:font-medium` |
-| typography-weight | leak | `apps/console/src/modules/design-system/ComponentShowcase.tsx:234,263,312,318,324,330` | `font-medium` / `font-semibold` |
-| typography-arbitrary-size | needs-decision | `apps/console/src/modules/design-system/IconShowcase.tsx:51` | `nx:text-[10px]` |
-| typography-leading | leak | `apps/console/src/modules/design-system/IconShowcase.tsx:51` | `nx:leading-tight` |
-| typography-weight | leak | `apps/console/src/modules/inbox/conversation-list.tsx:69` | `font-semibold` / `font-medium` |
-| spacing-arbitrary | needs-decision | `apps/console/src/modules/inbox/conversation-thread.tsx:234` | `nx:max-w-[75%]` |
-| spacing-arbitrary | needs-decision | `apps/console/src/modules/inbox/inbox-route.tsx:57` | `nx:h-[calc(100svh-3.5rem)]` |
-| typography-weight | leak | `apps/console/src/modules/people/member-card.tsx:17` | `nx:font-medium` |
-| typography-weight | leak | `apps/console/src/modules/people/people-columns.tsx:94` | `nx:font-medium` |
-| typography-weight | leak | `apps/console/src/modules/projects/issue-card.tsx:22` | `nx:font-medium` |
-| typography-leading | leak | `apps/console/src/modules/projects/issue-detail-route.tsx:110` | `nx:leading-relaxed` |
-| typography-weight | leak | `apps/console/src/modules/projects/issues-columns.tsx:97` | `nx:font-medium` |
-| typography-weight | leak | `apps/console/src/shell/app-sidebar.tsx:77,81,176` | `font-bold` / `font-semibold` / `font-normal` |
-| typography-weight | leak | `apps/console/src/shell/notifications-menu.tsx:188` | `nx:font-medium` |
+| Family                    | Bucket                           | Location                                                                               | Token / pattern                               |
+| ------------------------- | -------------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------- |
+| typography-weight         | leak                             | `apps/console/src/app/auth-layout.tsx:20`                                              | `nx:font-bold`                                |
+| typography-leading        | leak                             | `apps/console/src/app/auth-layout.tsx:27`                                              | `nx:leading-snug`                             |
+| typography-tracking       | leak                             | `apps/console/src/app/not-found.tsx:13`                                                | `nx:tracking-wide`                            |
+| color-literal             | allowed-one-off / needs-decision | `apps/console/src/hooks/useTheme.ts:4-17`                                              | 11 swatch hex values                          |
+| spacing-arbitrary         | needs-decision                   | `apps/console/src/modules/analytics/analytics-charts.tsx:25`                           | `nx:h-[260px]`                                |
+| typography-weight         | leak                             | `apps/console/src/modules/analytics/analytics-route.tsx:185`                           | `nx:font-medium`                              |
+| typography-weight         | leak                             | `apps/console/src/modules/auth/verify-route.tsx:58`                                    | `nx:font-medium`                              |
+| typography-weight         | leak                             | `apps/console/src/modules/billing/billing-route.tsx:242`                               | `nx:font-medium`                              |
+| typography-weight         | leak                             | `apps/console/src/modules/billing/plan-sheet.tsx:123`                                  | `nx:font-medium`                              |
+| spacing-arbitrary         | needs-decision                   | `apps/console/src/modules/coming-soon.tsx:26`                                          | `nx:min-h-[60svh]`                            |
+| typography-weight         | leak                             | `apps/console/src/modules/crm/contact-card.tsx:17`                                     | `nx:font-medium`                              |
+| typography-weight         | leak                             | `apps/console/src/modules/crm/contacts-board.tsx:157`                                  | `nx:font-medium`                              |
+| typography-weight         | leak                             | `apps/console/src/modules/crm/contacts-columns.tsx:88`                                 | `nx:font-medium`                              |
+| typography-weight         | leak                             | `apps/console/src/modules/design-system/ComponentShowcase.tsx:234,263,312,318,324,330` | `font-medium` / `font-semibold`               |
+| typography-arbitrary-size | needs-decision                   | `apps/console/src/modules/design-system/IconShowcase.tsx:51`                           | `nx:text-[10px]`                              |
+| typography-leading        | leak                             | `apps/console/src/modules/design-system/IconShowcase.tsx:51`                           | `nx:leading-tight`                            |
+| typography-weight         | leak                             | `apps/console/src/modules/inbox/conversation-list.tsx:69`                              | `font-semibold` / `font-medium`               |
+| spacing-arbitrary         | needs-decision                   | `apps/console/src/modules/inbox/conversation-thread.tsx:234`                           | `nx:max-w-[75%]`                              |
+| spacing-arbitrary         | needs-decision                   | `apps/console/src/modules/inbox/inbox-route.tsx:57`                                    | `nx:h-[calc(100svh-3.5rem)]`                  |
+| typography-weight         | leak                             | `apps/console/src/modules/people/member-card.tsx:17`                                   | `nx:font-medium`                              |
+| typography-weight         | leak                             | `apps/console/src/modules/people/people-columns.tsx:94`                                | `nx:font-medium`                              |
+| typography-weight         | leak                             | `apps/console/src/modules/projects/issue-card.tsx:22`                                  | `nx:font-medium`                              |
+| typography-leading        | leak                             | `apps/console/src/modules/projects/issue-detail-route.tsx:110`                         | `nx:leading-relaxed`                          |
+| typography-weight         | leak                             | `apps/console/src/modules/projects/issues-columns.tsx:97`                              | `nx:font-medium`                              |
+| typography-weight         | leak                             | `apps/console/src/shell/app-sidebar.tsx:77,81,176`                                     | `font-bold` / `font-semibold` / `font-normal` |
+| typography-weight         | leak                             | `apps/console/src/shell/notifications-menu.tsx:188`                                    | `nx:font-medium`                              |
 
 ## Non-Runtime Appendix
 
 The scanner also saw these non-runtime candidates. They are intentionally excluded from source-leak counts:
 
-| Kind | Candidate count | Treatment |
-| --- | ---: | --- |
-| `story` | 258 | Story/demo sizing, literals, and assertions; useful for future story policy but not runtime leakage. |
-| `docs-out-of-scope` | 525 | Marketing/docs consumer; excluded by scope. |
-| `token-output` | 1,059 | Generated theme CSS and package token CSS; token values are expected here. |
-| `token-source` | 465 | DTCG token JSON; raw values are canonical source, not leaks. |
-| `token-infrastructure` | 108 | Scripts/tests manipulating token values; not class leakage. |
-| `guard-source` | 8 | Existing lint rule/test strings. |
-| `other` | 1 | Package metadata/non-runtime residue. |
+| Kind                   | Candidate count | Treatment                                                                                            |
+| ---------------------- | --------------: | ---------------------------------------------------------------------------------------------------- |
+| `story`                |             258 | Story/demo sizing, literals, and assertions; useful for future story policy but not runtime leakage. |
+| `docs-out-of-scope`    |             525 | Marketing/docs consumer; excluded by scope.                                                          |
+| `token-output`         |           1,059 | Generated theme CSS and package token CSS; token values are expected here.                           |
+| `token-source`         |             465 | DTCG token JSON; raw values are canonical source, not leaks.                                         |
+| `token-infrastructure` |             108 | Scripts/tests manipulating token values; not class leakage.                                          |
+| `guard-source`         |               8 | Existing lint rule/test strings.                                                                     |
+| `other`                |               1 | Package metadata/non-runtime residue.                                                                |
 
 ## Plug Proposal
 
 Ranked narrow plugs:
 
-| Rank | Plug | Why | Notes |
-| ---: | --- | --- | --- |
-| 1 | Add focused lint for typography non-size utilities: `font-*`, `leading-*`, `tracking-*`. | This is the biggest primary runtime leak family and has no reset/lint protection. | Derive allowlists from typography token/composite source or add a drift test. Avoid hardcoding a second live list without a guard. |
-| 2 | Add z-index numeric lint with a local-stacking policy. | Six primary numeric hits exist. | Do not blindly force `z-10` to `z-overlay`; tokens are structural layers, while several hits are local overlap. |
-| 3 | Add arbitrary radius/border lint for component runtime. | Chart has real arbitrary radius/border leaks. | Allowlist `rounded-[inherit]` and forced-colors system keywords such as `ButtonBorder`. |
-| 4 | Extend raw primitive color lint to `fill`, `stroke`, `ring`, `from`, `via`, `to`. | Current runtime is clean, but the seam remains open. | Keep system-color and selector-literal exceptions out of this rule. |
-| 5 | Add a documented exception list for arbitrary spacing/sizing. | Arbitrary values are not inherently bad; several are relative geometry or calc values with no exact scale equivalent. | Enforce exact scale replacement only when an exact Nexus scale value exists. |
-| 6 | Add a focus presence audit for known focusable controls. | Existing rules require outline focus tokens, but no automated presence guard exists. | Scope carefully around roving-focus overlay rows that intentionally use background tint instead of outline. |
-| 7 | Add docs to `responsive.md` for Drawer, OverlayLayout, and Sidebar if accepted as viewport exceptions. | Current local source uses viewport prefixes beyond the explicit Dialog and future Sheet text. | This is documentation/policy closure, not a class migration. |
-| 8 | Consider a console-only cleanup issue. | `apps/console` has 47 runtime candidates, mostly typography. | Keep separate from design-system package hard gates unless console is intended to be a strict consumer example. |
+| Rank | Plug                                                                                                   | Why                                                                                                                   | Notes                                                                                                                              |
+| ---: | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+|    1 | Add focused lint for typography non-size utilities: `font-*`, `leading-*`, `tracking-*`.               | This is the biggest primary runtime leak family and has no reset/lint protection.                                     | Derive allowlists from typography token/composite source or add a drift test. Avoid hardcoding a second live list without a guard. |
+|    2 | Add z-index numeric lint with a local-stacking policy.                                                 | Six primary numeric hits exist.                                                                                       | Do not blindly force `z-10` to `z-overlay`; tokens are structural layers, while several hits are local overlap.                    |
+|    3 | Add arbitrary radius/border lint for component runtime.                                                | Chart has real arbitrary radius/border leaks.                                                                         | Allowlist `rounded-[inherit]` and forced-colors system keywords such as `ButtonBorder`.                                            |
+|    4 | Extend raw primitive color lint to `fill`, `stroke`, `ring`, `from`, `via`, `to`.                      | Current runtime is clean, but the seam remains open.                                                                  | Keep system-color and selector-literal exceptions out of this rule.                                                                |
+|    5 | Add a documented exception list for arbitrary spacing/sizing.                                          | Arbitrary values are not inherently bad; several are relative geometry or calc values with no exact scale equivalent. | Enforce exact scale replacement only when an exact Nexus scale value exists.                                                       |
+|    6 | Add a focus presence audit for known focusable controls.                                               | Existing rules require outline focus tokens, but no automated presence guard exists.                                  | Scope carefully around roving-focus overlay rows that intentionally use background tint instead of outline.                        |
+|    7 | Add docs to `responsive.md` for Drawer, OverlayLayout, and Sidebar if accepted as viewport exceptions. | Current local source uses viewport prefixes beyond the explicit Dialog and future Sheet text.                         | This is documentation/policy closure, not a class migration.                                                                       |
+|    8 | Consider a console-only cleanup issue.                                                                 | `apps/console` has 47 runtime candidates, mostly typography.                                                          | Keep separate from design-system package hard gates unless console is intended to be a strict consumer example.                    |
+
+## Implementation Follow-Up
+
+This branch now implements the rank-1 typography non-size plug:
+
+- `@nexus/nx-class-conventions` now reports raw runtime `nx:font-*`, `nx:leading-*`, and `nx:tracking-*` utilities so typography weight, line-height, and letter-spacing stay owned by composites.
+- The new guard is runtime-scoped: stories and `apps/docs` remain excluded from this hard gate.
+- The guard includes drift checks for raw font-weight and letter-spacing names against `typography-vega.json`.
+- Runtime call sites in `packages/react/src` and `apps/console/src` were migrated where an existing composite matched the intent.
+- Two narrow runtime exceptions remain documented in tests: Avatar initials need diameter-coupled fallback typography, and Chart monospace numeric values need a future numeric typography token.
 
 ## Validation And Rerun Checklist
 
@@ -431,12 +442,14 @@ Completed in this pass:
 - Read repo instructions, responsive/component rules, existing reset block, existing ESLint rule, spacing JSON guard, semantic color audit script, z-index tokens, typography composites, package browser floor, and issue #496.
 - Ran Modern Web Guidance CSS lookup and applied the repo browser-floor override.
 - Ran deterministic mechanical scans over primary, secondary, docs, stories, token source/output, and guard source, then classified runtime findings.
+- Implemented the rank-1 typography non-size lint plug and migrated in-scope runtime typography leaks.
+- Ran `pnpm vitest run packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js --project unit`, `pnpm lint`, `pnpm format:check`, and `pnpm typecheck`.
 
 Not run in this pass:
 
-- No source plugs were implemented, so `pnpm lint`, `pnpm typecheck`, app builds, reset-efficacy build grep, and per-app emission gates are deferred until a plug is approved.
+- App builds, reset-efficacy build grep, and per-app emission gates remain deferred because this pass did not implement reset-layer or app-emission plugs.
 
-If plugs are approved, validation should include:
+For remaining plugs, validation should include:
 
 1. Re-run the Phase 1 family patterns and confirm report counts remain intentional.
 2. Run `pnpm lint`, `pnpm typecheck`, and `pnpm format:check`.


### PR DESCRIPTION
## Summary

- add runtime-scoped @nexus/nx-class-conventions checks for raw nx:font-*, nx:leading-*, and nx:tracking-* typography utilities
- migrate in-scope packages/react/src and apps/console/src runtime usages to existing typography composites where possible
- document the baseline audit plus implementation follow-up in reports/nexus-style-token-audit.md

## Notes

- stories and apps/docs remain outside the hard runtime gate
- two narrow exceptions are documented in rule tests: Avatar initials and Chart monospace numeric values

## Validation

- pnpm vitest run packages/eslint-plugin-nexus/__tests__/nx-class-conventions.test.js --project unit
- pnpm lint
- pnpm format:check
- pnpm typecheck