### PR TITLE
ci: run format and lint for docs app changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: >-
-      needs.changes.outputs.packages == 'true' ||
+      needs.changes.outputs.browser_source == 'true' ||
       needs.changes.outputs.browser == 'true' ||
       needs.changes.outputs.ci == 'true'
     steps:
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     if: >-
-      needs.changes.outputs.packages == 'true' ||
+      needs.changes.outputs.browser_source == 'true' ||
       needs.changes.outputs.browser == 'true' ||
       needs.changes.outputs.ci == 'true'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,9 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ needs.changes.outputs.ci }}" = "true" ]; then
+            pnpm turbo build
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
             pnpm turbo build --filter="...[origin/$BASE_REF]"
           else
             pnpm turbo build
@@ -276,7 +278,9 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "${{ needs.changes.outputs.ci }}" = "true" ]; then
+            pnpm turbo typecheck
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
             pnpm turbo typecheck --filter="...[origin/$BASE_REF]"
           else
             pnpm turbo typecheck


### PR DESCRIPTION
## Summary
- run full-tree format-check and lint when apps/docs changes
- use the existing browser_source path filter for these full-tree jobs
- keep browser and workflow triggers unchanged

## Why
format-check and lint execute full-tree commands, but their job gates used the narrower packages output. That output intentionally excludes apps/docs, so docs-only formatting or lint failures could skip the jobs and still pass the CI aggregator.

## Validation
- git diff --check -- .github/workflows/ci.yml
- pnpm exec prettier --check .github/workflows/ci.yml