### PR TITLE
chore(console): consume @nexus/react/appearance from dist + gate dist types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,9 @@ jobs:
             pnpm turbo typecheck
           fi
 
+      - name: Appearance dist-type contract
+        run: pnpm --filter @nexus/react typecheck:dist-appearance
+
   # ============================================
   # React Package Jobs
   # ============================================

--- a/apps/console/tsconfig.json
+++ b/apps/console/tsconfig.json
@@ -1,11 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "../..",
-    "paths": {
-      "@/*": ["packages/react/src/*"],
-      "@nexus/react/appearance": ["packages/react/src/appearance/index.ts"]
-    },
     "useDefineForClassFields": true,
     "allowImportingTsExtensions": true,
     "jsx": "react-jsx",

--- a/apps/console/vite.config.ts
+++ b/apps/console/vite.config.ts
@@ -1,6 +1,5 @@
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
-import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vite';
 
 import {
@@ -22,12 +21,4 @@ export default defineConfig({
     react(),
     tailwindcss(),
   ],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('../../packages/react/src', import.meta.url)),
-      '@nexus/react/appearance': fileURLToPath(
-        new URL('../../packages/react/src/appearance/index.ts', import.meta.url)
-      ),
-    },
-  },
 });


### PR DESCRIPTION
## Summary

- Drop the console's source aliases (`@` + `@nexus/react/appearance`) now that #547 repaired the appearance dist `.d.ts` — the console consumes the package from **dist**, like its 47 existing main `@nexus/react` imports already do.
- Remove the coupled `baseUrl` + `@/*` + appearance `paths` from `apps/console/tsconfig.json` (they only existed to make the source-aliased appearance resolve its internal `@/components/ui/*` imports).
- Wire `typecheck:dist-appearance` into the CI **TypeScript Check** job so the appearance dist-type contract is enforced. It was only a manual script — the original dts bug (#547) hid for two phases precisely because nothing typechecked against the dist `.d.ts`.

## GitHub Issue

Part of #531. Completes #547 criterion #3 (console consumes dist) / the deferred #545 finding-1 (architect review).

## Test Plan

- [x] `pnpm --filter @nexus/console typecheck` clean — console consumes `@nexus/react/appearance` from dist, no alias
- [x] `pnpm --filter @nexus/console build` ok — vite resolves `/appearance` from dist
- [x] `pnpm --filter @nexus/react typecheck:dist-appearance` passes — consumer infers real types (`state: NexusAppearanceState`, not `any`)
- [x] prettier + eslint clean on changed files
- [ ] CI green, including the new dist-appearance probe step in TypeScript Check

Verified in an isolated worktree off `main`.
