### PR TITLE
docs(platform): define security headers and demo auth policy

### DIFF
--- a/apps/console/src/app/session.test.ts
+++ b/apps/console/src/app/session.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { User } from '../lib/auth-api';
+
+import { DEMO_SESSION_STORAGE_KEY, useSession } from './session';
+
+const DEMO_USER: User = {
+  id: 'demo@atlas.dev',
+  name: 'Demo User',
+  email: 'demo@atlas.dev',
+};
+
+function readStoredUser(): User | null {
+  const raw = window.localStorage.getItem(DEMO_SESSION_STORAGE_KEY);
+  if (!raw) return null;
+
+  const stored = JSON.parse(raw) as { state?: { user?: User | null } };
+  return stored.state?.user ?? null;
+}
+
+beforeEach(() => {
+  useSession.setState({ user: null });
+  window.localStorage.clear();
+});
+
+describe('useSession', () => {
+  it('persists the demo user for the mock console session', () => {
+    useSession.getState().signIn(DEMO_USER);
+
+    expect(useSession.getState().user).toMatchObject(DEMO_USER);
+    expect(readStoredUser()).toMatchObject(DEMO_USER);
+  });
+
+  it('removes script-readable demo session storage on sign out', () => {
+    useSession.getState().signIn(DEMO_USER);
+
+    expect(readStoredUser()).toMatchObject(DEMO_USER);
+
+    useSession.getState().signOut();
+
+    expect(useSession.getState().user).toBeNull();
+    expect(window.localStorage.getItem(DEMO_SESSION_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/apps/console/src/app/session.ts
+++ b/apps/console/src/app/session.ts
@@ -3,26 +3,38 @@ import { persist } from 'zustand/middleware';
 
 import type { User } from '../lib/auth-api';
 
+export const DEMO_SESSION_STORAGE_KEY = 'nexus-console-session';
+
 type SessionState = {
   user: User | null;
   signIn: (user: User) => void;
   signOut: () => void;
 };
 
+function clearDemoSessionStorage() {
+  try {
+    window.localStorage.removeItem(DEMO_SESSION_STORAGE_KEY);
+  } catch {
+    // localStorage can fail in privacy modes; in-memory sign-out still succeeds.
+  }
+}
+
 /**
- * The single source of session truth. The auth screens write the verified user
- * here on sign-in; the router's `beforeLoad` guards read it synchronously via
- * `useSession.getState()`. `persist` uses localStorage (synchronous), so the
- * store is hydrated before the first render — a guard never sees a stale `null`
- * on reload.
+ * Demo-only session state for the mock console. The auth screens write the
+ * mock-verified user here on sign-in; route guards read it synchronously via
+ * `useSession.getState()`. Production auth must use server-issued HttpOnly
+ * cookies instead of script-readable storage.
  */
 export const useSession = create<SessionState>()(
   persist(
     (set) => ({
       user: null,
       signIn: (user) => set({ user }),
-      signOut: () => set({ user: null }),
+      signOut: () => {
+        set({ user: null });
+        clearDemoSessionStorage();
+      },
     }),
-    { name: 'nexus-console-session' }
+    { name: DEMO_SESSION_STORAGE_KEY }
   )
 );

--- a/apps/console/src/lib/auth-api.ts
+++ b/apps/console/src/lib/auth-api.ts
@@ -1,8 +1,8 @@
 /**
- * Auth API client. Thin typed wrappers over the mock endpoints served by MSW
- * (`src/mocks/handlers.ts`) — there is no real backend. Screens call these
- * through TanStack Query mutations; the resolved user is written into the
- * session store (`app/session.ts`), which is the single source of session truth.
+ * Demo auth API client. Thin typed wrappers over the mock endpoints served by
+ * MSW (`src/mocks/handlers.ts`) — there is no real backend. Screens call these
+ * through TanStack Query mutations; the mock-verified user is written into the
+ * demo session store (`app/session.ts`).
  */
 
 export type User = {
@@ -37,7 +37,7 @@ export const login = (creds: Credentials) =>
 export const signup = (input: SignupInput) =>
   post<{ email: string }>('/api/auth/signup', input);
 
-/** OTP check succeeds → the authenticated user is returned. */
+/** OTP check succeeds -> the mock-verified demo user is returned. */
 export const verifyOtp = (input: VerifyInput) =>
   post<{ user: User }>('/api/auth/verify-otp', input);
 

--- a/apps/console/src/mocks/handlers.ts
+++ b/apps/console/src/mocks/handlers.ts
@@ -124,13 +124,13 @@ const membersStore: MemberDetail[] = MEMBERS.map((m) => ({ ...m }));
 const notificationsStore: Notification[] = NOTIFICATIONS.map((n) => ({ ...n }));
 
 /**
- * MSW request handlers — there is no real backend. Auth is a two-step flow: a
- * credentials check (login/signup) hands the email to the OTP step, which is
- * what actually authenticates and returns the user. CRM handlers follow.
+ * MSW request handlers — there is no real backend. Demo auth is a two-step
+ * flow: a credentials check (login/signup) hands the email to the OTP step,
+ * which mock-verifies and returns the demo user. CRM handlers follow.
  */
 export const handlers: RequestHandler[] = [
   // Credentials check — no real validation (any email + an 8+ char password
-  // passes); the OTP step below is the only actual auth gate. Proceeds to OTP.
+  // passes); the OTP step below is the only demo gate. Proceeds to OTP.
   http.post('/api/auth/login', async ({ request }) => {
     const { email, password } = (await request.json()) as LoginBody;
     if (!email || !password || password.length < 8) {
@@ -153,7 +153,7 @@ export const handlers: RequestHandler[] = [
     return HttpResponse.json({ email });
   }),
 
-  // OTP step: the fixed demo code authenticates and returns the user.
+  // OTP step: the fixed demo code mock-verifies and returns the user.
   http.post('/api/auth/verify-otp', async ({ request }) => {
     const { email, code } = (await request.json()) as VerifyBody;
     if (!email || code !== OTP_CODE) {

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -8,6 +8,7 @@ import { DOCS_THEME_BOOTSTRAP_CSP_HASH } from './theme-csp';
 const SCRIPT_SRC = [
   "'self'",
   DOCS_THEME_BOOTSTRAP_CSP_HASH,
+  "'report-sample'",
   process.env.NODE_ENV === 'development' ? "'unsafe-eval'" : null,
 ]
   .filter(Boolean)
@@ -28,10 +29,41 @@ const CONTENT_SECURITY_POLICY_REPORT_ONLY = [
   "font-src 'self'",
   `connect-src ${CONNECT_SRC}`,
   "object-src 'none'",
-  "base-uri 'self'",
+  "base-uri 'none'",
   "form-action 'self'",
   "frame-ancestors 'none'",
 ].join('; ');
+
+const PERMISSIONS_POLICY = [
+  'camera=()',
+  'geolocation=()',
+  'microphone=()',
+  'payment=()',
+  'usb=()',
+].join(', ');
+
+const SECURITY_HEADERS = [
+  {
+    key: 'Content-Security-Policy-Report-Only',
+    value: CONTENT_SECURITY_POLICY_REPORT_ONLY,
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'SAMEORIGIN',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: PERMISSIONS_POLICY,
+  },
+];
 
 const nextConfig: NextConfig = {
   transpilePackages: ['@nexus/react'],
@@ -46,12 +78,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: '/:path*',
-        headers: [
-          {
-            key: 'Content-Security-Policy-Report-Only',
-            value: CONTENT_SECURITY_POLICY_REPORT_ONLY,
-          },
-        ],
+        headers: SECURITY_HEADERS,
       },
     ];
   },

--- a/docs/platform/security-auth-policy.md
+++ b/docs/platform/security-auth-policy.md
@@ -1,0 +1,71 @@
+# Platform Security And Demo Auth Policy
+
+This policy records the production-readiness boundary for the Nexus docs app,
+demo console, and package appearance runtime. It covers the Track B hardening
+work for #394 and #398.
+
+## Source-Owned Docs Headers
+
+`apps/docs/next.config.ts` is the source default for the Next docs app. Hosts
+that do not honor Next `headers()` must mirror these headers in their CDN or
+platform config.
+
+| Header                                | Source default                                            | Rationale                                                                       |
+| ------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `Content-Security-Policy-Report-Only` | Report-only CSP with the docs theme bootstrap hash        | Existing app rollout should collect compatibility evidence before enforcement.  |
+| `Referrer-Policy`                     | `strict-origin-when-cross-origin`                         | Avoids leaking full URLs cross-origin while preserving useful origin referrers. |
+| `X-Content-Type-Options`              | `nosniff`                                                 | Requires browsers to trust declared content types.                              |
+| `X-Frame-Options`                     | `SAMEORIGIN`                                              | Blocks cross-origin clickjacking while preserving same-origin docs previews.    |
+| `Permissions-Policy`                  | Disable camera, geolocation, microphone, payment, and usb | The docs app does not need these powerful browser capabilities.                 |
+
+The report-only CSP intentionally allows the hashed inline docs theme bootstrap
+and inline styles while the app is audited. `apps/docs/scripts/audit-csp-inventory.mjs`
+must be used after a docs build to inspect the actual inline script inventory,
+including the `/appearance-ssr` fixture added for package first-paint proof.
+
+## Deployment-Owned Security Policy
+
+These controls depend on the production host, reporting service, HTTPS
+ownership, or cross-origin integration inventory, so they are not enforced from
+source in this PR.
+
+| Control                | Deployment decision                                                                                                                                |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CSP enforcement        | Move from report-only only after violations are understood and framework inline behavior is accounted for.                                         |
+| CSP reporting endpoint | Add `Reporting-Endpoints` / `report-to` only when a real endpoint exists and report payloads are scrubbed for PII or secrets.                      |
+| HSTS                   | Start with `Strict-Transport-Security: max-age=300`; expand to one year, `includeSubDomains`, and `preload` only after HTTPS and subdomain audits. |
+| COOP / CORP / COEP     | Evaluate popup, embed, package fixture, and cross-origin asset compatibility before enforcement.                                                   |
+| Vite console headers   | Configure at the static host; the console appearance bootstrap is inline and needs its own hash or nonce before CSP enforcement.                   |
+
+## Demo Console Session Policy
+
+The console auth flow is MSW-backed demo behavior. It is useful for showing the
+Atlas shell, but it is not a production auth boundary and must not be copied as
+a production session pattern.
+
+- `apps/console/src/app/session.ts` may persist the demo `User` object in
+  `localStorage` only for the mock console.
+- Demo logout must clear the script-readable `nexus-console-session` key.
+- Production auth/session state must be server-issued cookie state, for example
+  `__Host-session=...; Secure; HttpOnly; SameSite=Lax; Path=/`.
+- Do not set a `Domain` attribute unless a deliberate cross-subdomain auth
+  design requires it.
+- Production state-changing requests need server-side CSRF and origin checks in
+  addition to cookie attributes.
+- A production logout endpoint should expire the server session cookie and can
+  use `Clear-Site-Data` for `"cookies"`, `"storage"`, and `"cache"` when the
+  product accepts that non-sensitive preferences may be cleared too.
+
+## Non-Sensitive Preference Storage
+
+Script-readable storage remains allowed for non-sensitive preferences. These
+values must not contain auth tokens, session identifiers, credentials, or PII.
+
+- Docs and package appearance preferences may use the sanitized appearance
+  cookie/local snapshot model. CSS is derived fresh from sanitized state.
+- The docs `/appearance-ssr` fixture may read the appearance state cookie on the
+  server and emit a first-paint package script with `storageKey={false}`.
+- Console appearance and shell preferences, such as `nexus-console-sidebar`,
+  may use `localStorage`.
+- The shared `sidebar_state` cookie is a client-set UI preference only. It uses
+  `SameSite=Lax`; it cannot be `HttpOnly` because the client owns the write.

--- a/packages/react/src/components/ui/sidebar/sidebar.tsx
+++ b/packages/react/src/components/ui/sidebar/sidebar.tsx
@@ -149,8 +149,8 @@ function SidebarProvider({
       }
 
       _setOpen(openState);
-      // Persist uncontrolled open state to a cookie for server-side restore.
-      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+      // Persist non-sensitive uncontrolled open state for server-side restore.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; SameSite=Lax`;
     },
     [setOpenProp, open]
   );


### PR DESCRIPTION
## Summary

- complete the docs app source-owned security header baseline with report-only CSP, referrer policy, nosniff, same-origin framing, and a defensive permissions policy
- document the source-owned vs deployment-owned security/auth boundary for the docs app, Vite console, and appearance preference storage
- mark console auth/session storage as demo-only, clear the script-readable demo session key on logout, and cover that behavior with a unit test
- add `SameSite=Lax` to the non-sensitive client-set sidebar preference cookie

## GitHub Issue

Closes #394
Closes #398

## Modern Web Guidance Findings

- `security`: retrofit existing apps incrementally; keep CSP report-only until inline/runtime behavior and reporting are understood.
- `security`: low-risk companion headers are appropriate now, including `Referrer-Policy`, `X-Content-Type-Options`, clickjacking protection, and a defensive `Permissions-Policy`.
- `privacy`: production auth/session state should not live in script-readable storage; use server-issued `Secure; HttpOnly; SameSite=Lax` cookies.
- `privacy`: `Clear-Site-Data` belongs on a real server logout endpoint, not the current client-only demo logout.

## Security Header Decisions And Rollout Notes

- Docs source now emits `Content-Security-Policy-Report-Only`, not enforced CSP, because the app still has intentional inline first-paint scripts and Next runtime inline output.
- The docs CSP includes the hashed docs theme bootstrap and `report-sample`; production reporting endpoints and PII scrubbing remain deployment-owned.
- `base-uri` is tightened to `'none'`; the source scan found no `<base>` usage in active app/docs/package source.
- HSTS, enforced CSP, COOP, CORP, and COEP remain deployment-owned pending HTTPS/subdomain and cross-origin compatibility review.
- Vite console security headers remain static-host owned; future console CSP enforcement must account for the inline appearance bootstrap.

## Demo Vs Production Auth/Session Policy

- The console `localStorage` session is explicitly demo-only for the MSW-backed mock auth flow.
- Demo sign-out now removes `localStorage["nexus-console-session"]` after clearing in-memory state.
- Production auth/session policy is documented as server-issued `__Host-session=...; Secure; HttpOnly; SameSite=Lax; Path=/`, plus server-side CSRF/origin protections.
- Script-readable storage remains allowed only for non-sensitive preferences such as appearance state, console sidebar state, and the shared `sidebar_state` UI cookie.

## Test Plan

- [x] `pnpm test:unit -- apps/console/src/app/session.test.ts`
- [x] `pnpm --filter @nexus/core build`
- [x] `pnpm --filter @nexus/react build`
- [x] `pnpm --filter @nexus/docs typecheck`
- [x] `pnpm --filter @nexus/console typecheck`
- [x] `pnpm --filter @nexus/react typecheck`
- [x] `pnpm --filter @nexus/docs build`
- [x] `pnpm --filter @nexus/console build`
- [x] `pnpm --filter @nexus/docs audit:csp`
- [x] `curl -sI http://127.0.0.1:4311/`
- [x] `curl -sI http://127.0.0.1:4311/appearance-ssr`
- [x] Negative source check for `Strict-Transport-Security`, enforced `Content-Security-Policy`, COOP, CORP, and COEP in `apps/docs/next.config.ts`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm format:check`

## Git Proof

- Branch: `aish/platform-hardening-394-398`
- Base: `origin/main` at `5fc8ba55451beb1d632c39546453fc10ff0d468b`
- Merge target: `main`
- Commit: `2a20913d0 docs(platform): define security headers and demo auth policy`
- Changed files:
  - `apps/console/src/app/session.test.ts`
  - `apps/console/src/app/session.ts`
  - `apps/console/src/lib/auth-api.ts`
  - `apps/console/src/mocks/handlers.ts`
  - `apps/docs/next.config.ts`
  - `docs/platform/security-auth-policy.md`
  - `packages/react/src/components/ui/sidebar/sidebar.tsx`
