### PR TITLE
fix(dialog): align close offsets with spacing modes

### DIFF
--- a/packages/react/src/components/ui/dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/ui/dialog/Dialog.stories.tsx
@@ -41,6 +41,37 @@ const meta: Meta<typeof Dialog> = {
 export default meta;
 type Story = StoryObj<typeof Dialog>;
 
+function getCloseButtonInsets(surface: HTMLElement, closeButton: HTMLElement) {
+  const surfaceRect = surface.getBoundingClientRect();
+  const closeButtonRect = closeButton.getBoundingClientRect();
+
+  return {
+    top: Math.round(closeButtonRect.top - surfaceRect.top),
+    right: Math.round(surfaceRect.right - closeButtonRect.right),
+  };
+}
+
+async function expectCloseButtonInsets(
+  surface: HTMLElement,
+  closeButton: HTMLElement,
+  expectedPx: number
+) {
+  await waitFor(() => {
+    const insets = getCloseButtonInsets(surface, closeButton);
+    expect(insets.top).toBe(expectedPx);
+    expect(insets.right).toBe(expectedPx);
+  });
+}
+
+function restoreDocumentStyleMode(previousStyle: string | null) {
+  if (previousStyle == null) {
+    document.documentElement.removeAttribute('data-style');
+    return;
+  }
+
+  document.documentElement.setAttribute('data-style', previousStyle);
+}
+
 // ============================================
 // BASIC STORIES
 // ============================================
@@ -602,6 +633,8 @@ export const CloseButtonFocus: Story = {
       'nx:focus-visible:outline-offset-(--focus-offset)'
     );
     await expect(closeButton).toHaveClass(
+      'nx:right-6',
+      'nx:top-6',
       'nx:after:absolute',
       'nx:after:-inset-2.5',
       'nx:lg:after:hidden'
@@ -611,6 +644,68 @@ export const CloseButtonFocus: Story = {
     await waitFor(() => {
       expect(document.querySelector('[role="dialog"]')).toBeNull();
     });
+  },
+};
+
+export const CloseButtonTracksSpacingModes: Story = {
+  parameters: {
+    a11y: { test: 'off' },
+    docs: {
+      description: {
+        story:
+          'Regression sentinel: the built-in close button uses the same `spacing-6` inset as Dialog chrome, so it follows the active `data-style` mode instead of staying on a smaller fixed offset.',
+      },
+    },
+  },
+  render: (_args) => (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline">Open spacing dialog</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Spacing-mode close offset</DialogTitle>
+          <DialogDescription>
+            The close button should stay aligned to the dialog chrome inset.
+          </DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  ),
+  play: async ({ canvasElement }) => {
+    const previousStyle = document.documentElement.getAttribute('data-style');
+    const canvas = within(canvasElement);
+
+    document.documentElement.setAttribute('data-style', 'nova');
+
+    try {
+      await userEvent.click(
+        canvas.getByRole('button', { name: 'Open spacing dialog' })
+      );
+
+      const dialog = await within(document.body).findByRole('dialog');
+      const closeButton = within(dialog).getByRole('button', { name: 'Close' });
+
+      await expect(closeButton).toHaveClass('nx:right-6', 'nx:top-6');
+      await expectCloseButtonInsets(dialog, closeButton, 22);
+
+      document.documentElement.setAttribute('data-style', 'maia');
+      await expectCloseButtonInsets(dialog, closeButton, 28);
+
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(document.querySelector('[role="dialog"]')).toBeNull();
+      });
+    } finally {
+      restoreDocumentStyleMode(previousStyle);
+
+      if (document.querySelector('[role="dialog"]')) {
+        await userEvent.keyboard('{Escape}');
+        await waitFor(() => {
+          expect(document.querySelector('[role="dialog"]')).toBeNull();
+        });
+      }
+    }
   },
 };
 

--- a/packages/react/src/components/ui/dialog/dialog.tsx
+++ b/packages/react/src/components/ui/dialog/dialog.tsx
@@ -5,6 +5,7 @@ import * as DialogPrimitive from '@radix-ui/react-dialog';
 import {
   containsComposedSlot,
   defaultOverlayLayout,
+  overlayCloseButtonClassName,
   overlayContentVariants,
   overlayHeaderVariants,
   type OverlayLayoutContextValue,
@@ -182,16 +183,7 @@ function DialogContent({
           {showCloseButton && (
             <DialogPrimitive.Close
               data-slot="dialog-close-button"
-              className={cn(
-                'nx:absolute nx:right-6 nx:top-6 nx:rounded-sm nx:p-1 nx:text-muted-foreground-subtle',
-                'nx:after:absolute nx:after:-inset-2.5 nx:lg:after:hidden',
-                'nx:transition-colors',
-                'nx:motion-reduce:transition-none',
-                'nx:hover:bg-background-hover nx:hover:text-foreground',
-                'nx:focus-visible:bg-background-hover nx:focus-visible:text-foreground',
-                'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
-                'nx:disabled:pointer-events-none'
-              )}
+              className={overlayCloseButtonClassName}
             >
               <IconX className="nx:size-4" />
               <span className="nx:sr-only">Close</span>

--- a/packages/react/src/components/ui/dialog/dialog.tsx
+++ b/packages/react/src/components/ui/dialog/dialog.tsx
@@ -183,7 +183,7 @@ function DialogContent({
             <DialogPrimitive.Close
               data-slot="dialog-close-button"
               className={cn(
-                'nx:absolute nx:right-4 nx:top-4 nx:rounded-sm nx:p-1 nx:text-muted-foreground-subtle',
+                'nx:absolute nx:right-6 nx:top-6 nx:rounded-sm nx:p-1 nx:text-muted-foreground-subtle',
                 'nx:after:absolute nx:after:-inset-2.5 nx:lg:after:hidden',
                 'nx:transition-colors',
                 'nx:motion-reduce:transition-none',

--- a/packages/react/src/components/ui/overlay-layout/overlay-layout.ts
+++ b/packages/react/src/components/ui/overlay-layout/overlay-layout.ts
@@ -53,6 +53,17 @@ const overlayFooterVariants = cva('nx:flex nx:gap-2 nx:px-6', {
   },
 });
 
+const overlayCloseButtonClassName = [
+  'nx:absolute nx:right-6 nx:top-6 nx:rounded-sm nx:p-1 nx:text-muted-foreground-subtle',
+  'nx:after:absolute nx:after:-inset-2.5 nx:lg:after:hidden',
+  'nx:transition-colors',
+  'nx:motion-reduce:transition-none',
+  'nx:hover:bg-background-hover nx:hover:text-foreground',
+  'nx:focus-visible:bg-background-hover nx:focus-visible:text-foreground',
+  'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
+  'nx:disabled:pointer-events-none',
+].join(' ');
+
 type OverlayVariant = NonNullable<
   VariantProps<typeof overlayHeaderVariants>['variant']
 >;
@@ -98,6 +109,7 @@ export {
   containsComposedSlot,
   defaultOverlayLayout,
   type OverlayButtonOrientation,
+  overlayCloseButtonClassName,
   overlayContentVariants,
   overlayFooterVariants,
   overlayHeaderVariants,

--- a/packages/react/src/components/ui/sheet/Sheet.stories.tsx
+++ b/packages/react/src/components/ui/sheet/Sheet.stories.tsx
@@ -360,6 +360,8 @@ export const WithDataAttributes: Story = {
     await expect(
       document.querySelector('[data-slot="sheet-close-button"]')
     ).toHaveClass(
+      'nx:right-6',
+      'nx:top-6',
       'nx:after:absolute',
       'nx:after:-inset-2.5',
       'nx:lg:after:hidden'

--- a/packages/react/src/components/ui/sheet/sheet.tsx
+++ b/packages/react/src/components/ui/sheet/sheet.tsx
@@ -180,7 +180,7 @@ function SheetContent({
           <DialogPrimitive.Close
             data-slot="sheet-close-button"
             className={cn(
-              'nx:absolute nx:right-4 nx:top-4 nx:rounded-sm nx:p-1 nx:text-muted-foreground-subtle',
+              'nx:absolute nx:right-6 nx:top-6 nx:rounded-sm nx:p-1 nx:text-muted-foreground-subtle',
               'nx:after:absolute nx:after:-inset-2.5 nx:lg:after:hidden',
               'nx:transition-colors',
               'nx:motion-reduce:transition-none',

--- a/packages/react/src/components/ui/sheet/sheet.tsx
+++ b/packages/react/src/components/ui/sheet/sheet.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { cva, type VariantProps } from 'class-variance-authority';
 
+import { overlayCloseButtonClassName } from '@/components/ui/overlay-layout/overlay-layout';
 import { IconX } from '@/lib/icons';
 import { cn } from '@/lib/utils';
 
@@ -179,16 +180,7 @@ function SheetContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="sheet-close-button"
-            className={cn(
-              'nx:absolute nx:right-6 nx:top-6 nx:rounded-sm nx:p-1 nx:text-muted-foreground-subtle',
-              'nx:after:absolute nx:after:-inset-2.5 nx:lg:after:hidden',
-              'nx:transition-colors',
-              'nx:motion-reduce:transition-none',
-              'nx:hover:bg-background-hover nx:hover:text-foreground',
-              'nx:focus-visible:bg-background-hover nx:focus-visible:text-foreground',
-              'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
-              'nx:disabled:pointer-events-none'
-            )}
+            className={overlayCloseButtonClassName}
           >
             <IconX className="nx:size-4" />
             <span className="nx:sr-only">Close</span>


### PR DESCRIPTION
## Summary

- Move the built-in Dialog and Sheet close affordances from `spacing-4` to `spacing-6` offsets so the absolute X aligns with the overlay chrome inset.
- Centralize the shared overlay close-button class contract so Dialog and Sheet cannot drift independently.
- Add a Dialog Storybook regression sentinel that measures the rendered close-button inset across nova and maia spacing modes.
- Keep CardAction out of scope because it is already in-flow in the CardHeader grid and receives its inset from header padding.

## GitHub Issue

Closes #242

## Test Plan

- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component dialog`
- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component sheet`
- [x] `pnpm --filter @nexus/core build`
- [x] `pnpm --filter @nexus/react typecheck`
- [x] `pnpm exec eslint packages/react/src/components/ui/overlay-layout/overlay-layout.ts packages/react/src/components/ui/dialog/dialog.tsx packages/react/src/components/ui/sheet/sheet.tsx --max-warnings 0`
- [x] `pnpm exec prettier --check packages/react/src/components/ui/overlay-layout/overlay-layout.ts packages/react/src/components/ui/dialog/dialog.tsx packages/react/src/components/ui/sheet/sheet.tsx`
- [x] `pnpm test:storybook -- packages/react/src/components/ui/dialog/Dialog.stories.tsx packages/react/src/components/ui/sheet/Sheet.stories.tsx`
