### PR TITLE
fix(react): settle control sizing contract

### DIFF
--- a/.claude/rules/components.md
+++ b/.claude/rules/components.md
@@ -9,7 +9,6 @@
 | Principle                 | Why                                                              |
 | ------------------------- | ---------------------------------------------------------------- |
 | **Semantic tokens only**  | Enables theming; primitives are implementation details           |
-| **Padding-based sizing**  | Fixed heights break in flex layouts                              |
 | **Data attributes**       | Enable CSS hooks for testing, styling, and state inspection      |
 | **CVA for enum variants** | Clear variant-to-class mapping; boolean logic stays in component |
 | **Named interfaces**      | Self-documenting; enables JSDoc; better IDE experience           |
@@ -75,9 +74,30 @@ Semantic color tokens adapt to theme automatically. Do not write `dark:` modifie
 
 ## Sizing Convention
 
-Use padding for sizing, not fixed heights (`nx:px-4 nx:py-2`, not `nx:h-10 nx:px-4`) — fixed heights break in flex layouts. **Exceptions:** avatars, progress bars, modals may need fixed dimensions.
+This table records component surfaces with an explicit sizing contract. It is
+not a complete component inventory. For an unlisted component or surface,
+inspect its source and define or update its contract in the same PR before
+changing sizing.
 
-**Touch targets (mobile-first):** interactive controls must clear a **~44px minimum tap-target** — tune `nx:p-*` so the rendered hit area meets it (or extend it with an `::after` overlay), not by shrinking the control. See [responsive.md § Touch targets](responsive.md#touch-targets).
+| Component surface             | Visual box                                                        | Inline spacing                                    | Width contract                                 |
+| ----------------------------- | ----------------------------------------------------------------- | ------------------------------------------------- | ---------------------------------------------- |
+| `Button` text sizes           | `sm/default/lg`: `nx:h-8` / `nx:h-10` / `nx:h-12`                 | `nx:px-2.5` / `nx:px-3` / `nx:px-3.5`, `nx:gap-1` | Content-width; no base `min-w-*` floor         |
+| `Button` icon sizes           | `icon-sm/icon/icon-lg`: `nx:size-8` / `nx:size-10` / `nx:size-12` | `nx:p-0`, `nx:gap-0`                              | Square visual box                              |
+| `Input`                       | `sm/default/lg`: `nx:h-8` / `nx:h-10` / `nx:h-12`                 | `nx:px-2.5` / `nx:px-3` / `nx:px-3.5`, `nx:py-0`  | Layout-controlled `nx:w-full`                  |
+| `SelectTrigger`               | default only: `nx:h-10`                                           | `nx:px-3`, `nx:py-0`, `nx:gap-2`                  | Layout-controlled `nx:w-full`                  |
+| `ButtonGroupText`             | `sm/default/lg`: `nx:h-8` / `nx:h-10` / `nx:h-12`                 | `nx:px-2.5` / `nx:px-3` / `nx:px-3.5`, `nx:gap-2` | Content-width addon                            |
+| `Button` inside `ButtonGroup` | Inherits the `Button` row through `ButtonGroupSizeContext`        | Inherits the `Button` row                         | Same as the `Button` row                       |
+| `Textarea`                    | `nx:min-h-16`                                                     | `nx:px-3`, `nx:py-2`                              | Layout-controlled `nx:w-full`; rows may expand |
+
+Button minimum widths are intentionally not part of the base variant contract.
+If a future product surface needs a minimum labeled action width, add a
+component-specific class or API at that surface so the width cannot leak onto
+icon-only or composed Buttons.
+
+**Touch targets (mobile-first):** interactive components must clear a **~44px
+minimum tap-target**. A visual box may be denser on pointer-fine surfaces; for
+touch, use padding where it fits or a coarse-pointer hit-area overlay such as an
+`::after` inset. See [responsive.md § Touch targets](responsive.md#touch-targets).
 
 ## Responsive behaviour
 

--- a/.claude/rules/responsive.md
+++ b/.claude/rules/responsive.md
@@ -23,9 +23,16 @@ Nexus is designed **mobile-first and desktop-first**: **Narrow (mobile) and Stan
 
 ## Touch targets
 
-Both Narrow (mobile) and Standard (desktop) are first-class, so every interactive control must be comfortably **tappable**, not just clickable. **Minimum interactive target: ~44px** (WCAG 2.5.5 Target Size · Apple HIG 44pt; Material's 48dp is the roomier bar). This is a **hit-area floor, not a visual-size mandate** — a control may look smaller as long as its tappable area clears ~44px on touch (extend it with padding, or an `::after` hit-area overlay as Sidebar does with `nx:after:-inset-2`).
-
-Because Nexus sizes by padding, not fixed height (see [components.md § Sizing Convention](components.md#sizing-convention)), meet the floor with padding — `nx:p-*` tuned so the rendered hit area reaches ~44px — not a hardcoded `nx:h-11`. Pointer-fine surfaces (mouse) may render denser; the touch case sets the floor.
+Both Narrow (mobile) and Standard (desktop) are first-class, so every interactive
+component must be comfortably **tappable**, not just clickable. **Minimum
+interactive target: ~44px** (WCAG 2.5.5 Target Size · Apple HIG 44pt;
+Material's 48dp is the roomier bar). This is a **hit-area floor, not a
+visual-size mandate** — a component may look smaller as long as its tappable
+area clears ~44px on touch. Component visual sizes are defined in
+[components.md § Sizing Convention](components.md#sizing-convention); this
+section only governs the extra hit area. For touch, extend the hit area with
+padding where it fits or with a coarse-pointer `::after` overlay such as
+Sidebar's `nx:after:-inset-2` pattern.
 
 ## Decision tree — which responsive mechanism
 

--- a/.claude/rules/shadcn-divergences.md
+++ b/.claude/rules/shadcn-divergences.md
@@ -5,19 +5,18 @@
 
 ## Quick Reference
 
-| Category           | shadcn/ui              | Nexus                                  |
-| ------------------ | ---------------------- | -------------------------------------- |
-| CSS Prefix         | none                   | `nx:`                                  |
-| Token path         | `bg-primary`           | `nx:bg-primary-background`             |
-| Destructive naming | `destructive`          | `error`                                |
-| Hover states       | `hover:bg-primary/90`  | `nx:hover:bg-primary-background-hover` |
-| Accent (hover)     | `hover:bg-accent`      | `nx:hover:bg-background-hover`         |
-| Card/container     | `bg-card`              | `nx:bg-container`                      |
-| Border input       | `border-input`         | `nx:border-border-default`             |
-| Focus ring         | `ring-ring`            | `nx:outline-focus-default`             |
-| Overlay            | `bg-black/80`          | `nx:bg-overlay`                        |
-| Component sizing   | Fixed heights (`h-10`) | Padding-based (`px-4 py-2`)            |
-| Data attributes    | Optional               | Required                               |
+| Category           | shadcn/ui             | Nexus                                  |
+| ------------------ | --------------------- | -------------------------------------- |
+| CSS Prefix         | none                  | `nx:`                                  |
+| Token path         | `bg-primary`          | `nx:bg-primary-background`             |
+| Destructive naming | `destructive`         | `error`                                |
+| Hover states       | `hover:bg-primary/90` | `nx:hover:bg-primary-background-hover` |
+| Accent (hover)     | `hover:bg-accent`     | `nx:hover:bg-background-hover`         |
+| Card/container     | `bg-card`             | `nx:bg-container`                      |
+| Border input       | `border-input`        | `nx:border-border-default`             |
+| Focus ring         | `ring-ring`           | `nx:outline-focus-default`             |
+| Overlay            | `bg-black/80`         | `nx:bg-overlay`                        |
+| Data attributes    | Optional              | Required                               |
 
 ## Token Architecture
 
@@ -296,14 +295,20 @@ The Nexus `overlay` token has built-in opacity appropriate for modal overlays.
 
 ### Sizing
 
-| shadcn             | Nexus               | Notes                |
-| ------------------ | ------------------- | -------------------- |
-| `h-10 px-4 py-2`   | `nx:px-4 nx:py-2`   | Remove fixed heights |
-| `h-9 px-3`         | `nx:px-3 nx:py-1.5` | Padding-based        |
-| `h-11 px-8`        | `nx:px-8 nx:py-3`   | Padding-based        |
-| `h-10 w-10` (icon) | `nx:p-2.5`          | Square padding       |
+Use [components.md § Sizing Convention](components.md#sizing-convention) for
+surfaces with an explicit sizing contract. The examples below are translations
+for listed surfaces, not general defaults for every adapted component.
 
-**Why:** Fixed heights break in flex layouts. Padding-based sizing is more robust.
+| shadcn             | Nexus                       | Applies to                                 |
+| ------------------ | --------------------------- | ------------------------------------------ |
+| `h-10 px-4 py-2`   | `nx:h-10 nx:px-3 nx:py-0`   | Default `Button`, `Input`, `SelectTrigger` |
+| `h-9 px-3`         | `nx:h-8 nx:px-2.5 nx:py-0`  | Compact `Button` and `Input`               |
+| `h-11 px-8`        | `nx:h-12 nx:px-3.5 nx:py-0` | Large `Button` and `Input`                 |
+| `h-10 w-10` (icon) | `nx:size-10 nx:p-0`         | Default icon-only `Button`                 |
+
+For any adapted component not listed there, do not copy a row by analogy.
+Inspect the component, choose the contract explicitly, and update the table in
+the same PR.
 
 ### Data Attributes (Required)
 
@@ -354,7 +359,7 @@ When adapting shadcn components:
 
 ### Component Structure
 
-- [ ] Remove fixed heights (`h-10`, `h-9`, `h-11`), use padding
+- [ ] Match sizing to `components.md` § Sizing Convention; add a row there before introducing a new sizing contract
 - [ ] Add `data-slot`, `data-variant`, `data-size` attributes
 - [ ] Keep variant prop names unchanged (`destructive` not `error`)
 

--- a/RTK.md
+++ b/RTK.md
@@ -105,7 +105,8 @@ Tailwind conventions:
 - Put `nx:` before modifiers: `nx:hover:*`, `nx:md:*`, `nx:[&>svg]:*`.
 - Use semantic token utilities, not raw primitives, in component code.
 - Do not add `dark:` modifiers to semantic token utilities; semantic tokens already adapt by theme.
-- Prefer padding-based sizing over fixed heights, except for components where fixed dimensions are intrinsic.
+- Treat `.claude/rules/components.md` § Sizing Convention as the single source
+  for component sizing values; do not infer a value from a similar component.
 - Use the canonical focus outline tokens from `.claude/rules/components.md`.
 
 Responsive conventions:

--- a/packages/react/src/components/ui/button/Button.stories.tsx
+++ b/packages/react/src/components/ui/button/Button.stories.tsx
@@ -380,6 +380,51 @@ export const LoadingPreservesDefaultWidth: Story = {
   },
 };
 
+export const TextButtonsStayContentWidth: Story = {
+  parameters: {
+    a11y: { test: 'off' },
+    docs: {
+      description: {
+        story:
+          'Decision sentinel: labeled Buttons do not carry a min-width floor. Text buttons remain content-width, while icon-only buttons keep their dedicated square size so width rules cannot leak between the two contracts.',
+      },
+    },
+  },
+  render: () => (
+    <div
+      data-style="vega"
+      className="nx:flex nx:items-center nx:gap-2 nx:p-10 nx:bg-background"
+    >
+      <Button data-testid="button-content-short">Go</Button>
+      <Button data-testid="button-content-long">Confirm transfer</Button>
+      <Button size="icon" aria-label="Icon action">
+        <IconStar />
+      </Button>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const shortButton = canvas.getByTestId('button-content-short');
+    const longButton = canvas.getByTestId('button-content-long');
+    const iconButton = canvas.getByLabelText('Icon action');
+    const hasMinWidthClass = (element: HTMLElement) =>
+      Array.from(element.classList).some((className) =>
+        className.startsWith('nx:min-w-')
+      );
+
+    expect(hasMinWidthClass(shortButton)).toBe(false);
+    expect(hasMinWidthClass(longButton)).toBe(false);
+    expect(Math.round(shortButton.getBoundingClientRect().width)).toBeLessThan(
+      64
+    );
+    expect(
+      Math.round(longButton.getBoundingClientRect().width)
+    ).toBeGreaterThan(Math.round(shortButton.getBoundingClientRect().width));
+    await expect(iconButton).toHaveClass('nx:size-10');
+    expect(Math.round(iconButton.getBoundingClientRect().width)).toBe(40);
+  },
+};
+
 export const ManualBusyState: Story = {
   args: {
     'aria-busy': true,

--- a/packages/react/src/components/ui/select/Select.stories.tsx
+++ b/packages/react/src/components/ui/select/Select.stories.tsx
@@ -7,7 +7,7 @@ import {
   SPACING_MODES,
 } from '../../../stories/spacing-modes';
 import {
-  expectHeightFixedAcrossModes,
+  expectHeightPerMode,
   expectHeightPinned,
 } from '../../../stories/test-utils';
 import { NativeSelect, NativeSelectOption } from '../native-select';
@@ -33,6 +33,16 @@ const meta: Meta<typeof Select> = {
 
 export default meta;
 type Story = StoryObj<typeof Select>;
+
+const SELECT_TRIGGER_HEIGHTS = {
+  vega: 40,
+  lyra: 42,
+  maia: 44,
+  mira: 40,
+  nova: 38,
+  luma: 40,
+  sera: 40,
+} as const;
 
 // ============================================
 // BASIC STORIES
@@ -770,7 +780,7 @@ export const AllModes: Story = {
     docs: {
       description: {
         story:
-          "Each row scopes `data-style` locally on the trigger wrapper. `SelectTrigger` uses numeric `py-2 gap-2 px-3` with `typography-body-default`, matching the fixed form-field rhythm instead of role spacing utilities. `SelectContent` portals to `document.body`, so opened items pick up document-level mode, not the row's wrapper.",
+          "Each row scopes `data-style` locally on the trigger wrapper. `SelectTrigger` uses the single-line control height scale (`h-10`) with numeric `px-3 gap-2`, matching Button/Input/ButtonGroup mechanics. `SelectContent` portals to `document.body`, so opened items pick up document-level mode, not the row's wrapper.",
       },
     },
   },
@@ -796,13 +806,13 @@ export const AllModes: Story = {
   ),
 };
 
-export const SelectTriggerIsDensityStable: Story = {
+export const SelectTriggerScaleHeightFollowsModes: Story = {
   parameters: {
     a11y: { test: 'off' },
     docs: {
       description: {
         story:
-          'Density-stability sentinel for `SelectTrigger`. It stays on numeric `py-2 gap-2 px-3` rather than role spacing utilities, so every spacing mode resolves to the same canonical 38px height. Trigger is not portaled so dimensional measurement on the wrapper works directly.',
+          'Scale-utility sentinel for `SelectTrigger`. It uses `h-10`, so the rendered height follows the active Nexus spacing mode like the other single-line controls. Trigger is not portaled so dimensional measurement on the wrapper works directly.',
       },
     },
   },
@@ -830,10 +840,10 @@ export const SelectTriggerIsDensityStable: Story = {
     </div>
   ),
   play: async ({ canvasElement }) => {
-    await expectHeightFixedAcrossModes(
+    await expectHeightPerMode(
       within(canvasElement),
-      SPACING_MODES.map((mode) => `select-stable-host-${mode}`),
-      38
+      'select-stable-host',
+      SELECT_TRIGGER_HEIGHTS
     );
   },
 };
@@ -844,7 +854,7 @@ export const VegaDefaultHeightPinned: Story = {
     docs: {
       description: {
         story:
-          'Regression sentinel: pins the `SelectTrigger` height in vega mode.',
+          'Regression sentinel: pins the `SelectTrigger` height in vega mode to the default single-line control scale.',
       },
     },
   },
@@ -865,7 +875,7 @@ export const VegaDefaultHeightPinned: Story = {
     </div>
   ),
   play: async ({ canvasElement }) => {
-    await expectHeightPinned(within(canvasElement), 'select-vega-host', 38);
+    await expectHeightPinned(within(canvasElement), 'select-vega-host', 40);
   },
 };
 

--- a/packages/react/src/components/ui/select/select.tsx
+++ b/packages/react/src/components/ui/select/select.tsx
@@ -67,7 +67,7 @@ function SelectTrigger({ className, children, ...props }: SelectTriggerProps) {
       className={cn(
         'nx:group/select-trigger nx:flex nx:w-full nx:items-center nx:justify-between nx:gap-2',
         'nx:rounded-md nx:border nx:border-border-default nx:bg-background nx:transition-colors nx:enabled:hover:bg-background-hover',
-        'nx:px-3 nx:py-2 nx:typography-body-default',
+        'nx:h-10 nx:px-3 nx:py-0 nx:typography-body-default',
         'nx:whitespace-nowrap',
         'nx:data-[placeholder]:text-muted-foreground',
         'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',


### PR DESCRIPTION
## Summary

- Settle the remaining #433 sizing rule: single-line controls use the fixed Nexus height scale, multiline/content-shaped controls stay padding/min-height based, and labeled Buttons stay content-width without a base `min-w-*` floor.
- Align `SelectTrigger` with the default single-line control scale (`nx:h-10 nx:py-0`) so Button/Input/Select/ButtonGroup mechanics are no longer mixed.
- Add Storybook sentinels for SelectTrigger per-mode height and Button content-width/no-min-width behavior, and update the canonical component/RTK/shadcn/responsive docs.

## GitHub Issue

Closes #433

## Changed Files

- `.claude/rules/components.md`
- `.claude/rules/responsive.md`
- `.claude/rules/shadcn-divergences.md`
- `RTK.md`
- `packages/react/src/components/ui/button/Button.stories.tsx`
- `packages/react/src/components/ui/select/Select.stories.tsx`
- `packages/react/src/components/ui/select/select.tsx`

## Test Plan

- [x] Modern Web Guidance gate attempted: `npx --offline -y modern-web-guidance@latest search "button input select textarea control sizing fixed height padding min-width" --skill-version 2026_05_16-c5e7870` failed with `ENOTCACHED`; fell back to the local Modern Web Guidance skill/docs per repo playbook.
- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component button`
- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component select`
- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component input`
- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component textarea`
- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component button-group`
- [x] `pnpm test:storybook -- packages/react/src/components/ui/button/Button.stories.tsx packages/react/src/components/ui/select/Select.stories.tsx` (passed 112 files / 786 tests; Vitest ran the full Storybook project despite the file args)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `./node_modules/.bin/prettier --check .claude/rules/components.md .claude/rules/responsive.md .claude/rules/shadcn-divergences.md RTK.md packages/react/src/components/ui/button/Button.stories.tsx packages/react/src/components/ui/select/Select.stories.tsx packages/react/src/components/ui/select/select.tsx`
- [x] `git diff --check`
