### PR TITLE
feat(appearance): first-paint bootstrap

### DIFF
--- a/docs/superpowers/plans/2026-06-27-phase-c-first-paint-bootstrap-plan.md
+++ b/docs/superpowers/plans/2026-06-27-phase-c-first-paint-bootstrap-plan.md
@@ -1,0 +1,369 @@
+# Phase C — Appearance First-Paint Bootstrap — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+>
+> **Supersedes** the draft "Phase C: Appearance First-Paint Bootstrap" (by Codex). This version resolves the council review in [`reports/phase-c-plan-council-review.md`](../../../reports/phase-c-plan-council-review.md). Two of the review's findings were **refuted** and are deliberately NOT acted on (see Decisions 3 and 8). Builds on the **real Phase B in PR #536** (`codex/phase-b-appearance-package`) — read the live provider via `git show FETCH_HEAD:packages/react/src/appearance/provider.tsx` after `git fetch origin codex/phase-b-appearance-package`.
+
+**Goal:** Eliminate the appearance theme flash/hydration-mismatch on first paint — a pre-React inline `<head>` script applies the persisted (or default) theme before the browser paints, and the provider becomes SSR-safe by construction.
+
+**Architecture:** A single engine-free **pure resolver** in `@nexus/core` is the keystone: the inline bootstrap script and the React provider's mount-init both apply its output, so they agree by construction. Persisted storage becomes a versioned snapshot carrying pre-derived CSS, so the inline script ships **no** OKLCH/APCA engine. A `createNexusAppearance({storageKey, defaultState})` factory closes the provider and the script over one config so their defaults can't drift.
+
+**Tech Stack:** TypeScript, React 19, classic (non-module) inline `<script>`, Tailwind v4, vitest (jsdom + node env), `@nexus/test-utils`.
+
+## Global Constraints
+
+- **No engine in the inline script.** The bootstrap applies a CSS **snapshot**; it never imports/derives OKLCH/APCA. `culori`/`apca-w3` must not appear in any shipped browser script.
+- **Browser floor Safari 15.4 / Firefox 113.** No `light-dark()` in emitted CSS. **No `blocking="render"`** — unsupported across the entire Safari floor (shipped 18.2) and all Firefox; a classic non-module inline `<head>` script is parser-blocking by default, which is the correct cross-browser no-flash mechanism (MWG `dark-mode` guide; repo precedent `apps/docs/app/_components/ThemeBootstrap.tsx`).
+- **`color-scheme` is dual-sourced on purpose:** `<meta name="color-scheme" content="…">` is MANDATORY (MWG `dark-mode` L11/L129) as the no-JS parse-time FOUC floor; the inline `style.colorScheme` on `:root` is the post-resolve concrete value. Both are set (Decision 8).
+- **Tests:** logic via `*.test.ts(x)` outside `packages/react/src/components/**`, run from root `pnpm test:unit <path>` (the `unit` vitest project is jsdom; SSR tests use `// @vitest-environment node`). jsdom cannot observe "before React" — the no-flash guarantee needs a documented **manual** check (no in-repo first-paint-timing harness exists).
+- **Pre-production** (`project-stage.md`): no migration shims, no aliases, change in place.
+
+## Execution Status
+
+- [x] Task 1: core versioned appearance snapshots.
+- [x] Task 2: engine-free first-paint resolver.
+- [x] Task 3: parser-blocking bootstrap script factory.
+- [x] Task 4: SSR-safe provider init, snapshot persistence, and mounted flag.
+- [x] Task 5: React script component and `createNexusAppearance` factory.
+- [x] Task 6: provider/bootstrap equivalence, stale-cache recovery, default CSS, version recovery, and system-mode coverage.
+- [x] Task 7: chose the **document the embed** path for this branch. Static brand-baseline alignment remains an owner-gated product decision.
+- [x] Task 8: host setup docs and verification sweep.
+
+## Verification Status
+
+Completed on `codex/phase-c-appearance-first-paint`:
+
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test:unit`
+- `pnpm --filter @nexus/core build`
+- `pnpm --filter @nexus/react build`
+- `pnpm size-limit`
+- `pnpm audit:browser-support`
+- tracked-file Prettier check via `git ls-files ... | xargs pnpm exec prettier --check`
+- generated bootstrap script scan for engine references and unsafe script markers
+
+Local `pnpm format:check` sees unrelated untracked scratch markdown already
+present in this checkout, so the tracked-file Prettier check is the relevant PR
+gate until those scratch files are cleaned separately.
+
+---
+
+## Decisions locked (resolving the council review)
+
+1. **Pure resolver is the keystone (NEW-1).** Add `resolveFirstPaint(snapshot, systemPrefersDark) → { className: 'dark'|''; dataAttrs: Record<string,string>; colorScheme: 'light'|'dark'; metaColorScheme: 'light'|'dark'|'light dark'; themeCss: string; prefsCss: string }` to `@nexus/core`, engine-free (CSS comes from the snapshot). The inline script and the provider's mount-init both apply it → identical output → no drift, no hydration-time repaint.
+2. **Provider becomes SSR-safe by construction.** Render inits to `defaultState` deterministically (server == client first render); a mount `useEffect` reads the snapshot and `setState`s the real value; expose a `mounted` flag so consumers can render neutral-until-mounted. The provider's apply-effects re-apply the **same** values the bootstrap already set (idempotent — no visual flash because identical). This captures the epic L103 _intent_ (SSR-safe init) without its impossible mechanism ("read full state from the DOM" — refuted: the DOM can't carry brandColor/contrast/tone/prefs).
+3. **REFUTED — keep reading storage, not the DOM.** The provider keeps localStorage as the source of truth for `state` (the DOM only carries the no-flash _pixels_). Do not attempt DOM-state reconstruction.
+4. **`version` gates the CSS cache, never the state (C3).** Snapshot = `{ version, state, themeCss, prefsCss }`. On any readable payload the provider recovers `state` via `sanitizeNexusAppearance` and **re-derives** CSS (it has the engine) — never resets. The cached `themeCss`/`prefsCss` are a disposable cache for the _next_ load's engine-free script; the script falls back to the embedded default on version mismatch (one-paint default flash, self-heals when the provider re-writes a current snapshot).
+5. **Snapshot is the ONLY storage format (C5).** Drop the "read both snapshot and raw Phase B state" shim — #536 is unmerged (zero persisted users), pre-prod + epic L134 make reset-to-default acceptable. `sanitizeNexusAppearance` resets anything unreadable.
+6. **`createNexusAppearanceSnapshot(state, themeCss, prefsCss)` takes pre-derived CSS (NEW-3)** — the provider already memoizes both; never derive twice.
+7. **One config, two artifacts (C12).** `createNexusAppearance({ storageKey, defaultState }) → { NexusAppearanceProvider, NexusAppearanceScript }`, both closed over the same config. The bootstrap `<style>` tags MUST carry the exact attributes the provider's `upsertStyle` queries — `data-nexus-appearance-theme` / `data-nexus-appearance-prefs` — so the provider reuses them instead of stacking a second tag.
+8. **REFUTED — keep the `color-scheme` meta.** The plan's meta sync (system→`light dark`, pinned→`light`/`dark`) is MWG-MANDATORY and the no-JS floor — it is NOT wrong. Keep it; coordinate it with Phase B's existing concrete `style.colorScheme` (Decision/Global-constraint above).
+9. **First-visit default CSS source must be explicit (C-B2).** The appearance default (`brandColor #339cff`, blue) ≠ the shipped `nexus.css` light `:root` primary (`var(--nx-color-black-base)`, achromatic — the `--brand=black` build default). **Preferred fix (precursor, Task 7):** align the shipped brand default to the appearance default so first-visit needs zero embedded CSS (owner decision — only `brandColor` diverges; `surfaceTone=stone` already agrees). **Chosen for this branch:** document the fallback and keep the script embedding the default snapshot CSS (~12 KB raw / ~1.7 KB gzip). The plan must not silently rely on `nexus.css` (achromatic).
+10. **Drop "reject unsafe CSS" (C10).** Same-origin localStorage is writable only by your own code or an XSS that already won. Rely on `sanitizeNexusAppearance(state)` + `textContent` (never `innerHTML`). Keep the `</script>`/`light-dark(` absence assertions on the _generated_ script.
+11. **MWG gate (process).** This phase's plan PR must include the Modern Web Guidance section: searched `dark-mode` + `flicker-free-client-side-ab-testing`; documented the parser-blocking rationale; browser-floor decision (no `blocking="render"`).
+
+---
+
+## File Structure
+
+**Create:**
+
+- `packages/core/src/lib/appearance-snapshot.ts` — `NexusAppearanceSnapshot`, `SNAPSHOT_VERSION`, `createNexusAppearanceSnapshot`, `sanitizeNexusAppearanceSnapshot`, `resolveFirstPaint`, `createNexusAppearanceBootstrapScript`.
+- `packages/core/src/lib/appearance-snapshot.test.ts`.
+- `packages/react/src/appearance/script.tsx` — `NexusAppearanceScript` + `createNexusAppearance` factory.
+- `packages/react/src/appearance/provider.test.tsx` additions + `packages/react/src/appearance/provider.ssr.test.tsx` (node env).
+- `docs/superpowers/specs/2026-06-27-appearance-host-setup.md` — host-app `<head>` setup.
+
+**Modify:**
+
+- `packages/core/src/index.ts` — export the snapshot module.
+- `packages/react/src/appearance/provider.tsx` — SSR-safe init + `mounted` + snapshot write + reuse the resolver.
+- `packages/react/src/appearance/index.ts` — export `NexusAppearanceScript`, `createNexusAppearance`.
+- (Task 7, owner-gated) `packages/core/package.json` `build:tailwind` brand default + regenerate `packages/tailwind/*.css`.
+
+---
+
+## Task 1: Core — snapshot type, factory, sanitizer (version gates CSS cache)
+
+**Files:** Create `packages/core/src/lib/appearance-snapshot.ts`, `appearance-snapshot.test.ts`.
+
+**Interfaces:**
+
+- Produces: `SNAPSHOT_VERSION` (const `1`), `NexusAppearanceSnapshot = { version: number; state: NexusAppearanceState; themeCss: string; prefsCss: string }`, `createNexusAppearanceSnapshot(state, themeCss, prefsCss): NexusAppearanceSnapshot`, `sanitizeNexusAppearanceSnapshot(raw): NexusAppearanceSnapshot`. Consumes `NexusAppearanceState`, `sanitizeNexusAppearance`, `createNexusThemeContract`, `deriveTheme`, `themeToCss`, `appearancePrefsToCss` from `./appearance-model` / `./derive-theme`.
+
+- [ ] **Step 1: Failing tests.**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_NEXUS_APPEARANCE,
+  createNexusThemeContract,
+  deriveTheme,
+  themeToCss,
+  appearancePrefsToCss,
+} from '../index';
+import {
+  SNAPSHOT_VERSION,
+  createNexusAppearanceSnapshot,
+  sanitizeNexusAppearanceSnapshot,
+} from './appearance-snapshot';
+
+const css = (s = DEFAULT_NEXUS_APPEARANCE) =>
+  themeToCss(deriveTheme(createNexusThemeContract(s)));
+const prefs = (s = DEFAULT_NEXUS_APPEARANCE) => appearancePrefsToCss(s.prefs);
+
+it('createNexusAppearanceSnapshot stores pre-derived CSS verbatim (no re-derivation)', () => {
+  const snap = createNexusAppearanceSnapshot(
+    DEFAULT_NEXUS_APPEARANCE,
+    css(),
+    prefs()
+  );
+  expect(snap.version).toBe(SNAPSHOT_VERSION);
+  expect(snap.themeCss).toBe(css()); // byte-identical — not recomputed
+  expect(snap.state.brandColor).toBe('#339cff');
+});
+
+it('sanitize recovers state on version mismatch (never resets) but drops the stale CSS cache', () => {
+  const dark = {
+    ...DEFAULT_NEXUS_APPEARANCE,
+    mode: 'dark' as const,
+    brandColor: '#ff0000',
+  };
+  const raw = {
+    version: 999,
+    state: dark,
+    themeCss: 'STALE',
+    prefsCss: 'STALE',
+  };
+  const out = sanitizeNexusAppearanceSnapshot(raw);
+  expect(out.state).toEqual(dark); // state recovered, not DEFAULT
+  expect(out.themeCss).not.toBe('STALE'); // cache discarded → re-derived current CSS
+  expect(out.themeCss).toBe(css(dark));
+});
+
+it('sanitize resets to default snapshot on unreadable payload', () => {
+  expect(sanitizeNexusAppearanceSnapshot('garbage').state).toEqual(
+    DEFAULT_NEXUS_APPEARANCE
+  );
+  expect(sanitizeNexusAppearanceSnapshot(null).themeCss).toBe(css());
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL.** `pnpm test:unit packages/core/src/lib/appearance-snapshot.test.ts`
+- [ ] **Step 3: Implement.** `createNexusAppearanceSnapshot` = `{ version: SNAPSHOT_VERSION, state, themeCss, prefsCss }` (verbatim). `sanitizeNexusAppearanceSnapshot(raw)`: parse object; if there is no readable `raw.state`, reset to the default snapshot (Decision 5: no raw Phase B state shim); otherwise `state = sanitizeNexusAppearance(raw.state)`. If `raw.version === SNAPSHOT_VERSION` and `themeCss`/`prefsCss` are strings, trust them; **else re-derive** `themeCss = themeToCss(deriveTheme(createNexusThemeContract(state)))`, `prefsCss = appearancePrefsToCss(state.prefs)`. Return the current-version snapshot. (This is the engine-bearing path — the provider uses it; the engine-free script uses `resolveFirstPaint`, Task 2.)
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Commit.** `git commit -m "feat(core): NexusAppearance snapshot (version gates CSS cache, recovers state)"`
+
+---
+
+## Task 2: Core — the pure resolver (engine-free)
+
+**Files:** Modify `appearance-snapshot.ts`, `appearance-snapshot.test.ts`.
+
+**Interfaces:** Produces `resolveFirstPaint(snapshot: NexusAppearanceSnapshot, systemPrefersDark: boolean) → { className: ''|'dark'; dataAttrs: { 'data-style','data-radius','data-shadow','data-borderwidth' }; colorScheme: 'light'|'dark'; metaColorScheme: 'light'|'dark'|'light dark'; themeCss: string; prefsCss: string }`. **Engine-free** — reads only `snapshot.state` + `snapshot.{themeCss,prefsCss}`.
+
+- [ ] **Step 1: Failing tests.**
+
+```ts
+import {
+  resolveFirstPaint,
+  createNexusAppearanceSnapshot,
+} from './appearance-snapshot';
+import { DEFAULT_NEXUS_APPEARANCE } from '../index';
+const snap = (s) => createNexusAppearanceSnapshot(s, 'THEME', 'PREFS');
+
+it('pinned dark resolves concretely; meta is pinned', () => {
+  const r = resolveFirstPaint(
+    snap({ ...DEFAULT_NEXUS_APPEARANCE, mode: 'dark' }),
+    false
+  );
+  expect(r.className).toBe('dark');
+  expect(r.colorScheme).toBe('dark');
+  expect(r.metaColorScheme).toBe('dark');
+  expect(r.dataAttrs['data-style']).toBe('mira'); // density default
+});
+it('system mode uses the OS pref for class/colorScheme but emits meta "light dark"', () => {
+  const r = resolveFirstPaint(
+    snap({ ...DEFAULT_NEXUS_APPEARANCE, mode: 'system' }),
+    true
+  );
+  expect(r.className).toBe('dark'); // OS prefers dark
+  expect(r.colorScheme).toBe('dark');
+  expect(r.metaColorScheme).toBe('light dark'); // no-JS floor (MWG)
+});
+it('passes snapshot CSS through untouched (no engine)', () => {
+  expect(
+    resolveFirstPaint(snap(DEFAULT_NEXUS_APPEARANCE), false).themeCss
+  ).toBe('THEME');
+});
+```
+
+- [ ] **Step 2: Run — FAIL.** **Step 3: Implement** (pure function: `mode==='system' ? systemPrefersDark : mode==='dark'` → concrete; `metaColorScheme = mode==='system' ? 'light dark' : mode`; `dataAttrs` from `state.density/corners/elevation/stroke`; CSS passed through). **Step 4: PASS.** **Step 5: Commit** `feat(core): engine-free resolveFirstPaint`.
+
+---
+
+## Task 3: Core — bootstrap script factory (engine-free, parser-blocking)
+
+**Files:** Modify `appearance-snapshot.ts`, `appearance-snapshot.test.ts`; export all from `packages/core/src/index.ts`.
+
+**Interfaces:** Produces `createNexusAppearanceBootstrapScript(options?: { storageKey?: string; defaultSnapshot?: NexusAppearanceSnapshot; }): string` — a **classic, non-module** JS string for an inline `<head>` `<script>`. At runtime it: reads `localStorage[storageKey]`, parses + version-checks inline, runs the `resolveFirstPaint` logic (inlined — no import), and applies `className`/`dataAttrs`/`colorScheme`/`metaColorScheme` + injects the two `<style data-nexus-appearance-*>` tags. On missing/invalid/version-mismatch storage it applies the **embedded default snapshot** (so first-visit/empty-storage is flash-free — Decision 9).
+
+> **Implementer note:** the generator embeds `JSON.stringify(defaultSnapshot)` (default themeCss/prefsCss baked in at generation time, where the engine is available) so the runtime script needs no engine. ESCAPE the embedded JSON for inline-`<script>` safety: replace `</`→`<\/`, `<!--`→`<\!--`, `<![CDATA[`, U+2028→` `, U+2029→` `. The script must be tiny apart from the embedded default CSS — if Task 7 aligns the baseline, the default CSS can be omitted and the script applies attrs-only on first visit.
+
+- [ ] **Step 1: Failing tests.**
+
+```ts
+import { createNexusAppearanceBootstrapScript, createNexusAppearanceSnapshot } from './appearance-snapshot';
+import { DEFAULT_NEXUS_APPEARANCE, /* css/prefs helpers */ } from '../index';
+
+const script = createNexusAppearanceBootstrapScript();
+it('is engine-free and injection-safe', () => {
+  expect(script).not.toMatch(/culori|apca|deriveTheme|themeToCss|rampFromSeed|seedOklch/i); // no engine
+  expect(script).not.toContain('</script');
+  expect(script).not.toContain('light-dark(');
+  expect(script).not.toMatch(/ | /);
+});
+it('applies a stored dark snapshot to the document (jsdom — mutations, not timing)', () => {
+  const dark = createNexusAppearanceSnapshot({ ...DEFAULT_NEXUS_APPEARANCE, mode: 'dark' }, /*themeCss*/'', /*prefsCss*/'');
+  localStorage.setItem('nexus-appearance', JSON.stringify(dark));
+  new Function(createNexusAppearanceBootstrapScript())(); // execute the classic script body
+  expect(document.documentElement.classList.contains('dark')).toBe(true);
+  expect(document.documentElement.getAttribute('data-radius')).toBe('sharp');
+  expect(document.querySelectorAll('style[data-nexus-appearance-theme]')).toHaveLength(1);
+});
+it('falls back to the embedded default on empty storage', () => {
+  localStorage.clear();
+  new Function(createNexusAppearanceBootstrapScript())();
+  expect(document.documentElement.getAttribute('data-style')).toBe('mira');
+});
+```
+
+- [ ] **Step 2: Run — FAIL.** **Step 3: Implement** the factory (build the default snapshot from `DEFAULT_NEXUS_APPEARANCE` via Task 1 at generation time; emit the escaped string; inline the resolver logic + `matchMedia('(prefers-color-scheme: dark)').matches` for system; apply via `setAttribute`/`classList`/`style.colorScheme` + `meta[name=color-scheme]` + upsert `<style data-nexus-appearance-theme>`/`[data-nexus-appearance-prefs]` with `textContent`). **Step 4: PASS.** **Step 5:** add `export * from './lib/appearance-snapshot'` to `packages/core/src/index.ts`; **Commit** `feat(core): createNexusAppearanceBootstrapScript`.
+
+---
+
+## Task 4: Provider — SSR-safe init + mounted + snapshot write
+
+**Files:** Modify `packages/react/src/appearance/provider.tsx`; add cases to `provider.test.tsx`; create `provider.ssr.test.tsx`.
+
+**Interfaces:** `NexusAppearanceContextValue` gains `mounted: boolean`. Behavior changes only — props unchanged.
+
+- [ ] **Step 1: Failing tests** (`provider.test.tsx`, jsdom):
+
+```ts
+it('first render is the default state; storage is adopted after mount', async () => {
+  localStorage.setItem('nexus-appearance', JSON.stringify(createNexusAppearanceSnapshot({ ...DEFAULT_NEXUS_APPEARANCE, surfaceTone: 'slate' }, '', '')));
+  const seen: string[] = [];
+  function Probe() { const { state, mounted } = useNexusAppearance(); seen.push(`${mounted}:${state.surfaceTone}`); return null; }
+  render(<NexusAppearanceProvider><Probe /></NexusAppearanceProvider>);
+  expect(seen[0]).toBe('false:stone');          // deterministic default first (SSR-safe)
+  await waitFor(() => expect(seen.at(-1)).toBe('true:slate')); // adopted post-mount
+});
+
+it('writes the snapshot format (version + state + css) in uncontrolled mode', async () => {
+  const { result } = renderHook(() => useNexusAppearance(), { wrapper: ({ children }) => <NexusAppearanceProvider storageKey="k">{children}</NexusAppearanceProvider> });
+  act(() => result.current.setState((s) => ({ ...s, mode: 'dark' })));
+  await waitFor(() => {
+    const snap = JSON.parse(localStorage.getItem('k')!);
+    expect(snap.version).toBe(1);
+    expect(snap.state.mode).toBe('dark');
+    expect(typeof snap.themeCss).toBe('string'); // pre-derived CSS persisted (Decision 6)
+  });
+});
+
+it('reuses a bootstrap-created <style> tag instead of stacking a second (C12)', () => {
+  const pre = document.createElement('style'); pre.setAttribute('data-nexus-appearance-theme',''); pre.textContent='/*boot*/'; document.head.appendChild(pre);
+  render(<NexusAppearanceProvider><div/></NexusAppearanceProvider>);
+  expect(document.querySelectorAll('style[data-nexus-appearance-theme]')).toHaveLength(1);
+});
+```
+
+- [ ] **Step 2: SSR test** (`provider.ssr.test.tsx`, first line `// @vitest-environment node`):
+
+```ts
+// @vitest-environment node
+import { renderToString } from 'react-dom/server';
+it('renders without window (SSR) and does not throw', () => {
+  expect(() => renderToString(<NexusAppearanceProvider><span>ok</span></NexusAppearanceProvider>)).not.toThrow();
+});
+```
+
+- [ ] **Step 3: Run — FAIL.** **Step 4: Implement.** Refactor `provider.tsx` (real source at `FETCH_HEAD`):
+  - Replace `useState(() => readStoredState(...))` with `useState(initialState)` (deterministic default → server and client first render are byte-identical) + `const [mounted, setMounted] = useState(false)`.
+  - A mount effect reads the snapshot (`sanitizeNexusAppearanceSnapshot`), `setInternalState(snap.state)`, `setMounted(true)`.
+  - **The ordering hazard (this is the part that reintroduces the flash if done naively):** the DOM apply-effects must NOT paint the _default_ over the DOM the bootstrap already set, then correct to stored — that is the exact flash this phase kills. The bootstrap owns first-paint pixels; the provider must apply only the **storage-read** values, never the transient default. Gate the four apply-effects so they run only once `mounted` (i.e. after the snapshot read), trusting the bootstrap's pre-paint DOM until then. (If a host runs the provider with no bootstrap script — CSR without `<head>` injection — there is still a one-effect flash; that's why Task 8 docs require the script for no-flash. Do not try to fix that with a render-time storage read — it reintroduces the SSR hydration mismatch.)
+  - Change `writeStoredState` to persist `createNexusAppearanceSnapshot(state, themeCss, prefsCss)` (pass the memoized `themeCss`/`prefsCss` — Decision 6, no second derivation).
+  - Expose `mounted` in context. Controlled mode unchanged (no storage read/write).
+  - **Step 5: Run — PASS** (`pnpm test:unit packages/react/src/appearance/provider`). **Step 6: Commit** `feat(react): SSR-safe provider init + snapshot persistence`.
+
+---
+
+## Task 5: React — `createNexusAppearance` factory + `NexusAppearanceScript`
+
+**Files:** Create `packages/react/src/appearance/script.tsx`; export from `index.ts`.
+
+**Interfaces:** `createNexusAppearance(config: { storageKey?: string; defaultState?: NexusAppearanceState }) → { NexusAppearanceProvider: FC<Omit<Props,'storageKey'|'defaultState'>>; NexusAppearanceScript: FC<{ nonce?: string }> }`, both closed over `config` (Decision 7). `NexusAppearanceScript` SSR-renders `<script nonce dangerouslySetInnerHTML={{ __html: createNexusAppearanceBootstrapScript({ storageKey, defaultSnapshot }) }} />`.
+
+- [ ] **Step 1: Failing test** — `createNexusAppearance({ storageKey: 'x' })` returns a Provider and Script that both use `'x'`; rendering `<NexusAppearanceScript/>` to string contains the bootstrap body and the `nonce`. (Use `renderToStaticMarkup`.)
+- [ ] **Step 2: FAIL. Step 3: Implement** (the factory builds the default snapshot from `config.defaultState ?? DEFAULT_NEXUS_APPEARANCE`; the Script is a server component-safe `<script>`; **document** that it must be SSR'd into `<head>` — a client-rendered inline script does not run parser-blocking and React 19 won't dedupe it). **Step 4: PASS. Step 5: Commit** `feat(react): createNexusAppearance factory + NexusAppearanceScript`.
+
+---
+
+## Task 6: Equivalence + no-flash verification (the load-bearing tests)
+
+**Files:** `appearance-snapshot.test.ts`, `provider.test.tsx`.
+
+- [ ] **Step 1: Byte-equivalence test (C11)** — the snapshot CSS the script applies must equal what the provider re-derives, **byte-for-byte**, off the **sanitized** state (else a hydration repaint). Seed storage with a snapshot for a non-default state that sanitization _alters_ (e.g. `contrast: 999`), mount the provider, after the effect assert `document.querySelector('style[data-nexus-appearance-theme]').textContent === themeToCss(deriveTheme(createNexusThemeContract(sanitizeNexusAppearance(state))))`. Run the same assertion with the **DEFAULT** state (pins C-B2: empty storage applies the default _themeCss_, not just attrs).
+- [ ] **Step 2: Version-recovery test (C3)** — snapshot `{version:999, state:<valid non-default>}` → provider mounts to that state (not DEFAULT).
+- [ ] **Step 3: System-mode `matchMedia` override** — reuse the existing override pattern (the shared mock at `packages/test-utils/src/setup.ts` hardcodes `matches:false`; restore in `afterEach`); assert system→dark applies `.dark` and the `change` listener flips it.
+- [ ] **Step 4: Run + Commit** `test: snapshot/provider equivalence + recovery + system-mode`.
+
+---
+
+## Task 7 (owner-gated precursor): align the shipped brand default — OR document the embed
+
+**Files (if aligning):** `packages/core/package.json` `build:tailwind` `--brand`, regenerate `packages/tailwind/*.css`.
+
+This is the C-B2 owner decision (blue brand identity). Do **one**:
+
+- [ ] **Align (preferred):** change `build:tailwind --brand=black` → the appearance default brand and regenerate, so `nexus.css :root` light/dark primary == `themeToCss(deriveTheme(createNexusThemeContract(DEFAULT_NEXUS_APPEARANCE)))` for the brand tokens. Then Task 3's script can omit the embedded default CSS (attrs-only first visit). Run `pnpm --filter @nexus/core audit:contrast` + `pnpm --filter @nexus/core build:tailwind`. **Likely a separate small precursor PR** (`feedback-precursor-pr-for-arch-fixes`).
+- [x] **Or document the embed:** keep `--brand=black`, accept the script embeds the default snapshot CSS (~1.7 KB gzip), and note in the PR that the static `nexus.css` baseline is the non-appearance fallback only.
+
+> Decision owner: confirm blue-vs-achromatic brand default before this task. The plan is correct either way; only Task 3's embed size changes.
+
+---
+
+## Task 8: Host-setup docs + verification sweep
+
+- [ ] **Step 1: Docs (epic L104).** Write host-app setup: Next.js app-router — render `<NexusAppearanceScript/>` inside the root layout `<head>`; add `suppressHydrationWarning` to `<html>`; note consumers should gate theme-dependent UI on `mounted` (from `useNexusAppearance`). Include the `<meta name="color-scheme" content="light dark">` default. Plain-HTML hosts: inline `createNexusAppearanceBootstrapScript()` in `<head>`.
+- [ ] **Step 2: Manual no-flash check (epic L110, jsdom can't).** Documented steps: in a Next.js sandbox, set a dark snapshot, hard-refresh, confirm no light flash; toggle OS theme in `system` mode; confirm no hydration warning in console.
+- [ ] **Step 3: Full gate.**
+
+```bash
+pnpm typecheck && pnpm lint && pnpm format:check && pnpm test:unit \
+  && pnpm --filter @nexus/core build && pnpm --filter @nexus/react build \
+  && pnpm size-limit && pnpm audit:browser-support
+```
+
+- [ ] **Step 4:** Confirm no engine in the script: `! rg -qi "culori|apca" packages/core/dist/**/appearance-snapshot*` and the generated script string carries no derivation engine code. Embedded default CSS may contain inert `oklch(` values. **Commit.**
+
+---
+
+## Self-Review (against the council review)
+
+- **C-B1 (SSR unverifiable + docs dropped):** Task 4 makes the provider SSR-safe by construction + Task 8 restores host-setup docs + a manual no-flash step (the only vehicle — jsdom/Playwright can't see first paint). ✔ Honest limit: no in-repo SSR consumer exercises it; verified by unit (SSR-render, equivalence) + manual.
+- **C-B2 (first-visit default source):** Decision 9 + Task 7 — align the baseline (preferred) or document the embed. ✔
+- **Keystone / C3 / C5 / NEW-3 / C12:** pure resolver (Task 2) consumed by script (Task 3) + provider (Task 4); version gates the CSS cache (Task 1); snapshot-only (Task 1/5); pre-derived CSS persisted (Task 4/6); one config factory + style-attr contract (Task 5/6-Step3). ✔
+- **Refuted, deliberately NOT done:** read-from-DOM (Decision 3), drop-the-meta (Decision 8), reduce-motion bootstrap (components honor `prefers-reduced-motion` natively). ✔
+- **C10/MWG:** unsafe-CSS validation dropped (Decision 10); MWG section required on the PR (Decision 11). ✔
+- **Placeholder scan:** the bootstrap-script internals are specified by interface + escaping rules + tests, not fabricated; all test code is concrete. **Type consistency:** `NexusAppearanceSnapshot` (Task 1) flows through `resolveFirstPaint` (Task 2), the script (Task 3), and the provider (Task 4) unchanged.
+
+---
+
+## Execution Handoff
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, review between.
+2. **Inline Execution** — with checkpoints.
+
+**Dependency order:** Tasks 1→2→3 (core, sequential) → Task 4 (provider) → Task 5 (factory) → Task 6 (equivalence tests) → Task 8 (docs/sweep). Task 7 is an independent owner-gated precursor (ideally a separate PR) and can run in parallel.

--- a/docs/superpowers/specs/2026-06-27-appearance-host-setup.md
+++ b/docs/superpowers/specs/2026-06-27-appearance-host-setup.md
@@ -1,0 +1,110 @@
+# Appearance Host Setup
+
+Phase C makes appearance first-paint safe when the host renders the bootstrap
+script in the document head before React mounts. The bootstrap is a classic
+inline script on purpose: it is parser-blocking across the Nexus browser floor
+and does not rely on `blocking="render"`.
+
+## React / Next.js App Router
+
+Create one configured appearance pair and render the script in `<head>`. Put
+`suppressHydrationWarning` on `<html>` because the script may set `.dark` and
+the appearance `data-*` attributes before React hydrates.
+
+```tsx
+// app/appearance.tsx
+import { createNexusAppearance } from '@nexus/react/appearance';
+
+export const { NexusAppearanceProvider, NexusAppearanceScript } =
+  createNexusAppearance({
+    storageKey: 'nexus-appearance',
+  });
+```
+
+```tsx
+// app/layout.tsx
+import { NexusAppearanceProvider, NexusAppearanceScript } from './appearance';
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <meta name="color-scheme" content="light dark" />
+        <NexusAppearanceScript />
+      </head>
+      <body>
+        <NexusAppearanceProvider>{children}</NexusAppearanceProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+If the app uses a CSP nonce, pass it to the script component:
+
+```tsx
+<NexusAppearanceScript nonce={nonce} />
+```
+
+Theme-dependent UI can read `mounted` from `useNexusAppearance()` and render a
+neutral fallback until it is `true`. This is only needed for UI that displays
+the persisted appearance state itself; ordinary styled components can render
+normally because the CSS variables are already present.
+
+## Plain HTML Hosts
+
+Plain HTML hosts can inline the core script string in `<head>` before any
+rendered content that depends on Nexus appearance variables.
+
+```ts
+import { createNexusAppearanceBootstrapScript } from '@nexus/core';
+
+const script = createNexusAppearanceBootstrapScript({
+  storageKey: 'nexus-appearance',
+});
+```
+
+```html
+<head>
+  <meta name="color-scheme" content="light dark" />
+  <script>
+    /* insert createNexusAppearanceBootstrapScript() output here */
+  </script>
+</head>
+```
+
+The script writes:
+
+- `.dark` on `<html>` when the resolved mode is dark
+- `data-style`, `data-radius`, `data-shadow`, and `data-borderwidth`
+- `color-scheme` on `<html>` plus the `color-scheme` meta content
+- `style[data-nexus-appearance-theme]`
+- `style[data-nexus-appearance-prefs]`
+
+## Default CSS Source
+
+The static `nexus.css` baseline still uses the non-appearance fallback brand.
+Until the shipped baseline is aligned with the appearance default, the bootstrap
+embeds the default appearance CSS snapshot so first visit is still flash-free.
+
+This is intentional for Phase C. A later owner decision can align the static
+baseline and shrink the first-visit script payload.
+
+## Manual No-Flash QA
+
+Automated unit tests verify the resolver, SSR render safety, style-tag reuse,
+snapshot recovery, and provider/bootstrap equivalence. They cannot observe the
+browser's first paint.
+
+Before release, check a server-rendered host manually:
+
+1. Store a dark `nexus-appearance` snapshot.
+2. Hard-refresh the page.
+3. Confirm there is no light flash before hydration.
+4. Set appearance mode to `system`, toggle the OS color scheme, and hard-refresh.
+5. Confirm the page starts in the OS-selected scheme.
+6. Confirm the console has no hydration warning for `<html>` attributes.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export type {
 } from './lib/adjust-contrast';
 export { adjustContrast } from './lib/adjust-contrast';
 export * from './lib/appearance-model';
+export * from './lib/appearance-snapshot';
 export type {
   DerivedTheme,
   NexusSurfaceTone,

--- a/packages/core/src/lib/appearance-snapshot.test.ts
+++ b/packages/core/src/lib/appearance-snapshot.test.ts
@@ -7,6 +7,7 @@ import {
 } from './appearance-model';
 import {
   createNexusAppearanceSnapshot,
+  resolveFirstPaint,
   sanitizeNexusAppearanceSnapshot,
   SNAPSHOT_VERSION,
 } from './appearance-snapshot';
@@ -72,5 +73,45 @@ describe('NexusAppearanceSnapshot', () => {
     });
 
     expect(snapshot.state).toEqual(DEFAULT_NEXUS_APPEARANCE);
+  });
+});
+
+describe('resolveFirstPaint', () => {
+  const snapshotFor = (state = DEFAULT_NEXUS_APPEARANCE) =>
+    createNexusAppearanceSnapshot(state, 'THEME', 'PREFS');
+
+  it('resolves pinned dark mode concretely', () => {
+    const result = resolveFirstPaint(
+      snapshotFor({ ...DEFAULT_NEXUS_APPEARANCE, mode: 'dark' }),
+      false
+    );
+
+    expect(result.className).toBe('dark');
+    expect(result.colorScheme).toBe('dark');
+    expect(result.metaColorScheme).toBe('dark');
+    expect(result.dataAttrs).toEqual({
+      'data-style': 'mira',
+      'data-radius': 'sharp',
+      'data-shadow': 'maia',
+      'data-borderwidth': 'vega',
+    });
+  });
+
+  it('resolves system mode from the OS preference and keeps meta dual-scheme', () => {
+    const result = resolveFirstPaint(
+      snapshotFor({ ...DEFAULT_NEXUS_APPEARANCE, mode: 'system' }),
+      true
+    );
+
+    expect(result.className).toBe('dark');
+    expect(result.colorScheme).toBe('dark');
+    expect(result.metaColorScheme).toBe('light dark');
+  });
+
+  it('passes snapshot CSS through without derivation', () => {
+    const result = resolveFirstPaint(snapshotFor(), false);
+
+    expect(result.themeCss).toBe('THEME');
+    expect(result.prefsCss).toBe('PREFS');
   });
 });

--- a/packages/core/src/lib/appearance-snapshot.test.ts
+++ b/packages/core/src/lib/appearance-snapshot.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  appearancePrefsToCss,
+  createNexusThemeContract,
+  DEFAULT_NEXUS_APPEARANCE,
+} from './appearance-model';
+import {
+  createNexusAppearanceSnapshot,
+  sanitizeNexusAppearanceSnapshot,
+  SNAPSHOT_VERSION,
+} from './appearance-snapshot';
+import { deriveTheme, themeToCss } from './derive-theme';
+
+function themeCss(state = DEFAULT_NEXUS_APPEARANCE): string {
+  return themeToCss(deriveTheme(createNexusThemeContract(state)));
+}
+
+function prefsCss(state = DEFAULT_NEXUS_APPEARANCE): string {
+  return appearancePrefsToCss(state.prefs);
+}
+
+describe('NexusAppearanceSnapshot', () => {
+  it('stores pre-derived CSS verbatim', () => {
+    const theme = themeCss();
+    const prefs = prefsCss();
+    const snapshot = createNexusAppearanceSnapshot(
+      DEFAULT_NEXUS_APPEARANCE,
+      theme,
+      prefs
+    );
+
+    expect(snapshot).toEqual({
+      version: SNAPSHOT_VERSION,
+      state: DEFAULT_NEXUS_APPEARANCE,
+      themeCss: theme,
+      prefsCss: prefs,
+    });
+  });
+
+  it('recovers state on version mismatch and refreshes the stale CSS cache', () => {
+    const dark = {
+      ...DEFAULT_NEXUS_APPEARANCE,
+      mode: 'dark' as const,
+      brandColor: '#ff0000',
+    };
+    const snapshot = sanitizeNexusAppearanceSnapshot({
+      version: 999,
+      state: dark,
+      themeCss: 'STALE',
+      prefsCss: 'STALE',
+    });
+
+    expect(snapshot.version).toBe(SNAPSHOT_VERSION);
+    expect(snapshot.state).toEqual(dark);
+    expect(snapshot.themeCss).toBe(themeCss(dark));
+    expect(snapshot.prefsCss).toBe(prefsCss(dark));
+  });
+
+  it('resets to the default snapshot on unreadable payloads', () => {
+    const snapshot = sanitizeNexusAppearanceSnapshot('garbage');
+
+    expect(snapshot.state).toEqual(DEFAULT_NEXUS_APPEARANCE);
+    expect(snapshot.themeCss).toBe(themeCss());
+    expect(snapshot.prefsCss).toBe(prefsCss());
+  });
+
+  it('does not treat a raw Phase B state object as a snapshot payload', () => {
+    const snapshot = sanitizeNexusAppearanceSnapshot({
+      ...DEFAULT_NEXUS_APPEARANCE,
+      mode: 'dark',
+    });
+
+    expect(snapshot.state).toEqual(DEFAULT_NEXUS_APPEARANCE);
+  });
+});

--- a/packages/core/src/lib/appearance-snapshot.test.ts
+++ b/packages/core/src/lib/appearance-snapshot.test.ts
@@ -222,6 +222,26 @@ describe('createNexusAppearanceBootstrapScript', () => {
     ).toBe('light dark');
   });
 
+  it('does not force dark in system mode when matchMedia is unavailable', () => {
+    const system = createNexusAppearanceSnapshot(
+      { ...DEFAULT_NEXUS_APPEARANCE, mode: 'system' },
+      ':root {}',
+      ':root {}'
+    );
+    window.localStorage.setItem('nexus-appearance', JSON.stringify(system));
+    Reflect.set(window, 'matchMedia', undefined);
+
+    new Function(createNexusAppearanceBootstrapScript())();
+
+    const root = document.documentElement;
+    expect(root.classList.contains('dark')).toBe(false);
+    expect(root.style.colorScheme).toBe('light');
+    expect(
+      document.querySelector<HTMLMetaElement>('meta[name="color-scheme"]')
+        ?.content
+    ).toBe('light dark');
+  });
+
   it.each([
     ['light', false],
     ['light', true],

--- a/packages/core/src/lib/appearance-snapshot.test.ts
+++ b/packages/core/src/lib/appearance-snapshot.test.ts
@@ -157,8 +157,8 @@ describe('createNexusAppearanceBootstrapScript', () => {
 
     new Function(createNexusAppearanceBootstrapScript())();
 
-    expect(document.documentElement).toHaveClass('dark');
-    expect(document.documentElement).toHaveAttribute('data-radius', 'sharp');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.getAttribute('data-radius')).toBe('sharp');
     expect(document.documentElement.style.colorScheme).toBe('dark');
     expect(
       document.querySelector<HTMLMetaElement>('meta[name="color-scheme"]')
@@ -183,8 +183,8 @@ describe('createNexusAppearanceBootstrapScript', () => {
       })
     )();
 
-    expect(document.documentElement).toHaveAttribute('data-style', 'mira');
-    expect(document.documentElement).not.toHaveClass('dark');
+    expect(document.documentElement.getAttribute('data-style')).toBe('mira');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
     expect(
       document.querySelectorAll('style[data-nexus-appearance-theme]')
     ).toHaveLength(1);
@@ -211,7 +211,7 @@ describe('createNexusAppearanceBootstrapScript', () => {
 
     new Function(createNexusAppearanceBootstrapScript())();
 
-    expect(document.documentElement).toHaveClass('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
     expect(
       document.querySelector<HTMLMetaElement>('meta[name="color-scheme"]')
         ?.content

--- a/packages/core/src/lib/appearance-snapshot.test.ts
+++ b/packages/core/src/lib/appearance-snapshot.test.ts
@@ -22,6 +22,20 @@ function prefsCss(state = DEFAULT_NEXUS_APPEARANCE): string {
   return appearancePrefsToCss(state.prefs);
 }
 
+function mockSystemPrefersDark(matches: boolean): void {
+  const mediaQuery: MediaQueryList = {
+    matches,
+    media: '(prefers-color-scheme: dark)',
+    onchange: null,
+    addEventListener: vi.fn(),
+    addListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    removeEventListener: vi.fn(),
+    removeListener: vi.fn(),
+  };
+  window.matchMedia = vi.fn(() => mediaQuery);
+}
+
 describe('NexusAppearanceSnapshot', () => {
   it('stores pre-derived CSS verbatim', () => {
     const theme = themeCss();
@@ -197,17 +211,7 @@ describe('createNexusAppearanceBootstrapScript', () => {
       ':root {}'
     );
     window.localStorage.setItem('nexus-appearance', JSON.stringify(system));
-    const mediaQuery: MediaQueryList = {
-      matches: true,
-      media: '(prefers-color-scheme: dark)',
-      onchange: null,
-      addEventListener: vi.fn(),
-      addListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-      removeEventListener: vi.fn(),
-      removeListener: vi.fn(),
-    };
-    window.matchMedia = vi.fn(() => mediaQuery);
+    mockSystemPrefersDark(true);
 
     new Function(createNexusAppearanceBootstrapScript())();
 
@@ -217,4 +221,45 @@ describe('createNexusAppearanceBootstrapScript', () => {
         ?.content
     ).toBe('light dark');
   });
+
+  it.each([
+    ['light', false],
+    ['light', true],
+    ['dark', false],
+    ['dark', true],
+    ['system', false],
+    ['system', true],
+  ] as const)(
+    'applies the same resolution as resolveFirstPaint (mode=%s, systemPrefersDark=%s)',
+    (mode, prefersDark) => {
+      const snapshot = createNexusAppearanceSnapshot(
+        { ...DEFAULT_NEXUS_APPEARANCE, mode },
+        ':root { --t: 1; }',
+        ':root { --p: 1; }'
+      );
+      const expected = resolveFirstPaint(snapshot, prefersDark);
+      window.localStorage.setItem('nexus-appearance', JSON.stringify(snapshot));
+      mockSystemPrefersDark(prefersDark);
+
+      new Function(createNexusAppearanceBootstrapScript())();
+
+      const root = document.documentElement;
+      expect(root.classList.contains('dark')).toBe(
+        expected.className === 'dark'
+      );
+      expect(root.style.colorScheme).toBe(expected.colorScheme);
+      expect(
+        document.querySelector<HTMLMetaElement>('meta[name="color-scheme"]')
+          ?.content
+      ).toBe(expected.metaColorScheme);
+      for (const attr of [
+        'data-style',
+        'data-radius',
+        'data-shadow',
+        'data-borderwidth',
+      ] as const) {
+        expect(root.getAttribute(attr)).toBe(expected.dataAttrs[attr]);
+      }
+    }
+  );
 });

--- a/packages/core/src/lib/appearance-snapshot.test.ts
+++ b/packages/core/src/lib/appearance-snapshot.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   appearancePrefsToCss,
@@ -6,6 +6,7 @@ import {
   DEFAULT_NEXUS_APPEARANCE,
 } from './appearance-model';
 import {
+  createNexusAppearanceBootstrapScript,
   createNexusAppearanceSnapshot,
   resolveFirstPaint,
   sanitizeNexusAppearanceSnapshot,
@@ -113,5 +114,107 @@ describe('resolveFirstPaint', () => {
 
     expect(result.themeCss).toBe('THEME');
     expect(result.prefsCss).toBe('PREFS');
+  });
+});
+
+describe('createNexusAppearanceBootstrapScript', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.matchMedia = originalMatchMedia;
+    document.documentElement.classList.remove('dark');
+    document.documentElement.removeAttribute('data-style');
+    document.documentElement.removeAttribute('data-radius');
+    document.documentElement.removeAttribute('data-shadow');
+    document.documentElement.removeAttribute('data-borderwidth');
+    document.documentElement.style.colorScheme = '';
+    document
+      .querySelectorAll(
+        'meta[name="color-scheme"], style[data-nexus-appearance-theme], style[data-nexus-appearance-prefs]'
+      )
+      .forEach((node) => node.remove());
+  });
+
+  it('is engine-free and safe to inline in a classic script tag', () => {
+    const script = createNexusAppearanceBootstrapScript();
+
+    expect(script).not.toMatch(
+      /culori|apca|deriveTheme|themeToCss|rampFromSeed|seedOklch/i
+    );
+    expect(script).not.toContain('</script');
+    expect(script).not.toContain('light-dark(');
+    expect(script).not.toMatch(/\u2028|\u2029/);
+  });
+
+  it('applies a stored dark snapshot to the document', () => {
+    const dark = createNexusAppearanceSnapshot(
+      { ...DEFAULT_NEXUS_APPEARANCE, mode: 'dark' },
+      ':root { --test-theme: dark; }',
+      ':root { --test-prefs: dark; }'
+    );
+    window.localStorage.setItem('nexus-appearance', JSON.stringify(dark));
+
+    new Function(createNexusAppearanceBootstrapScript())();
+
+    expect(document.documentElement).toHaveClass('dark');
+    expect(document.documentElement).toHaveAttribute('data-radius', 'sharp');
+    expect(document.documentElement.style.colorScheme).toBe('dark');
+    expect(
+      document.querySelector<HTMLMetaElement>('meta[name="color-scheme"]')
+        ?.content
+    ).toBe('dark');
+    expect(
+      document.querySelector('style[data-nexus-appearance-theme]')?.textContent
+    ).toBe(':root { --test-theme: dark; }');
+    expect(
+      document.querySelector('style[data-nexus-appearance-prefs]')?.textContent
+    ).toBe(':root { --test-prefs: dark; }');
+  });
+
+  it('falls back to the embedded default snapshot on empty storage', () => {
+    new Function(
+      createNexusAppearanceBootstrapScript({
+        defaultSnapshot: createNexusAppearanceSnapshot(
+          DEFAULT_NEXUS_APPEARANCE,
+          '',
+          ''
+        ),
+      })
+    )();
+
+    expect(document.documentElement).toHaveAttribute('data-style', 'mira');
+    expect(document.documentElement).not.toHaveClass('dark');
+    expect(
+      document.querySelectorAll('style[data-nexus-appearance-theme]')
+    ).toHaveLength(1);
+  });
+
+  it('uses matchMedia for system mode', () => {
+    const system = createNexusAppearanceSnapshot(
+      { ...DEFAULT_NEXUS_APPEARANCE, mode: 'system' },
+      ':root {}',
+      ':root {}'
+    );
+    window.localStorage.setItem('nexus-appearance', JSON.stringify(system));
+    const mediaQuery: MediaQueryList = {
+      matches: true,
+      media: '(prefers-color-scheme: dark)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      addListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      removeEventListener: vi.fn(),
+      removeListener: vi.fn(),
+    };
+    window.matchMedia = vi.fn(() => mediaQuery);
+
+    new Function(createNexusAppearanceBootstrapScript())();
+
+    expect(document.documentElement).toHaveClass('dark');
+    expect(
+      document.querySelector<HTMLMetaElement>('meta[name="color-scheme"]')
+        ?.content
+    ).toBe('light dark');
   });
 });

--- a/packages/core/src/lib/appearance-snapshot.ts
+++ b/packages/core/src/lib/appearance-snapshot.ts
@@ -35,7 +35,7 @@ export interface NexusAppearanceBootstrapScriptOptions {
   defaultSnapshot?: NexusAppearanceSnapshot;
 }
 
-const DEFAULT_STORAGE_KEY = 'nexus-appearance';
+export const DEFAULT_STORAGE_KEY = 'nexus-appearance';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
@@ -61,12 +61,22 @@ export function createNexusAppearanceSnapshot(
   };
 }
 
-export function createDefaultNexusAppearanceSnapshot(): NexusAppearanceSnapshot {
+export function createNexusAppearanceSnapshotFromState(
+  state: NexusAppearanceState
+): NexusAppearanceSnapshot {
   return createNexusAppearanceSnapshot(
-    DEFAULT_NEXUS_APPEARANCE,
-    deriveThemeCss(DEFAULT_NEXUS_APPEARANCE),
-    derivePrefsCss(DEFAULT_NEXUS_APPEARANCE)
+    state,
+    deriveThemeCss(state),
+    derivePrefsCss(state)
   );
+}
+
+let cachedDefaultSnapshot: NexusAppearanceSnapshot | undefined;
+
+export function createDefaultNexusAppearanceSnapshot(): NexusAppearanceSnapshot {
+  return (cachedDefaultSnapshot ??= createNexusAppearanceSnapshotFromState(
+    DEFAULT_NEXUS_APPEARANCE
+  ));
 }
 
 export function sanitizeNexusAppearanceSnapshot(
@@ -86,11 +96,7 @@ export function sanitizeNexusAppearanceSnapshot(
     return createNexusAppearanceSnapshot(state, raw.themeCss, raw.prefsCss);
   }
 
-  return createNexusAppearanceSnapshot(
-    state,
-    deriveThemeCss(state),
-    derivePrefsCss(state)
-  );
+  return createNexusAppearanceSnapshotFromState(state);
 }
 
 export function resolveFirstPaint(
@@ -132,5 +138,5 @@ export function createNexusAppearanceBootstrapScript(
     ? sanitizeNexusAppearanceSnapshot(options.defaultSnapshot)
     : createDefaultNexusAppearanceSnapshot();
 
-  return `(function(){try{var k=${JSON.stringify(storageKey)};var f=${escapeInlineScriptJson(defaultSnapshot)};var s=f;try{var r=window.localStorage&&window.localStorage.getItem(k);if(r){var p=JSON.parse(r);if(p&&p.version===f.version&&p.state&&typeof p.themeCss==="string"&&typeof p.prefsCss==="string"){s=p;}}}catch(e){}var st=s.state||f.state;var m=st.mode==="dark"||st.mode==="light"||st.mode==="system"?st.mode:f.state.mode;var sys=false;try{sys=m==="system"&&window.matchMedia&&window.matchMedia("(prefers-color-scheme: dark)").matches;}catch(e){}var dark=m==="dark"||sys;var root=document.documentElement;root.classList.toggle("dark",dark);root.setAttribute("data-style",typeof st.density==="string"?st.density:f.state.density);root.setAttribute("data-radius",typeof st.corners==="string"?st.corners:f.state.corners);root.setAttribute("data-shadow",typeof st.elevation==="string"?st.elevation:f.state.elevation);root.setAttribute("data-borderwidth",typeof st.stroke==="string"?st.stroke:f.state.stroke);root.style.colorScheme=dark?"dark":"light";var meta=document.querySelector('meta[name="color-scheme"]');if(!meta){meta=document.createElement("meta");meta.setAttribute("name","color-scheme");document.head.appendChild(meta);}meta.setAttribute("content",m==="system"?"light dark":m);function upsert(attr,css){var list=document.querySelectorAll("style["+attr+"]");var el=list[0]||document.createElement("style");for(var i=1;i<list.length;i++){list[i].remove();}el.setAttribute(attr,"");el.textContent=css||"";if(!el.parentNode){document.head.appendChild(el);}}upsert("data-nexus-appearance-theme",s.themeCss);upsert("data-nexus-appearance-prefs",s.prefsCss);}catch(e){}})();`;
+  return `(function(){try{var k=${escapeInlineScriptJson(storageKey)};var f=${escapeInlineScriptJson(defaultSnapshot)};var s=f;try{var r=window.localStorage&&window.localStorage.getItem(k);if(r){var p=JSON.parse(r);if(p&&p.version===f.version&&p.state&&typeof p.themeCss==="string"&&typeof p.prefsCss==="string"){s=p;}}}catch(e){}var st=s.state||f.state;var m=st.mode==="dark"||st.mode==="light"||st.mode==="system"?st.mode:f.state.mode;var sys=false;try{sys=m==="system"&&window.matchMedia&&window.matchMedia("(prefers-color-scheme: dark)").matches;}catch(e){}var dark=m==="dark"||sys===true;var root=document.documentElement;root.classList.toggle("dark",dark);root.setAttribute("data-style",typeof st.density==="string"?st.density:f.state.density);root.setAttribute("data-radius",typeof st.corners==="string"?st.corners:f.state.corners);root.setAttribute("data-shadow",typeof st.elevation==="string"?st.elevation:f.state.elevation);root.setAttribute("data-borderwidth",typeof st.stroke==="string"?st.stroke:f.state.stroke);root.style.colorScheme=dark?"dark":"light";var meta=document.querySelector('meta[name="color-scheme"]');if(!meta){meta=document.createElement("meta");meta.setAttribute("name","color-scheme");document.head.appendChild(meta);}meta.setAttribute("content",m==="system"?"light dark":m);function upsert(attr,css){var list=document.querySelectorAll("style["+attr+"]");var el=list[0]||document.createElement("style");for(var i=1;i<list.length;i++){list[i].remove();}el.setAttribute(attr,"");el.textContent=css||"";if(!el.parentNode){document.head.appendChild(el);}}upsert("data-nexus-appearance-theme",s.themeCss);upsert("data-nexus-appearance-prefs",s.prefsCss);}catch(e){}})();`;
 }

--- a/packages/core/src/lib/appearance-snapshot.ts
+++ b/packages/core/src/lib/appearance-snapshot.ts
@@ -30,6 +30,13 @@ export interface NexusFirstPaintResolution {
   prefsCss: string;
 }
 
+export interface NexusAppearanceBootstrapScriptOptions {
+  storageKey?: string;
+  defaultSnapshot?: NexusAppearanceSnapshot;
+}
+
+const DEFAULT_STORAGE_KEY = 'nexus-appearance';
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
 
@@ -108,4 +115,22 @@ export function resolveFirstPaint(
     themeCss: snapshot.themeCss,
     prefsCss: snapshot.prefsCss,
   };
+}
+
+function escapeInlineScriptJson(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003C')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+export function createNexusAppearanceBootstrapScript(
+  options: NexusAppearanceBootstrapScriptOptions = {}
+): string {
+  const storageKey = options.storageKey ?? DEFAULT_STORAGE_KEY;
+  const defaultSnapshot = options.defaultSnapshot
+    ? sanitizeNexusAppearanceSnapshot(options.defaultSnapshot)
+    : createDefaultNexusAppearanceSnapshot();
+
+  return `(function(){try{var k=${JSON.stringify(storageKey)};var f=${escapeInlineScriptJson(defaultSnapshot)};var s=f;try{var r=window.localStorage&&window.localStorage.getItem(k);if(r){var p=JSON.parse(r);if(p&&p.version===f.version&&p.state&&typeof p.themeCss==="string"&&typeof p.prefsCss==="string"){s=p;}}}catch(e){}var st=s.state||f.state;var m=st.mode==="dark"||st.mode==="light"||st.mode==="system"?st.mode:f.state.mode;var sys=false;try{sys=m==="system"&&window.matchMedia&&window.matchMedia("(prefers-color-scheme: dark)").matches;}catch(e){}var dark=m==="dark"||sys;var root=document.documentElement;root.classList.toggle("dark",dark);root.setAttribute("data-style",typeof st.density==="string"?st.density:f.state.density);root.setAttribute("data-radius",typeof st.corners==="string"?st.corners:f.state.corners);root.setAttribute("data-shadow",typeof st.elevation==="string"?st.elevation:f.state.elevation);root.setAttribute("data-borderwidth",typeof st.stroke==="string"?st.stroke:f.state.stroke);root.style.colorScheme=dark?"dark":"light";var meta=document.querySelector('meta[name="color-scheme"]');if(!meta){meta=document.createElement("meta");meta.setAttribute("name","color-scheme");document.head.appendChild(meta);}meta.setAttribute("content",m==="system"?"light dark":m);function upsert(attr,css){var list=document.querySelectorAll("style["+attr+"]");var el=list[0]||document.createElement("style");for(var i=1;i<list.length;i++){list[i].remove();}el.setAttribute(attr,"");el.textContent=css||"";if(!el.parentNode){document.head.appendChild(el);}}upsert("data-nexus-appearance-theme",s.themeCss);upsert("data-nexus-appearance-prefs",s.prefsCss);}catch(e){}})();`;
 }

--- a/packages/core/src/lib/appearance-snapshot.ts
+++ b/packages/core/src/lib/appearance-snapshot.ts
@@ -16,6 +16,20 @@ export interface NexusAppearanceSnapshot {
   prefsCss: string;
 }
 
+export interface NexusFirstPaintResolution {
+  className: '' | 'dark';
+  dataAttrs: {
+    'data-style': string;
+    'data-radius': string;
+    'data-shadow': string;
+    'data-borderwidth': string;
+  };
+  colorScheme: 'light' | 'dark';
+  metaColorScheme: 'light' | 'dark' | 'light dark';
+  themeCss: string;
+  prefsCss: string;
+}
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null;
 
@@ -70,4 +84,28 @@ export function sanitizeNexusAppearanceSnapshot(
     deriveThemeCss(state),
     derivePrefsCss(state)
   );
+}
+
+export function resolveFirstPaint(
+  snapshot: NexusAppearanceSnapshot,
+  systemPrefersDark: boolean
+): NexusFirstPaintResolution {
+  const { state } = snapshot;
+  const dark =
+    state.mode === 'dark' ||
+    (state.mode === 'system' && systemPrefersDark === true);
+
+  return {
+    className: dark ? 'dark' : '',
+    dataAttrs: {
+      'data-style': state.density,
+      'data-radius': state.corners,
+      'data-shadow': state.elevation,
+      'data-borderwidth': state.stroke,
+    },
+    colorScheme: dark ? 'dark' : 'light',
+    metaColorScheme: state.mode === 'system' ? 'light dark' : state.mode,
+    themeCss: snapshot.themeCss,
+    prefsCss: snapshot.prefsCss,
+  };
 }

--- a/packages/core/src/lib/appearance-snapshot.ts
+++ b/packages/core/src/lib/appearance-snapshot.ts
@@ -1,0 +1,73 @@
+import {
+  appearancePrefsToCss,
+  createNexusThemeContract,
+  DEFAULT_NEXUS_APPEARANCE,
+  type NexusAppearanceState,
+  sanitizeNexusAppearance,
+} from './appearance-model';
+import { deriveTheme, themeToCss } from './derive-theme';
+
+export const SNAPSHOT_VERSION = 1;
+
+export interface NexusAppearanceSnapshot {
+  version: typeof SNAPSHOT_VERSION;
+  state: NexusAppearanceState;
+  themeCss: string;
+  prefsCss: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+function deriveThemeCss(state: NexusAppearanceState): string {
+  return themeToCss(deriveTheme(createNexusThemeContract(state)));
+}
+
+function derivePrefsCss(state: NexusAppearanceState): string {
+  return appearancePrefsToCss(state.prefs);
+}
+
+export function createNexusAppearanceSnapshot(
+  state: NexusAppearanceState,
+  themeCss: string,
+  prefsCss: string
+): NexusAppearanceSnapshot {
+  return {
+    version: SNAPSHOT_VERSION,
+    state,
+    themeCss,
+    prefsCss,
+  };
+}
+
+export function createDefaultNexusAppearanceSnapshot(): NexusAppearanceSnapshot {
+  return createNexusAppearanceSnapshot(
+    DEFAULT_NEXUS_APPEARANCE,
+    deriveThemeCss(DEFAULT_NEXUS_APPEARANCE),
+    derivePrefsCss(DEFAULT_NEXUS_APPEARANCE)
+  );
+}
+
+export function sanitizeNexusAppearanceSnapshot(
+  raw: unknown
+): NexusAppearanceSnapshot {
+  if (!isRecord(raw) || !isRecord(raw.state)) {
+    return createDefaultNexusAppearanceSnapshot();
+  }
+
+  const state = sanitizeNexusAppearance(raw.state);
+
+  if (
+    raw.version === SNAPSHOT_VERSION &&
+    typeof raw.themeCss === 'string' &&
+    typeof raw.prefsCss === 'string'
+  ) {
+    return createNexusAppearanceSnapshot(state, raw.themeCss, raw.prefsCss);
+  }
+
+  return createNexusAppearanceSnapshot(
+    state,
+    deriveThemeCss(state),
+    derivePrefsCss(state)
+  );
+}

--- a/packages/react/src/appearance/index.ts
+++ b/packages/react/src/appearance/index.ts
@@ -8,5 +8,10 @@ export type {
   NexusResolvedAppearanceMode,
 } from './provider';
 export { NexusAppearanceProvider, useNexusAppearance } from './provider';
+export type {
+  CreateNexusAppearanceOptions,
+  NexusAppearanceScriptProps,
+} from './script';
+export { createNexusAppearance, NexusAppearanceScript } from './script';
 export type { NexusThemeQuickControlProps } from './theme-quick-control';
 export { NexusThemeQuickControl } from './theme-quick-control';

--- a/packages/react/src/appearance/provider.ssr.test.tsx
+++ b/packages/react/src/appearance/provider.ssr.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment node
+
+import { renderToString } from 'react-dom/server';
+
+import { describe, expect, it } from 'vitest';
+
+import { NexusAppearanceProvider } from './provider';
+
+describe('NexusAppearanceProvider SSR', () => {
+  it('renders without window or document', () => {
+    expect(() =>
+      renderToString(
+        <NexusAppearanceProvider>
+          <span>ok</span>
+        </NexusAppearanceProvider>
+      )
+    ).not.toThrow();
+  });
+});

--- a/packages/react/src/appearance/provider.test.tsx
+++ b/packages/react/src/appearance/provider.test.tsx
@@ -1,8 +1,15 @@
 import type { ComponentProps, ReactNode } from 'react';
 
 import {
+  appearancePrefsToCss,
+  createNexusAppearanceBootstrapScript,
   createNexusAppearanceSnapshot,
+  createNexusThemeContract,
   DEFAULT_NEXUS_APPEARANCE,
+  deriveTheme,
+  type NexusAppearanceState,
+  sanitizeNexusAppearance,
+  themeToCss,
 } from '@nexus/core';
 import { act, render, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -18,10 +25,38 @@ function resetAppearanceDom(): void {
   document.documentElement.style.colorScheme = '';
   document
     .querySelectorAll(
-      'style[data-nexus-appearance-theme], style[data-nexus-appearance-prefs]'
+      'meta[name="color-scheme"], style[data-nexus-appearance-theme], style[data-nexus-appearance-prefs]'
     )
     .forEach((style) => style.remove());
   window.localStorage.clear();
+}
+
+function snapshotFor(state: NexusAppearanceState) {
+  return createNexusAppearanceSnapshot(
+    state,
+    themeToCss(deriveTheme(createNexusThemeContract(state))),
+    appearancePrefsToCss(state.prefs)
+  );
+}
+
+function captureAppearanceDom() {
+  const root = document.documentElement;
+
+  return {
+    dark: root.classList.contains('dark'),
+    style: root.getAttribute('data-style'),
+    radius: root.getAttribute('data-radius'),
+    shadow: root.getAttribute('data-shadow'),
+    borderwidth: root.getAttribute('data-borderwidth'),
+    colorScheme: root.style.colorScheme,
+    metaColorScheme: document.querySelector<HTMLMetaElement>(
+      'meta[name="color-scheme"]'
+    )?.content,
+    themeCss: document.querySelector('style[data-nexus-appearance-theme]')
+      ?.textContent,
+    prefsCss: document.querySelector('style[data-nexus-appearance-prefs]')
+      ?.textContent,
+  };
 }
 
 function wrapperFor(
@@ -61,11 +96,7 @@ describe('NexusAppearanceProvider', () => {
     window.localStorage.setItem(
       'nexus-appearance',
       JSON.stringify(
-        createNexusAppearanceSnapshot(
-          { ...DEFAULT_NEXUS_APPEARANCE, surfaceTone: 'slate' },
-          '',
-          ''
-        )
+        snapshotFor({ ...DEFAULT_NEXUS_APPEARANCE, surfaceTone: 'slate' })
       )
     );
     const seen: string[] = [];
@@ -84,6 +115,104 @@ describe('NexusAppearanceProvider', () => {
 
     expect(seen[0]).toBe('false:stone');
     await waitFor(() => expect(seen[seen.length - 1]).toBe('true:slate'));
+  });
+
+  it('keeps the bootstrap-painted DOM equivalent after provider hydration', async () => {
+    const mediaQuery: MediaQueryList = {
+      matches: true,
+      media: '(prefers-color-scheme: dark)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      addListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      removeEventListener: vi.fn(),
+      removeListener: vi.fn(),
+    };
+    window.matchMedia = vi.fn(() => mediaQuery);
+    window.localStorage.setItem(
+      'nexus-appearance',
+      JSON.stringify(
+        snapshotFor({
+          ...DEFAULT_NEXUS_APPEARANCE,
+          mode: 'system',
+          surfaceTone: 'slate',
+          density: 'nova',
+          corners: 'mellow',
+          elevation: 'nova',
+          stroke: 'nova',
+        })
+      )
+    );
+
+    new Function(createNexusAppearanceBootstrapScript())();
+    const beforeHydration = captureAppearanceDom();
+
+    const { result } = renderHook(() => useNexusAppearance(), {
+      wrapper: wrapperFor(),
+    });
+
+    await waitFor(() => expect(result.current.mounted).toBe(true));
+
+    expect(captureAppearanceDom()).toEqual(beforeHydration);
+    expect(result.current.resolvedMode).toBe('dark');
+  });
+
+  it('repairs readable snapshots against the sanitized state after hydration', async () => {
+    const rawState = {
+      ...DEFAULT_NEXUS_APPEARANCE,
+      mode: 'dark',
+      surfaceTone: 'slate',
+      contrast: 999,
+    };
+    const sanitizedState = sanitizeNexusAppearance(rawState);
+    window.localStorage.setItem(
+      'nexus-appearance',
+      JSON.stringify({
+        version: 1,
+        state: rawState,
+        themeCss: 'STALE',
+        prefsCss: 'STALE',
+      })
+    );
+
+    new Function(createNexusAppearanceBootstrapScript())();
+    expect(
+      document.querySelector('style[data-nexus-appearance-theme]')?.textContent
+    ).toBe('STALE');
+
+    renderHook(() => useNexusAppearance(), {
+      wrapper: wrapperFor(),
+    });
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('style[data-nexus-appearance-theme]')
+          ?.textContent
+      ).toBe(themeToCss(deriveTheme(createNexusThemeContract(sanitizedState))));
+    });
+  });
+
+  it('applies the embedded default theme CSS before the provider mounts', async () => {
+    const defaultThemeCss = themeToCss(
+      deriveTheme(createNexusThemeContract(DEFAULT_NEXUS_APPEARANCE))
+    );
+
+    new Function(createNexusAppearanceBootstrapScript())();
+
+    expect(
+      document.querySelector('style[data-nexus-appearance-theme]')?.textContent
+    ).toBe(defaultThemeCss);
+
+    renderHook(() => useNexusAppearance(), {
+      wrapper: wrapperFor(),
+    });
+
+    await waitFor(() => {
+      expect(
+        document.querySelector('style[data-nexus-appearance-theme]')
+          ?.textContent
+      ).toBe(defaultThemeCss);
+    });
   });
 
   it('injects exactly one theme and prefs style tag across updates', () => {
@@ -136,6 +265,45 @@ describe('NexusAppearanceProvider', () => {
       });
       expect(typeof snapshot.themeCss).toBe('string');
       expect(typeof snapshot.prefsCss).toBe('string');
+    });
+  });
+
+  it('recovers stale snapshot versions through the provider and refreshes storage', async () => {
+    const key = 'stale-appearance';
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        version: 999,
+        state: {
+          ...DEFAULT_NEXUS_APPEARANCE,
+          mode: 'dark',
+          surfaceTone: 'gray',
+        },
+        themeCss: 'STALE',
+        prefsCss: 'STALE',
+      })
+    );
+
+    const { result } = renderHook(() => useNexusAppearance(), {
+      wrapper: wrapperFor({ storageKey: key }),
+    });
+
+    await waitFor(() => expect(result.current.mounted).toBe(true));
+
+    expect(result.current.state).toMatchObject({
+      mode: 'dark',
+      surfaceTone: 'gray',
+    });
+
+    await waitFor(() => {
+      const snapshot = JSON.parse(window.localStorage.getItem(key) ?? '{}');
+
+      expect(snapshot).toMatchObject({
+        version: 1,
+        state: { mode: 'dark', surfaceTone: 'gray' },
+      });
+      expect(snapshot.themeCss).not.toBe('STALE');
+      expect(snapshot.prefsCss).not.toBe('STALE');
     });
   });
 

--- a/packages/react/src/appearance/provider.test.tsx
+++ b/packages/react/src/appearance/provider.test.tsx
@@ -1,7 +1,10 @@
 import type { ComponentProps, ReactNode } from 'react';
 
-import { DEFAULT_NEXUS_APPEARANCE } from '@nexus/core';
-import { act, renderHook } from '@testing-library/react';
+import {
+  createNexusAppearanceSnapshot,
+  DEFAULT_NEXUS_APPEARANCE,
+} from '@nexus/core';
+import { act, render, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { NexusAppearanceProvider, useNexusAppearance } from './provider';
@@ -54,6 +57,35 @@ describe('NexusAppearanceProvider', () => {
     expect(root.style.colorScheme).toBe('light');
   });
 
+  it('first renders default state, then adopts stored state after mount', async () => {
+    window.localStorage.setItem(
+      'nexus-appearance',
+      JSON.stringify(
+        createNexusAppearanceSnapshot(
+          { ...DEFAULT_NEXUS_APPEARANCE, surfaceTone: 'slate' },
+          '',
+          ''
+        )
+      )
+    );
+    const seen: string[] = [];
+
+    function Probe() {
+      const { mounted, state } = useNexusAppearance();
+      seen.push(`${mounted}:${state.surfaceTone}`);
+      return null;
+    }
+
+    render(
+      <NexusAppearanceProvider>
+        <Probe />
+      </NexusAppearanceProvider>
+    );
+
+    expect(seen[0]).toBe('false:stone');
+    await waitFor(() => expect(seen[seen.length - 1]).toBe('true:slate'));
+  });
+
   it('injects exactly one theme and prefs style tag across updates', () => {
     const { result, rerender } = renderHook(() => useNexusAppearance(), {
       wrapper: wrapperFor({ storageKey: false }),
@@ -85,19 +117,25 @@ describe('NexusAppearanceProvider', () => {
     ).toContain('font-size: 16px');
   });
 
-  it('round-trips uncontrolled state through storage', () => {
+  it('writes uncontrolled state as a versioned snapshot', async () => {
     const key = 'test-appearance';
-    const { result, unmount } = renderHook(() => useNexusAppearance(), {
+    const { result } = renderHook(() => useNexusAppearance(), {
       wrapper: wrapperFor({ storageKey: key }),
     });
 
     act(() => {
       result.current.setState((state) => ({ ...state, surfaceTone: 'slate' }));
     });
-    unmount();
 
-    expect(JSON.parse(window.localStorage.getItem(key) ?? '{}')).toMatchObject({
-      surfaceTone: 'slate',
+    await waitFor(() => {
+      const snapshot = JSON.parse(window.localStorage.getItem(key) ?? '{}');
+
+      expect(snapshot).toMatchObject({
+        version: 1,
+        state: { surfaceTone: 'slate' },
+      });
+      expect(typeof snapshot.themeCss).toBe('string');
+      expect(typeof snapshot.prefsCss).toBe('string');
     });
   });
 
@@ -129,6 +167,29 @@ describe('NexusAppearanceProvider', () => {
       expect.objectContaining({ surfaceTone: 'gray' })
     );
     expect(window.localStorage.getItem('controlled-appearance')).toBeNull();
+  });
+
+  it('reuses bootstrap-created style tags instead of stacking duplicates', async () => {
+    const theme = document.createElement('style');
+    theme.setAttribute('data-nexus-appearance-theme', '');
+    theme.textContent = '/* boot theme */';
+    const prefs = document.createElement('style');
+    prefs.setAttribute('data-nexus-appearance-prefs', '');
+    prefs.textContent = '/* boot prefs */';
+    document.head.append(theme, prefs);
+
+    renderHook(() => useNexusAppearance(), {
+      wrapper: wrapperFor({ storageKey: false }),
+    });
+
+    await waitFor(() => {
+      expect(
+        document.querySelectorAll('style[data-nexus-appearance-theme]')
+      ).toHaveLength(1);
+      expect(
+        document.querySelectorAll('style[data-nexus-appearance-prefs]')
+      ).toHaveLength(1);
+    });
   });
 
   it('notifies onStateChange with the composed next state in uncontrolled mode', () => {

--- a/packages/react/src/appearance/provider.tsx
+++ b/packages/react/src/appearance/provider.tsx
@@ -13,11 +13,15 @@ import {
 
 import {
   appearancePrefsToCss,
+  createNexusAppearanceSnapshot,
   createNexusThemeContract,
   DEFAULT_NEXUS_APPEARANCE,
   deriveTheme,
+  type NexusAppearanceSnapshot,
   type NexusAppearanceState,
+  resolveFirstPaint,
   sanitizeNexusAppearance,
+  sanitizeNexusAppearanceSnapshot,
   themeToCss,
 } from '@nexus/core';
 
@@ -25,6 +29,12 @@ const DEFAULT_STORAGE_KEY = 'nexus-appearance';
 const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
 const THEME_STYLE_SELECTOR = 'style[data-nexus-appearance-theme]';
 const PREFS_STYLE_SELECTOR = 'style[data-nexus-appearance-prefs]';
+const APPEARANCE_DATA_ATTRS = [
+  'data-style',
+  'data-radius',
+  'data-shadow',
+  'data-borderwidth',
+] as const;
 
 export type NexusResolvedAppearanceMode = 'light' | 'dark';
 
@@ -32,6 +42,7 @@ export interface NexusAppearanceContextValue {
   state: NexusAppearanceState;
   setState: Dispatch<SetStateAction<NexusAppearanceState>>;
   resolvedMode: NexusResolvedAppearanceMode;
+  mounted: boolean;
   reset: () => void;
 }
 
@@ -50,39 +61,67 @@ const canUseDOM = (): boolean =>
   typeof window !== 'undefined' && typeof document !== 'undefined';
 
 function resolveAppearanceMode(
-  mode: NexusAppearanceState['mode']
+  mode: NexusAppearanceState['mode'],
+  systemPrefersDark = false
 ): NexusResolvedAppearanceMode {
   if (mode === 'dark') return 'dark';
   if (mode === 'light') return 'light';
-  if (!canUseDOM() || typeof window.matchMedia !== 'function') return 'light';
-  return window.matchMedia(COLOR_SCHEME_QUERY).matches ? 'dark' : 'light';
+  return systemPrefersDark ? 'dark' : 'light';
 }
 
-function readStoredState(
+function systemPrefersDark(): boolean {
+  if (!canUseDOM() || typeof window.matchMedia !== 'function') return false;
+  return window.matchMedia(COLOR_SCHEME_QUERY).matches;
+}
+
+function snapshotFromState(
+  state: NexusAppearanceState
+): NexusAppearanceSnapshot {
+  return createNexusAppearanceSnapshot(
+    state,
+    themeToCss(deriveTheme(createNexusThemeContract(state))),
+    appearancePrefsToCss(state.prefs)
+  );
+}
+
+function readStoredSnapshot(
   storageKey: string | false,
-  fallback: NexusAppearanceState
-): NexusAppearanceState {
+  fallback: NexusAppearanceSnapshot
+): NexusAppearanceSnapshot {
   if (!canUseDOM() || storageKey === false) return fallback;
 
   try {
     const raw = window.localStorage.getItem(storageKey);
 
-    return raw ? sanitizeNexusAppearance(JSON.parse(raw)) : fallback;
+    return raw ? sanitizeNexusAppearanceSnapshot(JSON.parse(raw)) : fallback;
   } catch {
     return fallback;
   }
 }
 
-function writeStoredState(
+function writeStoredSnapshot(
   storageKey: string | false,
-  state: NexusAppearanceState
+  snapshot: NexusAppearanceSnapshot
 ): void {
   if (!canUseDOM() || storageKey === false) return;
 
   try {
-    window.localStorage.setItem(storageKey, JSON.stringify(state));
+    window.localStorage.setItem(storageKey, JSON.stringify(snapshot));
   } catch {
     // Storage can fail in privacy modes or quota-constrained embeds.
+  }
+}
+
+function syncColorSchemeMeta(content: 'light' | 'dark' | 'light dark'): void {
+  const meta =
+    document.querySelector<HTMLMetaElement>('meta[name="color-scheme"]') ??
+    document.createElement('meta');
+
+  meta.setAttribute('name', 'color-scheme');
+  meta.setAttribute('content', content);
+
+  if (!meta.parentNode) {
+    document.head.appendChild(meta);
   }
 }
 
@@ -144,10 +183,10 @@ export function NexusAppearanceProvider({
     () => sanitizeNexusAppearance(defaultState ?? DEFAULT_NEXUS_APPEARANCE),
     [defaultState]
   );
-  const [internalState, setInternalState] = useState<NexusAppearanceState>(() =>
-    readStoredState(storageKey, initialState)
-  );
+  const [internalState, setInternalState] =
+    useState<NexusAppearanceState>(initialState);
   const activeState = state ?? internalState;
+  const [mounted, setMounted] = useState(false);
   const [resolvedMode, setResolvedMode] = useState<NexusResolvedAppearanceMode>(
     () => resolveAppearanceMode(activeState.mode)
   );
@@ -159,8 +198,39 @@ export function NexusAppearanceProvider({
     () => appearancePrefsToCss(activeState.prefs),
     [activeState.prefs]
   );
+  const activeSnapshot = useMemo(
+    () => createNexusAppearanceSnapshot(activeState, themeCss, prefsCss),
+    [activeState, prefsCss, themeCss]
+  );
+  const firstPaint = useMemo(
+    () => resolveFirstPaint(activeSnapshot, resolvedMode === 'dark'),
+    [activeSnapshot, resolvedMode]
+  );
 
   const internalStateRef = useRef(internalState);
+
+  useEffect(() => {
+    if (!canUseDOM()) return;
+
+    if (isControlled) {
+      setResolvedMode(
+        resolveAppearanceMode((state ?? initialState).mode, systemPrefersDark())
+      );
+      setMounted(true);
+      return;
+    }
+
+    const snapshot = readStoredSnapshot(
+      storageKey,
+      snapshotFromState(initialState)
+    );
+    internalStateRef.current = snapshot.state;
+    setInternalState(snapshot.state);
+    setResolvedMode(
+      resolveAppearanceMode(snapshot.state.mode, systemPrefersDark())
+    );
+    setMounted(true);
+  }, [initialState, isControlled, state, storageKey]);
 
   const setState = useCallback<Dispatch<SetStateAction<NexusAppearanceState>>>(
     (update) => {
@@ -181,27 +251,28 @@ export function NexusAppearanceProvider({
   }, [initialState, setState]);
 
   useEffect(() => {
-    if (!isControlled) {
-      writeStoredState(storageKey, activeState);
+    if (mounted && !isControlled) {
+      writeStoredSnapshot(storageKey, activeSnapshot);
     }
-  }, [activeState, isControlled, storageKey]);
+  }, [activeSnapshot, isControlled, mounted, storageKey]);
 
   useEffect(() => {
-    if (!canUseDOM()) return;
+    if (!canUseDOM() || !mounted) return;
 
     const root = document.documentElement;
 
-    root.setAttribute('data-style', activeState.density);
-    root.setAttribute('data-radius', activeState.corners);
-    root.setAttribute('data-shadow', activeState.elevation);
-    root.setAttribute('data-borderwidth', activeState.stroke);
-  }, [activeState]);
+    for (const attr of APPEARANCE_DATA_ATTRS) {
+      root.setAttribute(attr, firstPaint.dataAttrs[attr]);
+    }
+  }, [firstPaint, mounted]);
 
   useEffect(() => {
-    if (!canUseDOM()) return;
+    if (!canUseDOM() || !mounted) return;
 
     const apply = () => {
-      setResolvedMode(resolveAppearanceMode(activeState.mode));
+      setResolvedMode(
+        resolveAppearanceMode(activeState.mode, systemPrefersDark())
+      );
     };
 
     apply();
@@ -217,36 +288,37 @@ export function NexusAppearanceProvider({
     mediaQuery.addEventListener('change', apply);
 
     return () => mediaQuery.removeEventListener('change', apply);
-  }, [activeState.mode]);
+  }, [activeState.mode, mounted]);
 
   useEffect(() => {
-    if (!canUseDOM()) return;
+    if (!canUseDOM() || !mounted) return;
 
     const root = document.documentElement;
 
-    root.classList.toggle('dark', resolvedMode === 'dark');
-    root.style.colorScheme = resolvedMode;
-  }, [resolvedMode]);
+    root.classList.toggle('dark', firstPaint.className === 'dark');
+    root.style.colorScheme = firstPaint.colorScheme;
+    syncColorSchemeMeta(firstPaint.metaColorScheme);
+  }, [firstPaint, mounted]);
 
   useEffect(() => {
-    if (!canUseDOM()) return;
+    if (!canUseDOM() || !mounted) return;
 
     const themeStyle = upsertStyle(
       THEME_STYLE_SELECTOR,
       'data-nexus-appearance-theme'
     );
-    themeStyle.textContent = themeCss;
-  }, [themeCss]);
+    themeStyle.textContent = firstPaint.themeCss;
+  }, [firstPaint, mounted]);
 
   useEffect(() => {
-    if (!canUseDOM()) return;
+    if (!canUseDOM() || !mounted) return;
 
     const prefsStyle = upsertStyle(
       PREFS_STYLE_SELECTOR,
       'data-nexus-appearance-prefs'
     );
-    prefsStyle.textContent = prefsCss;
-  }, [prefsCss]);
+    prefsStyle.textContent = firstPaint.prefsCss;
+  }, [firstPaint, mounted]);
 
   useEffect(() => {
     if (!canUseDOM()) return;
@@ -255,8 +327,8 @@ export function NexusAppearanceProvider({
   }, []);
 
   const value = useMemo<NexusAppearanceContextValue>(
-    () => ({ state: activeState, setState, resolvedMode, reset }),
-    [activeState, reset, resolvedMode, setState]
+    () => ({ state: activeState, setState, resolvedMode, mounted, reset }),
+    [activeState, mounted, reset, resolvedMode, setState]
   );
 
   return (

--- a/packages/react/src/appearance/provider.tsx
+++ b/packages/react/src/appearance/provider.tsx
@@ -16,6 +16,7 @@ import {
   createNexusAppearanceSnapshot,
   createNexusThemeContract,
   DEFAULT_NEXUS_APPEARANCE,
+  DEFAULT_STORAGE_KEY,
   deriveTheme,
   type NexusAppearanceSnapshot,
   type NexusAppearanceState,
@@ -25,7 +26,6 @@ import {
   themeToCss,
 } from '@nexus/core';
 
-const DEFAULT_STORAGE_KEY = 'nexus-appearance';
 const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
 const THEME_STYLE_SELECTOR = 'style[data-nexus-appearance-theme]';
 const PREFS_STYLE_SELECTOR = 'style[data-nexus-appearance-prefs]';
@@ -74,26 +74,18 @@ function systemPrefersDark(): boolean {
   return window.matchMedia(COLOR_SCHEME_QUERY).matches;
 }
 
-function snapshotFromState(
-  state: NexusAppearanceState
-): NexusAppearanceSnapshot {
-  return createNexusAppearanceSnapshot(
-    state,
-    themeToCss(deriveTheme(createNexusThemeContract(state))),
-    appearancePrefsToCss(state.prefs)
-  );
-}
-
-function readStoredSnapshot(
+function readStoredState(
   storageKey: string | false,
-  fallback: NexusAppearanceSnapshot
-): NexusAppearanceSnapshot {
+  fallback: NexusAppearanceState
+): NexusAppearanceState {
   if (!canUseDOM() || storageKey === false) return fallback;
 
   try {
     const raw = window.localStorage.getItem(storageKey);
 
-    return raw ? sanitizeNexusAppearanceSnapshot(JSON.parse(raw)) : fallback;
+    return raw
+      ? sanitizeNexusAppearanceSnapshot(JSON.parse(raw)).state
+      : fallback;
   } catch {
     return fallback;
   }
@@ -220,15 +212,10 @@ export function NexusAppearanceProvider({
       return;
     }
 
-    const snapshot = readStoredSnapshot(
-      storageKey,
-      snapshotFromState(initialState)
-    );
-    internalStateRef.current = snapshot.state;
-    setInternalState(snapshot.state);
-    setResolvedMode(
-      resolveAppearanceMode(snapshot.state.mode, systemPrefersDark())
-    );
+    const nextState = readStoredState(storageKey, initialState);
+    internalStateRef.current = nextState;
+    setInternalState(nextState);
+    setResolvedMode(resolveAppearanceMode(nextState.mode, systemPrefersDark()));
     setMounted(true);
   }, [initialState, isControlled, state, storageKey]);
 

--- a/packages/react/src/appearance/script.test.tsx
+++ b/packages/react/src/appearance/script.test.tsx
@@ -1,0 +1,55 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { DEFAULT_NEXUS_APPEARANCE } from '@nexus/core';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useNexusAppearance } from './provider';
+import { createNexusAppearance, NexusAppearanceScript } from './script';
+
+describe('NexusAppearanceScript', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders the bootstrap script with nonce and storage key', () => {
+    const html = renderToStaticMarkup(
+      <NexusAppearanceScript
+        nonce="nonce-1"
+        storageKey="custom-appearance"
+        defaultState={{ ...DEFAULT_NEXUS_APPEARANCE, mode: 'dark' }}
+      />
+    );
+
+    expect(html).toContain('nonce="nonce-1"');
+    expect(html).toContain('custom-appearance');
+    expect(html).toContain('data-nexus-appearance-script');
+  });
+
+  it('creates a provider and script closed over the same config', async () => {
+    const appearance = createNexusAppearance({
+      storageKey: 'factory-appearance',
+      defaultState: { ...DEFAULT_NEXUS_APPEARANCE, surfaceTone: 'slate' },
+    });
+
+    const html = renderToStaticMarkup(
+      <appearance.NexusAppearanceScript nonce="nonce-2" />
+    );
+    expect(html).toContain('factory-appearance');
+
+    const { result } = renderHook(() => useNexusAppearance(), {
+      wrapper: ({ children }) => (
+        <appearance.NexusAppearanceProvider>
+          {children}
+        </appearance.NexusAppearanceProvider>
+      ),
+    });
+
+    await waitFor(() => expect(result.current.mounted).toBe(true));
+
+    const snapshot = JSON.parse(
+      window.localStorage.getItem('factory-appearance') ?? '{}'
+    );
+    expect(snapshot.state.surfaceTone).toBe('slate');
+  });
+});

--- a/packages/react/src/appearance/script.tsx
+++ b/packages/react/src/appearance/script.tsx
@@ -1,13 +1,9 @@
 import {
-  appearancePrefsToCss,
+  createDefaultNexusAppearanceSnapshot,
   createNexusAppearanceBootstrapScript,
-  createNexusAppearanceSnapshot,
-  createNexusThemeContract,
-  DEFAULT_NEXUS_APPEARANCE,
-  deriveTheme,
+  createNexusAppearanceSnapshotFromState,
   type NexusAppearanceState,
   sanitizeNexusAppearance,
-  themeToCss,
 } from '@nexus/core';
 
 import {
@@ -32,15 +28,11 @@ type ConfiguredProviderProps = Omit<
 >;
 
 function defaultSnapshotFor(defaultState: NexusAppearanceState | undefined) {
-  const state = sanitizeNexusAppearance(
-    defaultState ?? DEFAULT_NEXUS_APPEARANCE
-  );
-
-  return createNexusAppearanceSnapshot(
-    state,
-    themeToCss(deriveTheme(createNexusThemeContract(state))),
-    appearancePrefsToCss(state.prefs)
-  );
+  return defaultState
+    ? createNexusAppearanceSnapshotFromState(
+        sanitizeNexusAppearance(defaultState)
+      )
+    : createDefaultNexusAppearanceSnapshot();
 }
 
 export function NexusAppearanceScript({

--- a/packages/react/src/appearance/script.tsx
+++ b/packages/react/src/appearance/script.tsx
@@ -1,0 +1,100 @@
+import {
+  appearancePrefsToCss,
+  createNexusAppearanceBootstrapScript,
+  createNexusAppearanceSnapshot,
+  createNexusThemeContract,
+  DEFAULT_NEXUS_APPEARANCE,
+  deriveTheme,
+  type NexusAppearanceState,
+  sanitizeNexusAppearance,
+  themeToCss,
+} from '@nexus/core';
+
+import {
+  NexusAppearanceProvider,
+  type NexusAppearanceProviderProps,
+} from './provider';
+
+export interface NexusAppearanceScriptProps {
+  storageKey?: string;
+  defaultState?: NexusAppearanceState;
+  nonce?: string;
+}
+
+export interface CreateNexusAppearanceOptions {
+  storageKey?: string;
+  defaultState?: NexusAppearanceState;
+}
+
+type ConfiguredProviderProps = Omit<
+  NexusAppearanceProviderProps,
+  'storageKey' | 'defaultState'
+>;
+
+function defaultSnapshotFor(defaultState: NexusAppearanceState | undefined) {
+  const state = sanitizeNexusAppearance(
+    defaultState ?? DEFAULT_NEXUS_APPEARANCE
+  );
+
+  return createNexusAppearanceSnapshot(
+    state,
+    themeToCss(deriveTheme(createNexusThemeContract(state))),
+    appearancePrefsToCss(state.prefs)
+  );
+}
+
+export function NexusAppearanceScript({
+  storageKey,
+  defaultState,
+  nonce,
+}: NexusAppearanceScriptProps) {
+  return (
+    <script
+      data-nexus-appearance-script=""
+      nonce={nonce}
+      dangerouslySetInnerHTML={{
+        __html: createNexusAppearanceBootstrapScript({
+          storageKey,
+          defaultSnapshot: defaultSnapshotFor(defaultState),
+        }),
+      }}
+    />
+  );
+}
+
+export function createNexusAppearance({
+  storageKey,
+  defaultState,
+}: CreateNexusAppearanceOptions = {}) {
+  function ConfiguredNexusAppearanceProvider({
+    children,
+    ...props
+  }: ConfiguredProviderProps) {
+    return (
+      <NexusAppearanceProvider
+        {...props}
+        storageKey={storageKey}
+        defaultState={defaultState}
+      >
+        {children}
+      </NexusAppearanceProvider>
+    );
+  }
+
+  function ConfiguredNexusAppearanceScript({
+    nonce,
+  }: Pick<NexusAppearanceScriptProps, 'nonce'>) {
+    return (
+      <NexusAppearanceScript
+        nonce={nonce}
+        storageKey={storageKey}
+        defaultState={defaultState}
+      />
+    );
+  }
+
+  return {
+    NexusAppearanceProvider: ConfiguredNexusAppearanceProvider,
+    NexusAppearanceScript: ConfiguredNexusAppearanceScript,
+  };
+}

--- a/packages/test-utils/src/setup.ts
+++ b/packages/test-utils/src/setup.ts
@@ -15,20 +15,22 @@ class ResizeObserverMock {
 
 globalThis.ResizeObserver = ResizeObserverMock;
 
-// Mock matchMedia for responsive components
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: (query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }),
-});
+if (typeof window !== 'undefined') {
+  // Mock matchMedia for responsive components
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
 
 // Mock IntersectionObserver for lazy-loading components
 class IntersectionObserverMock {

--- a/reports/phase-c-plan-council-review.md
+++ b/reports/phase-c-plan-council-review.md
@@ -1,0 +1,87 @@
+# Phase C Plan — Council Review
+
+**Plan reviewed:** "Phase C: Appearance First-Paint Bootstrap" (by Codex)
+**Method:** 5-agent council (architect / sde2 / tester / omissions-sweep / adversarial refuter), reviewed against the **real Phase B in PR #536** (`codex/phase-b-appearance-package`, OPEN) — not the Phase B plan — plus the authoritative Modern Web Guidance `dark-mode` + `flicker-free` guides. (One agent — the sde2 implementation-feasibility lens — stalled on an API error mid-run; its scope was partially recovered by the architect (bundle/React-19) and tester (style-tag contract) agents, and the gaps it would have owned are flagged below.)
+
+**Verdict:** **The hard parts are right; the plan is under-specified and ships its headline guarantee unverified.** Codex's two riskiest-looking decisions (parser-blocking non-module script; `color-scheme` meta sync) are **correct and backed by primary sources** — I had two findings that the council/MWG **refuted**, reported in §4. The real problems are a dropped SSR-setup deliverable and a scattered design that one refactor would fix.
+
+---
+
+## A note on calibration (read this first — it's the trust point)
+
+Three findings did **not** survive verification — two of my own, one the council raised — and I'm leading with them rather than burying them:
+
+- **"The `color-scheme` meta is wrong for system mode" — REFUTED.** The MWG `dark-mode` guide makes `<meta name="color-scheme" content="light dark">` for system (and `light`/`dark` pinned) **MANDATORY** — it's the no-JS, parse-time FOUC floor (guide L11, L124, L129, L132). Codex's meta sync is the canonical pattern. (One council agent also argued "drop the meta" — it was wrong too; the primary source settles it.)
+- **"The provider must read initial state from the DOM" (epic L103) — REFUTED.** The bootstrap stamps only `.dark` + 4 `data-*` axes + an **opaque, one-way-derived** `<style>`. `brandColor`, `surfaceTone`, `contrast`, and all `prefs` are **not reconstructable** from the DOM. So Phase B's `useState(() => readStoredState(...))` (localStorage, client-only via `canUseDOM`) is **CSR-correct**, and omitting the epic's instruction is right, not a defect. The epic contradicts itself here (its own resolver L110 takes the "persisted payload," i.e. localStorage). The remaining nuance is purely about SSR: a client-only initializer read makes the first client render diverge from the server's default render — so an SSR host needs init-to-default + read-storage-in-a-mount-effect + a `mounted` guard for consumers. That's a **documented future requirement** (no in-scope appearance consumer is SSR yet — see C-B1), not a current provider rewrite.
+
+- **"Reduced-motion FOUC at first paint" (council omissions sweep) — CUT.** The claim was that `reduceMotion: 'system'` users would see full-speed animation before the provider mounts. But Nexus components honor `@media (prefers-reduced-motion: reduce)` **natively** (`packages/react/src/index.css` + tabs, drawer, tooltip, navigation-menu, progress, …) — parse-time, zero JS, zero flash. So system mode needs no bootstrap action; the finding was wrong. `appearancePrefsToCss` correctly emits a reduction block only for the explicit `'on'` override.
+
+A review that only piles on isn't trustworthy. These were real candidates that the evidence killed — including one the council surfaced that I vetted rather than forwarded.
+
+---
+
+## 1. Blocking (verified — resolve before implementation)
+
+### C-B1. The no-flash guarantee is **structurally unverifiable** in this phase, and the host-setup Docs deliverable (epic L104) is dropped
+
+This is the load-bearing gap. The whole phase exists to prove "no flash / no hydration mismatch before React," yet **no in-scope consumer of the appearance API is server-rendered**, so nothing exercises it:
+
+- `apps/console` (the Phase D dogfood) is **CSR** — `apps/console/src/main.tsx` uses `createRoot` (Vite SPA), so there is no hydration and a mismatch is structurally invisible.
+- `apps/docs` runs Next.js, but it **self-themes with its own bootstrap** (`apps/docs/app/_components/ThemeBootstrap.tsx` → `DOCS_THEME_BOOTSTRAP_SCRIPT`, attribute `data-nexus-theme-bootstrap`) and does **not** consume `@nexus/react/appearance` (verified: no `NexusAppearance*` / `nexus-appearance` refs in `apps/docs`). So it is _not_ the host the appearance bootstrap "should have been wired" into — it's a separate theming workstream.
+- **jsdom can't see it either.** The `unit` vitest project is jsdom (no paint timing); Storybook/Playwright play-functions run **after** mount. There is no in-repo first-paint-timing harness (no raw `@playwright/test`, no `renderToString`/`hydrateRoot`). So "bootstrap applies before React" is asserted by a test that cannot observe "before React."
+- **The shippable artifact is wrong for SSR.** `NexusAppearanceScript` as a React-tree component gives no first-paint guarantee on Next: React 19 dedupes `<script src>` but **not** inline `dangerouslySetInnerHTML` scripts, and a client-rendered inline script doesn't run parser-blocking. The usable SSR artifact is `createNexusAppearanceBootstrapScript()` injected into the **root-layout `<head>`** — the classic-inline-script-in-head pattern the repo already blesses (docs' own `ThemeBootstrap.tsx` is the live proof). The plan ships both and never says which an SSR host uses.
+
+**Fix:** build the provider **SSR-safe by construction** (init-to-default + read-storage-in-a-mount-effect + a `mounted` guard for consumers — paralleling how the epic deferred console dogfood to D) and **restore the epic-L104 Docs deliverable**: `<head>` injection of the string factory + `suppressHydrationWarning` on `<html>` + the manual no-flash check. The point isn't that an existing SSR host was dropped — it's that the guarantee is **unbuilt and unverifiable** until an SSR consumer exists, so it must be made correct by construction and documented, not asserted by a jsdom test.
+
+### C-B2. First-visit default has no specified source, and the static baseline ≠ the runtime default (C4, recalibrated)
+
+On first visit (empty storage) the appearance default derives a **blue** primary (`brandColor #339cff` → `oklch(0.46 0.16 251)`), but the shipped `nexus.css` `:root` light primary is `var(--nx-color-black-base)` — **achromatic** (`nexus.css:106`; the `--brand=black` build default). Empirically confirmed in the compiled `apps/docs` CSS: light `:root` primary = black-base, `.dark` = white-base. So first paint flips **near-black → blue** unless the script materializes the default theme CSS before paint — and it **cannot** lean on `nexus.css`, which is achromatic.
+
+Recalibration (the council corrected my framing): the embedded default CSS is **12,228 bytes raw but ~1,666 bytes gzipped**, and **returning users self-carry `themeCss` in their own snapshot**, so "too big for a small script" is **not** the real issue. The real issue is two-fold and unspecified:
+
+1. The plan asserts "default snapshot applied before React" but never says **where the first-visit default `themeCss` comes from** — a script-embedded constant, a server-rendered `<style data-nexus-appearance-theme>`, or an aligned baseline.
+2. The static baseline (`--brand=black`) and the runtime default (`#339cff`) **must be generated from one canonical state** and currently diverge. Reject "embed ~full default CSS into every page" — pay a build-time fix, not a perpetual runtime cost. **Align `nexus.css :root` with `themeToCss(deriveTheme(createNexusThemeContract(DEFAULT_NEXUS_APPEARANCE)))`** as a small precursor (only `brandColor` diverges — `surfaceTone` already agrees at `stone`; `--brand=black` looks like a stale `build:tailwind` placeholder predating the blue-locked decision). Then first-visit needs **zero** per-user CSS and "small script" holds. The blue-vs-achromatic brand identity call is the owner's, but "one canonical source" is not optional.
+
+---
+
+## 2. Should-fix
+
+**Extract the pure resolver — the keystone the epic mandates and the plan omits (NEW, architect).** Epic L110 requires a unit-tested pure resolver; the plan never names it. Make one engine-free `resolveFirstPaint(snapshot, systemPrefersDark) → { className, dataAttrs, colorScheme, themeCss, prefsCss }` (CSS read **from the stored snapshot**, no engine). Build the bootstrap **script** as a thin DOM-applier over it, and the **provider's mount-init** on the same function. Then: script and provider agree **by construction** (kills the dual-`defaultState` drift), stored CSS == applied CSS (kills the hydration-time repaint), and snapshot parse/sanitize/version-gate live in one place. This single refactor collapses three separate findings.
+
+**`version` must gate the CSS cache, never the state (C3).** The snapshot's `themeCss`/`prefsCss` are a **derived cache** for the next load's engine-free script; `state` is the source of truth and the provider already re-derives via `useMemo` (it never reads stored CSS). So on version mismatch: **recover + `sanitizeNexusAppearance(state)`** (one correcting paint), discard only the cached CSS — **never** reset state. The plan's "wrong version → fall back to the default snapshot" **permanently loses the user's theme** on any engine bump. (`sanitizeNexusAppearance` already does field-by-field recovery, so `version` is semantically an _engine/CSS-cache_ token, not a state-schema token.)
+
+**Drop the dual-read backcompat shim (C5).** "Read both snapshot and raw Phase B state" is a migration shim. #536 is **unmerged** → the raw format has **zero** persisted users; pre-prod (`project-stage.md`) + epic L134 make reset-to-default explicitly acceptable. Snapshot is the only format; `sanitizeNexusAppearance` resets anything else.
+
+**Don't re-derive CSS the provider already holds (NEW, architect).** The provider memoizes `themeCss`/`prefsCss` for its live `<style>` tags; a separate `createNexusAppearanceSnapshot(state)` that calls `themeToCss(deriveTheme(...))` **again** does two derivations per change that must stay byte-identical. Pass the memoized CSS in: `createNexusAppearanceSnapshot(state, themeCss, prefsCss)`.
+
+**Pin the `<style>` reuse contract (C12).** The bootstrap's `<style>` tags **must** carry the exact attributes the provider's `upsertStyle` queries — `data-nexus-appearance-theme` / `data-nexus-appearance-prefs` (`provider.tsx`) — or the provider **stacks a second tag** on mount → two conflicting style tags, source-order paint = flash. Specify and test this.
+
+**Test plan — the headline tests are missing or unrunnable (tester).** Map each epic acceptance (L110-112) to a real vehicle: (a) the **pure resolver** unit (above) — plain vitest, deterministic, no `eval` of a stringified script; (b) **byte-for-byte** equivalence — mount the provider over a seeded snapshot and assert `styleEl.textContent === snapshot.themeCss` (the provider's mount effect overwrites the bootstrap CSS with re-derived CSS off the **sanitized** state, so any drift = repaint), and run it on the **DEFAULT** fixture to pin C-B2; (c) **provider renders without `window`** — a `// @vitest-environment node` + `renderToString` test (epic L111); (d) **no-flash** — an explicit **manual** step (stored-dark → hard refresh → observe), since neither jsdom nor play-functions can see first paint; (e) the **style-tag reuse** test (pre-create the bootstrap's tag, mount, assert exactly one + content stable); (f) **version-mismatch recovery** (valid non-default state at `version:999` → mounts to that state, not default); (g) reuse the existing `matchMedia` override pattern (the shared mock hardcodes `matches:false`). Don't author the "reads raw Phase B state" test — it's deleted with the C5 shim.
+
+**Add the mandated Modern Web Guidance section (process).** The plan has none, despite being a pure browser-platform feature. Its decisions are correct — but document the parser-blocking rationale and cite the gate (`dark-mode`, `flicker-free-client-side-ab-testing`).
+
+---
+
+## 3. Minor
+
+- **"Reject unsafe CSS" is theater (C10).** Same-origin `localStorage` is writable only by your own code or an XSS that already won. Drop the arbitrary-CSS validation; rely on `state` sanitization + `textContent` (already planned). If kept, specify a concrete structural allowlist and test _that_.
+- **CSP `nonce` threading unspecified** — does `createNexusAppearanceBootstrapScript({ nonce })` accept it; which tag receives it?
+- **Storage quota** — the snapshot is 2-5× the Phase B state (it carries `themeCss`+`prefsCss`); note quota/privacy-mode failure (pre-prod-acceptable if documented).
+- **API inconsistency** — `sanitizeNexusAppearanceSnapshot(raw, fallbackState?)` adds a fallback param `sanitizeNexusAppearance(raw)` lacks (the resolver removes the need); branch `codex/…` vs the `{username}/…` convention.
+- **sde2 lens gap** — the stalled agent would have owned the generator's full escaping set (beyond `</script>`: `<!--`, `<![CDATA[`, U+2028/U+2029); worth a pass before implementation.
+
+---
+
+## 4. What the plan got RIGHT (primary-source-verified — not faint praise)
+
+- **Parser-blocking, non-module inline `<head>` script, no `blocking="render"`** — exactly correct. MWG `dark-mode` L134 prescribes "an inline script (NOT `type=module`, NOT `defer`)"; `blocking="render"` is unsupported across the **entire** Safari 15.4 floor (Safari shipped it in 18.2) and all Firefox, so the A/B-guide's module+`blocking` pattern would flash on most of the floor. The repo already blesses this exact pattern — `apps/docs/app/_components/ThemeBootstrap.tsx` is a live classic-inline-`dangerouslySetInnerHTML`-script (docs' _own_ bootstrap, not the appearance one, but proof the pattern is the repo's chosen approach).
+- **`color-scheme` `<meta>` sync** (system → `light dark`, pinned → `light`/`dark`) — MWG-**mandatory** and the no-JS FOUC floor. Correct.
+- **Pre-deriving CSS into the snapshot so the inline script ships no engine** — the right data/applier split; cleanly satisfies "don't inline OKLCH/APCA."
+- **`textContent` not `innerHTML`; `</script>` and `light-dark(` absence tests** — sound security and Safari-floor instincts.
+- **Controlled mode stays persistence-free; one storage key** — consistent with Phase B, no key sprawl.
+
+---
+
+## 5. Net recommendation
+
+The mechanism choices are right and well-judged — the review's job here was mostly to **verify** them (and to retract two of my own findings that didn't hold). The plan is not yet executable because it (C-B1) drops the SSR host-setup Docs deliverable and therefore ships its headline no-flash guarantee unverified, and (C-B2) leaves the first-visit default CSS source unspecified atop a static-vs-runtime brand-default divergence. Both are closed cleanly by: extract the **pure resolver** (keystone), **align the shipped brand default** with the appearance default (small precursor), restore the **host-setup docs + a manual/SSR no-flash check**, and make `version` gate the CSS cache (recover state, never reset). Do those and Phase C is sound.


### PR DESCRIPTION
## Summary

Part of #531.

Phase C adds first-paint-safe appearance bootstrapping so hosts can apply persisted Nexus appearance before React mounts.

- Add versioned `NexusAppearanceSnapshot` storage with pre-derived theme/prefs CSS.
- Add an engine-free first-paint resolver and classic inline bootstrap script factory in `@nexus/core`.
- Make the React appearance provider SSR-safe: deterministic first render, post-mount snapshot adoption, `mounted` flag, snapshot persistence, and bootstrap style-tag reuse.
- Add `NexusAppearanceScript` and `createNexusAppearance()` so provider and script share one config.
- Add host setup docs for Next.js/App Router and plain HTML hosts, including manual no-flash QA.

## Notes

Task 7's brand-baseline decision is documented, not changed here: the static `nexus.css` baseline remains the non-appearance fallback, and the bootstrap embeds the default appearance CSS snapshot for first-visit no-flash behavior.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:unit` - 37 files, 687 tests passed
- `pnpm --filter @nexus/core build`
- `pnpm --filter @nexus/react build`
- `pnpm size-limit`
- `pnpm audit:browser-support`
- tracked-file Prettier check via `git ls-files ... | xargs pnpm exec prettier --check`
- generated bootstrap script scan for engine references and unsafe script markers

Local note: root `pnpm format:check` sees unrelated untracked scratch markdown in this checkout, so the tracked-file Prettier check is the relevant PR signal.
