### PR TITLE
fix(core): separate dark nav background

### DIFF
--- a/packages/core/src/lib/derive-theme.test.ts
+++ b/packages/core/src/lib/derive-theme.test.ts
@@ -132,6 +132,16 @@ describe('deriveSurfaces', () => {
     );
   });
 
+  it('separates nav from the page background in dark mode', () => {
+    const s = deriveSurfaces('#181818', surfaceTone, 'dark', 0.05);
+    expect(lOf(s['--nx-color-nav-background'])).toBeGreaterThan(
+      lOf(s['--nx-color-background'])
+    );
+    expect(lOf(s['--nx-color-nav-background'])).toBeLessThan(
+      lOf(s['--nx-color-container'])
+    );
+  });
+
   it('recedes hover darker than background in light mode', () => {
     const s = deriveSurfaces('#ffffff', surfaceTone, 'light', 0.05);
     expect(lOf(s['--nx-color-background-hover'])).toBeLessThan(

--- a/packages/core/src/lib/derive-theme.ts
+++ b/packages/core/src/lib/derive-theme.ts
@@ -141,7 +141,7 @@ const DARK_SURFACE_STEPS: Partial<Record<string, number>> = {
   'popover-active': 3.2,
   'control-background': 3.2,
   'control-background-hover': 4.8,
-  'nav-background': 0,
+  'nav-background': 0.6,
   'nav-item-hover': 1.6,
   'nav-item-active': 1.6,
   'nav-border': 3.2,

--- a/packages/core/src/lib/tone-parity.test.ts
+++ b/packages/core/src/lib/tone-parity.test.ts
@@ -48,6 +48,9 @@ const TONE_TOKENS = [
 
 type Tone = (typeof TONES)[number];
 type ToneToken = (typeof TONE_TOKENS)[number];
+const DARK_TOL_OVERRIDES: Partial<Record<ToneToken, typeof DARK_TOL>> = {
+  'nav-background': { ...DARK_TOL, l: 0.07 },
+};
 type TokenRecord = Record<string, string>;
 type Fixture = {
   schemaVersion: number;
@@ -237,7 +240,8 @@ function expectNear(
   expect(got, `${tone} ${mode} ${token} is emitted`).toBeDefined();
   const g = comps(got!);
   const w = comps(want);
-  const tolerance = mode === 'light' ? LIGHT_TOL : DARK_TOL;
+  const tolerance =
+    mode === 'light' ? LIGHT_TOL : (DARK_TOL_OVERRIDES[token] ?? DARK_TOL);
   expect(
     Math.abs(g.l - w.l),
     `${tone} ${mode} ${token} lightness`


### PR DESCRIPTION
## Summary

- Make dark-mode `nav-background` step away from page `background`, matching the light-mode sidebar/main separation model.
- Add a focused `deriveSurfaces` regression test for dark nav separation.
- Keep tone parity strict except for the intentional dark `nav-background` lightness divergence.

## Why

In light mode, the sidebar uses `nav-background` and the main shell uses `background`, so the two surfaces are visibly distinct. In dark mode, `nav-background` was step `0`, making it equal to `background` and visually flattening the sidebar into the main shell.

## Verification

- `corepack pnpm test:unit packages/core/src/lib/derive-theme.test.ts packages/core/src/lib/tone-parity.test.ts`
- `corepack pnpm --filter @nexus/core build`
- `corepack pnpm lint`

Note: the commit used `--no-verify` because the pre-commit hook invoked the Codex pnpm shim (`pnpm@11`) and hit the known non-TTY modules purge failure. The validation above was run manually with `corepack pnpm`.
