### PR TITLE
feat(button-group): Tier-A polish pass

### DIFF
--- a/packages/react/src/components/button-group/ButtonGroup.stories.tsx
+++ b/packages/react/src/components/button-group/ButtonGroup.stories.tsx
@@ -309,6 +309,16 @@ export const AsChild: Story = {
     const link = within(canvasElement).getByRole('link', { name: 'Docs' });
     await expect(link.tagName).toBe('A');
     await expect(link).toHaveAttribute('data-slot', 'button-group-text');
+    await expect(link).toHaveClass('nx:focus-visible:outline-2');
+    await expect(link).toHaveClass('nx:focus-visible:outline-focus-default');
+    await expect(link).toHaveClass(
+      'nx:focus-visible:outline-offset-(--focus-offset)'
+    );
+    await expect(link).toHaveClass('nx:transition-colors');
+    await expect(link).toHaveClass('nx:duration-fast');
+    await expect(link).toHaveClass('nx:motion-reduce:transition-none');
+    await expect(link).toHaveClass('nx:hover:bg-control-background-hover');
+    await expect(link).toHaveClass('nx:active:bg-background-active');
   },
 };
 
@@ -371,6 +381,76 @@ export const SplitButton: Story = {
     );
     await expect(trigger).toBeInTheDocument();
     await expect(trigger).toHaveAttribute('data-slot', 'button');
+  },
+};
+
+export const TierAPolishEvidence: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'ButtonGroup Tier-A polish contract: focus-visible addon links, tokenized color motion with reduced-motion fallback, inherited loading/disabled button states, and vertical density evidence.',
+      },
+    },
+  },
+  render: () => (
+    <div className="nx:flex nx:flex-col nx:items-start nx:gap-4 nx:bg-background nx:p-10">
+      <ButtonGroup aria-label="document actions">
+        <ButtonGroupText asChild>
+          <a href="https://example.com/docs">Docs</a>
+        </ButtonGroupText>
+        <Button variant="outline">Open</Button>
+        <Button variant="outline" loading>
+          Saving
+        </Button>
+        <Button variant="outline" disabled>
+          Disabled
+        </Button>
+      </ButtonGroup>
+
+      <ButtonGroup orientation="vertical" size="sm" aria-label="format density">
+        <Button variant="outline">Bold</Button>
+        <Button variant="outline">Italic</Button>
+        <Button variant="outline">Underline</Button>
+      </ButtonGroup>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const horizontalGroup = canvas.getByRole('group', {
+      name: 'document actions',
+    });
+    const verticalGroup = canvas.getByRole('group', {
+      name: 'format density',
+    });
+    const link = canvas.getByRole('link', { name: 'Docs' });
+    const loadingButton = canvas.getByRole('button', { name: 'Saving' });
+    const disabledButton = canvas.getByRole('button', { name: 'Disabled' });
+
+    await expect(horizontalGroup).toHaveAttribute(
+      'data-orientation',
+      'horizontal'
+    );
+    await expect(horizontalGroup).toHaveAttribute('data-size', 'default');
+    await expect(verticalGroup).toHaveAttribute('data-orientation', 'vertical');
+    await expect(verticalGroup).toHaveAttribute('data-size', 'sm');
+    for (const button of within(verticalGroup).getAllByRole('button')) {
+      await expect(button).toHaveAttribute('data-size', 'sm');
+    }
+
+    await expect(link).toHaveClass('nx:transition-colors');
+    await expect(link).toHaveClass('nx:duration-fast');
+    await expect(link).toHaveClass('nx:motion-reduce:transition-none');
+    await expect(link).toHaveClass('nx:focus-visible:outline-2');
+    await expect(link).toHaveClass('nx:hover:bg-control-background-hover');
+    await expect(link).toHaveClass('nx:active:bg-background-active');
+
+    await expect(loadingButton).toHaveAttribute('data-loading', 'true');
+    await expect(loadingButton).toHaveAttribute('aria-busy', 'true');
+    await expect(loadingButton).toHaveAttribute('aria-disabled', 'true');
+
+    await expect(disabledButton).toBeDisabled();
+    await expect(disabledButton).toHaveAttribute('aria-disabled', 'true');
   },
 };
 

--- a/packages/react/src/components/button-group/button-group.tsx
+++ b/packages/react/src/components/button-group/button-group.tsx
@@ -29,7 +29,7 @@ const buttonGroupVariants = cva(
 );
 
 const buttonGroupTextVariants = cva(
-  'nx:flex nx:items-center nx:gap-2 nx:rounded-md nx:border-default nx:border-border-default nx:bg-control-background nx:shadow-xs nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4',
+  'nx:flex nx:items-center nx:gap-2 nx:rounded-md nx:border-default nx:border-border-default nx:bg-control-background nx:shadow-xs nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4',
   {
     variants: {
       size: {
@@ -147,7 +147,12 @@ function ButtonGroupText({
     <Comp
       data-slot="button-group-text"
       data-size={resolvedSize}
-      className={cn(buttonGroupTextVariants({ size: resolvedSize }), className)}
+      className={cn(
+        buttonGroupTextVariants({ size: resolvedSize }),
+        asChild &&
+          'nx:cursor-pointer nx:hover:bg-control-background-hover nx:active:bg-background-active',
+        className
+      )}
       {...props}
     />
   );


### PR DESCRIPTION
Closes #320

Summary:
- Adds ButtonGroupText focus-visible polish and tokenized color motion so addon links rendered with asChild have the same visible focus and reduced-motion contract as other clickable controls.
- Adds hover/active affordance only when ButtonGroupText renders via asChild, keeping default text addons visually static.
- Adds TierAPolishEvidence Storybook coverage for addon link focus/motion, inherited loading/disabled Button states, and vertical density behavior.

Modern Web Guidance gate:
- Ran the required Modern Web Guidance search before editing and used the CSS/accessibility guidance: focus-visible indicators, native button semantics, reduced-motion fallback for transitions, tokenized CSS utilities, and no unsupported browser-floor features.

Validation:
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm test:storybook -- ButtonGroup