### PR TITLE
fix(react): repair appearance dist types

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,6 +28,7 @@
     "build": "vite build",
     "clean": "rm -rf dist",
     "typecheck": "pnpm generate:base-variants && tsc --noEmit",
+    "typecheck:dist-appearance": "node scripts/typecheck-appearance-dist.mjs",
     "generate:base-variants": "node scripts/generate-base-variants.mjs",
     "audit:storybook-coverage": "node scripts/audit-storybook-coverage.mjs",
     "storybook": "pnpm generate:base-variants && storybook dev -p 6006",

--- a/packages/react/scripts/typecheck-appearance-dist.mjs
+++ b/packages/react/scripts/typecheck-appearance-dist.mjs
@@ -1,0 +1,78 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(scriptDir, '..');
+const repoRoot = path.resolve(packageRoot, '../..');
+const consumerRoot = path.join(repoRoot, 'apps', 'console');
+const probeDir = path.join(consumerRoot, '.appearance-dist-typecheck');
+const probePath = path.join(probeDir, 'probe.ts');
+const tsconfigPath = path.join(probeDir, 'tsconfig.json');
+const tscBin = path.join(repoRoot, 'node_modules', 'typescript', 'bin', 'tsc');
+
+const requiredDistFiles = [
+  path.join(packageRoot, 'dist', 'appearance.d.ts'),
+  path.join(packageRoot, '..', 'core', 'dist', 'runtime', 'index.d.ts'),
+];
+
+for (const distFile of requiredDistFiles) {
+  if (!existsSync(distFile)) {
+    throw new Error(
+      `Missing ${path.relative(repoRoot, distFile)}. Run package builds before this dist typecheck.`
+    );
+  }
+}
+
+await rm(probeDir, { recursive: true, force: true });
+await mkdir(probeDir, { recursive: true });
+
+await writeFile(
+  probePath,
+  `import type { NexusAppearanceState } from '@nexus/core';
+import { useNexusAppearance } from '@nexus/react/appearance';
+
+const { setState } = useNexusAppearance();
+
+setState((state) => {
+  const inferred: NexusAppearanceState = state;
+  const mode: NexusAppearanceState['mode'] = state.mode;
+
+  // @ts-expect-error proves the updater state is not any.
+  state.notARealNexusAppearanceField;
+
+  return { ...inferred, mode };
+});
+`
+);
+
+await writeFile(
+  tsconfigPath,
+  JSON.stringify(
+    {
+      extends: '../../../tsconfig.base.json',
+      compilerOptions: {
+        noEmit: true,
+        jsx: 'react-jsx',
+      },
+      include: ['probe.ts'],
+    },
+    null,
+    2
+  )
+);
+
+const result = spawnSync(
+  process.execPath,
+  [tscBin, '--project', tsconfigPath],
+  {
+    cwd: repoRoot,
+    stdio: 'inherit',
+  }
+);
+
+await rm(probeDir, { recursive: true, force: true });
+
+process.exit(result.status ?? 1);

--- a/packages/react/src/appearance/provider.tsx
+++ b/packages/react/src/appearance/provider.tsx
@@ -12,18 +12,14 @@ import {
 } from 'react';
 
 import {
-  appearancePrefsToCss,
-  createNexusAppearanceSnapshot,
-  createNexusThemeContract,
+  createNexusAppearanceSnapshotFromState,
   DEFAULT_NEXUS_APPEARANCE,
   DEFAULT_STORAGE_KEY,
-  deriveTheme,
   type NexusAppearanceSnapshot,
   type NexusAppearanceState,
   resolveFirstPaint,
   sanitizeNexusAppearance,
   sanitizeNexusAppearanceSnapshot,
-  themeToCss,
 } from '@nexus/core';
 
 const COLOR_SCHEME_QUERY = '(prefers-color-scheme: dark)';
@@ -182,17 +178,9 @@ export function NexusAppearanceProvider({
   const [resolvedMode, setResolvedMode] = useState<NexusResolvedAppearanceMode>(
     () => resolveAppearanceMode(activeState.mode)
   );
-  const themeCss = useMemo(
-    () => themeToCss(deriveTheme(createNexusThemeContract(activeState))),
-    [activeState]
-  );
-  const prefsCss = useMemo(
-    () => appearancePrefsToCss(activeState.prefs),
-    [activeState.prefs]
-  );
   const activeSnapshot = useMemo(
-    () => createNexusAppearanceSnapshot(activeState, themeCss, prefsCss),
-    [activeState, prefsCss, themeCss]
+    () => createNexusAppearanceSnapshotFromState(activeState),
+    [activeState]
   );
   const firstPaint = useMemo(
     () => resolveFirstPaint(activeSnapshot, resolvedMode === 'dark'),

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
       include: ['src'],
       exclude: ['**/*.test.ts', '**/*.test.tsx', '**/*.stories.tsx'],
       outDir: 'dist',
-      rollupTypes: true,
       beforeWriteFile(filePath, content) {
         const normalizedPath = filePath.split(path.sep).join('/');
 
@@ -20,10 +19,7 @@ export default defineConfig({
           return {
             filePath: path.resolve(__dirname, 'dist/appearance.d.ts'),
             content: content
-              .replace(
-                /export \* from '\.\/([^']+)';/g,
-                "export * from './appearance/$1';"
-              )
+              .replace(/from '\.\/([^']+)'/g, "from './appearance/$1'")
               .replace(
                 '//# sourceMappingURL=index.d.ts.map',
                 '//# sourceMappingURL=appearance.d.ts.map'


### PR DESCRIPTION
## Summary

- Fix the `@nexus/react/appearance` declaration entry so named re-exports point at emitted `dist/appearance/*` declarations instead of dangling `./provider`, `./script`, etc.
- Remove the obsolete `rollupTypes` setting and keep per-module declaration emission because the installed `vite-plugin-dts@5.0.3` supports `bundleTypes`, but bundling all entries hits an API Extractor `Unable to follow symbol "Root"` failure on the main entry and would regress the package build.
- Delegate provider snapshot CSS derivation to the existing `@nexus/core` snapshot helper so the appearance chunk stays free of direct `deriveTheme` imports while keeping `@nexus/core` external.
- Add `pnpm --filter @nexus/react typecheck:dist-appearance`, a tiny no-alias dist-consumer probe that proves `useNexusAppearance().setState((state) => ...)` receives `NexusAppearanceState` rather than `any`.

## GitHub Issue

Closes #547

## Test Plan

- [x] `pnpm --filter @nexus/core build`
- [x] `pnpm --filter @nexus/react build`
- [x] `grep -nE "from '\\./(provider|script|appearance-settings|theme-quick-control)'" packages/react/dist/appearance.d.ts` returns no matches
- [x] `pnpm --filter @nexus/react typecheck:dist-appearance`
- [x] `! grep -q deriveTheme packages/react/dist/appearance.mjs`
- [x] `grep -n "@nexus/core" packages/react/dist/appearance.mjs`
- [x] `pnpm --filter @nexus/react typecheck`
- [x] `pnpm --filter @nexus/console typecheck`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm test:unit`
- [x] `pnpm size-limit`
