### PR TITLE
feat(tailwind): add border utility aliases

### DIFF
--- a/apps/docs/public/themes/border-color-aliases.css
+++ b/apps/docs/public/themes/border-color-aliases.css
@@ -1,0 +1,57 @@
+/* Border Color Alias Utilities */
+
+@utility border-color-default {
+  border-color: var(--color-border-default);
+}
+
+@utility border-color-default-alpha {
+  border-color: var(--color-border-default-alpha);
+}
+
+@utility border-color-active {
+  border-color: var(--color-border-active);
+}
+
+@utility border-color-disabled {
+  border-color: var(--color-border-disabled);
+}
+
+@utility border-color-warning {
+  border-color: var(--color-border-warning);
+}
+
+@utility border-color-warning-active {
+  border-color: var(--color-border-warning-active);
+}
+
+@utility border-color-success {
+  border-color: var(--color-border-success);
+}
+
+@utility border-color-success-active {
+  border-color: var(--color-border-success-active);
+}
+
+@utility border-color-error {
+  border-color: var(--color-border-error);
+}
+
+@utility border-color-error-active {
+  border-color: var(--color-border-error-active);
+}
+
+@utility border-color-information {
+  border-color: var(--color-border-information);
+}
+
+@utility border-color-information-active {
+  border-color: var(--color-border-information-active);
+}
+
+@utility border-color-primary {
+  border-color: var(--color-border-primary);
+}
+
+@utility border-color-primary-active {
+  border-color: var(--color-border-primary-active);
+}

--- a/apps/docs/public/themes/borderwidth-utilities.css
+++ b/apps/docs/public/themes/borderwidth-utilities.css
@@ -69,3 +69,75 @@
   border-left-style: var(--tw-border-style, solid);
   border-left-width: var(--nx-borderwidth-thick);
 }
+
+/* Border Width Alias Utilities */
+
+@utility border-width-default {
+  border-style: var(--tw-border-style, solid);
+  border-width: var(--nx-borderwidth-default);
+}
+
+@utility border-width-x-default {
+  border-inline-style: var(--tw-border-style, solid);
+  border-inline-width: var(--nx-borderwidth-default);
+}
+
+@utility border-width-y-default {
+  border-block-style: var(--tw-border-style, solid);
+  border-block-width: var(--nx-borderwidth-default);
+}
+
+@utility border-width-t-default {
+  border-top-style: var(--tw-border-style, solid);
+  border-top-width: var(--nx-borderwidth-default);
+}
+
+@utility border-width-r-default {
+  border-right-style: var(--tw-border-style, solid);
+  border-right-width: var(--nx-borderwidth-default);
+}
+
+@utility border-width-b-default {
+  border-bottom-style: var(--tw-border-style, solid);
+  border-bottom-width: var(--nx-borderwidth-default);
+}
+
+@utility border-width-l-default {
+  border-left-style: var(--tw-border-style, solid);
+  border-left-width: var(--nx-borderwidth-default);
+}
+
+@utility border-width-thick {
+  border-style: var(--tw-border-style, solid);
+  border-width: var(--nx-borderwidth-thick);
+}
+
+@utility border-width-x-thick {
+  border-inline-style: var(--tw-border-style, solid);
+  border-inline-width: var(--nx-borderwidth-thick);
+}
+
+@utility border-width-y-thick {
+  border-block-style: var(--tw-border-style, solid);
+  border-block-width: var(--nx-borderwidth-thick);
+}
+
+@utility border-width-t-thick {
+  border-top-style: var(--tw-border-style, solid);
+  border-top-width: var(--nx-borderwidth-thick);
+}
+
+@utility border-width-r-thick {
+  border-right-style: var(--tw-border-style, solid);
+  border-right-width: var(--nx-borderwidth-thick);
+}
+
+@utility border-width-b-thick {
+  border-bottom-style: var(--tw-border-style, solid);
+  border-bottom-width: var(--nx-borderwidth-thick);
+}
+
+@utility border-width-l-thick {
+  border-left-style: var(--tw-border-style, solid);
+  border-left-width: var(--nx-borderwidth-thick);
+}

--- a/apps/docs/public/themes/globals.css
+++ b/apps/docs/public/themes/globals.css
@@ -16,6 +16,7 @@
 @import './motion-snappy.css';
 @import './typography-utilities.css';
 @import './borderwidth-utilities.css';
+@import './border-color-aliases.css';
 @import './motion-utilities.css';
 @import './spacing-utilities.css';
 

--- a/packages/core/scripts/__tests__/generate-modular.test.js
+++ b/packages/core/scripts/__tests__/generate-modular.test.js
@@ -126,6 +126,7 @@ describe('generateModular', () => {
     const files = fs.readdirSync(distDir);
     expect(files).toContain('spacing-utilities.css');
     expect(files).toContain('motion-utilities.css');
+    expect(files).toContain('border-color-aliases.css');
 
     const spacingUtilities = fs.readFileSync(
       path.join(distDir, 'spacing-utilities.css'),
@@ -143,12 +144,23 @@ describe('generateModular', () => {
       /transition-duration:\s*var\(--nx-motion-duration-fast\);/
     );
 
+    const borderColorAliases = fs.readFileSync(
+      path.join(distDir, 'border-color-aliases.css'),
+      'utf8'
+    );
+    expect(borderColorAliases).toMatch(/@utility border-color-default \{/);
+    expect(borderColorAliases).toMatch(
+      /border-color:\s*var\(--color-border-default\);/
+    );
+
     // globals.css does NOT inline sibling utilities — it @imports them.
     const globals = fs.readFileSync(path.join(distDir, 'globals.css'), 'utf8');
     expect(globals).not.toMatch(/@utility p-container \{/);
     expect(globals).not.toMatch(/@utility duration-fast \{/);
+    expect(globals).not.toMatch(/@utility border-color-default \{/);
     expect(globals).toMatch(/@import\s+['"]\.\/spacing-utilities\.css['"]/);
     expect(globals).toMatch(/@import\s+['"]\.\/motion-utilities\.css['"]/);
+    expect(globals).toMatch(/@import\s+['"]\.\/border-color-aliases\.css['"]/);
   });
 
   it('@utility declarations bind the right prefixed CSS vars', () => {

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -8,7 +8,11 @@ import { fileURLToPath } from 'url';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { generateTailwindPackage } from '../generate-tailwind-package.js';
-import { DEFAULT_CONFIG } from '../utils.js';
+import {
+  DEFAULT_CONFIG,
+  generateBorderColorAliasUtilitiesCSS,
+  generateBorderWidthUtilitiesCSS,
+} from '../utils.js';
 
 const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
 const SEMANTIC_DIR = path.resolve(TEST_DIR, '..', '..', 'tokens', 'semantic');
@@ -142,6 +146,31 @@ afterAll(() => {
     const dir = tmpDirs.pop();
     fs.rmSync(dir, { recursive: true, force: true });
   }
+});
+
+describe('border alias utility generators', () => {
+  it('reports the actual number of emitted border width utilities', () => {
+    const result = generateBorderWidthUtilitiesCSS([
+      { cssName: 'nx-borderwidth-default' },
+      { cssName: 'nx-borderwidth-thick' },
+    ]);
+
+    expect(result.count).toBe(28);
+    expect(result.css.match(/^@utility /gm)).toHaveLength(result.count);
+  });
+
+  it('emits color aliases only for approved semantic border names', () => {
+    const result = generateBorderColorAliasUtilitiesCSS([
+      { cssName: 'color-border-default' },
+      { cssName: 'color-border-radius-sm' },
+      { cssName: 'color-nav-border' },
+    ]);
+
+    expect(result.count).toBe(1);
+    expect(result.css).toMatch(/@utility border-color-default \{/);
+    expect(result.css).not.toMatch(/border-color-radius-sm/);
+    expect(result.css).not.toMatch(/border-color-nav-border/);
+  });
 });
 
 describe('generateTailwindPackage', () => {
@@ -849,6 +878,28 @@ describe('generateTailwindPackage', () => {
   });
 
   it('border-color-aliases.css declares aliases for border semantic colors', () => {
+    const aliases = [
+      ...borderColorAliasesCSS.matchAll(
+        /^@utility border-color-([a-z0-9-]+) \{/gm
+      ),
+    ].map((match) => match[1]);
+    expect(aliases).toEqual([
+      'default',
+      'default-alpha',
+      'active',
+      'disabled',
+      'warning',
+      'warning-active',
+      'success',
+      'success-active',
+      'error',
+      'error-active',
+      'information',
+      'information-active',
+      'primary',
+      'primary-active',
+    ]);
+
     const defaultBlock = extractBlock(
       borderColorAliasesCSS,
       '@utility border-color-default'

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -152,6 +152,7 @@ describe('generateTailwindPackage', () => {
   let motionUtilitiesCSS;
   let spacingUtilitiesCSS;
   let borderWidthUtilitiesCSS;
+  let borderColorAliasesCSS;
   let warnings;
 
   beforeAll(async () => {
@@ -172,6 +173,7 @@ describe('generateTailwindPackage', () => {
     motionUtilitiesCSS = read(distDir, 'motion-utilities.css');
     spacingUtilitiesCSS = read(distDir, 'spacing-utilities.css');
     borderWidthUtilitiesCSS = read(distDir, 'borderwidth-utilities.css');
+    borderColorAliasesCSS = read(distDir, 'border-color-aliases.css');
   });
 
   it('emits a :root block in variables.css', () => {
@@ -765,6 +767,7 @@ describe('generateTailwindPackage', () => {
       'motion-utilities.css',
       'spacing-utilities.css',
       'borderwidth-utilities.css',
+      'border-color-aliases.css',
     ]) {
       const importMatch = nexusCSS.match(
         new RegExp(`@import\\s+['"](\\./${fileName})['"]`)
@@ -813,12 +816,73 @@ describe('generateTailwindPackage', () => {
     );
   });
 
+  it('borderwidth-utilities.css declares self-describing stroke width aliases', () => {
+    const defaultBlock = extractBlock(
+      borderWidthUtilitiesCSS,
+      '@utility border-width-default'
+    );
+    expect(defaultBlock).toMatch(
+      /border-width:\s*var\(--nx-borderwidth-default\);/
+    );
+
+    const bottomBlock = extractBlock(
+      borderWidthUtilitiesCSS,
+      '@utility border-width-b-default'
+    );
+    expect(bottomBlock).toMatch(
+      /border-bottom-style:\s*var\(--tw-border-style, solid\);/
+    );
+    expect(bottomBlock).toMatch(
+      /border-bottom-width:\s*var\(--nx-borderwidth-default\);/
+    );
+
+    const inlineBlock = extractBlock(
+      borderWidthUtilitiesCSS,
+      '@utility border-width-x-thick'
+    );
+    expect(inlineBlock).toMatch(
+      /border-inline-style:\s*var\(--tw-border-style, solid\);/
+    );
+    expect(inlineBlock).toMatch(
+      /border-inline-width:\s*var\(--nx-borderwidth-thick\);/
+    );
+  });
+
+  it('border-color-aliases.css declares aliases for border semantic colors', () => {
+    const defaultBlock = extractBlock(
+      borderColorAliasesCSS,
+      '@utility border-color-default'
+    );
+    expect(defaultBlock).toMatch(
+      /border-color:\s*var\(--color-border-default\);/
+    );
+
+    const errorBlock = extractBlock(
+      borderColorAliasesCSS,
+      '@utility border-color-error'
+    );
+    expect(errorBlock).toMatch(/border-color:\s*var\(--color-border-error\);/);
+
+    const informationActiveBlock = extractBlock(
+      borderColorAliasesCSS,
+      '@utility border-color-information-active'
+    );
+    expect(informationActiveBlock).toMatch(
+      /border-color:\s*var\(--color-border-information-active\);/
+    );
+  });
+
   it('compiles runtime stroke utilities for all-side and one-side borders', async () => {
     const css = compactCss(
       await compileGeneratedTailwind(distDir, [
         'nx:border-default',
+        'nx:border-width-default',
         'nx:border-b-default',
+        'nx:border-width-b-default',
         'nx:border-x-thick',
+        'nx:border-width-x-thick',
+        'nx:border-color-default',
+        'nx:border-color-error',
       ])
     );
 
@@ -829,6 +893,8 @@ describe('generateTailwindPackage', () => {
     expect(css).toMatch(
       /border-inline-width:\s*var\(--nx-borderwidth-thick\);/
     );
+    expect(css).toMatch(/border-color:\s*var\(--color-border-default\);/);
+    expect(css).toMatch(/border-color:\s*var\(--color-border-error\);/);
   });
 
   it('spacing-utilities.css declares all 4 role utilities with correct property bindings', () => {

--- a/packages/core/scripts/generate-modular.js
+++ b/packages/core/scripts/generate-modular.js
@@ -21,6 +21,7 @@ import {
   filterDivergentDark,
   formatDistCssFiles,
   formatTokenValue,
+  generateBorderColorAliasUtilitiesCSS,
   generateBorderWidthUtilitiesCSS,
   generateMotionUtilitiesCSS,
   generateNativeBrowserUIThemeCSS,
@@ -333,6 +334,7 @@ function generateModularGlobalsCSS(
       './motion-snappy.css',
       './typography-utilities.css',
       './borderwidth-utilities.css',
+      './border-color-aliases.css',
       './motion-utilities.css',
       './spacing-utilities.css',
     ],
@@ -365,6 +367,10 @@ function generateModularGlobalsCSS(
   // the same local graph.
   const spacingUtilities = generateSpacingRoleUtilitiesCSS(defaultSpacingRole);
   writeModularFile(distDir, 'spacing-utilities.css', spacingUtilities.css);
+
+  const borderColorAliases =
+    generateBorderColorAliasUtilitiesCSS(semanticTokens);
+  writeModularFile(distDir, 'border-color-aliases.css', borderColorAliases.css);
 
   return (
     semanticTokens.length +

--- a/packages/core/scripts/generate-modular.js
+++ b/packages/core/scripts/generate-modular.js
@@ -305,6 +305,8 @@ function generateModularGlobalsCSS(
   const shadowTokens = collectShadowTokens(TOKENS_DIR, primitiveMap);
   const zIndexTokens = collectZIndexTokens(SEMANTIC_DIR);
   const breakpointTokens = collectBreakpointsTokens(SEMANTIC_DIR);
+  const borderColorAliases =
+    generateBorderColorAliasUtilitiesCSS(semanticTokens);
 
   // Generate using shared function. Spacing is split: numeric default tokens
   // seed @theme for Tailwind utility codegen; role tokens drive the inline
@@ -334,7 +336,7 @@ function generateModularGlobalsCSS(
       './motion-snappy.css',
       './typography-utilities.css',
       './borderwidth-utilities.css',
-      './border-color-aliases.css',
+      ...(borderColorAliases.css ? ['./border-color-aliases.css'] : []),
       './motion-utilities.css',
       './spacing-utilities.css',
     ],
@@ -368,9 +370,13 @@ function generateModularGlobalsCSS(
   const spacingUtilities = generateSpacingRoleUtilitiesCSS(defaultSpacingRole);
   writeModularFile(distDir, 'spacing-utilities.css', spacingUtilities.css);
 
-  const borderColorAliases =
-    generateBorderColorAliasUtilitiesCSS(semanticTokens);
-  writeModularFile(distDir, 'border-color-aliases.css', borderColorAliases.css);
+  if (borderColorAliases.css) {
+    writeModularFile(
+      distDir,
+      'border-color-aliases.css',
+      borderColorAliases.css
+    );
+  }
 
   return (
     semanticTokens.length +

--- a/packages/core/scripts/generate-tailwind-package.js
+++ b/packages/core/scripts/generate-tailwind-package.js
@@ -427,6 +427,7 @@ function collectLightSemanticTokens(semanticFiles, primitiveMap) {
 function generateNexusCSS(
   semanticFiles,
   primitiveMap,
+  lightSemanticTokens,
   usedModes,
   spacingModes,
   spacingDefault,
@@ -449,10 +450,6 @@ function generateNexusCSS(
   // Light + dark semantic color accumulators. Dimension tokens (e.g.
   // focus.offset) are collected separately into `dimensionTokens` so they emit
   // at :root, not @theme (see generateRootDimensionsCSS / #506).
-  const lightSemanticTokens = collectLightSemanticTokens(
-    semanticFiles,
-    primitiveMap
-  );
   const darkSemanticTokens = [];
   const dimensionTokens = [];
 
@@ -616,6 +613,10 @@ export async function generateTailwindPackage(
     primitiveTokens,
     darkPrimitiveTokens
   );
+  const lightSemanticTokens = collectLightSemanticTokens(
+    semanticFiles,
+    primitiveMap
+  );
 
   const variablesCSS = generateVariablesCSS(
     primitiveTokens,
@@ -639,9 +640,8 @@ export async function generateTailwindPackage(
     log.success(`Generated ${borderWidth.count} border width utilities`);
   }
 
-  const borderColorAliases = generateBorderColorAliasUtilitiesCSS(
-    collectLightSemanticTokens(semanticFiles, primitiveMap)
-  );
+  const borderColorAliases =
+    generateBorderColorAliasUtilitiesCSS(lightSemanticTokens);
   if (borderColorAliases.css) {
     writeDistFile('border-color-aliases.css', borderColorAliases.css);
     log.success(
@@ -684,6 +684,7 @@ export async function generateTailwindPackage(
   const nexusCSS = generateNexusCSS(
     semanticFiles,
     primitiveMap,
+    lightSemanticTokens,
     usedModes,
     spacingModes,
     spacingDefault,

--- a/packages/core/scripts/generate-tailwind-package.js
+++ b/packages/core/scripts/generate-tailwind-package.js
@@ -26,6 +26,7 @@ import {
   formatDistCssFiles,
   formatTokenValue,
   generateBaseLayerCSS,
+  generateBorderColorAliasUtilitiesCSS,
   generateBorderWidthUtilitiesCSS,
   generateMotionUtilitiesCSS,
   generateNativeBrowserUIThemeCSS,
@@ -397,6 +398,32 @@ function generateVariablesCSS(primitiveTokens, divergentDark, usedModes) {
  * canonical default baseline because @theme drives Tailwind's utility codegen
  * (build-time); the cascade flip happens at runtime via the per-mode blocks.
  */
+function collectLightSemanticTokens(semanticFiles, primitiveMap) {
+  const lightSemanticTokens = [];
+
+  for (const themed of semanticFiles.themed) {
+    lightSemanticTokens.push(
+      ...collectSemanticColorTokensVarRef(
+        SEMANTIC_DIR,
+        themed.light,
+        primitiveMap
+      )
+    );
+  }
+
+  for (const standaloneFile of semanticFiles.standalone) {
+    lightSemanticTokens.push(
+      ...collectSemanticColorTokensVarRef(
+        SEMANTIC_DIR,
+        standaloneFile,
+        primitiveMap
+      )
+    );
+  }
+
+  return lightSemanticTokens;
+}
+
 function generateNexusCSS(
   semanticFiles,
   primitiveMap,
@@ -422,22 +449,19 @@ function generateNexusCSS(
   // Light + dark semantic color accumulators. Dimension tokens (e.g.
   // focus.offset) are collected separately into `dimensionTokens` so they emit
   // at :root, not @theme (see generateRootDimensionsCSS / #506).
-  const lightSemanticTokens = [];
+  const lightSemanticTokens = collectLightSemanticTokens(
+    semanticFiles,
+    primitiveMap
+  );
   const darkSemanticTokens = [];
   const dimensionTokens = [];
 
   for (const themed of semanticFiles.themed) {
-    const lightTokens = collectSemanticColorTokensVarRef(
-      SEMANTIC_DIR,
-      themed.light,
-      primitiveMap
-    );
     const darkTokens = collectSemanticColorTokensVarRef(
       SEMANTIC_DIR,
       themed.dark,
       primitiveMap
     );
-    lightSemanticTokens.push(...lightTokens);
     darkSemanticTokens.push(...darkTokens);
   }
 
@@ -445,13 +469,6 @@ function generateNexusCSS(
   // --color-focus-* utilities in @theme; dimension leaves (focus.offset) go to
   // dimensionTokens for the :root block, not @theme (see generateRootDimensionsCSS).
   for (const standaloneFile of semanticFiles.standalone) {
-    lightSemanticTokens.push(
-      ...collectSemanticColorTokensVarRef(
-        SEMANTIC_DIR,
-        standaloneFile,
-        primitiveMap
-      )
-    );
     if (!FILES_WITH_DEDICATED_DIMENSION_COLLECTORS.has(standaloneFile)) {
       dimensionTokens.push(
         ...collectSemanticDimensionTokens(SEMANTIC_DIR, standaloneFile)
@@ -504,6 +521,7 @@ function generateNexusCSS(
       './variables.css',
       './typography-utilities.css',
       './borderwidth-utilities.css',
+      './border-color-aliases.css',
       './motion-utilities.css',
       './spacing-utilities.css',
     ],
@@ -619,6 +637,16 @@ export async function generateTailwindPackage(
   if (borderWidth.css) {
     writeDistFile('borderwidth-utilities.css', borderWidth.css);
     log.success(`Generated ${borderWidth.count} border width utilities`);
+  }
+
+  const borderColorAliases = generateBorderColorAliasUtilitiesCSS(
+    collectLightSemanticTokens(semanticFiles, primitiveMap)
+  );
+  if (borderColorAliases.css) {
+    writeDistFile('border-color-aliases.css', borderColorAliases.css);
+    log.success(
+      `Generated ${borderColorAliases.count} border color alias utilities`
+    );
   }
 
   // Spacing role utilities — data-driven from default role tokens. Numeric

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -711,13 +711,15 @@ export function generateTypographyUtilitiesCSS(tokensDir, primitiveMap) {
 // BORDER WIDTH UTILITIES
 // ============================================
 
+const BORDER_WIDTH_UTILITIES_PER_TOKEN = 14;
+
 /**
  * Generate border width utility CSS from token array.
  * Creates @utility rules with border-{side?}-{name} patterns for all
  * borderwidth tokens, so runtime stroke modes can affect one-sided borders.
  *
  * @param {object[]} tokens - Array of borderwidth tokens with cssName property (e.g., "nx-borderwidth-default")
- * @returns {{ css: string, count: number }} Generated CSS and token count
+ * @returns {{ css: string, count: number }} Generated CSS and utility count
  */
 export function generateBorderWidthUtilitiesCSS(tokens) {
   if (!tokens || tokens.length === 0) {
@@ -809,7 +811,34 @@ export function generateBorderWidthUtilitiesCSS(tokens) {
     css += `}\n\n`;
   }
 
-  return { css, count: tokens.length };
+  return { css, count: tokens.length * BORDER_WIDTH_UTILITIES_PER_TOKEN };
+}
+
+const BORDER_COLOR_ALIAS_NAMES = new Set([
+  'default',
+  'default-alpha',
+  'active',
+  'disabled',
+  'warning',
+  'warning-active',
+  'success',
+  'success-active',
+  'error',
+  'error-active',
+  'information',
+  'information-active',
+  'primary',
+  'primary-active',
+]);
+
+function getBorderColorAliasName(cssName) {
+  const prefix = 'color-border-';
+  if (!cssName.startsWith(prefix)) {
+    return null;
+  }
+
+  const name = cssName.slice(prefix.length);
+  return BORDER_COLOR_ALIAS_NAMES.has(name) ? name : null;
 }
 
 /**
@@ -818,12 +847,12 @@ export function generateBorderWidthUtilitiesCSS(tokens) {
  * semantic color token in the border namespace.
  *
  * @param {object[]} tokens - Array of semantic color tokens with cssName property (e.g., "color-border-default")
- * @returns {{ css: string, count: number }} Generated CSS and token count
+ * @returns {{ css: string, count: number }} Generated CSS and utility count
  */
 export function generateBorderColorAliasUtilitiesCSS(tokens) {
-  const borderColorTokens = (tokens ?? []).filter((token) =>
-    token.cssName.startsWith('color-border-')
-  );
+  const borderColorTokens = (tokens ?? [])
+    .map((token) => ({ token, name: getBorderColorAliasName(token.cssName) }))
+    .filter(({ name }) => name !== null);
 
   if (borderColorTokens.length === 0) {
     return { css: '', count: 0 };
@@ -831,8 +860,7 @@ export function generateBorderColorAliasUtilitiesCSS(tokens) {
 
   let css = `/* Border Color Alias Utilities */\n\n`;
 
-  for (const token of borderColorTokens) {
-    const name = token.cssName.replace('color-border-', '');
+  for (const { token, name } of borderColorTokens) {
     css += `@utility border-color-${name} {\n`;
     css += `  border-color: var(--${token.cssName});\n`;
     css += `}\n\n`;

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -767,7 +767,78 @@ export function generateBorderWidthUtilitiesCSS(tokens) {
     css += `}\n\n`;
   }
 
+  css += `/* Border Width Alias Utilities */\n\n`;
+
+  for (const token of tokens) {
+    const name = token.cssName.replace('nx-borderwidth-', '');
+    const value = `var(--${token.cssName})`;
+
+    css += `@utility border-width-${name} {\n`;
+    css += `  border-style: var(--tw-border-style, solid);\n`;
+    css += `  border-width: ${value};\n`;
+    css += `}\n\n`;
+
+    css += `@utility border-width-x-${name} {\n`;
+    css += `  border-inline-style: var(--tw-border-style, solid);\n`;
+    css += `  border-inline-width: ${value};\n`;
+    css += `}\n\n`;
+
+    css += `@utility border-width-y-${name} {\n`;
+    css += `  border-block-style: var(--tw-border-style, solid);\n`;
+    css += `  border-block-width: ${value};\n`;
+    css += `}\n\n`;
+
+    css += `@utility border-width-t-${name} {\n`;
+    css += `  border-top-style: var(--tw-border-style, solid);\n`;
+    css += `  border-top-width: ${value};\n`;
+    css += `}\n\n`;
+
+    css += `@utility border-width-r-${name} {\n`;
+    css += `  border-right-style: var(--tw-border-style, solid);\n`;
+    css += `  border-right-width: ${value};\n`;
+    css += `}\n\n`;
+
+    css += `@utility border-width-b-${name} {\n`;
+    css += `  border-bottom-style: var(--tw-border-style, solid);\n`;
+    css += `  border-bottom-width: ${value};\n`;
+    css += `}\n\n`;
+
+    css += `@utility border-width-l-${name} {\n`;
+    css += `  border-left-style: var(--tw-border-style, solid);\n`;
+    css += `  border-left-width: ${value};\n`;
+    css += `}\n\n`;
+  }
+
   return { css, count: tokens.length };
+}
+
+/**
+ * Generate border color alias utility CSS from semantic color tokens.
+ * Creates @utility rules with border-color-{name} patterns for every
+ * semantic color token in the border namespace.
+ *
+ * @param {object[]} tokens - Array of semantic color tokens with cssName property (e.g., "color-border-default")
+ * @returns {{ css: string, count: number }} Generated CSS and token count
+ */
+export function generateBorderColorAliasUtilitiesCSS(tokens) {
+  const borderColorTokens = (tokens ?? []).filter((token) =>
+    token.cssName.startsWith('color-border-')
+  );
+
+  if (borderColorTokens.length === 0) {
+    return { css: '', count: 0 };
+  }
+
+  let css = `/* Border Color Alias Utilities */\n\n`;
+
+  for (const token of borderColorTokens) {
+    const name = token.cssName.replace('color-border-', '');
+    css += `@utility border-color-${name} {\n`;
+    css += `  border-color: var(--${token.cssName});\n`;
+    css += `}\n\n`;
+  }
+
+  return { css, count: borderColorTokens.length };
 }
 
 // ============================================

--- a/packages/react/src/appearance/appearance-reactivity.test.tsx
+++ b/packages/react/src/appearance/appearance-reactivity.test.tsx
@@ -75,9 +75,9 @@ describe('Appearance reactivity component contracts', () => {
 
     const input = screen.getByLabelText('Email');
 
-    expect(input).toHaveClass('nx:border-default');
-    expect(input).toHaveClass('nx:border-border-default');
-    expect(input).toHaveClass('nx:aria-invalid:border-border-error');
+    expect(input).toHaveClass('nx:border-width-default');
+    expect(input).toHaveClass('nx:border-color-default');
+    expect(input).toHaveClass('nx:aria-invalid:border-color-error');
     expectNoRawBorderWidth(input);
   });
 
@@ -87,7 +87,8 @@ describe('Appearance reactivity component contracts', () => {
 
     expect(card).toHaveClass('nx:bg-container');
     expect(card).toHaveClass('nx:text-container-foreground');
-    expect(card).toHaveClass('nx:border-default');
+    expect(card).toHaveClass('nx:border-width-default');
+    expect(card).toHaveClass('nx:border-color-default');
     expect(card).toHaveClass('nx:shadow-sm');
     expectNoRawBorderWidth(card as Element);
   });

--- a/packages/react/src/components/ui/accordion/accordion.tsx
+++ b/packages/react/src/components/ui/accordion/accordion.tsx
@@ -68,9 +68,9 @@ function AccordionItem({ className, ...props }: AccordionItemProps) {
     <AccordionPrimitive.Item
       data-slot="accordion-item"
       className={cn(
-        'nx:border-border-default nx:px-4 nx:transition-colors nx:hover:bg-background-hover nx:data-disabled:border-border-disabled nx:data-disabled:text-disabled-foreground nx:data-disabled:hover:bg-transparent nx:data-[state=open]:pb-4',
+        'nx:border-color-default nx:px-4 nx:transition-colors nx:hover:bg-background-hover nx:data-disabled:border-color-disabled nx:data-disabled:text-disabled-foreground nx:data-disabled:hover:bg-transparent nx:data-[state=open]:pb-4',
         'nx:group-data-[variant=stacked]/accordion:border-b-default nx:group-data-[variant=stacked]/accordion:last:border-b-0',
-        'nx:group-data-[variant=floating]/accordion:rounded-md nx:group-data-[variant=floating]/accordion:border-default',
+        'nx:group-data-[variant=floating]/accordion:rounded-md nx:group-data-[variant=floating]/accordion:border-width-default',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/card/card.tsx
+++ b/packages/react/src/components/ui/card/card.tsx
@@ -39,7 +39,7 @@ function Card({ className, ...props }: CardProps) {
     <div
       data-slot="card"
       className={cn(
-        'nx:overflow-hidden nx:rounded-xl nx:border-default nx:border-border-default nx:bg-container nx:text-container-foreground nx:shadow-sm',
+        'nx:overflow-hidden nx:rounded-xl nx:border-width-default nx:border-color-default nx:bg-container nx:text-container-foreground nx:shadow-sm',
         className
       )}
       {...props}

--- a/packages/react/src/components/ui/input/Input.stories.tsx
+++ b/packages/react/src/components/ui/input/Input.stories.tsx
@@ -397,7 +397,7 @@ export const VisualStateTokens: Story = {
       'nx:disabled:placeholder:text-disabled-foreground'
     );
     await expect(disabledEmpty).toHaveClass(
-      'nx:disabled:border-border-disabled'
+      'nx:disabled:border-color-disabled'
     );
     // Disabled uses a token color, not opacity-50 — opacity stays 1.
     await expect(window.getComputedStyle(disabledEmpty).opacity).toBe('1');

--- a/packages/react/src/components/ui/input/input.tsx
+++ b/packages/react/src/components/ui/input/input.tsx
@@ -6,13 +6,13 @@ import { cn } from '@/lib/utils';
 
 const inputVariants = cva(
   [
-    'nx:flex nx:w-full nx:rounded-md nx:border-default nx:border-border-default',
+    'nx:flex nx:w-full nx:rounded-md nx:border-width-default nx:border-color-default',
     'nx:bg-background nx:text-foreground nx:transition-colors nx:enabled:hover:bg-background-hover',
     'nx:file:border-0 nx:file:bg-transparent nx:file:typography-label-default nx:file:text-foreground nx:disabled:file:text-disabled-foreground',
     'nx:placeholder:text-muted-foreground',
     'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
-    'nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error',
-    'nx:disabled:cursor-not-allowed nx:disabled:border-border-disabled nx:disabled:bg-disabled nx:disabled:text-disabled-foreground nx:disabled:placeholder:text-disabled-foreground',
+    'nx:aria-invalid:border-color-error nx:aria-invalid:focus-visible:outline-focus-error',
+    'nx:disabled:cursor-not-allowed nx:disabled:border-color-disabled nx:disabled:bg-disabled nx:disabled:text-disabled-foreground nx:disabled:placeholder:text-disabled-foreground',
   ],
   {
     variants: {

--- a/packages/react/src/lib/utils.test.ts
+++ b/packages/react/src/lib/utils.test.ts
@@ -5,6 +5,12 @@ import { describe, expect, it } from 'vitest';
 
 import { cn, NEXUS_CLASS_GROUPS, ROLE_CLASS_GROUPS } from './utils';
 
+function utilityNames(css: string) {
+  return [...css.matchAll(/@utility ([a-z-]+) \{/g)].flatMap((match) =>
+    match[1] ? [match[1]] : []
+  );
+}
+
 describe('cn — gap class group', () => {
   it('collapses two role gap utilities with last-one-wins semantics', () => {
     expect(cn('nx:gap-container', 'nx:gap-layout-section')).toBe(
@@ -25,11 +31,7 @@ describe('cn — role-utility class group parity', () => {
       resolve(here, '../../../tailwind/spacing-utilities.css'),
       'utf8'
     );
-    const emitted = new Set(
-      [...spacingUtilitiesCss.matchAll(/@utility ([a-z-]+) \{/g)].map(
-        (m) => m[1]
-      )
-    );
+    const emitted = new Set(utilityNames(spacingUtilitiesCss));
     const configured = new Set(Object.values(ROLE_CLASS_GROUPS).flat());
 
     expect([...configured].sort()).toEqual([...emitted].sort());
@@ -46,6 +48,15 @@ describe('cn — border width token utilities', () => {
     );
     expect(cn('nx:border-default', 'nx:border-transparent')).toBe(
       'nx:border-default nx:border-transparent'
+    );
+  });
+
+  it('keeps new stroke width aliases alongside new border color aliases', () => {
+    expect(cn('nx:border-width-default', 'nx:border-color-default')).toBe(
+      'nx:border-width-default nx:border-color-default'
+    );
+    expect(cn('nx:border-color-default', 'nx:border-width-default')).toBe(
+      'nx:border-color-default nx:border-width-default'
     );
   });
 
@@ -67,6 +78,19 @@ describe('cn — border width token utilities', () => {
     ).toBe('nx:border-x-default nx:border-border-default');
   });
 
+  it('collapses new stroke width aliases with old stroke width names', () => {
+    expect(cn('nx:border-width-default', 'nx:border-0')).toBe('nx:border-0');
+    expect(cn('nx:border-0', 'nx:border-width-default')).toBe(
+      'nx:border-width-default'
+    );
+    expect(cn('nx:border-default', 'nx:border-width-thick')).toBe(
+      'nx:border-width-thick'
+    );
+    expect(cn('nx:border-width-b-default', 'nx:border-b-thick')).toBe(
+      'nx:border-b-thick'
+    );
+  });
+
   it('collapses Nexus stroke utilities against native border-width overrides', () => {
     expect(cn('nx:border-default', 'nx:border-0')).toBe('nx:border-0');
     expect(cn('nx:border-0', 'nx:border-default')).toBe('nx:border-default');
@@ -83,6 +107,23 @@ describe('cn — border width token utilities', () => {
   });
 });
 
+describe('cn — border color token utilities', () => {
+  it('collapses new border color aliases with old border-border names', () => {
+    expect(cn('nx:border-color-default', 'nx:border-transparent')).toBe(
+      'nx:border-transparent'
+    );
+    expect(cn('nx:border-transparent', 'nx:border-color-default')).toBe(
+      'nx:border-color-default'
+    );
+    expect(cn('nx:border-border-default', 'nx:border-color-error')).toBe(
+      'nx:border-color-error'
+    );
+    expect(cn('nx:border-color-active', 'nx:border-border-active')).toBe(
+      'nx:border-border-active'
+    );
+  });
+});
+
 describe('cn — custom utility class group parity', () => {
   it('classGroups cover exactly the border width utilities emitted by @nexus/core', () => {
     const here = dirname(fileURLToPath(import.meta.url));
@@ -90,11 +131,7 @@ describe('cn — custom utility class group parity', () => {
       resolve(here, '../../../tailwind/borderwidth-utilities.css'),
       'utf8'
     );
-    const emitted = new Set(
-      [...borderWidthUtilitiesCss.matchAll(/@utility ([a-z-]+) \{/g)].map(
-        (m) => m[1]
-      )
-    );
+    const emitted = new Set(utilityNames(borderWidthUtilitiesCss));
     const configured = new Set(
       Object.entries(NEXUS_CLASS_GROUPS)
         .filter(
@@ -104,5 +141,28 @@ describe('cn — custom utility class group parity', () => {
     );
 
     expect([...configured].sort()).toEqual([...emitted].sort());
+  });
+
+  it('classGroups cover every generated border color alias and old equivalent', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const borderColorAliasesCss = readFileSync(
+      resolve(here, '../../../tailwind/border-color-aliases.css'),
+      'utf8'
+    );
+    const emittedAliases = utilityNames(borderColorAliasesCss);
+    const configured = NEXUS_CLASS_GROUPS['border-color'];
+    const configuredAliases = configured.filter((name) =>
+      name.startsWith('border-color-')
+    );
+    const configuredOldNames = configured.filter((name) =>
+      name.startsWith('border-border-')
+    );
+
+    expect(configuredAliases.sort()).toEqual([...emittedAliases].sort());
+    expect(configuredOldNames.sort()).toEqual(
+      emittedAliases
+        .map((name) => name.replace('border-color-', 'border-border-'))
+        .sort()
+    );
   });
 });

--- a/packages/react/src/lib/utils.ts
+++ b/packages/react/src/lib/utils.ts
@@ -15,18 +15,87 @@ export const ROLE_CLASS_GROUPS = {
 };
 
 const BORDER_WIDTH_CLASS_GROUPS = {
-  'border-w': ['border-default', 'border-thick'],
-  'border-w-x': ['border-x-default', 'border-x-thick'],
-  'border-w-y': ['border-y-default', 'border-y-thick'],
-  'border-w-t': ['border-t-default', 'border-t-thick'],
-  'border-w-r': ['border-r-default', 'border-r-thick'],
-  'border-w-b': ['border-b-default', 'border-b-thick'],
-  'border-w-l': ['border-l-default', 'border-l-thick'],
+  'border-w': [
+    'border-default',
+    'border-thick',
+    'border-width-default',
+    'border-width-thick',
+  ],
+  'border-w-x': [
+    'border-x-default',
+    'border-x-thick',
+    'border-width-x-default',
+    'border-width-x-thick',
+  ],
+  'border-w-y': [
+    'border-y-default',
+    'border-y-thick',
+    'border-width-y-default',
+    'border-width-y-thick',
+  ],
+  'border-w-t': [
+    'border-t-default',
+    'border-t-thick',
+    'border-width-t-default',
+    'border-width-t-thick',
+  ],
+  'border-w-r': [
+    'border-r-default',
+    'border-r-thick',
+    'border-width-r-default',
+    'border-width-r-thick',
+  ],
+  'border-w-b': [
+    'border-b-default',
+    'border-b-thick',
+    'border-width-b-default',
+    'border-width-b-thick',
+  ],
+  'border-w-l': [
+    'border-l-default',
+    'border-l-thick',
+    'border-width-l-default',
+    'border-width-l-thick',
+  ],
+};
+
+const BORDER_COLOR_CLASS_GROUPS = {
+  'border-color': [
+    'border-border-default',
+    'border-color-default',
+    'border-border-default-alpha',
+    'border-color-default-alpha',
+    'border-border-active',
+    'border-color-active',
+    'border-border-disabled',
+    'border-color-disabled',
+    'border-border-warning',
+    'border-color-warning',
+    'border-border-warning-active',
+    'border-color-warning-active',
+    'border-border-success',
+    'border-color-success',
+    'border-border-success-active',
+    'border-color-success-active',
+    'border-border-error',
+    'border-color-error',
+    'border-border-error-active',
+    'border-color-error-active',
+    'border-border-information',
+    'border-color-information',
+    'border-border-information-active',
+    'border-color-information-active',
+    'border-border-primary',
+    'border-color-primary',
+    'border-border-primary-active',
+    'border-color-primary-active',
+  ],
 };
 
 export const NEXUS_CLASS_GROUPS = {
   ...ROLE_CLASS_GROUPS,
   ...BORDER_WIDTH_CLASS_GROUPS,
+  ...BORDER_COLOR_CLASS_GROUPS,
 };
 
 type NexusClassGroupId = keyof typeof NEXUS_CLASS_GROUPS;

--- a/packages/tailwind/ALIAS.md
+++ b/packages/tailwind/ALIAS.md
@@ -1,0 +1,15 @@
+# Border Naming Aliases
+
+Nexus ships two utility aliases for the border axis:
+
+| Concept                | Original name              | Alias                       |
+| ---------------------- | -------------------------- | --------------------------- |
+| Default stroke width   | `nx:border-default`        | `nx:border-width-default`   |
+| Thick stroke width     | `nx:border-thick`          | `nx:border-width-thick`     |
+| Side-aware widths      | `nx:border-t-default`      | `nx:border-width-t-default` |
+| Semantic default color | `nx:border-border-default` | `nx:border-color-default`   |
+| Semantic state colors  | `nx:border-border-error`   | `nx:border-color-error`     |
+
+Both names work. The aliases point at the same CSS variable lookups as the
+original utilities; prefer the alias when it makes the border width or color
+intent clearer.

--- a/packages/tailwind/border-color-aliases.css
+++ b/packages/tailwind/border-color-aliases.css
@@ -1,0 +1,57 @@
+/* Border Color Alias Utilities */
+
+@utility border-color-default {
+  border-color: var(--color-border-default);
+}
+
+@utility border-color-default-alpha {
+  border-color: var(--color-border-default-alpha);
+}
+
+@utility border-color-active {
+  border-color: var(--color-border-active);
+}
+
+@utility border-color-disabled {
+  border-color: var(--color-border-disabled);
+}
+
+@utility border-color-warning {
+  border-color: var(--color-border-warning);
+}
+
+@utility border-color-warning-active {
+  border-color: var(--color-border-warning-active);
+}
+
+@utility border-color-success {
+  border-color: var(--color-border-success);
+}
+
+@utility border-color-success-active {
+  border-color: var(--color-border-success-active);
+}
+
+@utility border-color-error {
+  border-color: var(--color-border-error);
+}
+
+@utility border-color-error-active {
+  border-color: var(--color-border-error-active);
+}
+
+@utility border-color-information {
+  border-color: var(--color-border-information);
+}
+
+@utility border-color-information-active {
+  border-color: var(--color-border-information-active);
+}
+
+@utility border-color-primary {
+  border-color: var(--color-border-primary);
+}
+
+@utility border-color-primary-active {
+  border-color: var(--color-border-primary-active);
+}

--- a/packages/tailwind/borderwidth-utilities.css
+++ b/packages/tailwind/borderwidth-utilities.css
@@ -69,3 +69,75 @@
   border-left-style: var(--tw-border-style, solid);
   border-left-width: var(--nx-borderwidth-thick);
 }
+
+/* Border Width Alias Utilities */
+
+@utility border-width-default {
+  border-style: var(--tw-border-style, solid);
+  border-width: var(--nx-borderwidth-default);
+}
+
+@utility border-width-x-default {
+  border-inline-style: var(--tw-border-style, solid);
+  border-inline-width: var(--nx-borderwidth-default);
+}
+
+@utility border-width-y-default {
+  border-block-style: var(--tw-border-style, solid);
+  border-block-width: var(--nx-borderwidth-default);
+}
+
+@utility border-width-t-default {
+  border-top-style: var(--tw-border-style, solid);
+  border-top-width: var(--nx-borderwidth-default);
+}
+
+@utility border-width-r-default {
+  border-right-style: var(--tw-border-style, solid);
+  border-right-width: var(--nx-borderwidth-default);
+}
+
+@utility border-width-b-default {
+  border-bottom-style: var(--tw-border-style, solid);
+  border-bottom-width: var(--nx-borderwidth-default);
+}
+
+@utility border-width-l-default {
+  border-left-style: var(--tw-border-style, solid);
+  border-left-width: var(--nx-borderwidth-default);
+}
+
+@utility border-width-thick {
+  border-style: var(--tw-border-style, solid);
+  border-width: var(--nx-borderwidth-thick);
+}
+
+@utility border-width-x-thick {
+  border-inline-style: var(--tw-border-style, solid);
+  border-inline-width: var(--nx-borderwidth-thick);
+}
+
+@utility border-width-y-thick {
+  border-block-style: var(--tw-border-style, solid);
+  border-block-width: var(--nx-borderwidth-thick);
+}
+
+@utility border-width-t-thick {
+  border-top-style: var(--tw-border-style, solid);
+  border-top-width: var(--nx-borderwidth-thick);
+}
+
+@utility border-width-r-thick {
+  border-right-style: var(--tw-border-style, solid);
+  border-right-width: var(--nx-borderwidth-thick);
+}
+
+@utility border-width-b-thick {
+  border-bottom-style: var(--tw-border-style, solid);
+  border-bottom-width: var(--nx-borderwidth-thick);
+}
+
+@utility border-width-l-thick {
+  border-left-style: var(--tw-border-style, solid);
+  border-left-width: var(--nx-borderwidth-thick);
+}

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -11,6 +11,7 @@
 @import './variables.css';
 @import './typography-utilities.css';
 @import './borderwidth-utilities.css';
+@import './border-color-aliases.css';
 @import './motion-utilities.css';
 @import './spacing-utilities.css';
 


### PR DESCRIPTION
## Summary
- Generate self-describing `border-width-*` aliases for border width utilities while preserving the existing `border-*` names.
- Generate semantic `border-color-*` aliases and include them in the Tailwind and docs theme CSS outputs.
- Teach `cn()` to merge old/new border utility names, migrate representative Card/Input/Accordion usage, and document the alias surface.

## GitHub Issue
N/A

## Test Plan
- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test:unit`
- [x] `pnpm test:storybook`
- [x] `pnpm audit:contrast`
- [x] `pnpm audit:browser-support`
