### PR TITLE
test(appearance): audit runtime utility reactivity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,9 @@ jobs:
       - name: React package boundary contract
         run: pnpm --filter @nexus/react audit:package-boundary
 
+      - name: Appearance reactivity audit
+        run: pnpm audit:appearance-reactivity
+
       - name: Appearance dist-type contract
         run: pnpm --filter @nexus/react typecheck:dist-appearance
 

--- a/apps/console/src/modules/design-system/appearance/theme-quick-control.tsx
+++ b/apps/console/src/modules/design-system/appearance/theme-quick-control.tsx
@@ -61,7 +61,7 @@ function SwatchRow({ label, value, onSelect }: SwatchRowProps) {
             >
               <span
                 className={cn(
-                  'nx:size-5 nx:rounded-full nx:border-2 nx:transition-colors',
+                  'nx:size-5 nx:rounded-full nx:border-thick nx:transition-colors',
                   active ? 'nx:border-foreground' : 'nx:border-border-default'
                 )}
                 style={{ backgroundColor: option.color }}

--- a/docs/superpowers/plans/2026-06-29-issue-563-appearance-reactivity.md
+++ b/docs/superpowers/plans/2026-06-29-issue-563-appearance-reactivity.md
@@ -1,0 +1,153 @@
+# #563 Appearance Reactivity Guardrail
+
+## Summary
+
+#562 fixed the known Appearance disconnects. #563 adds a narrow guardrail so
+future changes cannot update provider state / runtime CSS while real Nexus UI
+quietly bypasses those runtime tokens.
+
+This is tooling and tests only:
+
+- no public API changes
+- no token value retuning
+- no visual redesign
+- no broad component migration
+
+Branch: `codex/issue-563-appearance-reactivity-audit` from latest `main`.
+
+## Correct Runtime Model
+
+The guardrail must not ban valid Nexus runtime utilities.
+
+- `nx:rounded-*` is runtime-aware through `--radius-* -> --nx-radius-*`, and
+  `[data-radius]` changes those variables.
+- `nx:shadow-*` is runtime-aware through `--shadow-* -> --nx-shadow-*`; #559
+  already calibrated the public shadow modes.
+- ordinary semantic text/color utilities such as `nx:text-foreground`,
+  `nx:text-muted-foreground`, and `nx:border-border-default` are valid.
+- built-in spacing utilities are mostly static; only role utilities such as
+  `nx:p-container` / `nx:gap-container` are density-aware today.
+
+Therefore #563 audits only the bypass classes that are both high risk and
+actionable now:
+
+- raw border-width utilities after the #562 stroke migration
+- arbitrary dimension-like literals that bypass token scales
+- `cn()` merge regressions around runtime stroke utilities
+
+## Implementation
+
+Add a React package audit:
+
+- `packages/react/scripts/audit-appearance-reactivity.mjs`
+- `packages/react/scripts/appearance-reactivity.config.mjs`
+
+Default scan roots:
+
+- `packages/react/src/components`
+- `apps/console/src/modules/design-system/appearance`
+
+Excluded:
+
+- stories and tests
+- `packages/react/src/appearance`
+- docs fixtures
+- showcase/demo surfaces such as ComponentShowcase / IconShowcase
+
+Rules:
+
+- flag raw stroke-width utilities:
+  - `nx:border`
+  - `nx:border-x/y/t/r/b/l`
+  - numeric widths such as `nx:border-2`, `nx:border-b-2`
+  - dimension arbitrary widths such as `nx:border-[1.5px]`
+- do not flag style/color/table utilities:
+  - `nx:border-dashed`
+  - `nx:border-transparent`
+  - `nx:border-border-default`
+  - `nx:border-nav-border`
+  - `nx:border-collapse`
+- flag dimension-like arbitrary text sizes:
+  - `nx:text-[13px]`, `nx:text-[1.25rem]`
+- do not flag system color arbitrary text:
+  - `nx:text-[CanvasText]`
+- flag dimension-like arbitrary spacing/radius:
+  - `nx:p-[13px]`
+  - `nx:gap-[7px]`
+  - `nx:rounded-[2px]`
+- do not flag inherited/runtime forms:
+  - `nx:rounded-md`
+  - `nx:rounded-[inherit]`
+  - `nx:shadow-lg`
+- flag arbitrary shadow utilities:
+  - `nx:shadow-[...]`
+
+Allowlist:
+
+- sidecar config only
+- each entry requires `file`, exact `className` or `ruleId`, and `reason`
+- no wildcard allowlists
+- report line numbers in output, but do not key allowlist stability to line
+  numbers
+
+Scripts / CI:
+
+- add `@nexus/react` script: `audit:appearance-reactivity`
+- add root script: `audit:appearance-reactivity`
+- run it in CI after `audit:package-boundary`
+
+## Tests
+
+Add classifier tests for:
+
+- raw `nx:border` fails
+- `nx:border-default` passes
+- `nx:border-border-default` passes
+- `nx:border-dashed` passes
+- `nx:border-[1.5px]` fails
+- `nx:text-[13px]` fails
+- `nx:text-[CanvasText]` passes
+- `nx:rounded-md` passes
+- `nx:rounded-[2px]` fails
+- `nx:shadow-lg` passes
+- `nx:shadow-[...]` fails
+- allowlist entries must be narrow and reasoned
+
+Add component consumption tests for:
+
+- Button emits runtime stroke/radius classes.
+- Input emits runtime stroke + semantic border color.
+- Card emits semantic surface + runtime shadow class.
+- Sheet emits runtime side stroke + shadow class.
+- Tabs emit runtime trigger/indicator stroke classes.
+
+Extend `cn()` tests for:
+
+- runtime stroke width survives next to semantic border color.
+- side-specific runtime stroke width merges correctly.
+- native override such as `nx:border-0` still wins intentionally.
+- generated borderwidth utilities remain covered by `NEXUS_CLASS_GROUPS`.
+
+## Validation
+
+Run:
+
+```bash
+pnpm audit:appearance-reactivity
+pnpm test:unit packages/react/scripts/audit-appearance-reactivity.test.js
+pnpm test:unit packages/react/src/lib/utils.test.ts
+pnpm test:unit packages/react/src/appearance
+pnpm test:unit
+pnpm --filter @nexus/react build
+pnpm typecheck
+pnpm lint
+pnpm build
+```
+
+Acceptance criteria:
+
+- raw border-width regressions fail automatically.
+- arbitrary dimension escapes fail automatically.
+- valid semantic/runtime utilities are not false-positive noise.
+- every allowlist entry is narrow and justified.
+- #563 remains a guardrail PR, not a token or UI redesign PR.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "audit:contrast": "pnpm --filter @nexus/core audit:contrast",
     "audit:mode-codenames": "pnpm --filter @nexus/core audit:mode-codenames",
     "audit:mode-distinctness": "pnpm --filter @nexus/core audit:mode-distinctness",
+    "audit:appearance-reactivity": "pnpm --filter @nexus/react audit:appearance-reactivity",
     "audit:storybook-coverage": "pnpm --filter @nexus/react audit:storybook-coverage -- --all",
     "validate:spacing-modes": "pnpm --filter @nexus/core validate:spacing-modes",
     "console": "cd apps/console && pnpm dev",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,6 +34,7 @@
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
     "typecheck:dist-appearance": "node scripts/typecheck-appearance-dist.mjs",
+    "audit:appearance-reactivity": "node scripts/audit-appearance-reactivity.mjs",
     "audit:package-boundary": "node scripts/audit-package-boundary.mjs",
     "audit:storybook-coverage": "node scripts/audit-storybook-coverage.mjs",
     "storybook": "storybook dev -p 6006",

--- a/packages/react/scripts/appearance-reactivity.config.mjs
+++ b/packages/react/scripts/appearance-reactivity.config.mjs
@@ -58,6 +58,6 @@ export const APPEARANCE_REACTIVITY_ALLOWLIST = [
     file: 'packages/react/src/components/ui/chart/chart.tsx',
     className: 'nx:border-[1.5px]',
     reason:
-      'Dashed chart tooltip mark uses a fixed stroke matching chart glyphs.',
+      'Chart tooltip mark uses a fixed stroke matching chart glyphs.',
   },
 ];

--- a/packages/react/scripts/appearance-reactivity.config.mjs
+++ b/packages/react/scripts/appearance-reactivity.config.mjs
@@ -1,0 +1,63 @@
+export const APPEARANCE_REACTIVITY_SCAN_ROOTS = [
+  'packages/react/src/components',
+  'apps/console/src/modules/design-system/appearance',
+];
+
+export const APPEARANCE_REACTIVITY_ALLOWLIST = [
+  {
+    file: 'packages/react/src/components/ui/avatar/avatar.tsx',
+    className: 'nx:text-[0.625rem]',
+    reason: 'Avatar initials scale with the fixed avatar size ladder.',
+  },
+  {
+    file: 'packages/react/src/components/ui/avatar/avatar.tsx',
+    className: 'nx:text-[0.6875rem]',
+    reason: 'Avatar initials scale with the fixed avatar size ladder.',
+  },
+  {
+    file: 'packages/react/src/components/ui/avatar/avatar.tsx',
+    className: 'nx:text-[0.75rem]',
+    reason: 'Avatar initials scale with the fixed avatar size ladder.',
+  },
+  {
+    file: 'packages/react/src/components/ui/avatar/avatar.tsx',
+    className: 'nx:text-[1rem]',
+    reason: 'Avatar initials scale with the fixed avatar size ladder.',
+  },
+  {
+    file: 'packages/react/src/components/ui/avatar/avatar.tsx',
+    className: 'nx:text-[1.125rem]',
+    reason: 'Avatar initials scale with the fixed avatar size ladder.',
+  },
+  {
+    file: 'packages/react/src/components/ui/avatar/avatar.tsx',
+    className: 'nx:text-[1.25rem]',
+    reason: 'Avatar initials scale with the fixed avatar size ladder.',
+  },
+  {
+    file: 'packages/react/src/components/ui/avatar/avatar.tsx',
+    className: 'nx:text-[1.5rem]',
+    reason: 'Avatar initials scale with the fixed avatar size ladder.',
+  },
+  {
+    file: 'packages/react/src/components/ui/avatar/avatar.tsx',
+    className: 'nx:text-[1.875rem]',
+    reason: 'Avatar initials scale with the fixed avatar size ladder.',
+  },
+  {
+    file: 'packages/react/src/components/ui/avatar/avatar.tsx',
+    className: 'nx:text-[2.25rem]',
+    reason: 'Avatar initials scale with the fixed avatar size ladder.',
+  },
+  {
+    file: 'packages/react/src/components/ui/chart/chart.tsx',
+    className: 'nx:rounded-[2px]',
+    reason: 'Chart swatches need a tiny non-interactive mark radius.',
+  },
+  {
+    file: 'packages/react/src/components/ui/chart/chart.tsx',
+    className: 'nx:border-[1.5px]',
+    reason:
+      'Dashed chart tooltip mark uses a fixed stroke matching chart glyphs.',
+  },
+];

--- a/packages/react/scripts/audit-appearance-reactivity.mjs
+++ b/packages/react/scripts/audit-appearance-reactivity.mjs
@@ -8,10 +8,10 @@ import {
 } from './appearance-reactivity.config.mjs';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(scriptDir, '../..', '..');
-const CLASS_RE = /nx:[^\s"'`)}]+/g;
+const CLASS_RE = /nx:[^\s"'`}]+/g;
 const DIMENSION_RE =
   /(?:^|[^\w-])-?(?:\d+|\d*\.\d+)(?:px|rem|em|%|lh|vw|vh|svw|svh|lvw|lvh|dvw|dvh|ch|ex|cap|ic)\b/i;
+const CSS_DIMENSION_FUNCTION_RE = /^(?:calc|clamp|min|max)\(/i;
 
 const RULES = {
   rawBorderWidth: 'raw-border-width',
@@ -26,6 +26,26 @@ function toPosix(file) {
   return file.split(path.sep).join('/');
 }
 
+function findRepoRoot(startDir) {
+  let current = startDir;
+
+  while (true) {
+    if (existsSync(path.join(current, 'pnpm-workspace.yaml'))) {
+      return current;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new Error(
+        `Could not find repo root from ${toPosix(path.relative(process.cwd(), startDir))}.`
+      );
+    }
+    current = parent;
+  }
+}
+
+const repoRoot = findRepoRoot(scriptDir);
+
 function rel(file) {
   return toPosix(path.relative(repoRoot, file));
 }
@@ -38,13 +58,33 @@ function utilityForClassName(className) {
   const withoutPrefix = className.startsWith('nx:')
     ? className.slice(3)
     : className;
-  const parts = withoutPrefix.split(':');
+  let bracketDepth = 0;
+  let lastVariantSeparator = -1;
 
-  return parts[parts.length - 1];
+  for (let index = 0; index < withoutPrefix.length; index += 1) {
+    const char = withoutPrefix[index];
+
+    if (char === '[') {
+      bracketDepth += 1;
+    } else if (char === ']') {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+    } else if (char === ':' && bracketDepth === 0) {
+      lastVariantSeparator = index;
+    }
+  }
+
+  return withoutPrefix.slice(lastVariantSeparator + 1);
 }
 
 function isDimensionLiteral(value) {
-  return DIMENSION_RE.test(value);
+  const normalized = value.trim().replace(/_/g, ' ');
+  const withoutTypeHint = normalized.replace(/^length:/i, '');
+
+  return (
+    normalized !== withoutTypeHint ||
+    DIMENSION_RE.test(withoutTypeHint) ||
+    CSS_DIMENSION_FUNCTION_RE.test(withoutTypeHint)
+  );
 }
 
 function bracketValue(utility, prefix) {
@@ -132,9 +172,9 @@ function validateAllowlist(allowlist) {
     if (!entry.file || entry.file.includes('*')) {
       failures.push(`allowlist[${index}] must include a concrete file path.`);
     }
-    if (!entry.className && !entry.ruleId) {
+    if (!entry.className || entry.className.includes('*')) {
       failures.push(
-        `allowlist[${index}] must include an exact className or ruleId.`
+        `allowlist[${index}] must include an exact className.`
       );
     }
     if (!entry.reason) {
@@ -150,6 +190,7 @@ function isAllowed(violation, allowlist = APPEARANCE_REACTIVITY_ALLOWLIST) {
 
   return normalized.some((entry) => {
     if (entry.file !== violation.file) return false;
+    if (!entry.className) return false;
     if (entry.className && entry.className !== violation.className)
       return false;
     if (entry.ruleId && entry.ruleId !== violation.ruleId) return false;
@@ -188,9 +229,7 @@ function auditSource(
 
 function shouldScanFile(file) {
   if (!/\.[cm]?[jt]sx?$/.test(file)) return false;
-  if (file.endsWith('.stories.tsx')) return false;
-  if (file.endsWith('.test.tsx') || file.endsWith('.test.ts')) return false;
-  if (file.endsWith('.test.js') || file.endsWith('.test.mjs')) return false;
+  if (/\.(?:stories|test)\.[cm]?[jt]sx?$/.test(file)) return false;
 
   return true;
 }
@@ -304,6 +343,7 @@ export {
   classifyClassName,
   isAllowed,
   parseArgs,
+  shouldScanFile,
   utilityForClassName,
   validateAllowlist,
 };

--- a/packages/react/scripts/audit-appearance-reactivity.mjs
+++ b/packages/react/scripts/audit-appearance-reactivity.mjs
@@ -1,0 +1,309 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  APPEARANCE_REACTIVITY_ALLOWLIST,
+  APPEARANCE_REACTIVITY_SCAN_ROOTS,
+} from './appearance-reactivity.config.mjs';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, '../..', '..');
+const CLASS_RE = /nx:[^\s"'`)}]+/g;
+const DIMENSION_RE =
+  /(?:^|[^\w-])-?(?:\d+|\d*\.\d+)(?:px|rem|em|%|lh|vw|vh|svw|svh|lvw|lvh|dvw|dvh|ch|ex|cap|ic)\b/i;
+
+const RULES = {
+  rawBorderWidth: 'raw-border-width',
+  arbitraryTextSize: 'arbitrary-text-size',
+  arbitrarySpacing: 'arbitrary-spacing',
+  arbitraryRadius: 'arbitrary-radius',
+  arbitraryShadow: 'arbitrary-shadow',
+  arbitraryBorderWidth: 'arbitrary-border-width',
+};
+
+function toPosix(file) {
+  return file.split(path.sep).join('/');
+}
+
+function rel(file) {
+  return toPosix(path.relative(repoRoot, file));
+}
+
+function lineFor(source, index) {
+  return source.slice(0, index).split('\n').length;
+}
+
+function utilityForClassName(className) {
+  const withoutPrefix = className.startsWith('nx:')
+    ? className.slice(3)
+    : className;
+  const parts = withoutPrefix.split(':');
+
+  return parts[parts.length - 1];
+}
+
+function isDimensionLiteral(value) {
+  return DIMENSION_RE.test(value);
+}
+
+function bracketValue(utility, prefix) {
+  const match = utility.match(new RegExp(`^${prefix}-\\[(.+)\\]$`));
+  return match?.[1] ?? null;
+}
+
+function classifyClassName(className) {
+  const utility = utilityForClassName(className);
+
+  if (/^border(?:-[xytrbl])?$/.test(utility)) {
+    return {
+      ruleId: RULES.rawBorderWidth,
+      message:
+        'Use Nexus runtime stroke utilities such as nx:border-default or nx:border-b-default instead of raw border width.',
+    };
+  }
+
+  if (/^border(?:-[xytrbl])?-(?:[1-9]\d*(?:\.\d+)?)$/.test(utility)) {
+    return {
+      ruleId: RULES.rawBorderWidth,
+      message:
+        'Fixed numeric border widths bypass the Appearance stroke control.',
+    };
+  }
+
+  const arbitraryBorder = utility.match(/^border(?:-[xytrbl])?-\[(.+)\]$/);
+  if (arbitraryBorder && isDimensionLiteral(arbitraryBorder[1])) {
+    return {
+      ruleId: RULES.arbitraryBorderWidth,
+      message:
+        'Arbitrary border-width literals bypass the Appearance stroke control.',
+    };
+  }
+
+  const textValue = bracketValue(utility, 'text');
+  if (textValue && isDimensionLiteral(textValue)) {
+    return {
+      ruleId: RULES.arbitraryTextSize,
+      message:
+        'Arbitrary text-size literals bypass the Appearance typography scale.',
+    };
+  }
+
+  const spacingValue = utility.match(
+    /^(?:p|px|py|pt|pr|pb|pl|gap|gap-x|gap-y)-\[(.+)\]$/
+  )?.[1];
+  if (spacingValue && isDimensionLiteral(spacingValue)) {
+    return {
+      ruleId: RULES.arbitrarySpacing,
+      message:
+        'Arbitrary spacing literals bypass Nexus spacing/density tokens.',
+    };
+  }
+
+  const radiusValue = utility.match(/^rounded(?:-[a-z]+)?-\[(.+)\]$/)?.[1];
+  if (radiusValue && isDimensionLiteral(radiusValue)) {
+    return {
+      ruleId: RULES.arbitraryRadius,
+      message: 'Arbitrary radius literals bypass Nexus radius tokens.',
+    };
+  }
+
+  if (/^shadow-\[/.test(utility)) {
+    return {
+      ruleId: RULES.arbitraryShadow,
+      message: 'Arbitrary shadow literals bypass Nexus shadow tokens.',
+    };
+  }
+
+  return null;
+}
+
+function normalizeAllowlistEntry(entry) {
+  return {
+    ...entry,
+    file: toPosix(entry.file),
+  };
+}
+
+function validateAllowlist(allowlist) {
+  const failures = [];
+
+  for (const [index, entry] of allowlist.entries()) {
+    if (!entry.file || entry.file.includes('*')) {
+      failures.push(`allowlist[${index}] must include a concrete file path.`);
+    }
+    if (!entry.className && !entry.ruleId) {
+      failures.push(
+        `allowlist[${index}] must include an exact className or ruleId.`
+      );
+    }
+    if (!entry.reason) {
+      failures.push(`allowlist[${index}] must include a reason.`);
+    }
+  }
+
+  return failures;
+}
+
+function isAllowed(violation, allowlist = APPEARANCE_REACTIVITY_ALLOWLIST) {
+  const normalized = allowlist.map(normalizeAllowlistEntry);
+
+  return normalized.some((entry) => {
+    if (entry.file !== violation.file) return false;
+    if (entry.className && entry.className !== violation.className)
+      return false;
+    if (entry.ruleId && entry.ruleId !== violation.ruleId) return false;
+
+    return true;
+  });
+}
+
+function auditSource(
+  file,
+  source,
+  allowlist = APPEARANCE_REACTIVITY_ALLOWLIST
+) {
+  const violations = [];
+
+  for (const match of source.matchAll(CLASS_RE)) {
+    const className = match[0];
+    const classification = classifyClassName(className);
+
+    if (!classification) continue;
+
+    const violation = {
+      file,
+      line: lineFor(source, match.index ?? 0),
+      className,
+      ...classification,
+    };
+
+    if (!isAllowed(violation, allowlist)) {
+      violations.push(violation);
+    }
+  }
+
+  return violations;
+}
+
+function shouldScanFile(file) {
+  if (!/\.[cm]?[jt]sx?$/.test(file)) return false;
+  if (file.endsWith('.stories.tsx')) return false;
+  if (file.endsWith('.test.tsx') || file.endsWith('.test.ts')) return false;
+  if (file.endsWith('.test.js') || file.endsWith('.test.mjs')) return false;
+
+  return true;
+}
+
+function listFiles(root) {
+  const files = [];
+  const stack = [root];
+
+  while (stack.length) {
+    const current = stack.pop();
+    if (!current || !existsSync(current)) continue;
+
+    const entries = readdirSync(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+      } else if (shouldScanFile(fullPath)) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  return files.sort();
+}
+
+function auditFiles({
+  roots = APPEARANCE_REACTIVITY_SCAN_ROOTS,
+  allowlist = APPEARANCE_REACTIVITY_ALLOWLIST,
+} = {}) {
+  const allowlistFailures = validateAllowlist(allowlist);
+  if (allowlistFailures.length) {
+    return {
+      allowlistFailures,
+      violations: [],
+      scannedFiles: 0,
+    };
+  }
+
+  const violations = [];
+  let scannedFiles = 0;
+
+  for (const root of roots) {
+    const absoluteRoot = path.resolve(repoRoot, root);
+
+    for (const file of listFiles(absoluteRoot)) {
+      scannedFiles += 1;
+      const relativeFile = rel(file);
+      const source = readFileSync(file, 'utf8');
+      violations.push(...auditSource(relativeFile, source, allowlist));
+    }
+  }
+
+  return {
+    allowlistFailures: [],
+    violations,
+    scannedFiles,
+  };
+}
+
+function parseArgs(argv) {
+  return {
+    json: argv.includes('--json'),
+  };
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const result = auditFiles();
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  }
+
+  if (result.allowlistFailures.length) {
+    for (const failure of result.allowlistFailures) {
+      console.error(failure);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (result.violations.length) {
+    console.error('Appearance reactivity audit failed:');
+    for (const violation of result.violations) {
+      console.error(
+        `${violation.file}:${violation.line} ${violation.className} (${violation.ruleId}) - ${violation.message}`
+      );
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!options.json) {
+    console.log(
+      `Appearance reactivity audit clean (${result.scannedFiles} files scanned).`
+    );
+  }
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}
+
+export {
+  auditFiles,
+  auditSource,
+  classifyClassName,
+  isAllowed,
+  parseArgs,
+  utilityForClassName,
+  validateAllowlist,
+};

--- a/packages/react/scripts/audit-appearance-reactivity.test.js
+++ b/packages/react/scripts/audit-appearance-reactivity.test.js
@@ -5,6 +5,7 @@ import {
   classifyClassName,
   isAllowed,
   parseArgs,
+  shouldScanFile,
   utilityForClassName,
   validateAllowlist,
 } from './audit-appearance-reactivity.mjs';
@@ -46,6 +47,14 @@ describe('appearance reactivity audit classifier', () => {
     expect(classifyClassName('nx:text-[1.25rem]')).toMatchObject({
       ruleId: 'arbitrary-text-size',
     });
+    expect(classifyClassName('nx:text-[clamp(1rem,2vw,2rem)]')).toMatchObject({
+      ruleId: 'arbitrary-text-size',
+    });
+    expect(
+      classifyClassName('nx:text-[length:clamp(1rem,2vw,2rem)]')
+    ).toMatchObject({
+      ruleId: 'arbitrary-text-size',
+    });
     expect(classifyClassName('nx:text-[CanvasText]')).toBeNull();
     expect(classifyClassName('nx:bg-[Canvas]')).toBeNull();
   });
@@ -57,6 +66,9 @@ describe('appearance reactivity audit classifier', () => {
     expect(classifyClassName('nx:gap-[7px]')).toMatchObject({
       ruleId: 'arbitrary-spacing',
     });
+    expect(classifyClassName('nx:p-[calc(1rem+2px)]')).toMatchObject({
+      ruleId: 'arbitrary-spacing',
+    });
     expect(classifyClassName('nx:rounded-md')).toBeNull();
     expect(classifyClassName('nx:rounded-[2px]')).toMatchObject({
       ruleId: 'arbitrary-radius',
@@ -65,6 +77,12 @@ describe('appearance reactivity audit classifier', () => {
     expect(classifyClassName('nx:shadow-lg')).toBeNull();
     expect(classifyClassName('nx:shadow-[0_1px_2px_black]')).toMatchObject({
       ruleId: 'arbitrary-shadow',
+    });
+  });
+
+  it('flags CSS function arbitrary border widths', () => {
+    expect(classifyClassName('nx:border-[calc(1px+0.5px)]')).toMatchObject({
+      ruleId: 'arbitrary-border-width',
     });
   });
 
@@ -100,6 +118,21 @@ describe('appearance reactivity audit source scanning', () => {
       expect.objectContaining({
         line: 2,
         className: 'nx:text-[13px]',
+        ruleId: 'arbitrary-text-size',
+      }),
+    ]);
+  });
+
+  it('scans arbitrary CSS function classes without truncating the class name', () => {
+    const violations = auditSource(
+      'packages/react/src/components/ui/example/example.tsx',
+      '<div className="nx:text-[clamp(1rem,2vw,2rem)]" />',
+      []
+    );
+
+    expect(violations).toEqual([
+      expect.objectContaining({
+        className: 'nx:text-[clamp(1rem,2vw,2rem)]',
         ruleId: 'arbitrary-text-size',
       }),
     ]);
@@ -147,14 +180,30 @@ describe('appearance reactivity audit source scanning', () => {
         },
         {
           file: 'packages/react/src/components/ui/button/button.tsx',
+          ruleId: 'raw-border-width',
+          reason: 'rule-only wildcard',
+        },
+        {
+          file: 'packages/react/src/components/ui/button/button.tsx',
           className: 'nx:border',
         },
       ])
     ).toEqual([
       'allowlist[0] must include a concrete file path.',
-      'allowlist[1] must include an exact className or ruleId.',
-      'allowlist[2] must include a reason.',
+      'allowlist[1] must include an exact className.',
+      'allowlist[2] must include an exact className.',
+      'allowlist[3] must include a reason.',
     ]);
+  });
+
+  it('skips story and test files', () => {
+    expect(shouldScanFile('/repo/button.tsx')).toBe(true);
+    expect(shouldScanFile('/repo/button.stories.ts')).toBe(false);
+    expect(shouldScanFile('/repo/button.stories.tsx')).toBe(false);
+    expect(shouldScanFile('/repo/button.stories.js')).toBe(false);
+    expect(shouldScanFile('/repo/button.stories.jsx')).toBe(false);
+    expect(shouldScanFile('/repo/button.test.ts')).toBe(false);
+    expect(shouldScanFile('/repo/button.test.mjs')).toBe(false);
   });
 
   it('parses --json', () => {

--- a/packages/react/scripts/audit-appearance-reactivity.test.js
+++ b/packages/react/scripts/audit-appearance-reactivity.test.js
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  auditSource,
+  classifyClassName,
+  isAllowed,
+  parseArgs,
+  utilityForClassName,
+  validateAllowlist,
+} from './audit-appearance-reactivity.mjs';
+
+describe('appearance reactivity audit classifier', () => {
+  it('flags raw border-width utilities', () => {
+    expect(classifyClassName('nx:border')).toMatchObject({
+      ruleId: 'raw-border-width',
+    });
+    expect(classifyClassName('nx:border-b')).toMatchObject({
+      ruleId: 'raw-border-width',
+    });
+    expect(classifyClassName('nx:border-2')).toMatchObject({
+      ruleId: 'raw-border-width',
+    });
+    expect(classifyClassName('nx:border-b-2')).toMatchObject({
+      ruleId: 'raw-border-width',
+    });
+  });
+
+  it('allows runtime stroke, border color, style, transparent, and table utilities', () => {
+    expect(classifyClassName('nx:border-default')).toBeNull();
+    expect(classifyClassName('nx:border-thick')).toBeNull();
+    expect(classifyClassName('nx:border-b-default')).toBeNull();
+    expect(classifyClassName('nx:border-border-default')).toBeNull();
+    expect(classifyClassName('nx:border-nav-border')).toBeNull();
+    expect(classifyClassName('nx:border-dashed')).toBeNull();
+    expect(classifyClassName('nx:border-transparent')).toBeNull();
+    expect(classifyClassName('nx:border-collapse')).toBeNull();
+  });
+
+  it('flags dimension-like arbitrary literals without flagging system colors', () => {
+    expect(classifyClassName('nx:border-[1.5px]')).toMatchObject({
+      ruleId: 'arbitrary-border-width',
+    });
+    expect(classifyClassName('nx:text-[13px]')).toMatchObject({
+      ruleId: 'arbitrary-text-size',
+    });
+    expect(classifyClassName('nx:text-[1.25rem]')).toMatchObject({
+      ruleId: 'arbitrary-text-size',
+    });
+    expect(classifyClassName('nx:text-[CanvasText]')).toBeNull();
+    expect(classifyClassName('nx:bg-[Canvas]')).toBeNull();
+  });
+
+  it('flags arbitrary token-axis escapes while allowing runtime utilities', () => {
+    expect(classifyClassName('nx:p-[13px]')).toMatchObject({
+      ruleId: 'arbitrary-spacing',
+    });
+    expect(classifyClassName('nx:gap-[7px]')).toMatchObject({
+      ruleId: 'arbitrary-spacing',
+    });
+    expect(classifyClassName('nx:rounded-md')).toBeNull();
+    expect(classifyClassName('nx:rounded-[2px]')).toMatchObject({
+      ruleId: 'arbitrary-radius',
+    });
+    expect(classifyClassName('nx:rounded-[inherit]')).toBeNull();
+    expect(classifyClassName('nx:shadow-lg')).toBeNull();
+    expect(classifyClassName('nx:shadow-[0_1px_2px_black]')).toMatchObject({
+      ruleId: 'arbitrary-shadow',
+    });
+  });
+
+  it('classifies the final utility after Nexus variants', () => {
+    expect(
+      utilityForClassName('nx:data-[variant=default]:border-default')
+    ).toBe('border-default');
+    expect(
+      classifyClassName('nx:data-[state=active]:border-b-2')
+    ).toMatchObject({
+      ruleId: 'raw-border-width',
+    });
+  });
+});
+
+describe('appearance reactivity audit source scanning', () => {
+  it('reports unallowlisted violations with line numbers', () => {
+    const violations = auditSource(
+      'packages/react/src/components/ui/example/example.tsx',
+      [
+        '<div className="nx:border-default" />',
+        '<div className="nx:border nx:text-[13px]" />',
+      ].join('\n'),
+      []
+    );
+
+    expect(violations).toEqual([
+      expect.objectContaining({
+        line: 2,
+        className: 'nx:border',
+        ruleId: 'raw-border-width',
+      }),
+      expect.objectContaining({
+        line: 2,
+        className: 'nx:text-[13px]',
+        ruleId: 'arbitrary-text-size',
+      }),
+    ]);
+  });
+
+  it('honors narrow allowlist entries', () => {
+    const violation = {
+      file: 'packages/react/src/components/ui/chart/chart.tsx',
+      line: 12,
+      className: 'nx:border-[1.5px]',
+      ruleId: 'arbitrary-border-width',
+    };
+
+    expect(
+      isAllowed(violation, [
+        {
+          file: 'packages/react/src/components/ui/chart/chart.tsx',
+          className: 'nx:border-[1.5px]',
+          reason: 'Chart glyph stroke.',
+        },
+      ])
+    ).toBe(true);
+    expect(
+      isAllowed(violation, [
+        {
+          file: 'packages/react/src/components/ui/chart/chart.tsx',
+          className: 'nx:rounded-[2px]',
+          reason: 'Different exact class.',
+        },
+      ])
+    ).toBe(false);
+  });
+
+  it('rejects broad or unexplained allowlist entries', () => {
+    expect(
+      validateAllowlist([
+        {
+          file: 'packages/react/src/components/**',
+          className: 'nx:border',
+          reason: 'too broad',
+        },
+        {
+          file: 'packages/react/src/components/ui/button/button.tsx',
+          reason: 'missing class',
+        },
+        {
+          file: 'packages/react/src/components/ui/button/button.tsx',
+          className: 'nx:border',
+        },
+      ])
+    ).toEqual([
+      'allowlist[0] must include a concrete file path.',
+      'allowlist[1] must include an exact className or ruleId.',
+      'allowlist[2] must include a reason.',
+    ]);
+  });
+
+  it('parses --json', () => {
+    expect(parseArgs(['--json'])).toEqual({ json: true });
+    expect(parseArgs([])).toEqual({ json: false });
+  });
+});

--- a/packages/react/src/appearance/appearance-reactivity.test.tsx
+++ b/packages/react/src/appearance/appearance-reactivity.test.tsx
@@ -17,10 +17,18 @@ function expectNoRawBorderWidth(element: Element) {
       ? className.slice(3).split(':')
       : [className];
     const utility = parts[parts.length - 1];
+    const arbitraryBorderWidth = utility?.match(
+      /^border(?:-[xytrbl])?-\[(.+)\]$/
+    );
 
     return (
       /^border(?:-[xytrbl])?$/.test(utility ?? '') ||
-      /^border(?:-[xytrbl])?-(?:[1-9]\d*(?:\.\d+)?)$/.test(utility ?? '')
+      /^border(?:-[xytrbl])?-(?:[1-9]\d*(?:\.\d+)?)$/.test(utility ?? '') ||
+      (arbitraryBorderWidth
+        ? /(?:\d|\bcalc\(|\bclamp\(|\bmin\(|\bmax\()/i.test(
+            arbitraryBorderWidth[1]
+          )
+        : false)
     );
   });
 

--- a/packages/react/src/appearance/appearance-reactivity.test.tsx
+++ b/packages/react/src/appearance/appearance-reactivity.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+
+function classNames(element: Element) {
+  return Array.from(element.classList);
+}
+
+function expectNoRawBorderWidth(element: Element) {
+  const rawBorderWidth = classNames(element).filter((className) => {
+    const parts = className.startsWith('nx:')
+      ? className.slice(3).split(':')
+      : [className];
+    const utility = parts[parts.length - 1];
+
+    return (
+      /^border(?:-[xytrbl])?$/.test(utility ?? '') ||
+      /^border(?:-[xytrbl])?-(?:[1-9]\d*(?:\.\d+)?)$/.test(utility ?? '')
+    );
+  });
+
+  expect(rawBorderWidth).toEqual([]);
+}
+
+describe('Appearance reactivity component contracts', () => {
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+    vi.stubGlobal('cancelAnimationFrame', () => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('Button emits runtime stroke and radius utilities', () => {
+    render(<Button variant="outline">Save</Button>);
+
+    const button = screen.getByRole('button', { name: 'Save' });
+
+    expect(button).toHaveClass('nx:border-default');
+    expect(button).toHaveClass('nx:border-border-default');
+    expect(button).toHaveClass('nx:rounded-base');
+    expectNoRawBorderWidth(button);
+  });
+
+  it('Button lets consumer runtime stroke overrides win through cn()', () => {
+    render(<Button className="nx:border-thick">Save</Button>);
+
+    const button = screen.getByRole('button', { name: 'Save' });
+
+    expect(button).toHaveClass('nx:border-thick');
+    expect(button).not.toHaveClass('nx:border-default');
+    expectNoRawBorderWidth(button);
+  });
+
+  it('Input emits runtime stroke and semantic invalid-state border utilities', () => {
+    render(<Input aria-label="Email" aria-invalid />);
+
+    const input = screen.getByLabelText('Email');
+
+    expect(input).toHaveClass('nx:border-default');
+    expect(input).toHaveClass('nx:border-border-default');
+    expect(input).toHaveClass('nx:aria-invalid:border-border-error');
+    expectNoRawBorderWidth(input);
+  });
+
+  it('Card emits semantic surface and runtime shadow utilities', () => {
+    const { container } = render(<Card>Content</Card>);
+    const card = container.querySelector('[data-slot="card"]');
+
+    expect(card).toHaveClass('nx:bg-container');
+    expect(card).toHaveClass('nx:text-container-foreground');
+    expect(card).toHaveClass('nx:border-default');
+    expect(card).toHaveClass('nx:shadow-sm');
+    expectNoRawBorderWidth(card as Element);
+  });
+
+  it('SheetContent emits runtime side stroke and shadow utilities', () => {
+    render(
+      <Sheet open>
+        <SheetContent side="right" aria-describedby={undefined}>
+          <SheetTitle>Panel</SheetTitle>
+        </SheetContent>
+      </Sheet>
+    );
+
+    const sheet = document.querySelector('[data-slot="sheet-content"]');
+
+    expect(sheet).toHaveClass('nx:border-l-default');
+    expect(sheet).toHaveClass('nx:border-border-default');
+    expect(sheet).toHaveClass('nx:shadow-lg');
+    expectNoRawBorderWidth(sheet as Element);
+  });
+
+  it('Tabs emit runtime active indicator and trigger stroke utilities', () => {
+    render(
+      <Tabs defaultValue="one">
+        <TabsList>
+          <TabsTrigger value="one">One</TabsTrigger>
+        </TabsList>
+      </Tabs>
+    );
+
+    const trigger = screen.getByRole('tab', { name: 'One' });
+    const indicator = document.querySelector('[data-slot="tabs-indicator"]');
+
+    expect(trigger).toHaveClass('nx:border-default');
+    expect(trigger).toHaveClass('nx:border-transparent');
+    expectNoRawBorderWidth(trigger);
+    expect(indicator).toHaveClass('nx:data-[variant=default]:border-default');
+    expect(indicator).toHaveClass(
+      'nx:data-[variant=default]:border-border-default'
+    );
+  });
+});

--- a/packages/react/src/appearance/appearance-reactivity.test.tsx
+++ b/packages/react/src/appearance/appearance-reactivity.test.tsx
@@ -20,13 +20,14 @@ function expectNoRawBorderWidth(element: Element) {
     const arbitraryBorderWidth = utility?.match(
       /^border(?:-[xytrbl])?-\[(.+)\]$/
     );
+    const arbitraryBorderWidthValue = arbitraryBorderWidth?.[1];
 
     return (
       /^border(?:-[xytrbl])?$/.test(utility ?? '') ||
       /^border(?:-[xytrbl])?-(?:[1-9]\d*(?:\.\d+)?)$/.test(utility ?? '') ||
-      (arbitraryBorderWidth
+      (arbitraryBorderWidthValue !== undefined
         ? /(?:\d|\bcalc\(|\bclamp\(|\bmin\(|\bmax\()/i.test(
-            arbitraryBorderWidth[1]
+            arbitraryBorderWidthValue
           )
         : false)
     );

--- a/packages/react/src/components/ui/switch/switch.tsx
+++ b/packages/react/src/components/ui/switch/switch.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils';
 const switchVariants = cva(
   [
     'nx:peer nx:inline-flex nx:shrink-0 nx:cursor-pointer nx:items-center',
-    'nx:rounded-full nx:border-2 nx:border-border-default',
+    'nx:rounded-full nx:border-thick nx:border-border-default',
     'nx:transition-colors',
     'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
     'nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error',

--- a/packages/react/src/components/ui/tabs/tabs.tsx
+++ b/packages/react/src/components/ui/tabs/tabs.tsx
@@ -189,7 +189,7 @@ const tabsTriggerVariants = cva(
           'nx:data-[state=active]:text-foreground',
         ],
         underline: [
-          'nx:rounded-none nx:border-b-2 nx:border-transparent',
+          'nx:rounded-none nx:border-b-thick nx:border-transparent',
           'nx:bg-transparent',
           'nx:data-[state=active]:text-foreground',
         ],

--- a/packages/react/src/lib/utils.test.ts
+++ b/packages/react/src/lib/utils.test.ts
@@ -41,8 +41,14 @@ describe('cn — border width token utilities', () => {
     expect(cn('nx:border-default', 'nx:border-border-default')).toBe(
       'nx:border-default nx:border-border-default'
     );
+    expect(cn('nx:border-default', 'nx:border-border-primary')).toBe(
+      'nx:border-default nx:border-border-primary'
+    );
     expect(cn('nx:border-b-default', 'nx:border-border-default')).toBe(
       'nx:border-b-default nx:border-border-default'
+    );
+    expect(cn('nx:border-t-default', 'nx:border-border-default')).toBe(
+      'nx:border-t-default nx:border-border-default'
     );
     expect(cn('nx:border-default', 'nx:border-transparent')).toBe(
       'nx:border-default nx:border-transparent'


### PR DESCRIPTION
## Summary

Closes #563
Part of #531

Adds a narrow Appearance reactivity guardrail so runtime Appearance controls cannot drift away from real Nexus component usage.

## What Changed

- Added `pnpm audit:appearance-reactivity` for raw stroke-width regressions and arbitrary dimension escapes.
- Added narrow allowlist config for intentional Avatar and Chart literals.
- Added real component consumption tests for Button, Input, Card, Sheet, and Tabs.
- Extended `cn()` merge coverage for runtime stroke utilities with semantic border colors.
- Replaced remaining obvious raw stroke widths with runtime `border-thick` utilities in console quick control, Switch, and Tabs.
- Captured the corrected #563 plan in `docs/superpowers/plans/2026-06-29-issue-563-appearance-reactivity.md`.

## Validation

- `pnpm audit:appearance-reactivity`
- `pnpm test:unit packages/react/scripts/audit-appearance-reactivity.test.js`
- `pnpm test:unit packages/react/src/lib/utils.test.ts`
- `pnpm test:unit packages/react/src/appearance`
- `pnpm test:unit` — 49 files, 791 tests
- `pnpm --filter @nexus/react build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`

## Notes

This PR intentionally does not retune tokens, redesign UI, or broaden radius/shadow/spacing migrations. It only adds guardrails for the known high-risk disconnects.
