### PR TITLE
feat(motion): add motion token foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Token-driven design system for product UI. Three layers compose into one consumable surface:
 
-- **`@nexus/core`** — DTCG design tokens (color, spacing, radius, shadow, typography). Color emits as OKLCH at build time via a perceptual-L grid; spacing is per-mode (mode swap at runtime via the `data-style` attribute).
+- **`@nexus/core`** — DTCG design tokens (color, spacing, radius, shadow, typography, motion). Color emits as OKLCH at build time via a perceptual-L grid; spacing is per-mode (mode swap at runtime via the `data-style` attribute).
 - **`@nexus/tailwind`** — Tailwind CSS theme generated from the tokens. All utilities are namespaced with the `nx:` prefix.
 - **`@nexus/react`** — React components built on Radix UI primitives and the Tailwind layer. Variants via CVA; data-attribute test surface; padding-based sizing.
 

--- a/apps/console/public/themes/globals.css
+++ b/apps/console/public/themes/globals.css
@@ -16,6 +16,7 @@
 @import './motion-snappy.css';
 @import './typography-utilities.css';
 @import './borderwidth-utilities.css';
+@import './motion-utilities.css';
 @import './spacing-utilities.css';
 
 @custom-variant dark (&:is(.dark *));
@@ -182,13 +183,6 @@
   --border-thick: var(--nx-borderwidth-thick);
 
   /* Motion tokens */
-  --duration-0: var(--nx-motion-duration-0);
-  --duration-faster: var(--nx-motion-duration-faster);
-  --duration-fast: var(--nx-motion-duration-fast);
-  --duration-default: var(--nx-motion-duration-default);
-  --duration-moderate: var(--nx-motion-duration-moderate);
-  --duration-slow: var(--nx-motion-duration-slow);
-  --duration-slower: var(--nx-motion-duration-slower);
   --ease-linear: var(--nx-motion-ease-linear);
   --ease-enter: var(--nx-motion-ease-enter);
   --ease-exit: var(--nx-motion-ease-exit);

--- a/apps/console/public/themes/globals.css
+++ b/apps/console/public/themes/globals.css
@@ -13,6 +13,7 @@
 @import 'tailwindcss' prefix(nx);
 @import './color.css';
 @import './focus-default.css';
+@import './motion-snappy.css';
 @import './typography-utilities.css';
 @import './borderwidth-utilities.css';
 @import './spacing-utilities.css';
@@ -179,6 +180,19 @@
   /* Border width tokens */
   --border-default: var(--nx-borderwidth-default);
   --border-thick: var(--nx-borderwidth-thick);
+
+  /* Motion tokens */
+  --duration-0: var(--nx-motion-duration-0);
+  --duration-faster: var(--nx-motion-duration-faster);
+  --duration-fast: var(--nx-motion-duration-fast);
+  --duration-default: var(--nx-motion-duration-default);
+  --duration-moderate: var(--nx-motion-duration-moderate);
+  --duration-slow: var(--nx-motion-duration-slow);
+  --duration-slower: var(--nx-motion-duration-slower);
+  --ease-linear: var(--nx-motion-ease-linear);
+  --ease-enter: var(--nx-motion-ease-enter);
+  --ease-exit: var(--nx-motion-ease-exit);
+  --ease-move: var(--nx-motion-ease-move);
 
   /* Shadow tokens */
   --shadow-2xs: var(--nx-shadow-2xs-layer-1-x) var(--nx-shadow-2xs-layer-1-y)

--- a/apps/console/public/themes/motion-snappy.css
+++ b/apps/console/public/themes/motion-snappy.css
@@ -1,0 +1,15 @@
+/* motion: snappy */
+
+:root {
+  --nx-motion-duration-0: 0ms;
+  --nx-motion-duration-faster: 100ms;
+  --nx-motion-duration-fast: 150ms;
+  --nx-motion-duration-default: 200ms;
+  --nx-motion-duration-moderate: 240ms;
+  --nx-motion-duration-slow: 300ms;
+  --nx-motion-duration-slower: 500ms;
+  --nx-motion-ease-linear: linear;
+  --nx-motion-ease-enter: cubic-bezier(0.23, 1, 0.32, 1);
+  --nx-motion-ease-exit: cubic-bezier(0.4, 0, 1, 1);
+  --nx-motion-ease-move: cubic-bezier(0.77, 0, 0.175, 1);
+}

--- a/apps/console/public/themes/motion-utilities.css
+++ b/apps/console/public/themes/motion-utilities.css
@@ -1,0 +1,36 @@
+/* Motion duration utilities - data-driven from canonical motion tokens. */
+
+@utility duration-0 {
+  --tw-duration: var(--nx-motion-duration-0);
+  transition-duration: var(--nx-motion-duration-0);
+}
+
+@utility duration-faster {
+  --tw-duration: var(--nx-motion-duration-faster);
+  transition-duration: var(--nx-motion-duration-faster);
+}
+
+@utility duration-fast {
+  --tw-duration: var(--nx-motion-duration-fast);
+  transition-duration: var(--nx-motion-duration-fast);
+}
+
+@utility duration-default {
+  --tw-duration: var(--nx-motion-duration-default);
+  transition-duration: var(--nx-motion-duration-default);
+}
+
+@utility duration-moderate {
+  --tw-duration: var(--nx-motion-duration-moderate);
+  transition-duration: var(--nx-motion-duration-moderate);
+}
+
+@utility duration-slow {
+  --tw-duration: var(--nx-motion-duration-slow);
+  transition-duration: var(--nx-motion-duration-slow);
+}
+
+@utility duration-slower {
+  --tw-duration: var(--nx-motion-duration-slower);
+  transition-duration: var(--nx-motion-duration-slower);
+}

--- a/apps/console/src/styles/globals.css
+++ b/apps/console/src/styles/globals.css
@@ -16,6 +16,7 @@
 @import './motion-snappy.css';
 @import './typography-utilities.css';
 @import './borderwidth-utilities.css';
+@import './motion-utilities.css';
 @import './spacing-utilities.css';
 
 @custom-variant dark (&:is(.dark *));
@@ -182,13 +183,6 @@
   --border-thick: var(--nx-borderwidth-thick);
 
   /* Motion tokens */
-  --duration-0: var(--nx-motion-duration-0);
-  --duration-faster: var(--nx-motion-duration-faster);
-  --duration-fast: var(--nx-motion-duration-fast);
-  --duration-default: var(--nx-motion-duration-default);
-  --duration-moderate: var(--nx-motion-duration-moderate);
-  --duration-slow: var(--nx-motion-duration-slow);
-  --duration-slower: var(--nx-motion-duration-slower);
   --ease-linear: var(--nx-motion-ease-linear);
   --ease-enter: var(--nx-motion-ease-enter);
   --ease-exit: var(--nx-motion-ease-exit);

--- a/apps/console/src/styles/globals.css
+++ b/apps/console/src/styles/globals.css
@@ -13,6 +13,7 @@
 @import 'tailwindcss' prefix(nx);
 @import './color.css';
 @import './focus-default.css';
+@import './motion-snappy.css';
 @import './typography-utilities.css';
 @import './borderwidth-utilities.css';
 @import './spacing-utilities.css';
@@ -179,6 +180,19 @@
   /* Border width tokens */
   --border-default: var(--nx-borderwidth-default);
   --border-thick: var(--nx-borderwidth-thick);
+
+  /* Motion tokens */
+  --duration-0: var(--nx-motion-duration-0);
+  --duration-faster: var(--nx-motion-duration-faster);
+  --duration-fast: var(--nx-motion-duration-fast);
+  --duration-default: var(--nx-motion-duration-default);
+  --duration-moderate: var(--nx-motion-duration-moderate);
+  --duration-slow: var(--nx-motion-duration-slow);
+  --duration-slower: var(--nx-motion-duration-slower);
+  --ease-linear: var(--nx-motion-ease-linear);
+  --ease-enter: var(--nx-motion-ease-enter);
+  --ease-exit: var(--nx-motion-ease-exit);
+  --ease-move: var(--nx-motion-ease-move);
 
   /* Shadow tokens */
   --shadow-2xs: var(--nx-shadow-2xs-layer-1-x) var(--nx-shadow-2xs-layer-1-y)

--- a/apps/console/src/styles/motion-snappy.css
+++ b/apps/console/src/styles/motion-snappy.css
@@ -1,0 +1,15 @@
+/* motion: snappy */
+
+:root {
+  --nx-motion-duration-0: 0ms;
+  --nx-motion-duration-faster: 100ms;
+  --nx-motion-duration-fast: 150ms;
+  --nx-motion-duration-default: 200ms;
+  --nx-motion-duration-moderate: 240ms;
+  --nx-motion-duration-slow: 300ms;
+  --nx-motion-duration-slower: 500ms;
+  --nx-motion-ease-linear: linear;
+  --nx-motion-ease-enter: cubic-bezier(0.23, 1, 0.32, 1);
+  --nx-motion-ease-exit: cubic-bezier(0.4, 0, 1, 1);
+  --nx-motion-ease-move: cubic-bezier(0.77, 0, 0.175, 1);
+}

--- a/apps/console/src/styles/motion-utilities.css
+++ b/apps/console/src/styles/motion-utilities.css
@@ -1,0 +1,36 @@
+/* Motion duration utilities - data-driven from canonical motion tokens. */
+
+@utility duration-0 {
+  --tw-duration: var(--nx-motion-duration-0);
+  transition-duration: var(--nx-motion-duration-0);
+}
+
+@utility duration-faster {
+  --tw-duration: var(--nx-motion-duration-faster);
+  transition-duration: var(--nx-motion-duration-faster);
+}
+
+@utility duration-fast {
+  --tw-duration: var(--nx-motion-duration-fast);
+  transition-duration: var(--nx-motion-duration-fast);
+}
+
+@utility duration-default {
+  --tw-duration: var(--nx-motion-duration-default);
+  transition-duration: var(--nx-motion-duration-default);
+}
+
+@utility duration-moderate {
+  --tw-duration: var(--nx-motion-duration-moderate);
+  transition-duration: var(--nx-motion-duration-moderate);
+}
+
+@utility duration-slow {
+  --tw-duration: var(--nx-motion-duration-slow);
+  transition-duration: var(--nx-motion-duration-slow);
+}
+
+@utility duration-slower {
+  --tw-duration: var(--nx-motion-duration-slower);
+  transition-duration: var(--nx-motion-duration-slower);
+}

--- a/apps/docs/public/themes/globals.css
+++ b/apps/docs/public/themes/globals.css
@@ -16,6 +16,7 @@
 @import './motion-snappy.css';
 @import './typography-utilities.css';
 @import './borderwidth-utilities.css';
+@import './motion-utilities.css';
 @import './spacing-utilities.css';
 
 @custom-variant dark (&:is(.dark *));
@@ -182,13 +183,6 @@
   --border-thick: var(--nx-borderwidth-thick);
 
   /* Motion tokens */
-  --duration-0: var(--nx-motion-duration-0);
-  --duration-faster: var(--nx-motion-duration-faster);
-  --duration-fast: var(--nx-motion-duration-fast);
-  --duration-default: var(--nx-motion-duration-default);
-  --duration-moderate: var(--nx-motion-duration-moderate);
-  --duration-slow: var(--nx-motion-duration-slow);
-  --duration-slower: var(--nx-motion-duration-slower);
   --ease-linear: var(--nx-motion-ease-linear);
   --ease-enter: var(--nx-motion-ease-enter);
   --ease-exit: var(--nx-motion-ease-exit);

--- a/apps/docs/public/themes/globals.css
+++ b/apps/docs/public/themes/globals.css
@@ -13,6 +13,7 @@
 @import 'tailwindcss' prefix(nx);
 @import './color.css';
 @import './focus-default.css';
+@import './motion-snappy.css';
 @import './typography-utilities.css';
 @import './borderwidth-utilities.css';
 @import './spacing-utilities.css';
@@ -179,6 +180,19 @@
   /* Border width tokens */
   --border-default: var(--nx-borderwidth-default);
   --border-thick: var(--nx-borderwidth-thick);
+
+  /* Motion tokens */
+  --duration-0: var(--nx-motion-duration-0);
+  --duration-faster: var(--nx-motion-duration-faster);
+  --duration-fast: var(--nx-motion-duration-fast);
+  --duration-default: var(--nx-motion-duration-default);
+  --duration-moderate: var(--nx-motion-duration-moderate);
+  --duration-slow: var(--nx-motion-duration-slow);
+  --duration-slower: var(--nx-motion-duration-slower);
+  --ease-linear: var(--nx-motion-ease-linear);
+  --ease-enter: var(--nx-motion-ease-enter);
+  --ease-exit: var(--nx-motion-ease-exit);
+  --ease-move: var(--nx-motion-ease-move);
 
   /* Shadow tokens */
   --shadow-2xs: var(--nx-shadow-2xs-layer-1-x) var(--nx-shadow-2xs-layer-1-y)

--- a/apps/docs/public/themes/motion-snappy.css
+++ b/apps/docs/public/themes/motion-snappy.css
@@ -1,0 +1,15 @@
+/* motion: snappy */
+
+:root {
+  --nx-motion-duration-0: 0ms;
+  --nx-motion-duration-faster: 100ms;
+  --nx-motion-duration-fast: 150ms;
+  --nx-motion-duration-default: 200ms;
+  --nx-motion-duration-moderate: 240ms;
+  --nx-motion-duration-slow: 300ms;
+  --nx-motion-duration-slower: 500ms;
+  --nx-motion-ease-linear: linear;
+  --nx-motion-ease-enter: cubic-bezier(0.23, 1, 0.32, 1);
+  --nx-motion-ease-exit: cubic-bezier(0.4, 0, 1, 1);
+  --nx-motion-ease-move: cubic-bezier(0.77, 0, 0.175, 1);
+}

--- a/apps/docs/public/themes/motion-utilities.css
+++ b/apps/docs/public/themes/motion-utilities.css
@@ -1,0 +1,36 @@
+/* Motion duration utilities - data-driven from canonical motion tokens. */
+
+@utility duration-0 {
+  --tw-duration: var(--nx-motion-duration-0);
+  transition-duration: var(--nx-motion-duration-0);
+}
+
+@utility duration-faster {
+  --tw-duration: var(--nx-motion-duration-faster);
+  transition-duration: var(--nx-motion-duration-faster);
+}
+
+@utility duration-fast {
+  --tw-duration: var(--nx-motion-duration-fast);
+  transition-duration: var(--nx-motion-duration-fast);
+}
+
+@utility duration-default {
+  --tw-duration: var(--nx-motion-duration-default);
+  transition-duration: var(--nx-motion-duration-default);
+}
+
+@utility duration-moderate {
+  --tw-duration: var(--nx-motion-duration-moderate);
+  transition-duration: var(--nx-motion-duration-moderate);
+}
+
+@utility duration-slow {
+  --tw-duration: var(--nx-motion-duration-slow);
+  transition-duration: var(--nx-motion-duration-slow);
+}
+
+@utility duration-slower {
+  --tw-duration: var(--nx-motion-duration-slower);
+  transition-duration: var(--nx-motion-duration-slower);
+}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -26,7 +26,7 @@ All tokens follow the [Design Tokens Community Group](https://tr.designtokens.or
 - Color, radius, border-width, shadow, typography, focus, motion
 - Output: CSS variables with the `--nx-*` prefix
 - Example: `--nx-color-gray-950`, `--nx-radius-md`
-- Motion primitives also promote named Tailwind utilities such as `nx:duration-fast` and `nx:ease-enter` through `@theme`, while existing Tailwind numeric duration/ease defaults remain available until the repo-wide migration lands.
+- Motion primitives also promote named Tailwind utilities such as `nx:duration-fast` and `nx:ease-enter`: durations are emitted as explicit `@utility` rules, while easing uses Tailwind's `@theme` namespace. Existing Tailwind numeric duration/ease defaults remain available until the repo-wide migration lands.
 
 **Semantic** (`tokens/semantic/`)
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -23,9 +23,10 @@ All tokens follow the [Design Tokens Community Group](https://tr.designtokens.or
 **Primitives** (`tokens/primitives/`)
 
 - Context-independent base values
-- Color, radius, border-width, shadow, typography, focus
+- Color, radius, border-width, shadow, typography, focus, motion
 - Output: CSS variables with the `--nx-*` prefix
 - Example: `--nx-color-gray-950`, `--nx-radius-md`
+- Motion primitives also promote named Tailwind utilities such as `nx:duration-fast` and `nx:ease-enter` through `@theme`, while existing Tailwind numeric duration/ease defaults remain available until the repo-wide migration lands.
 
 **Semantic** (`tokens/semantic/`)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "build": "tsup",
     "typecheck": "tsc --noEmit",
     "build:tokens:modular": "node scripts/generate-modular.js --spacingDefault=mira",
-    "build:tailwind": "node scripts/generate-tailwind-package.js --base=stone --brand=black --borderwidth=vega --radius=sharp --shadow=maia --spacingDefault=mira",
+    "build:tailwind": "node scripts/generate-tailwind-package.js --base=stone --brand=black --borderwidth=vega --radius=sharp --shadow=maia --motion=snappy --spacingDefault=mira",
     "audit:contrast": "node scripts/audit-contrast.js",
     "audit:class-refs": "node scripts/audit-class-refs.js",
     "audit:colorblind": "node scripts/audit-colorblind.js",

--- a/packages/core/scripts/__tests__/generate-modular.test.js
+++ b/packages/core/scripts/__tests__/generate-modular.test.js
@@ -113,12 +113,13 @@ describe('generateModular', () => {
     expect(globals).not.toMatch(/--spacing-0:\s*var\(/);
   });
 
-  it('emits role @utility declarations into a sibling spacing-utilities.css (not inlined)', () => {
-    // Symmetric with the bundled-tailwind build: globals.css @imports
-    // spacing-utilities.css; sync-console-themes.js's STYLES_FILES
-    // allowlist includes the file so it reaches apps/console/src/styles/.
+  it('emits role and motion @utility declarations into sibling utility files', () => {
+    // Symmetric with the bundled-tailwind build: globals.css @imports sibling
+    // utility files; sync-console-themes.js's STYLES_FILES allowlist includes
+    // them so they reach apps/console/src/styles/.
     const files = fs.readdirSync(distDir);
     expect(files).toContain('spacing-utilities.css');
+    expect(files).toContain('motion-utilities.css');
 
     const spacingUtilities = fs.readFileSync(
       path.join(distDir, 'spacing-utilities.css'),
@@ -127,10 +128,21 @@ describe('generateModular', () => {
     expect(spacingUtilities).toMatch(/@utility p-container \{/);
     expect(spacingUtilities).toMatch(/@utility gap-layout-section \{/);
 
-    // globals.css does NOT inline role utilities — it @imports them.
+    const motionUtilities = fs.readFileSync(
+      path.join(distDir, 'motion-utilities.css'),
+      'utf8'
+    );
+    expect(motionUtilities).toMatch(/@utility duration-fast \{/);
+    expect(motionUtilities).toMatch(
+      /transition-duration:\s*var\(--nx-motion-duration-fast\);/
+    );
+
+    // globals.css does NOT inline sibling utilities — it @imports them.
     const globals = fs.readFileSync(path.join(distDir, 'globals.css'), 'utf8');
     expect(globals).not.toMatch(/@utility p-container \{/);
+    expect(globals).not.toMatch(/@utility duration-fast \{/);
     expect(globals).toMatch(/@import\s+['"]\.\/spacing-utilities\.css['"]/);
+    expect(globals).toMatch(/@import\s+['"]\.\/motion-utilities\.css['"]/);
   });
 
   it('@utility declarations bind the right prefixed CSS vars', () => {

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -310,6 +310,39 @@ describe('generateTailwindPackage', () => {
     expect(themeBlock).toMatch(/--text-\*:\s*initial;/);
   });
 
+  it('emits named motion tokens without resetting Tailwind default motion namespaces yet', () => {
+    const rootBlock = extractBlock(variablesCSS, ':root');
+    expect(rootBlock).toMatch(/--nx-motion-duration-fast:\s*150ms;/);
+    expect(rootBlock).toMatch(/--nx-motion-duration-default:\s*200ms;/);
+    expect(rootBlock).toMatch(
+      /--nx-motion-ease-enter:\s*cubic-bezier\(0\.23, 1, 0\.32, 1\);/
+    );
+    expect(rootBlock).toMatch(
+      /--nx-motion-ease-move:\s*cubic-bezier\(0\.77, 0, 0\.175, 1\);/
+    );
+
+    const themeBlock = extractBlock(nexusCSS, '@theme');
+    expect(themeBlock).toMatch(
+      /--duration-fast:\s*var\(--nx-motion-duration-fast\);/
+    );
+    expect(themeBlock).toMatch(
+      /--duration-default:\s*var\(--nx-motion-duration-default\);/
+    );
+    expect(themeBlock).toMatch(
+      /--ease-enter:\s*var\(--nx-motion-ease-enter\);/
+    );
+    expect(themeBlock).toMatch(
+      /--ease-move:\s*var\(--nx-motion-ease-move\);/
+    );
+
+    // The repo-wide motion migration is tracked separately (#530). Until
+    // hardcoded consumers are migrated, keep Tailwind's default duration/ease
+    // utilities available so existing classes do not silently lose motion.
+    expect(themeBlock).not.toMatch(/--duration-\*:\s*initial;/);
+    expect(themeBlock).not.toMatch(/--ease-\*:\s*initial;/);
+    expect(themeBlock).not.toMatch(/--animate-\*:\s*initial;/);
+  });
+
   it('registers numeric --spacing-N in @theme with direct px (not var() refs)', () => {
     // The numeric subset seeds @theme so Tailwind codegens nx:p-N / nx:m-N /
     // nx:h-N / nx:gap-N. After migration these are direct px values, not

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -1,7 +1,9 @@
 import fs from 'fs';
+import { createRequire } from 'module';
 import os from 'os';
 import path from 'path';
 import * as prettier from 'prettier';
+import { compile } from 'tailwindcss';
 import { fileURLToPath } from 'url';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -10,6 +12,8 @@ import { DEFAULT_CONFIG } from '../utils.js';
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const SEMANTIC_DIR = path.resolve(TEST_DIR, '..', '..', 'tokens', 'semantic');
+const require = createRequire(import.meta.url);
+const TAILWIND_ENTRY = require.resolve('tailwindcss/index.css');
 
 const SPACING_MODES = ['vega', 'lyra', 'maia', 'mira', 'nova', 'luma', 'sera'];
 
@@ -57,6 +61,29 @@ function extractDataStyleBlock(css, mode) {
   return match[1];
 }
 
+async function compileGeneratedTailwind(distDir, candidates) {
+  const source = [
+    `@import './nexus.css';`,
+    `@source inline("${candidates.join(' ')}");`,
+  ].join('\n');
+
+  const compiler = await compile(source, {
+    base: distDir,
+    loadStylesheet: async (id, base) => {
+      const filePath =
+        id === 'tailwindcss' ? TAILWIND_ENTRY : path.resolve(base, id);
+
+      return {
+        content: fs.readFileSync(filePath, 'utf8'),
+        path: filePath,
+        base: path.dirname(filePath),
+      };
+    },
+  });
+
+  return compiler.build([]);
+}
+
 afterAll(() => {
   while (tmpDirs.length > 0) {
     const dir = tmpDirs.pop();
@@ -69,6 +96,7 @@ describe('generateTailwindPackage', () => {
   let variablesCSS;
   let nexusCSS;
   let typographyCSS;
+  let motionUtilitiesCSS;
   let spacingUtilitiesCSS;
   let warnings;
 
@@ -87,6 +115,7 @@ describe('generateTailwindPackage', () => {
     variablesCSS = read(distDir, 'variables.css');
     nexusCSS = read(distDir, 'nexus.css');
     typographyCSS = read(distDir, 'typography-utilities.css');
+    motionUtilitiesCSS = read(distDir, 'motion-utilities.css');
     spacingUtilitiesCSS = read(distDir, 'spacing-utilities.css');
   });
 
@@ -322,18 +351,12 @@ describe('generateTailwindPackage', () => {
     );
 
     const themeBlock = extractBlock(nexusCSS, '@theme');
-    expect(themeBlock).toMatch(
-      /--duration-fast:\s*var\(--nx-motion-duration-fast\);/
-    );
-    expect(themeBlock).toMatch(
-      /--duration-default:\s*var\(--nx-motion-duration-default\);/
-    );
+    expect(themeBlock).not.toMatch(/--duration-fast:/);
+    expect(themeBlock).not.toMatch(/--duration-default:/);
     expect(themeBlock).toMatch(
       /--ease-enter:\s*var\(--nx-motion-ease-enter\);/
     );
-    expect(themeBlock).toMatch(
-      /--ease-move:\s*var\(--nx-motion-ease-move\);/
-    );
+    expect(themeBlock).toMatch(/--ease-move:\s*var\(--nx-motion-ease-move\);/);
 
     // The repo-wide motion migration is tracked separately (#530). Until
     // hardcoded consumers are migrated, keep Tailwind's default duration/ease
@@ -341,6 +364,54 @@ describe('generateTailwindPackage', () => {
     expect(themeBlock).not.toMatch(/--duration-\*:\s*initial;/);
     expect(themeBlock).not.toMatch(/--ease-\*:\s*initial;/);
     expect(themeBlock).not.toMatch(/--animate-\*:\s*initial;/);
+
+    const fastBlock = extractBlock(
+      motionUtilitiesCSS,
+      '@utility duration-fast'
+    );
+    expect(fastBlock).toMatch(
+      /--tw-duration:\s*var\(--nx-motion-duration-fast\);/
+    );
+    expect(fastBlock).toMatch(
+      /transition-duration:\s*var\(--nx-motion-duration-fast\);/
+    );
+
+    const defaultBlock = extractBlock(
+      motionUtilitiesCSS,
+      '@utility duration-default'
+    );
+    expect(defaultBlock).toMatch(
+      /--tw-duration:\s*var\(--nx-motion-duration-default\);/
+    );
+    expect(defaultBlock).toMatch(
+      /transition-duration:\s*var\(--nx-motion-duration-default\);/
+    );
+  });
+
+  it('compiles named motion utilities through Tailwind', async () => {
+    const compiledCSS = await compileGeneratedTailwind(distDir, [
+      'nx:duration-fast',
+      'nx:duration-default',
+      'nx:duration-150',
+      'nx:duration-(--nx-motion-duration-fast)',
+      'nx:ease-enter',
+    ]);
+
+    expect(compiledCSS).toMatch(
+      /\.nx\\:duration-fast\s*\{[\s\S]*?--tw-duration:\s*var\(--nx-motion-duration-fast\);[\s\S]*?transition-duration:\s*var\(--nx-motion-duration-fast\);/
+    );
+    expect(compiledCSS).toMatch(
+      /\.nx\\:duration-default\s*\{[\s\S]*?--tw-duration:\s*var\(--nx-motion-duration-default\);[\s\S]*?transition-duration:\s*var\(--nx-motion-duration-default\);/
+    );
+    expect(compiledCSS).toMatch(
+      /\.nx\\:duration-150\s*\{[\s\S]*?transition-duration:\s*150ms;/
+    );
+    expect(compiledCSS).toMatch(
+      /\.nx\\:duration-\\\(--nx-motion-duration-fast\\\)\s*\{[\s\S]*?transition-duration:\s*var\(--nx-motion-duration-fast\);/
+    );
+    expect(compiledCSS).toMatch(
+      /\.nx\\:ease-enter\s*\{[\s\S]*?transition-timing-function:\s*var\(--nx-ease-enter\);/
+    );
   });
 
   it('registers numeric --spacing-N in @theme with direct px (not var() refs)', () => {
@@ -478,19 +549,21 @@ describe('generateTailwindPackage', () => {
     }
   });
 
-  it('nexus.css imports ./spacing-utilities.css and the file resolves', () => {
-    const importMatch = nexusCSS.match(
-      /@import\s+['"](\.\/spacing-utilities\.css)['"]/
-    );
-    expect(
-      importMatch,
-      'nexus.css must @import ./spacing-utilities.css'
-    ).not.toBeNull();
-    const resolved = path.resolve(distDir, importMatch[1]);
-    expect(
-      fs.existsSync(resolved),
-      `imported file ${importMatch[1]} must exist`
-    ).toBe(true);
+  it('nexus.css imports generated utility files and each import resolves', () => {
+    for (const fileName of ['motion-utilities.css', 'spacing-utilities.css']) {
+      const importMatch = nexusCSS.match(
+        new RegExp(`@import\\s+['"](\\./${fileName})['"]`)
+      );
+      expect(
+        importMatch,
+        `nexus.css must @import ./${fileName}`
+      ).not.toBeNull();
+      const resolved = path.resolve(distDir, importMatch[1]);
+      expect(
+        fs.existsSync(resolved),
+        `imported file ${importMatch[1]} must exist`
+      ).toBe(true);
+    }
   });
 
   it('spacing-utilities.css declares all 4 role utilities with correct property bindings', () => {
@@ -619,6 +692,7 @@ describe('generateTailwindPackage', () => {
     for (const file of [
       'variables.css',
       'nexus.css',
+      'motion-utilities.css',
       'spacing-utilities.css',
     ]) {
       expect(read(dirA, file), `${file} differs across runs`).toBe(

--- a/packages/core/scripts/generate-modular.js
+++ b/packages/core/scripts/generate-modular.js
@@ -6,6 +6,7 @@ import {
   CANONICAL_SPACING_DEFAULT_MODE,
   collectBorderwidthTokens,
   collectBreakpointsTokens,
+  collectMotionTokens,
   collectRadiusTokens,
   collectSemanticColorTokensVarRef,
   collectSemanticDimensionTokens,
@@ -296,6 +297,9 @@ function generateModularGlobalsCSS(
   const borderwidthTokens = primitives.borderwidth?.modes?.[0]
     ? collectBorderwidthTokens(TOKENS_DIR, primitives.borderwidth.modes[0])
     : [];
+  const motionTokens = primitives.motion?.modes?.[0]
+    ? collectMotionTokens(TOKENS_DIR, primitives.motion.modes[0])
+    : [];
   const shadowTokens = collectShadowTokens(TOKENS_DIR, primitiveMap);
   const zIndexTokens = collectZIndexTokens(SEMANTIC_DIR);
   const breakpointTokens = collectBreakpointsTokens(SEMANTIC_DIR);
@@ -325,6 +329,7 @@ function generateModularGlobalsCSS(
       'tailwindcss',
       './color.css',
       './focus-default.css',
+      './motion-snappy.css',
       './typography-utilities.css',
       './borderwidth-utilities.css',
       './spacing-utilities.css',
@@ -334,6 +339,7 @@ function generateModularGlobalsCSS(
     spacingTokens: vegaSpacingNumeric,
     radiusTokens,
     borderwidthTokens,
+    motionTokens,
     shadowTokens,
     zIndexTokens,
     breakpointTokens,
@@ -352,9 +358,9 @@ function generateModularGlobalsCSS(
 
   writeModularFile(distDir, 'globals.css', css);
 
-  // Spacing role utilities — emitted as a sibling file (symmetric with the
-  // bundled build). `globals.css` `@import`s it; `sync-console-themes.js`'s
-  // STYLES_FILES allowlist carries it to `apps/console/src/styles/`.
+  // Sibling utility/primitive files are imported by `globals.css`; keep the
+  // console sync allowlist in step so build-time Tailwind processing can load
+  // the same local graph.
   const spacingUtilities = generateSpacingRoleUtilitiesCSS(vegaSpacingRole);
   writeModularFile(distDir, 'spacing-utilities.css', spacingUtilities.css);
 

--- a/packages/core/scripts/generate-modular.js
+++ b/packages/core/scripts/generate-modular.js
@@ -22,6 +22,7 @@ import {
   formatDistCssFiles,
   formatTokenValue,
   generateBorderWidthUtilitiesCSS,
+  generateMotionUtilitiesCSS,
   generateNativeBrowserUIThemeCSS,
   generateRootDimensionsCSS,
   generateSpacingModesCSS,
@@ -332,6 +333,7 @@ function generateModularGlobalsCSS(
       './motion-snappy.css',
       './typography-utilities.css',
       './borderwidth-utilities.css',
+      './motion-utilities.css',
       './spacing-utilities.css',
     ],
     tailwindPrefix: 'nx',
@@ -466,6 +468,16 @@ export async function generateModular({
     const borderWidth = generateBorderWidthUtilitiesCSS(borderwidthTokens);
     writeModularFile(distDir, 'borderwidth-utilities.css', borderWidth.css);
     console.log(`  ✓ ${borderWidth.count} border width utilities`);
+    totalFiles++;
+  }
+
+  // Generate motion duration utilities (use first mode as reference)
+  if (primitives.motion && primitives.motion.modes) {
+    const firstMode = primitives.motion.modes[0];
+    const motionTokens = collectMotionTokens(TOKENS_DIR, firstMode);
+    const motionUtilities = generateMotionUtilitiesCSS(motionTokens);
+    writeModularFile(distDir, 'motion-utilities.css', motionUtilities.css);
+    console.log(`  ✓ ${motionUtilities.count} motion duration utilities`);
     totalFiles++;
   }
 

--- a/packages/core/scripts/generate-tailwind-package.js
+++ b/packages/core/scripts/generate-tailwind-package.js
@@ -6,6 +6,7 @@ import {
   CANONICAL_SPACING_DEFAULT_MODE,
   collectBorderwidthTokens,
   collectBreakpointsTokens,
+  collectMotionTokens,
   collectRadiusTokens,
   collectSemanticColorTokensVarRef,
   collectSemanticDimensionTokens,
@@ -467,6 +468,8 @@ function generateNexusCSS(
     TOKENS_DIR,
     borderwidthMode
   );
+  const motionMode = usedModes.motion || 'snappy';
+  const motionTokens = collectMotionTokens(TOKENS_DIR, motionMode);
   const shadowTokens = collectShadowTokens(TOKENS_DIR, primitiveMap);
   const zIndexTokens = collectZIndexTokens(SEMANTIC_DIR);
   const breakpointTokens = collectBreakpointsTokens(SEMANTIC_DIR);
@@ -500,6 +503,7 @@ function generateNexusCSS(
     spacingTokens: vegaSpacingNumeric,
     radiusTokens,
     borderwidthTokens,
+    motionTokens,
     shadowTokens,
     zIndexTokens,
     breakpointTokens,
@@ -646,6 +650,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
       'shadow',
       'radius',
       'borderwidth',
+      'motion',
       'focus',
       'chart-categorical',
       'spacingDefault',

--- a/packages/core/scripts/generate-tailwind-package.js
+++ b/packages/core/scripts/generate-tailwind-package.js
@@ -23,6 +23,7 @@ import {
   formatTokenValue,
   generateBaseLayerCSS,
   generateBorderWidthUtilitiesCSS,
+  generateMotionUtilitiesCSS,
   generateNativeBrowserUIThemeCSS,
   generateRootDimensionsCSS,
   generateSpacingModesCSS,
@@ -496,6 +497,7 @@ function generateNexusCSS(
       './variables.css',
       './typography-utilities.css',
       './borderwidth-utilities.css',
+      './motion-utilities.css',
       './spacing-utilities.css',
     ],
     tailwindPrefix: 'nx',
@@ -607,6 +609,14 @@ export async function generateTailwindPackage(
   if (spacingUtilities.css) {
     writeDistFile('spacing-utilities.css', spacingUtilities.css);
     log.success(`Generated ${spacingUtilities.count} spacing role utilities`);
+  }
+
+  const motionUtilities = generateMotionUtilitiesCSS(
+    collectMotionTokens(TOKENS_DIR, usedModes.motion || 'snappy')
+  );
+  if (motionUtilities.css) {
+    writeDistFile('motion-utilities.css', motionUtilities.css);
+    log.success(`Generated ${motionUtilities.count} motion duration utilities`);
   }
 
   // `spacingDefault` controls which mode lands under `:root, [data-style="X"]`.

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -1217,9 +1217,11 @@ export function collectBorderwidthTokens(tokensDir, mode) {
 
 /**
  * Collect motion token mappings from a mode file.
- * Returns array of { cssName, varRef } for @theme block. The source primitive
- * variables stay namespaced as --nx-motion-* while Tailwind sees the standard
- * --duration-* and --ease-* namespaces for utility generation.
+ * Returns array of { group, key, cssName, varRef }. The source primitive
+ * variables stay namespaced as --nx-motion-*; easing tokens also enter
+ * Tailwind's --ease-* namespace, while duration tokens use explicit
+ * @utility declarations because Tailwind v4 does not codegen named
+ * duration-* utilities from --duration-* theme vars.
  *
  * @param {string} tokensDir - Path to tokens directory
  * @param {string} mode - Motion mode (e.g., 'snappy')
@@ -1250,6 +1252,8 @@ export function collectMotionTokens(tokensDir, mode) {
     for (const key of Object.keys(groupData)) {
       if (key.startsWith('$')) continue;
       tokens.push({
+        group,
+        key,
         cssName: `${group}-${key}`,
         varRef: `var(--nx-motion-${group}-${key})`,
       });
@@ -1257,6 +1261,37 @@ export function collectMotionTokens(tokensDir, mode) {
   }
 
   return tokens;
+}
+
+/**
+ * Generate `@utility` declarations for motion duration tokens.
+ *
+ * Tailwind v4 codegens named easing utilities from --ease-* theme vars, but
+ * not named duration utilities from --duration-* vars. Emit duration-* as
+ * explicit utilities so classes such as nx:duration-fast are real.
+ *
+ * @param {{group?: string, key?: string, cssName: string, varRef: string}[]} motionTokens
+ * @returns {{css: string, count: number}}
+ */
+export function generateMotionUtilitiesCSS(motionTokens) {
+  const durationTokens = motionTokens.filter(
+    (token) => token.group === 'duration'
+  );
+
+  if (durationTokens.length === 0) {
+    return { css: '', count: 0 };
+  }
+
+  let css = `/* Motion duration utilities - data-driven from canonical motion tokens. */\n\n`;
+
+  for (const token of durationTokens) {
+    css += `@utility duration-${token.key} {\n`;
+    css += `  --tw-duration: ${token.varRef};\n`;
+    css += `  transition-duration: ${token.varRef};\n`;
+    css += `}\n\n`;
+  }
+
+  return { css, count: durationTokens.length };
 }
 
 /**
@@ -1447,7 +1482,7 @@ export function collectSemanticDimensionTokens(semanticDir, fileName) {
  * @param {object[]} config.spacingTokens - Array of { cssName, value } for numeric spacing (Vega defaults; per-mode overrides live outside @theme)
  * @param {object[]} config.radiusTokens - Array of { cssName, varRef } for radius
  * @param {object[]} config.borderwidthTokens - Array of { cssName, varRef } for borderwidth
- * @param {object[]} config.motionTokens - Array of { cssName, varRef } for duration/ease
+ * @param {object[]} config.motionTokens - Array of { group, key, cssName, varRef } for duration/ease
  * @param {object[]} config.shadowTokens - Array of { cssName, value } for shadows
  * @param {object[]} [config.darkSemanticTokens] - Array of { cssName, value } for dark mode semantic tokens
  * @param {string} [config.darkSelector='.dark'] - CSS selector for dark mode
@@ -1537,7 +1572,9 @@ export function generateThemeCSS(config) {
   // Motion tokens
   if (motionTokens.length > 0) {
     css += `\n  /* Motion tokens */\n`;
-    for (const token of motionTokens) {
+    for (const token of motionTokens.filter(
+      (motionToken) => motionToken.group === 'ease'
+    )) {
       css += `  --${token.cssName}: ${token.varRef};\n`;
     }
   }

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -236,6 +236,7 @@ export const DEFAULT_CONFIG = {
   shadow: 'maia',
   radius: 'sharp',
   borderwidth: 'vega',
+  motion: 'snappy',
   focus: 'default',
   'chart-categorical': 'default',
   // see CANONICAL_SPACING_DEFAULT_MODE — controls :root cascade only (all 7 modes ship)
@@ -1215,6 +1216,50 @@ export function collectBorderwidthTokens(tokensDir, mode) {
 }
 
 /**
+ * Collect motion token mappings from a mode file.
+ * Returns array of { cssName, varRef } for @theme block. The source primitive
+ * variables stay namespaced as --nx-motion-* while Tailwind sees the standard
+ * --duration-* and --ease-* namespaces for utility generation.
+ *
+ * @param {string} tokensDir - Path to tokens directory
+ * @param {string} mode - Motion mode (e.g., 'snappy')
+ * @returns {object[]} Array of { cssName, varRef }
+ */
+export function collectMotionTokens(tokensDir, mode) {
+  const filePath = path.join(
+    tokensDir,
+    `primitives/motion/motion-${mode}.json`
+  );
+  if (!fs.existsSync(filePath)) {
+    throw new Error(
+      `Motion primitive file missing: ${filePath} (mode "${mode}")`
+    );
+  }
+
+  const tokenData = readTokenFile(filePath);
+  const tokens = [];
+
+  for (const group of ['duration', 'ease']) {
+    const groupData = tokenData[group];
+    if (!groupData || typeof groupData !== 'object') {
+      throw new Error(
+        `Motion primitive file ${filePath} must include a "${group}" group`
+      );
+    }
+
+    for (const key of Object.keys(groupData)) {
+      if (key.startsWith('$')) continue;
+      tokens.push({
+        cssName: `${group}-${key}`,
+        varRef: `var(--nx-motion-${group}-${key})`,
+      });
+    }
+  }
+
+  return tokens;
+}
+
+/**
  * Collect shadow token CSS values with var() references
  * Returns array of { cssName, value } for @theme block
  */
@@ -1402,6 +1447,7 @@ export function collectSemanticDimensionTokens(semanticDir, fileName) {
  * @param {object[]} config.spacingTokens - Array of { cssName, value } for numeric spacing (Vega defaults; per-mode overrides live outside @theme)
  * @param {object[]} config.radiusTokens - Array of { cssName, varRef } for radius
  * @param {object[]} config.borderwidthTokens - Array of { cssName, varRef } for borderwidth
+ * @param {object[]} config.motionTokens - Array of { cssName, varRef } for duration/ease
  * @param {object[]} config.shadowTokens - Array of { cssName, value } for shadows
  * @param {object[]} [config.darkSemanticTokens] - Array of { cssName, value } for dark mode semantic tokens
  * @param {string} [config.darkSelector='.dark'] - CSS selector for dark mode
@@ -1418,6 +1464,7 @@ export function generateThemeCSS(config) {
     spacingTokens = [],
     radiusTokens = [],
     borderwidthTokens = [],
+    motionTokens = [],
     shadowTokens = [],
     zIndexTokens = [],
     breakpointTokens = [],
@@ -1483,6 +1530,14 @@ export function generateThemeCSS(config) {
   if (borderwidthTokens.length > 0) {
     css += `\n  /* Border width tokens */\n`;
     for (const token of borderwidthTokens) {
+      css += `  --${token.cssName}: ${token.varRef};\n`;
+    }
+  }
+
+  // Motion tokens
+  if (motionTokens.length > 0) {
+    css += `\n  /* Motion tokens */\n`;
+    for (const token of motionTokens) {
       css += `  --${token.cssName}: ${token.varRef};\n`;
     }
   }

--- a/packages/core/tokens/primitives/motion/motion-snappy.json
+++ b/packages/core/tokens/primitives/motion/motion-snappy.json
@@ -1,0 +1,61 @@
+{
+  "duration": {
+    "0": {
+      "$value": "0ms",
+      "$type": "duration",
+      "$description": "Instant state changes and reduced-motion fallbacks."
+    },
+    "faster": {
+      "$value": "100ms",
+      "$type": "duration",
+      "$description": "Tiny feedback transitions such as pressed states."
+    },
+    "fast": {
+      "$value": "150ms",
+      "$type": "duration",
+      "$description": "Frequent lightweight UI transitions such as tab indicators and small fades."
+    },
+    "default": {
+      "$value": "200ms",
+      "$type": "duration",
+      "$description": "Default component motion for popovers, menus, and routine state changes."
+    },
+    "moderate": {
+      "$value": "240ms",
+      "$type": "duration",
+      "$description": "Slightly larger routine transitions that need a little more legibility."
+    },
+    "slow": {
+      "$value": "300ms",
+      "$type": "duration",
+      "$description": "Larger surfaces such as dialogs and compact sheets."
+    },
+    "slower": {
+      "$value": "500ms",
+      "$type": "duration",
+      "$description": "Large or rare surface motion where extra continuity is useful."
+    }
+  },
+  "ease": {
+    "linear": {
+      "$value": "linear",
+      "$type": "cubicBezier",
+      "$description": "Constant-rate motion for loops and progress-like animations."
+    },
+    "enter": {
+      "$value": "cubic-bezier(0.23, 1, 0.32, 1)",
+      "$type": "cubicBezier",
+      "$description": "Strong ease-out curve for elements entering or becoming active."
+    },
+    "exit": {
+      "$value": "cubic-bezier(0.4, 0, 1, 1)",
+      "$type": "cubicBezier",
+      "$description": "Accelerating curve for elements exiting or becoming hidden."
+    },
+    "move": {
+      "$value": "cubic-bezier(0.77, 0, 0.175, 1)",
+      "$type": "cubicBezier",
+      "$description": "Intentional on-screen movement between persistent positions."
+    }
+  }
+}

--- a/packages/tailwind/motion-utilities.css
+++ b/packages/tailwind/motion-utilities.css
@@ -1,0 +1,36 @@
+/* Motion duration utilities - data-driven from canonical motion tokens. */
+
+@utility duration-0 {
+  --tw-duration: var(--nx-motion-duration-0);
+  transition-duration: var(--nx-motion-duration-0);
+}
+
+@utility duration-faster {
+  --tw-duration: var(--nx-motion-duration-faster);
+  transition-duration: var(--nx-motion-duration-faster);
+}
+
+@utility duration-fast {
+  --tw-duration: var(--nx-motion-duration-fast);
+  transition-duration: var(--nx-motion-duration-fast);
+}
+
+@utility duration-default {
+  --tw-duration: var(--nx-motion-duration-default);
+  transition-duration: var(--nx-motion-duration-default);
+}
+
+@utility duration-moderate {
+  --tw-duration: var(--nx-motion-duration-moderate);
+  transition-duration: var(--nx-motion-duration-moderate);
+}
+
+@utility duration-slow {
+  --tw-duration: var(--nx-motion-duration-slow);
+  transition-duration: var(--nx-motion-duration-slow);
+}
+
+@utility duration-slower {
+  --tw-duration: var(--nx-motion-duration-slower);
+  transition-duration: var(--nx-motion-duration-slower);
+}

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -180,6 +180,19 @@
   --border-default: var(--nx-borderwidth-default);
   --border-thick: var(--nx-borderwidth-thick);
 
+  /* Motion tokens */
+  --duration-0: var(--nx-motion-duration-0);
+  --duration-faster: var(--nx-motion-duration-faster);
+  --duration-fast: var(--nx-motion-duration-fast);
+  --duration-default: var(--nx-motion-duration-default);
+  --duration-moderate: var(--nx-motion-duration-moderate);
+  --duration-slow: var(--nx-motion-duration-slow);
+  --duration-slower: var(--nx-motion-duration-slower);
+  --ease-linear: var(--nx-motion-ease-linear);
+  --ease-enter: var(--nx-motion-ease-enter);
+  --ease-exit: var(--nx-motion-ease-exit);
+  --ease-move: var(--nx-motion-ease-move);
+
   /* Shadow tokens */
   --shadow-2xs: var(--nx-shadow-2xs-layer-1-x) var(--nx-shadow-2xs-layer-1-y)
     var(--nx-shadow-2xs-layer-1-blur) var(--nx-shadow-2xs-layer-1-spread)

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -10,6 +10,7 @@
 @import './variables.css';
 @import './typography-utilities.css';
 @import './borderwidth-utilities.css';
+@import './motion-utilities.css';
 @import './spacing-utilities.css';
 
 @custom-variant dark (&:is(.dark *));
@@ -181,13 +182,6 @@
   --border-thick: var(--nx-borderwidth-thick);
 
   /* Motion tokens */
-  --duration-0: var(--nx-motion-duration-0);
-  --duration-faster: var(--nx-motion-duration-faster);
-  --duration-fast: var(--nx-motion-duration-fast);
-  --duration-default: var(--nx-motion-duration-default);
-  --duration-moderate: var(--nx-motion-duration-moderate);
-  --duration-slow: var(--nx-motion-duration-slow);
-  --duration-slower: var(--nx-motion-duration-slower);
   --ease-linear: var(--nx-motion-ease-linear);
   --ease-enter: var(--nx-motion-ease-enter);
   --ease-exit: var(--nx-motion-ease-exit);

--- a/packages/tailwind/variables.css
+++ b/packages/tailwind/variables.css
@@ -334,6 +334,19 @@
   --nx-focus-color-default: oklch(0.3791 0.1378 265.522);
   --nx-focus-color-error: oklch(0.3958 0.1331 25.723);
 
+  /* motion (snappy) */
+  --nx-motion-duration-0: 0ms;
+  --nx-motion-duration-faster: 100ms;
+  --nx-motion-duration-fast: 150ms;
+  --nx-motion-duration-default: 200ms;
+  --nx-motion-duration-moderate: 240ms;
+  --nx-motion-duration-slow: 300ms;
+  --nx-motion-duration-slower: 500ms;
+  --nx-motion-ease-linear: linear;
+  --nx-motion-ease-enter: cubic-bezier(0.23, 1, 0.32, 1);
+  --nx-motion-ease-exit: cubic-bezier(0.4, 0, 1, 1);
+  --nx-motion-ease-move: cubic-bezier(0.77, 0, 0.175, 1);
+
   /* radius (sharp) */
   --nx-radius-base: 0px;
   --nx-radius-sm: 0px;

--- a/scripts/sync-console-themes.js
+++ b/scripts/sync-console-themes.js
@@ -18,6 +18,7 @@ const STYLES_FILES = [
   'motion-snappy.css',
   'typography-utilities.css',
   'borderwidth-utilities.css',
+  'motion-utilities.css',
   'spacing-utilities.css',
 ];
 

--- a/scripts/sync-console-themes.js
+++ b/scripts/sync-console-themes.js
@@ -15,6 +15,7 @@ const STYLES_FILES = [
   'globals.css',
   'color.css',
   'focus-default.css',
+  'motion-snappy.css',
   'typography-utilities.css',
   'borderwidth-utilities.css',
   'spacing-utilities.css',


### PR DESCRIPTION
## Summary

- Adds the `motion-snappy` DTCG primitive scale for Nexus durations and easing curves.
- Emits `--nx-motion-*` variables plus usable named Tailwind motion utilities such as `nx:duration-fast` and `nx:ease-enter` in both packaged and modular theme outputs.
- Documents the motion primitive and keeps component behavior/migration work out of this foundation PR.

## GitHub Issue

Foundation PR for #530.

Supersedes the foundation portion of #159; Tabs polish now belongs to #530.

## Test Plan

- [x] `corepack pnpm tokens:tailwind`
- [x] `corepack pnpm tokens:modular`
- [x] `corepack pnpm exec vitest run packages/core/scripts/__tests__/generate-tailwind-package.test.js packages/core/scripts/__tests__/generate-modular.test.js`
- [x] `corepack pnpm audit:browser-support`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm exec prettier --check <touched files>`
- [x] `git diff --check`

## Notes

`tokens:tailwind`, `tokens:modular`, and the focused generator tests continue to print the existing Lyra spacing duplicate warning for `spacing-12` / `spacing-11`; this PR does not change that spacing behavior.
