### PR TITLE
feat(react): add heading semantics and field indicators

### DIFF
--- a/packages/react/src/components/ui/card/Card.stories.tsx
+++ b/packages/react/src/components/ui/card/Card.stories.tsx
@@ -78,6 +78,36 @@ export const WithDescription: Story = {
   ),
 };
 
+export const TitleAsHeading: Story = {
+  render: (_args) => (
+    <section aria-labelledby="card-section-heading">
+      <Card className="nx:w-[350px]">
+        <CardHeader>
+          <CardTitle asChild>
+            <h2 id="card-section-heading">Campaign overview</h2>
+          </CardTitle>
+          <CardDescription>
+            Use a section-level heading when the card sits directly below a page
+            heading.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p>Campaign metrics belong to this section of the page outline.</p>
+        </CardContent>
+      </Card>
+    </section>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const heading = canvas.getByRole('heading', {
+      level: 2,
+      name: 'Campaign overview',
+    });
+
+    await expect(heading).toHaveAttribute('data-slot', 'card-title');
+  },
+};
+
 export const WithAction: Story = {
   render: (_args) => (
     <Card className="nx:w-[350px]">
@@ -398,8 +428,11 @@ export const WithDataAttributes: Story = {
     await expect(footer).toBeInTheDocument();
 
     // Verify title text
-    const titleElement = canvas.getByText('Data Attributes Test');
-    await expect(titleElement).toBeInTheDocument();
+    const titleElement = canvas.getByRole('heading', {
+      level: 3,
+      name: 'Data Attributes Test',
+    });
+    await expect(titleElement).toHaveAttribute('data-slot', 'card-title');
   },
 };
 

--- a/packages/react/src/components/ui/card/card.tsx
+++ b/packages/react/src/components/ui/card/card.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import { Slot } from '@radix-ui/react-slot';
+
 import { cn } from '@/lib/utils';
 
 /**
@@ -90,21 +92,44 @@ function CardHeader({ className, ...props }: CardHeaderProps) {
  *
  * Props for the CardTitle component.
  */
-interface CardTitleProps extends React.ComponentProps<'h3'> {}
+interface CardTitleProps extends React.ComponentProps<'h3'> {
+  /**
+   * Render the title styles on a child element. Use this when the card title
+   * needs a different heading level in the page outline.
+   *
+   * @default false
+   * @example
+   * ```tsx
+   * <CardTitle asChild>
+   *   <h2>Section Title</h2>
+   * </CardTitle>
+   * ```
+   */
+  asChild?: boolean;
+}
 
 /**
  * CardTitle
  *
- * The primary heading of a card.
+ * The primary heading of a card. Renders as an `h3` by default; use `asChild`
+ * to apply card title styling to another heading level when the page outline
+ * needs one.
  *
  * @example
  * ```tsx
  * <CardTitle>Card Title</CardTitle>
  * ```
  */
-function CardTitle({ className, children, ...props }: CardTitleProps) {
+function CardTitle({
+  asChild = false,
+  className,
+  children,
+  ...props
+}: CardTitleProps) {
+  const Comp = asChild ? Slot : 'h3';
+
   return (
-    <h3
+    <Comp
       data-slot="card-title"
       className={cn(
         'nx:col-start-1 nx:min-w-0 nx:typography-heading-xsmall',
@@ -113,7 +138,7 @@ function CardTitle({ className, children, ...props }: CardTitleProps) {
       {...props}
     >
       {children}
-    </h3>
+    </Comp>
   );
 }
 

--- a/packages/react/src/components/ui/empty-state/EmptyState.stories.tsx
+++ b/packages/react/src/components/ui/empty-state/EmptyState.stories.tsx
@@ -59,6 +59,36 @@ export const WithoutAction: Story = {
   ),
 };
 
+export const TitleAsHeading: Story = {
+  render: () => (
+    <section aria-labelledby="empty-state-section-heading">
+      <EmptyState>
+        <EmptyStateHeader>
+          <EmptyStateMedia variant="icon">
+            <IconUsers aria-hidden />
+          </EmptyStateMedia>
+          <EmptyStateTitle asChild>
+            <h2 id="empty-state-section-heading">No contacts yet</h2>
+          </EmptyStateTitle>
+          <EmptyStateDescription>
+            The empty-state title can be the section heading without adding a
+            duplicate hidden heading.
+          </EmptyStateDescription>
+        </EmptyStateHeader>
+      </EmptyState>
+    </section>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const heading = canvas.getByRole('heading', {
+      level: 2,
+      name: 'No contacts yet',
+    });
+
+    await expect(heading).toHaveAttribute('data-slot', 'empty-state-title');
+  },
+};
+
 // Every structural part carries a data-slot hook; the media advertises its
 // variant.
 export const WithDataAttributes: Story = {

--- a/packages/react/src/components/ui/empty-state/empty-state.tsx
+++ b/packages/react/src/components/ui/empty-state/empty-state.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
@@ -144,17 +145,38 @@ function EmptyStateMedia({
  *
  * Props for the EmptyStateTitle component.
  */
-interface EmptyStateTitleProps extends React.ComponentProps<'div'> {}
+interface EmptyStateTitleProps extends React.ComponentProps<'div'> {
+  /**
+   * Render the title styles on a child element. Use this when the empty-state
+   * title should participate in the page outline as a real heading.
+   *
+   * @default false
+   * @example
+   * ```tsx
+   * <EmptyStateTitle asChild>
+   *   <h2>No contacts yet</h2>
+   * </EmptyStateTitle>
+   * ```
+   */
+  asChild?: boolean;
+}
 
 /**
  * EmptyStateTitle
  *
- * The headline of the empty state — what is missing. Renders a `div`, not a
- * heading element — set the heading level in your app if the region needs one.
+ * The headline of the empty state — what is missing. Renders as a `div` by
+ * default; use `asChild` to apply empty-state title styling to a semantic
+ * heading when the page outline needs one.
  */
-function EmptyStateTitle({ className, ...props }: EmptyStateTitleProps) {
+function EmptyStateTitle({
+  asChild = false,
+  className,
+  ...props
+}: EmptyStateTitleProps) {
+  const Comp = asChild ? Slot : 'div';
+
   return (
-    <div
+    <Comp
       data-slot="empty-state-title"
       className={cn('nx:typography-heading-xsmall', className)}
       {...props}

--- a/packages/react/src/components/ui/field/Field.stories.tsx
+++ b/packages/react/src/components/ui/field/Field.stories.tsx
@@ -194,7 +194,7 @@ export const RequiredAndOptionalIndicators: Story = {
       <Field>
         <FieldLabel htmlFor="field-optional-po">
           Purchase order{' '}
-          <FieldRequiredIndicator fallback="Optional">
+          <FieldRequiredIndicator fallback="Optional" aria-hidden>
             Required
           </FieldRequiredIndicator>
         </FieldLabel>

--- a/packages/react/src/components/ui/field/Field.stories.tsx
+++ b/packages/react/src/components/ui/field/Field.stories.tsx
@@ -12,6 +12,7 @@ import {
   FieldGroup,
   FieldLabel,
   FieldLegend,
+  FieldRequiredIndicator,
   FieldSeparator,
   FieldSet,
   FieldTitle,
@@ -179,6 +180,53 @@ export const WithSeparator: Story = {
       </Field>
     </FieldGroup>
   ),
+};
+
+export const RequiredAndOptionalIndicators: Story = {
+  render: () => (
+    <FieldGroup className="nx:w-80">
+      <Field>
+        <FieldLabel htmlFor="field-required-email">
+          Work email <FieldRequiredIndicator />
+        </FieldLabel>
+        <Input id="field-required-email" type="email" required />
+      </Field>
+      <Field>
+        <FieldLabel htmlFor="field-optional-po">
+          Purchase order{' '}
+          <FieldRequiredIndicator fallback="Optional">
+            Required
+          </FieldRequiredIndicator>
+        </FieldLabel>
+        <Input id="field-optional-po" />
+      </Field>
+    </FieldGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const requiredInput = canvas.getByRole('textbox', { name: 'Work email' });
+    const optionalInput = canvas.getByRole('textbox', {
+      name: 'Purchase order Optional',
+    });
+    const indicators = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>(
+        '[data-slot="field-required-indicator"]'
+      )
+    );
+    const [requiredIndicator, optionalIndicator] = indicators;
+
+    await expect(requiredInput).toHaveAttribute('required');
+    await expect(optionalInput).not.toHaveAttribute('required');
+    await expect(indicators).toHaveLength(2);
+
+    await expect(requiredIndicator).toHaveTextContent('*');
+    await expect(requiredIndicator).toHaveAttribute('aria-hidden', 'true');
+    await expect(requiredIndicator).not.toHaveAttribute('data-optional');
+
+    await expect(optionalIndicator).toHaveTextContent('Optional');
+    await expect(optionalIndicator).toHaveAttribute('data-optional', 'true');
+    await expect(optionalIndicator).not.toHaveAttribute('aria-hidden');
+  },
 };
 
 // The checkbox-card pattern: a FieldLabel wrapping a Field becomes a selectable card.

--- a/packages/react/src/components/ui/field/Field.stories.tsx
+++ b/packages/react/src/components/ui/field/Field.stories.tsx
@@ -194,7 +194,7 @@ export const RequiredAndOptionalIndicators: Story = {
       <Field>
         <FieldLabel htmlFor="field-optional-po">
           Purchase order{' '}
-          <FieldRequiredIndicator fallback="Optional" aria-hidden>
+          <FieldRequiredIndicator fallback="Optional">
             Required
           </FieldRequiredIndicator>
         </FieldLabel>
@@ -226,6 +226,9 @@ export const RequiredAndOptionalIndicators: Story = {
     await expect(optionalIndicator).toHaveTextContent('Optional');
     await expect(optionalIndicator).toHaveAttribute('data-optional', 'true');
     await expect(optionalIndicator).not.toHaveAttribute('aria-hidden');
+    await expect(optionalIndicator).toHaveClass(
+      'nx:data-[optional=true]:typography-body-default'
+    );
   },
 };
 

--- a/packages/react/src/components/ui/field/field.tsx
+++ b/packages/react/src/components/ui/field/field.tsx
@@ -181,6 +181,65 @@ function FieldLabel({
 }
 
 /**
+ * FieldRequiredIndicatorProps
+ *
+ * Props for the FieldRequiredIndicator component.
+ */
+interface FieldRequiredIndicatorProps extends React.ComponentProps<'span'> {
+  /**
+   * Optional-field content to render instead of the required marker. This
+   * remains readable by assistive tech and takes precedence over `children`.
+   * Required semantics still belong on the control via `required` or
+   * `aria-required`.
+   *
+   * @example
+   * ```tsx
+   * <FieldLabel htmlFor="email">
+   *   Email <FieldRequiredIndicator />
+   * </FieldLabel>
+   * <Input id="email" required />
+   * ```
+   *
+   * @example
+   * ```tsx
+   * <FieldRequiredIndicator fallback="Optional">Required</FieldRequiredIndicator>
+   * ```
+   */
+  fallback?: React.ReactNode;
+}
+
+/**
+ * FieldRequiredIndicator
+ *
+ * A label affordance for required or optional fields. Renders `*` by default
+ * with `aria-hidden`, or renders `fallback` as readable optional text.
+ */
+function FieldRequiredIndicator({
+  className,
+  children,
+  fallback,
+  'aria-hidden': ariaHidden,
+  ...props
+}: FieldRequiredIndicatorProps) {
+  const isOptional = fallback !== undefined;
+
+  return (
+    <span
+      aria-hidden={isOptional ? ariaHidden : true}
+      data-slot="field-required-indicator"
+      data-optional={isOptional ? 'true' : undefined}
+      className={cn(
+        'nx:text-error-subtle-foreground nx:data-[optional=true]:text-muted-foreground',
+        className
+      )}
+      {...props}
+    >
+      {isOptional ? fallback : (children ?? '*')}
+    </span>
+  );
+}
+
+/**
  * FieldTitle
  *
  * A non-`<label>` title for a field group or card (use when the title isn't
@@ -333,6 +392,8 @@ export {
   FieldLegend,
   type FieldLegendProps,
   type FieldProps,
+  FieldRequiredIndicator,
+  type FieldRequiredIndicatorProps,
   FieldSeparator,
   FieldSet,
   FieldTitle,

--- a/packages/react/src/components/ui/field/field.tsx
+++ b/packages/react/src/components/ui/field/field.tsx
@@ -185,7 +185,10 @@ function FieldLabel({
  *
  * Props for the FieldRequiredIndicator component.
  */
-interface FieldRequiredIndicatorProps extends React.ComponentProps<'span'> {
+type FieldRequiredIndicatorProps = Omit<
+  React.ComponentProps<'span'>,
+  'aria-hidden'
+> & {
   /**
    * Optional-field content to render instead of the required marker. This
    * remains readable by assistive tech and takes precedence over `children`.
@@ -206,7 +209,7 @@ interface FieldRequiredIndicatorProps extends React.ComponentProps<'span'> {
    * ```
    */
   fallback?: React.ReactNode;
-}
+};
 
 /**
  * FieldRequiredIndicator
@@ -218,21 +221,20 @@ function FieldRequiredIndicator({
   className,
   children,
   fallback,
-  'aria-hidden': _ariaHidden,
   ...props
 }: FieldRequiredIndicatorProps) {
   const isOptional = fallback !== undefined;
 
   return (
     <span
+      {...props}
       aria-hidden={isOptional ? undefined : true}
       data-slot="field-required-indicator"
       data-optional={isOptional ? 'true' : undefined}
       className={cn(
-        'nx:text-error-subtle-foreground nx:data-[optional=true]:text-muted-foreground',
+        'nx:text-error-subtle-foreground nx:data-[optional=true]:typography-body-default nx:data-[optional=true]:text-muted-foreground',
         className
       )}
-      {...props}
     >
       {isOptional ? fallback : (children ?? '*')}
     </span>

--- a/packages/react/src/components/ui/field/field.tsx
+++ b/packages/react/src/components/ui/field/field.tsx
@@ -218,14 +218,14 @@ function FieldRequiredIndicator({
   className,
   children,
   fallback,
-  'aria-hidden': ariaHidden,
+  'aria-hidden': _ariaHidden,
   ...props
 }: FieldRequiredIndicatorProps) {
   const isOptional = fallback !== undefined;
 
   return (
     <span
-      aria-hidden={isOptional ? ariaHidden : true}
+      aria-hidden={isOptional ? undefined : true}
       data-slot="field-required-indicator"
       data-optional={isOptional ? 'true' : undefined}
       className={cn(

--- a/packages/react/src/components/ui/form/Form.stories.tsx
+++ b/packages/react/src/components/ui/form/Form.stories.tsx
@@ -6,7 +6,12 @@ import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { z } from 'zod';
 
 import { Button } from '../button';
-import { Field, FieldDescription, FieldLabel } from '../field';
+import {
+  Field,
+  FieldDescription,
+  FieldLabel,
+  FieldRequiredIndicator,
+} from '../field';
 import { Input } from '../input';
 
 import {
@@ -280,16 +285,15 @@ function RequiredOptionalHouseRuleExample() {
         </div>
         <Field>
           <FieldLabel htmlFor="required-house-company">Company</FieldLabel>
-          <Input id="required-house-company" />
+          <Input id="required-house-company" required />
         </Field>
         <Field>
           <FieldLabel htmlFor="required-house-email">Work email</FieldLabel>
-          <Input id="required-house-email" type="email" />
+          <Input id="required-house-email" type="email" required />
         </Field>
         <Field>
           <FieldLabel htmlFor="required-house-po">
-            Purchase order{' '}
-            <span className="nx:text-muted-foreground">(optional)</span>
+            Purchase order <FieldRequiredIndicator fallback="Optional" />
           </FieldLabel>
           <Input id="required-house-po" />
         </Field>
@@ -315,8 +319,7 @@ function RequiredOptionalHouseRuleExample() {
         </Field>
         <Field>
           <FieldLabel htmlFor="optional-house-email">
-            Work email{' '}
-            <span className="nx:text-muted-foreground">(required)</span>
+            Work email <FieldRequiredIndicator />
           </FieldLabel>
           <Input id="optional-house-email" type="email" required />
         </Field>
@@ -390,10 +393,23 @@ export const RequiredOptionalHouseRule: Story = {
   },
   render: () => <RequiredOptionalHouseRuleExample />,
   play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
+    const indicators = Array.from(
+      canvasElement.querySelectorAll<HTMLElement>(
+        '[data-slot="field-required-indicator"]'
+      )
+    );
+    const optionalIndicator = indicators.find(
+      (indicator) => indicator.dataset.optional === 'true'
+    );
+    const requiredIndicator = indicators.find(
+      (indicator) => indicator.dataset.optional !== 'true'
+    );
 
-    await expect(canvas.getByText('(optional)')).toBeInTheDocument();
-    await expect(canvas.getByText('(required)')).toBeInTheDocument();
+    await expect(indicators).toHaveLength(2);
+    await expect(optionalIndicator).toHaveTextContent('Optional');
+    await expect(optionalIndicator).not.toHaveAttribute('aria-hidden');
+    await expect(requiredIndicator).toHaveTextContent('*');
+    await expect(requiredIndicator).toHaveAttribute('aria-hidden', 'true');
   },
 };
 


### PR DESCRIPTION
## Summary

- Add `asChild` semantic heading composition for `CardTitle` and `EmptyStateTitle`, preserving their existing default rendered elements.
- Add exported `FieldRequiredIndicator` with required `*` default, optional `fallback`, `fallback` over `children` precedence, and required-marker `aria-hidden` behavior.
- Add Storybook coverage for heading customization and required/optional label affordances, and wire the form house-rule example to the new indicator.

## GitHub Issue

Closes #412
Closes #450

## Test Plan

- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component card` - passed, 0 missing / 0 drift / 3 info.
- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component empty-state` - passed, 0 missing / 0 drift / 3 info.
- [x] `pnpm --filter @nexus/react audit:storybook-coverage --component field` - passed, 0 missing / 0 drift / 1 info.
- [x] `pnpm --filter @nexus/core build` - passed; needed in the fresh worktree so `@nexus/react` could resolve core declarations.
- [x] `pnpm --filter @nexus/react typecheck` - passed.
- [x] `pnpm test:storybook` - passed, 62 files / 716 tests; existing Chart stories emitted Recharts width warnings but the suite passed.
- [x] `pnpm lint` - passed, no issues found.
- [x] `git diff --check` - passed.
