### PR TITLE
feat(tooling): standalone design-system export script (interim, pre-CLI)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "docs:restore": "docker rm -f -v nexus-docs-restore >/dev/null 2>&1; docker create --name nexus-docs-restore ghcr.io/nexuslabs-ai-bot/nexus-docs-mcp:latest >/dev/null && docker cp nexus-docs-restore:/data/documents.db ./docs-mcp/data/documents.db && docker rm -v nexus-docs-restore >/dev/null && rm -f ./docs-mcp/data/documents.db-wal ./docs-mcp/data/documents.db-shm && echo 'Restored docs-mcp database from image into docs-mcp/data (stop docs:serve first)'",
     "size-limit": "size-limit",
     "export": "node scripts/export.mjs",
+    "export:verify": "node scripts/verify-export.mjs",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "pnpm turbo build && changeset publish",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "docs:pull": "docker pull ghcr.io/nexuslabs-ai-bot/nexus-docs-mcp:latest",
     "docs:restore": "docker rm -f -v nexus-docs-restore >/dev/null 2>&1; docker create --name nexus-docs-restore ghcr.io/nexuslabs-ai-bot/nexus-docs-mcp:latest >/dev/null && docker cp nexus-docs-restore:/data/documents.db ./docs-mcp/data/documents.db && docker rm -v nexus-docs-restore >/dev/null && rm -f ./docs-mcp/data/documents.db-wal ./docs-mcp/data/documents.db-shm && echo 'Restored docs-mcp database from image into docs-mcp/data (stop docs:serve first)'",
     "size-limit": "size-limit",
+    "export": "node scripts/export.mjs",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "pnpm turbo build && changeset publish",

--- a/scripts/export.mjs
+++ b/scripts/export.mjs
@@ -13,6 +13,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 // Package names that are PUBLISHED upstream deps — never rebranded into the fork.
 export const KEEP_PACKAGES = ['@nexus_ds/core', '@nexus_ds/eslint-plugin'];
@@ -571,3 +572,250 @@ export default tseslint.config(
   prettierConfig
 );
 `;
+
+// ============================================================================
+// CLI ORCHESTRATION
+// ============================================================================
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+// Files rebranded on copy; anything else is copied byte-for-byte.
+const TEXT_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.css',
+  '.json',
+  '.md',
+]);
+
+// eslint toolchain the produced root config imports; versions read from source root.
+const TOOLCHAIN_PACKAGES = [
+  '@eslint/js',
+  'eslint',
+  'eslint-config-prettier',
+  'eslint-plugin-jsx-a11y',
+  'eslint-plugin-react',
+  'eslint-plugin-react-hooks',
+  'eslint-plugin-simple-import-sort',
+  'globals',
+  'typescript-eslint',
+  'typescript',
+];
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeFile(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+/** Drop the `@storybook/addon-vitest` line — the produced Storybook is showcase-only. */
+function trimStorybookVitestAddon(text) {
+  return text.replace(/^\s*'@storybook\/addon-vitest',?\s*\n/m, '');
+}
+
+/**
+ * Recursively copy a tree, rebranding text files. `skip(srcPath)` excludes a
+ * path; `transform(srcPath, text)` post-processes rebranded text.
+ */
+function copyTree(srcDir, destDir, { scope, skip, transform }) {
+  fs.mkdirSync(destDir, { recursive: true });
+  for (const entry of fs.readdirSync(srcDir, { withFileTypes: true })) {
+    const srcPath = path.join(srcDir, entry.name);
+    if (skip?.(srcPath)) {
+      continue;
+    }
+    const destPath = path.join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      copyTree(srcPath, destPath, { scope, skip, transform });
+      continue;
+    }
+    if (!TEXT_EXTENSIONS.has(path.extname(entry.name))) {
+      fs.copyFileSync(srcPath, destPath);
+      continue;
+    }
+    let text = rebrandContent(fs.readFileSync(srcPath, 'utf8'), scope);
+    if (transform) {
+      text = transform(srcPath, text);
+    }
+    fs.writeFileSync(destPath, text);
+  }
+}
+
+/** Collect the minimal registry manifest entries from the source component tree. */
+function collectComponentEntries(componentsDir) {
+  const entries = [];
+  for (const dirent of fs.readdirSync(componentsDir, { withFileTypes: true })) {
+    if (!dirent.isDirectory()) {
+      continue;
+    }
+    const dir = path.join(componentsDir, dirent.name);
+    const files = [];
+    const sources = [];
+    const walk = (current) => {
+      for (const child of fs.readdirSync(current, { withFileTypes: true })) {
+        const childPath = path.join(current, child.name);
+        if (child.isDirectory()) {
+          walk(childPath);
+          continue;
+        }
+        if (child.name.endsWith('.stories.tsx')) {
+          continue;
+        }
+        files.push(path.relative(componentsDir, childPath));
+        if (child.name.endsWith('.tsx') || child.name.endsWith('.ts')) {
+          sources.push(fs.readFileSync(childPath, 'utf8'));
+        }
+      }
+    };
+    walk(dir);
+    entries.push({
+      name: dirent.name,
+      files: files.sort(),
+      deps: scanInternalDeps(sources.join('\n')),
+    });
+  }
+  return entries;
+}
+
+/** Fork packages/react into the produced repo, rebranded + showcase-only Storybook. */
+function forkReactPackage(destReactDir, scope, coreVersion, version) {
+  const srcReactDir = path.join(REPO_ROOT, 'packages', 'react');
+
+  copyTree(path.join(srcReactDir, 'src'), path.join(destReactDir, 'src'), { scope });
+  copyTree(path.join(srcReactDir, '.storybook'), path.join(destReactDir, '.storybook'), {
+    scope,
+    skip: (srcPath) => srcPath.endsWith('vitest.setup.ts'),
+    transform: (srcPath, text) =>
+      srcPath.endsWith('main.ts') ? trimStorybookVitestAddon(text) : text,
+  });
+  for (const file of ['vite.config.ts', 'tsconfig.json', 'components.json']) {
+    const src = path.join(srcReactDir, file);
+    writeFile(path.join(destReactDir, file), rebrandContent(fs.readFileSync(src, 'utf8'), scope));
+  }
+
+  const reactPkg = transformReactPackageJson(readJson(path.join(srcReactDir, 'package.json')), {
+    scope,
+    coreVersion,
+    version,
+  });
+  writeJson(path.join(destReactDir, 'package.json'), reactPkg);
+}
+
+/** Generate the rebranded tailwind package (CSS via the core generator + manifest). */
+async function writeTailwindPackage(destTailwindDir, tokenConfig, scope, version) {
+  const { generateTailwindPackage } = await import(
+    pathToFileURL(path.join(REPO_ROOT, 'packages', 'core', 'scripts', 'generate-tailwind-package.js')).href
+  );
+  fs.mkdirSync(destTailwindDir, { recursive: true });
+  await generateTailwindPackage(tokenConfig, { distDir: destTailwindDir });
+
+  const srcTailwindPkg = readJson(path.join(REPO_ROOT, 'packages', 'tailwind', 'package.json'));
+  writeJson(
+    path.join(destTailwindDir, 'package.json'),
+    transformTailwindPackageJson(srcTailwindPkg, { scope, version })
+  );
+}
+
+/** Write the produced monorepo root scaffold. */
+function writeRootScaffold(outDir, config, manifest) {
+  const { name, scope, policy, tokenConfig } = config;
+  const rootPkg = readJson(path.join(REPO_ROOT, 'package.json'));
+  const eslintPluginVersion = readJson(
+    path.join(REPO_ROOT, 'packages', 'eslint-plugin-nexus', 'package.json')
+  ).version;
+
+  const toolchain = {};
+  for (const dep of TOOLCHAIN_PACKAGES) {
+    const spec = rootPkg.devDependencies?.[dep];
+    if (!spec) {
+      throw new Error(`Toolchain dep "${dep}" not found in root devDependencies.`);
+    }
+    toolchain[dep] = spec;
+  }
+
+  writeJson(
+    path.join(outDir, 'package.json'),
+    renderRootPackageJson({
+      name,
+      scope,
+      eslintPluginVersion,
+      toolchain,
+      overrides: rootPkg.pnpm?.overrides ?? {},
+    })
+  );
+  writeFile(path.join(outDir, 'pnpm-workspace.yaml'), WORKSPACE_YAML);
+  writeFile(path.join(outDir, '.npmrc'), NPMRC_CONTENT);
+  writeFile(path.join(outDir, 'eslint.config.js'), ROOT_ESLINT_CONFIG);
+  writeFile(path.join(outDir, 'README.md'), renderReadme({ name, scope, tokenConfig }));
+  writeJson(path.join(outDir, 'registry.json'), manifest);
+  writeFile(
+    path.join(outDir, 'examples', 'app-appearance.tsx'),
+    renderAppAppearanceExample(scope, policy)
+  );
+}
+
+/** Resolve + prepare the output directory (refuse a non-empty target unless --force). */
+function prepareOutDir(out, force) {
+  const outDir = path.resolve(process.cwd(), out);
+  if (fs.existsSync(outDir) && fs.readdirSync(outDir).length > 0) {
+    if (!force) {
+      throw new Error(`Output dir "${outDir}" is not empty. Pass --force to overwrite.`);
+    }
+    if (fs.existsSync(path.join(outDir, '.git'))) {
+      throw new Error(`Refusing to overwrite "${outDir}": it looks like a git repo.`);
+    }
+    fs.rmSync(outDir, { recursive: true, force: true });
+  }
+  fs.mkdirSync(outDir, { recursive: true });
+  return outDir;
+}
+
+async function main(argv) {
+  const validChoices = discoverTokenChoices(path.join(REPO_ROOT, 'packages', 'core', 'tokens'));
+  const config = parseExportArgs(argv, { validChoices });
+  const coreVersion = readJson(path.join(REPO_ROOT, 'packages', 'core', 'package.json')).version;
+
+  const outDir = prepareOutDir(config.out, config.force);
+  console.log(`\n📦 Exporting "${config.name}" (${config.scope}) → ${outDir}`);
+  console.log(
+    `   tokens: ${TOKEN_CONFIG_KEYS.map((k) => `${k}=${config.tokenConfig[k]}`).join(' ')}`
+  );
+
+  forkReactPackage(path.join(outDir, 'packages', 'react'), config.scope, coreVersion, config.version);
+  console.log(`   ✓ forked ${config.scope}/react (Storybook showcase, rebranded)`);
+
+  await writeTailwindPackage(
+    path.join(outDir, 'packages', 'tailwind'),
+    config.tokenConfig,
+    config.scope,
+    config.version
+  );
+  console.log(`   ✓ generated ${config.scope}/tailwind`);
+
+  const entries = collectComponentEntries(
+    path.join(REPO_ROOT, 'packages', 'react', 'src', 'components')
+  );
+  writeRootScaffold(outDir, config, buildManifest(entries, { version: config.version }));
+  console.log(`   ✓ wrote root scaffold + registry (${entries.length} components)`);
+
+  console.log(`\n✨ Done. Next:\n   cd ${outDir} && pnpm install && pnpm build\n`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(`✗ ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/export.mjs
+++ b/scripts/export.mjs
@@ -1,0 +1,573 @@
+/**
+ * `pnpm export` — scaffold a standalone, rebranded design-system MONOREPO from
+ * this repo. The produced workspace forks `packages/react` + generates
+ * `packages/tailwind` as owned/publishable packages, and depends on the
+ * published `@nexus_ds/core` (runtime engine) + `@nexus_ds/eslint-plugin` (dev).
+ *
+ * Interim stopgap ahead of the CLI (registry + 3-way merge). See issue #541.
+ *
+ * This file holds the pure, side-effect-free helpers (unit-tested in
+ * `export.test.js`). The CLI orchestration lives below the helpers behind an
+ * `import.meta.url` guard so importing this module runs nothing.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Package names that are PUBLISHED upstream deps — never rebranded into the fork.
+export const KEEP_PACKAGES = ['@nexus_ds/core', '@nexus_ds/eslint-plugin'];
+
+// Token-shaping config axes fed to the `@nexus_ds/core` tailwind generator.
+export const TOKEN_CONFIG_KEYS = [
+  'base',
+  'brand',
+  'radius',
+  'borderwidth',
+  'shadow',
+  'motion',
+  'spacingDefault',
+];
+
+// Defaults mirror `DEFAULT_CONFIG` in packages/core/scripts/utils.js.
+export const DEFAULT_TOKEN_CONFIG = {
+  base: 'stone',
+  brand: 'black',
+  radius: 'square',
+  borderwidth: 'normal',
+  shadow: 'quiet',
+  motion: 'snappy',
+  spacingDefault: 'default',
+};
+
+// Appearance-provider wiring presets. Each maps a product policy onto the real
+// `createNexusAppearance` knobs — no invented provider API. See #541 notes.
+export const POLICY_PRESETS = {
+  // Product owner sets the appearance; end-users can't change it.
+  locked: { storageKey: false, cookieWriteKey: false },
+  // End-users pick; their choice persists to localStorage.
+  user: { storageKey: 'nexus-appearance' },
+  // Appearance seeded per request via cookie (multi-tenant SSR).
+  tenant: { cookieWriteKey: 'nexus-appearance' },
+};
+
+export const POLICY_OPTIONS = Object.keys(POLICY_PRESETS);
+
+/**
+ * Derive an npm scope (`@examlly`) from a product name (`examlly-design-system`)
+ * when `--scope` is not given: take the first `-`/`_`-delimited segment.
+ */
+export function deriveScope(name, explicitScope) {
+  if (explicitScope) {
+    if (!explicitScope.startsWith('@')) {
+      throw new Error(`--scope must start with "@" (got "${explicitScope}").`);
+    }
+    return explicitScope;
+  }
+  const first = String(name)
+    .trim()
+    .toLowerCase()
+    .split(/[-_/\s]/)[0]
+    .replace(/[^a-z0-9]/g, '');
+  if (!first) {
+    throw new Error(
+      `Cannot derive a scope from name "${name}". Pass --scope=@your-scope.`
+    );
+  }
+  return `@${first}`;
+}
+
+/**
+ * Enumerate valid token-config values from the committed token files, the same
+ * way the generator discovers them: base/brand from
+ * `tokens/semantic/{base,brands}-{value}-{light|dark}.json`, and
+ * radius/borderwidth/shadow/motion from `tokens/primitives/{category}/`.
+ */
+export function discoverTokenChoices(tokensDir) {
+  const semanticDir = path.join(tokensDir, 'semantic');
+  const primitivesDir = path.join(tokensDir, 'primitives');
+
+  const semanticModes = (prefix) => {
+    const seen = new Set();
+    for (const file of fs.readdirSync(semanticDir)) {
+      const match = file.match(new RegExp(`^${prefix}-(.+)-(?:light|dark)\\.json$`));
+      if (match) {
+        seen.add(match[1]);
+      }
+    }
+    return [...seen].sort();
+  };
+
+  const primitiveModes = (category) => {
+    const dir = path.join(primitivesDir, category);
+    if (!fs.existsSync(dir)) {
+      return [];
+    }
+    const seen = new Set();
+    for (const file of fs.readdirSync(dir)) {
+      const match = file.match(new RegExp(`^${category}-(.+?)(?:-(?:light|dark))?\\.json$`));
+      if (match) {
+        seen.add(match[1]);
+      }
+    }
+    return [...seen].sort();
+  };
+
+  return {
+    base: semanticModes('base'),
+    brand: semanticModes('brands'),
+    radius: primitiveModes('radius'),
+    borderwidth: primitiveModes('borderwidth'),
+    shadow: primitiveModes('shadow'),
+    motion: primitiveModes('motion'),
+    // spacingDefault is validated by the generator itself; accept any value.
+    spacingDefault: [],
+  };
+}
+
+/**
+ * Validate the chosen token config up-front against the discoverable value sets,
+ * so an unknown value fails with a clean message instead of a mid-generation
+ * throw. An empty valid-set for a key means "unconstrained here".
+ */
+export function validateTokenConfig(tokenConfig, validChoices) {
+  for (const key of TOKEN_CONFIG_KEYS) {
+    const valid = validChoices[key];
+    const value = tokenConfig[key];
+    if (valid && valid.length > 0 && !valid.includes(value)) {
+      throw new Error(
+        `Invalid --${key}="${value}". Valid values: ${valid.join(', ')}.`
+      );
+    }
+  }
+}
+
+/**
+ * Parse `--key=value` flags (and the boolean `--force`) into a structured export
+ * config. Token values are validated against `validChoices` (inject a fixed map
+ * in tests; the CLI passes `discoverTokenChoices`).
+ */
+export function parseExportArgs(argv, { validChoices } = {}) {
+  const flags = {};
+  for (const arg of argv) {
+    if (arg === '--force') {
+      flags.force = 'true';
+      continue;
+    }
+    const match = arg.match(/^--([\w-]+)=(.*)$/);
+    if (!match) {
+      throw new Error(`Invalid flag "${arg}". Use --key=value (or --force).`);
+    }
+    flags[match[1]] = match[2];
+  }
+
+  if (!flags.name) {
+    throw new Error('Missing required --name (e.g. --name=examlly-design-system).');
+  }
+
+  const name = flags.name;
+  const scope = deriveScope(name, flags.scope);
+  const policy = flags.policy ?? 'user';
+  if (!POLICY_OPTIONS.includes(policy)) {
+    throw new Error(
+      `Invalid --policy="${policy}". Valid values: ${POLICY_OPTIONS.join(', ')}.`
+    );
+  }
+
+  const tokenConfig = { ...DEFAULT_TOKEN_CONFIG };
+  for (const key of TOKEN_CONFIG_KEYS) {
+    if (flags[key] !== undefined) {
+      tokenConfig[key] = flags[key];
+    }
+  }
+  if (validChoices) {
+    validateTokenConfig(tokenConfig, validChoices);
+  }
+
+  return {
+    name,
+    scope,
+    policy,
+    version: flags.version ?? '0.1.0',
+    out: flags.out ?? path.join('..', name),
+    force: flags.force === 'true',
+    tokenConfig,
+  };
+}
+
+/**
+ * Rebrand copied source: rename ONLY the two forked packages
+ * (`@nexus_ds/react`, `@nexus_ds/tailwind`) to the target scope, across every
+ * file type (`.ts/.tsx/.css/.json/.md`). `@nexus_ds/core`,
+ * `@nexus_ds/eslint-plugin`, the `@nexus_ds/no-render-prop-types` eslint-disable
+ * directives, and the `nx:` / `--nx-*` prefixes are left untouched.
+ */
+export function rebrandContent(text, scope) {
+  return text
+    .split('@nexus_ds/react')
+    .join(`${scope}/react`)
+    .split('@nexus_ds/tailwind')
+    .join(`${scope}/tailwind`);
+}
+
+/**
+ * Transform the forked react package.json in place (read-modify-write): rebrand
+ * the name, repoint the tailwind workspace dep to the new scope, pin the core
+ * dep to a published range, and make it publishable. Structural fields (Radix
+ * pins, peers, exports) are preserved so the fork can't drift from upstream.
+ */
+export function transformReactPackageJson(pkg, { scope, coreVersion, version }) {
+  const next = structuredClone(pkg);
+  next.name = `${scope}/react`;
+  next.version = version;
+  delete next.private;
+  delete next['//'];
+  next.publishConfig = { access: 'public' };
+
+  if (next.dependencies?.['@nexus_ds/core']) {
+    next.dependencies['@nexus_ds/core'] = `^${coreVersion}`;
+  }
+  if (next.dependencies?.['@nexus_ds/tailwind']) {
+    const spec = next.dependencies['@nexus_ds/tailwind'];
+    delete next.dependencies['@nexus_ds/tailwind'];
+    next.dependencies[`${scope}/tailwind`] = spec;
+  }
+  return next;
+}
+
+/**
+ * Transform the forked tailwind package.json: rebrand the name, set a real
+ * version, and make it publishable. CSS exports / files / tailwindcss peer are
+ * preserved from source.
+ */
+export function transformTailwindPackageJson(pkg, { scope, version }) {
+  const next = structuredClone(pkg);
+  next.name = `${scope}/tailwind`;
+  next.version = version;
+  delete next.private;
+  next.publishConfig = { access: 'public' };
+  return next;
+}
+
+/**
+ * Scan a component source file for its intra-package (`@/`) dependencies,
+ * bucketed by root. Line comments are stripped so a commented import can't leak
+ * in. Used to build the minimal registry manifest (seed of the future CLI).
+ */
+export function scanInternalDeps(text) {
+  const withoutLineComments = text.replace(/\/\/.*$/gm, '');
+  const deps = { components: new Set(), lib: new Set(), hooks: new Set() };
+  const importRe = /@\/(components|lib|hooks)\/([\w-]+)/g;
+  let match;
+  while ((match = importRe.exec(withoutLineComments)) !== null) {
+    deps[match[1]].add(match[2]);
+  }
+  return {
+    components: [...deps.components].sort(),
+    lib: [...deps.lib].sort(),
+    hooks: [...deps.hooks].sort(),
+  };
+}
+
+/**
+ * Build the minimal `registry.json` manifest from per-component entries
+ * ({ name, files, deps }). This is the seed of the future CLI registry; nothing
+ * in the export reads it back.
+ */
+export function buildManifest(components, { version }) {
+  const sorted = [...components].sort((a, b) => a.name.localeCompare(b.name));
+  const map = {};
+  for (const entry of sorted) {
+    map[entry.name] = { files: entry.files, deps: entry.deps };
+  }
+  return { version, generatedFrom: '@nexus_ds/react', components: map };
+}
+
+/**
+ * Render the default appearance-provider wiring example for the chosen policy.
+ * Emits a standalone illustrative file that uses the real `createNexusAppearance`
+ * knobs from the published provider subentry.
+ */
+export function renderAppAppearanceExample(scope, policy) {
+  const preset = POLICY_PRESETS[policy];
+  const knobs = Object.entries(preset)
+    .map(([key, value]) => `  ${key}: ${JSON.stringify(value)},`)
+    .join('\n');
+  const notes = {
+    locked: 'the product owner sets the appearance; end-users cannot change it.',
+    user: 'end-users pick their appearance; the choice persists to localStorage.',
+    tenant: 'appearance is seeded per request via cookie (multi-tenant SSR).',
+  };
+
+  return `import { createNexusAppearance } from '${scope}/react/appearance';
+
+// Appearance policy "${policy}" — ${notes[policy]}
+// Swap the knobs below (storageKey / cookieWriteKey / defaultState) to change
+// the policy; re-run \`pnpm export --policy=<locked|user|tenant>\` to regenerate.
+export const { NexusAppearanceProvider } = createNexusAppearance({
+${knobs}
+});
+`;
+}
+
+/** Render the produced root package.json. Versions are injected by the CLI. */
+export function renderRootPackageJson({
+  name,
+  scope,
+  eslintPluginVersion,
+  toolchain,
+  overrides,
+}) {
+  return {
+    name,
+    version: '0.0.0',
+    private: true,
+    type: 'module',
+    scripts: {
+      build: 'pnpm -r --if-present build',
+      typecheck: 'pnpm -r --if-present typecheck',
+      lint: 'eslint . --max-warnings 0',
+      storybook: `pnpm --filter ${scope}/react storybook`,
+      'build-storybook': `pnpm --filter ${scope}/react build-storybook`,
+    },
+    devDependencies: {
+      ...toolchain,
+      '@nexus_ds/eslint-plugin': `^${eslintPluginVersion}`,
+    },
+    pnpm: { overrides },
+    engines: { node: '>=20.19.0' },
+  };
+}
+
+/** Render the produced README. */
+export function renderReadme({ name, scope, tokenConfig }) {
+  const tokenRows = TOKEN_CONFIG_KEYS.map(
+    (key) => `| \`${key}\` | \`${tokenConfig[key]}\` |`
+  ).join('\n');
+
+  return `# ${name}
+
+A standalone Nexus-derived design system. The \`react\` + \`tailwind\` packages are
+**yours to own and publish**; they depend on the published runtime engine
+\`@nexus_ds/core\` and the lint guardrails \`@nexus_ds/eslint-plugin\`.
+
+## Packages
+
+- \`${scope}/react\` — components + appearance provider/editor (Storybook showcase included).
+- \`${scope}/tailwind\` — design-token CSS. A future \`${scope}/vue\` / \`${scope}/svelte\`
+  can depend on the same token package unchanged.
+
+## Baseline token config
+
+| Axis | Value |
+| ---- | ----- |
+${tokenRows}
+
+Retheme at runtime via \`NexusAppearanceProvider\` (see \`examples/app-appearance.tsx\`).
+The \`nx:\` utility prefix is fixed — the engine emits \`--nx-*\` variables at runtime.
+
+## Develop
+
+\`\`\`bash
+pnpm install
+pnpm build
+pnpm lint
+pnpm typecheck
+pnpm build-storybook
+\`\`\`
+
+## Publish (order matters)
+
+\`${scope}/tailwind\` must publish **before** \`${scope}/react\` (react depends on it):
+
+\`\`\`bash
+pnpm --filter ${scope}/tailwind publish
+pnpm --filter ${scope}/react publish
+\`\`\`
+`;
+}
+
+// Static scaffold files (byte-identical to the source repo's irreducibles).
+
+export const NPMRC_CONTENT = `# Flat node_modules (npm/yarn-style) rather than pnpm's default isolated store.
+# Radix primitives expose inferred types that reference transitive packages
+# (e.g. @radix-ui/react-context); under the isolated linker TypeScript can't
+# name them portably and the .d.ts rollup fails with TS2742. Hoisting makes
+# those transitive types nameable from the top-level node_modules.
+node-linker=hoisted
+`;
+
+export const WORKSPACE_YAML = `packages:
+  - 'packages/*'
+
+onlyBuiltDependencies:
+  - esbuild
+`;
+
+/**
+ * The produced root eslint.config.js. Mirrors the source repo's flat config but
+ * drops the `apps/**` and `packages/core/tokens` scopes (no such files in the
+ * fork) and uses the PUBLISHED `@nexus_ds/eslint-plugin/config` preset helper
+ * rather than re-inlining rule names.
+ */
+export const ROOT_ESLINT_CONFIG = `import js from '@eslint/js';
+import { nexusComponentConfig } from '@nexus_ds/eslint-plugin/config';
+import prettierConfig from 'eslint-config-prettier';
+import jsxA11yPlugin from 'eslint-plugin-jsx-a11y';
+import reactPlugin from 'eslint-plugin-react';
+import reactHooksPlugin from 'eslint-plugin-react-hooks';
+import simpleImportSort from 'eslint-plugin-simple-import-sort';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/.turbo/**',
+      '**/coverage/**',
+      '**/storybook-static/**',
+      '**/build/**',
+      '**/out/**',
+    ],
+  },
+
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+
+  {
+    files: ['**/*.{jsx,tsx}'],
+    plugins: { react: reactPlugin },
+    languageOptions: {
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      globals: { ...globals.browser },
+    },
+    settings: { react: { version: 'detect' } },
+    rules: {
+      ...reactPlugin.configs.recommended.rules,
+      ...reactPlugin.configs['jsx-runtime'].rules,
+      'react/prop-types': 'off',
+      'react/react-in-jsx-scope': 'off',
+      'react/display-name': 'off',
+      'react/no-unescaped-entities': 'warn',
+    },
+  },
+
+  {
+    files: ['**/*.{jsx,tsx}'],
+    plugins: { 'react-hooks': reactHooksPlugin },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+    },
+  },
+
+  {
+    files: ['**/*.{jsx,tsx}'],
+    plugins: { 'jsx-a11y': jsxA11yPlugin },
+    rules: {
+      ...jsxA11yPlugin.configs.recommended.rules,
+      'jsx-a11y/anchor-is-valid': 'warn',
+      'jsx-a11y/click-events-have-key-events': 'warn',
+      'jsx-a11y/no-static-element-interactions': 'warn',
+    },
+  },
+
+  {
+    files: ['**/*.{js,jsx,ts,tsx}'],
+    plugins: { 'simple-import-sort': simpleImportSort },
+    rules: {
+      'simple-import-sort/imports': [
+        'error',
+        {
+          groups: [
+            ['^react', '^react-dom'],
+            ['^@?\\\\w'],
+            ['^@/'],
+            ['^\\\\.\\\\.'],
+            ['^\\\\./'],
+            ['^.+\\\\.css$'],
+          ],
+        },
+      ],
+      'simple-import-sort/exports': 'error',
+    },
+  },
+
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+      globals: { ...globals.browser, ...globals.node },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-non-null-assertion': 'error',
+      '@typescript-eslint/consistent-type-assertions': [
+        'error',
+        { objectLiteralTypeAssertions: 'allow-as-parameter' },
+      ],
+      '@typescript-eslint/consistent-type-imports': [
+        'warn',
+        { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
+      ],
+      '@typescript-eslint/no-import-type-side-effects': 'error',
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
+      'prefer-const': 'error',
+      'no-var': 'error',
+      eqeqeq: ['error', 'always', { null: 'ignore' }],
+      curly: ['error', 'all'],
+      'no-else-return': 'error',
+    },
+  },
+
+  {
+    files: ['**/*.{js,jsx,mjs,cjs}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: { ...globals.node },
+    },
+    rules: {
+      'no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
+    },
+  },
+
+  {
+    files: ['packages/react/src/components/**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-empty-object-type': [
+        'error',
+        { allowInterfaces: 'with-single-extends' },
+      ],
+    },
+  },
+
+  {
+    files: ['packages/react/src/**/*.{ts,tsx}'],
+    ...nexusComponentConfig(),
+  },
+
+  {
+    files: ['**/*.stories.tsx'],
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+
+  prettierConfig
+);
+`;

--- a/scripts/export.mjs
+++ b/scripts/export.mjs
@@ -18,6 +18,9 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 // Package names that are PUBLISHED upstream deps — never rebranded into the fork.
 export const KEEP_PACKAGES = ['@nexus_ds/core', '@nexus_ds/eslint-plugin'];
 
+// Workspace packages forked into the produced repo — rebranded to the target scope.
+export const REBRAND_PACKAGES = ['@nexus_ds/react', '@nexus_ds/tailwind'];
+
 // Token-shaping config axes fed to the `@nexus_ds/core` tailwind generator.
 export const TOKEN_CONFIG_KEYS = [
   'base',
@@ -80,8 +83,9 @@ export function deriveScope(name, explicitScope) {
 /**
  * Enumerate valid token-config values from the committed token files, the same
  * way the generator discovers them: base/brand from
- * `tokens/semantic/{base,brands}-{value}-{light|dark}.json`, and
- * radius/borderwidth/shadow/motion from `tokens/primitives/{category}/`.
+ * `tokens/semantic/{base,brands}-{value}-{light|dark}.json`,
+ * radius/borderwidth/shadow/motion from `tokens/primitives/{category}/`, and
+ * spacingDefault from `tokens/semantic/spacing-{mode}.json`.
  */
 export function discoverTokenChoices(tokensDir) {
   const semanticDir = path.join(tokensDir, 'semantic');
@@ -113,6 +117,19 @@ export function discoverTokenChoices(tokensDir) {
     return [...seen].sort();
   };
 
+  // Spacing modes ship as `semantic/spacing-{mode}.json` (no light/dark split),
+  // matching the generator's own `^spacing-([a-z]+)\.json$` discovery.
+  const spacingModes = () => {
+    const seen = new Set();
+    for (const file of fs.readdirSync(semanticDir)) {
+      const match = file.match(/^spacing-([a-z]+)\.json$/);
+      if (match) {
+        seen.add(match[1]);
+      }
+    }
+    return [...seen].sort();
+  };
+
   return {
     base: semanticModes('base'),
     brand: semanticModes('brands'),
@@ -120,8 +137,7 @@ export function discoverTokenChoices(tokensDir) {
     borderwidth: primitiveModes('borderwidth'),
     shadow: primitiveModes('shadow'),
     motion: primitiveModes('motion'),
-    // spacingDefault is validated by the generator itself; accept any value.
-    spacingDefault: [],
+    spacingDefault: spacingModes(),
   };
 }
 
@@ -203,11 +219,40 @@ export function parseExportArgs(argv, { validChoices } = {}) {
  * directives, and the `nx:` / `--nx-*` prefixes are left untouched.
  */
 export function rebrandContent(text, scope) {
-  return text
-    .split('@nexus_ds/react')
-    .join(`${scope}/react`)
-    .split('@nexus_ds/tailwind')
-    .join(`${scope}/tailwind`);
+  return REBRAND_PACKAGES.reduce(
+    (out, pkg) => out.split(pkg).join(pkg.replace('@nexus_ds', scope)),
+    text
+  );
+}
+
+const DEP_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+];
+
+/**
+ * Guard a produced manifest against un-forked `@nexus_ds/*` deps. After the
+ * transform the only `@nexus_ds/*` names that may survive are the published
+ * KEEP_PACKAGES; a new workspace dep (e.g. a future `@nexus_ds/icons`) would
+ * otherwise ship as an unresolved `workspace:*` range — fail loudly instead.
+ */
+function assertNoUnhandledNexusDeps(pkg) {
+  const unhandled = [];
+  for (const field of DEP_FIELDS) {
+    for (const name of Object.keys(pkg[field] ?? {})) {
+      if (name.startsWith('@nexus_ds/') && !KEEP_PACKAGES.includes(name)) {
+        unhandled.push(`${field}.${name}`);
+      }
+    }
+  }
+  if (unhandled.length > 0) {
+    throw new Error(
+      `Unhandled @nexus_ds/* dependency in the forked manifest: ${unhandled.join(', ')}. ` +
+        `Fork it (add to REBRAND_PACKAGES) or keep it published (add to KEEP_PACKAGES).`
+    );
+  }
 }
 
 /**
@@ -232,6 +277,8 @@ export function transformReactPackageJson(pkg, { scope, coreVersion, version }) 
     delete next.dependencies['@nexus_ds/tailwind'];
     next.dependencies[`${scope}/tailwind`] = spec;
   }
+
+  assertNoUnhandledNexusDeps(next);
   return next;
 }
 
@@ -246,20 +293,25 @@ export function transformTailwindPackageJson(pkg, { scope, version }) {
   next.version = version;
   delete next.private;
   next.publishConfig = { access: 'public' };
+
+  assertNoUnhandledNexusDeps(next);
   return next;
 }
 
 /**
  * Scan a component source file for its intra-package (`@/`) dependencies,
- * bucketed by root. Line comments are stripped so a commented import can't leak
- * in. Used to build the minimal registry manifest (seed of the future CLI).
+ * bucketed by root. Block and line comments are stripped (URLs preserved) so a
+ * commented import can't leak in. Used to build the minimal registry manifest
+ * (seed of the future CLI).
  */
 export function scanInternalDeps(text) {
-  const withoutLineComments = text.replace(/\/\/.*$/gm, '');
+  const withoutComments = text
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(?<!:)\/\/.*$/gm, '');
   const deps = { components: new Set(), lib: new Set(), hooks: new Set() };
   const importRe = /@\/(components|lib|hooks)\/([\w-]+)/g;
   let match;
-  while ((match = importRe.exec(withoutLineComments)) !== null) {
+  while ((match = importRe.exec(withoutComments)) !== null) {
     deps[match[1]].add(match[2]);
   }
   return {
@@ -766,15 +818,44 @@ function writeRootScaffold(outDir, config, manifest) {
   );
 }
 
+/** True if `child` is `parent` itself or nested inside it. */
+function isPathWithin(parent, child) {
+  const rel = path.relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+/** True if a `.git` entry exists anywhere within `dir` (skips node_modules). */
+function containsGitDir(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules') {
+      continue;
+    }
+    if (entry.name === '.git') {
+      return true;
+    }
+    if (entry.isDirectory() && containsGitDir(path.join(dir, entry.name))) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Resolve + prepare the output directory (refuse a non-empty target unless --force). */
 function prepareOutDir(out, force) {
   const outDir = path.resolve(process.cwd(), out);
+  // Never let --force `rmSync` a directory that is (or contains) this repo or
+  // the cwd — `--out=..` would otherwise wipe the repo's parent.
+  if (isPathWithin(outDir, REPO_ROOT) || isPathWithin(outDir, process.cwd())) {
+    throw new Error(
+      `Refusing to export into "${outDir}": it is or contains this repo / the current directory.`
+    );
+  }
   if (fs.existsSync(outDir) && fs.readdirSync(outDir).length > 0) {
     if (!force) {
       throw new Error(`Output dir "${outDir}" is not empty. Pass --force to overwrite.`);
     }
-    if (fs.existsSync(path.join(outDir, '.git'))) {
-      throw new Error(`Refusing to overwrite "${outDir}": it looks like a git repo.`);
+    if (containsGitDir(outDir)) {
+      throw new Error(`Refusing to overwrite "${outDir}": it contains a git repository.`);
     }
     fs.rmSync(outDir, { recursive: true, force: true });
   }

--- a/scripts/export.mjs
+++ b/scripts/export.mjs
@@ -843,11 +843,17 @@ function containsGitDir(dir) {
 /** Resolve + prepare the output directory (refuse a non-empty target unless --force). */
 function prepareOutDir(out, force) {
   const outDir = path.resolve(process.cwd(), out);
-  // Never let --force `rmSync` a directory that is (or contains) this repo or
-  // the cwd — `--out=..` would otherwise wipe the repo's parent.
-  if (isPathWithin(outDir, REPO_ROOT) || isPathWithin(outDir, process.cwd())) {
+  // Never let --force `rmSync` a directory entangled with this repo or the cwd:
+  // `--out=..` would wipe the repo's parent, and `--out=packages` would wipe
+  // tracked source *inside* the repo — the single root `.git` can't guard a
+  // subdir, so refuse both directions relative to REPO_ROOT.
+  if (
+    isPathWithin(outDir, REPO_ROOT) ||
+    isPathWithin(REPO_ROOT, outDir) ||
+    isPathWithin(outDir, process.cwd())
+  ) {
     throw new Error(
-      `Refusing to export into "${outDir}": it is or contains this repo / the current directory.`
+      `Refusing to export into "${outDir}": it overlaps this repo / the current directory.`
     );
   }
   if (fs.existsSync(outDir) && fs.readdirSync(outDir).length > 0) {

--- a/scripts/export.test.js
+++ b/scripts/export.test.js
@@ -293,10 +293,11 @@ describe('scanInternalDeps', () => {
       " * import { Tooltip } from '@/components/tooltip';",
       ' */',
       "const docs = 'https://example.com/guide'; // see @/components/should-not-leak",
+      "const cdn = 'https://x.io'; export { Button } from '@/components/button';",
       "import { useToast } from '@/hooks/use-toast';",
     ].join('\n');
     expect(scanInternalDeps(source)).toEqual({
-      components: [],
+      components: ['button'],
       lib: ['utils'],
       hooks: ['use-toast'],
     });

--- a/scripts/export.test.js
+++ b/scripts/export.test.js
@@ -10,6 +10,8 @@ import {
   parseExportArgs,
   rebrandContent,
   renderAppAppearanceExample,
+  renderReadme,
+  renderRootPackageJson,
   scanInternalDeps,
   transformReactPackageJson,
   transformTailwindPackageJson,
@@ -30,7 +32,14 @@ const VALID_CHOICES = {
   borderwidth: ['fine', 'normal', 'strong'],
   shadow: ['flat', 'quiet', 'soft', 'standard', 'strong'],
   motion: ['snappy'],
-  spacingDefault: [],
+  spacingDefault: [
+    'comfortable',
+    'compact',
+    'default',
+    'relaxed',
+    'spacious',
+    'tight',
+  ],
 };
 
 const DEFAULTS = {
@@ -80,6 +89,15 @@ describe('validateTokenConfig', () => {
     expect(() =>
       validateTokenConfig({ ...DEFAULTS, radius: 'octagon' }, VALID_CHOICES)
     ).toThrow(/Invalid --radius="octagon"\. Valid values: .*square/);
+  });
+
+  it('rejects an unknown spacingDefault against discovered modes', () => {
+    expect(() =>
+      validateTokenConfig(
+        { ...DEFAULTS, spacingDefault: 'roomy' },
+        VALID_CHOICES
+      )
+    ).toThrow(/Invalid --spacingDefault="roomy"\. Valid values: .*default/);
   });
 });
 
@@ -213,6 +231,23 @@ describe('transformReactPackageJson', () => {
     expect(source.name).toBe('@nexus_ds/react');
     expect(source.private).toBe(true);
   });
+
+  it('throws on an un-forked @nexus_ds/* dep in the produced manifest', () => {
+    const withStray = {
+      ...source,
+      dependencies: {
+        ...source.dependencies,
+        '@nexus_ds/icons': 'workspace:*',
+      },
+    };
+    expect(() =>
+      transformReactPackageJson(withStray, {
+        scope: '@examlly',
+        coreVersion: '0.1.0',
+        version: '0.1.0',
+      })
+    ).toThrow(/Unhandled @nexus_ds\/\* dependency.*@nexus_ds\/icons/);
+  });
 });
 
 describe('transformTailwindPackageJson', () => {
@@ -318,10 +353,52 @@ describe('discoverTokenChoices', () => {
     for (const f of ['radius-square.json', 'radius-round.json']) {
       fs.writeFileSync(path.join(radiusDir, f), '{}');
     }
+    for (const f of ['spacing-default.json', 'spacing-compact.json']) {
+      fs.writeFileSync(path.join(semantic, f), '{}');
+    }
 
     const choices = discoverTokenChoices(root);
     expect(choices.base).toEqual(['slate', 'stone']);
     expect(choices.brand).toEqual(['blue']);
     expect(choices.radius).toEqual(['round', 'square']);
+    expect(choices.spacingDefault).toEqual(['compact', 'default']);
+  });
+});
+
+describe('renderRootPackageJson', () => {
+  it('wires scripts, toolchain, eslint-plugin range, and overrides', () => {
+    const pkg = renderRootPackageJson({
+      name: 'acme-ds',
+      scope: '@acme',
+      eslintPluginVersion: '0.2.0',
+      toolchain: { eslint: '^9.0.0', typescript: '^5.5.0' },
+      overrides: { 'some-dep': '1.2.3' },
+    });
+    expect(pkg.name).toBe('acme-ds');
+    expect(pkg.private).toBe(true);
+    expect(pkg.devDependencies['@nexus_ds/eslint-plugin']).toBe('^0.2.0');
+    expect(pkg.devDependencies.eslint).toBe('^9.0.0');
+    expect(pkg.scripts.storybook).toBe('pnpm --filter @acme/react storybook');
+    expect(pkg.scripts['build-storybook']).toBe(
+      'pnpm --filter @acme/react build-storybook'
+    );
+    expect(pkg.pnpm.overrides).toEqual({ 'some-dep': '1.2.3' });
+  });
+});
+
+describe('renderReadme', () => {
+  it('documents both packages, the token table, and tailwind-before-react publish order', () => {
+    const readme = renderReadme({
+      name: 'acme-ds',
+      scope: '@acme',
+      tokenConfig: { ...DEFAULTS, base: 'slate' },
+    });
+    expect(readme).toContain('# acme-ds');
+    expect(readme).toContain('`@acme/react`');
+    expect(readme).toContain('`@acme/tailwind`');
+    expect(readme).toContain('| `base` | `slate` |');
+    expect(readme.indexOf('@acme/tailwind publish')).toBeLessThan(
+      readme.indexOf('@acme/react publish')
+    );
   });
 });

--- a/scripts/export.test.js
+++ b/scripts/export.test.js
@@ -285,6 +285,22 @@ describe('scanInternalDeps', () => {
       hooks: [],
     });
   });
+
+  it('strips block comments and does not treat :// URLs as line comments', () => {
+    const source = [
+      "import { cn } from '@/lib/utils';",
+      '/*',
+      " * import { Tooltip } from '@/components/tooltip';",
+      ' */',
+      "const docs = 'https://example.com/guide'; // see @/components/should-not-leak",
+      "import { useToast } from '@/hooks/use-toast';",
+    ].join('\n');
+    expect(scanInternalDeps(source)).toEqual({
+      components: [],
+      lib: ['utils'],
+      hooks: ['use-toast'],
+    });
+  });
 });
 
 describe('buildManifest', () => {

--- a/scripts/export.test.js
+++ b/scripts/export.test.js
@@ -1,0 +1,327 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  buildManifest,
+  deriveScope,
+  discoverTokenChoices,
+  parseExportArgs,
+  rebrandContent,
+  renderAppAppearanceExample,
+  scanInternalDeps,
+  transformReactPackageJson,
+  transformTailwindPackageJson,
+  validateTokenConfig,
+} from './export.mjs';
+
+const tempDirs = [];
+afterEach(() => {
+  while (tempDirs.length) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+const VALID_CHOICES = {
+  base: ['gray', 'neutral', 'slate', 'stone', 'zinc'],
+  brand: ['black', 'blue', 'orange', 'pink', 'purple', 'teal'],
+  radius: ['extra-round', 'round', 'smooth', 'square', 'subtle'],
+  borderwidth: ['fine', 'normal', 'strong'],
+  shadow: ['flat', 'quiet', 'soft', 'standard', 'strong'],
+  motion: ['snappy'],
+  spacingDefault: [],
+};
+
+const DEFAULTS = {
+  base: 'stone',
+  brand: 'black',
+  radius: 'square',
+  borderwidth: 'normal',
+  shadow: 'quiet',
+  motion: 'snappy',
+  spacingDefault: 'default',
+};
+
+describe('deriveScope', () => {
+  it('derives scope from the first segment of the name', () => {
+    expect(deriveScope('examlly-design-system')).toBe('@examlly');
+    expect(deriveScope('acme_ui')).toBe('@acme');
+  });
+
+  it('honors an explicit scope', () => {
+    expect(deriveScope('anything', '@custom')).toBe('@custom');
+  });
+
+  it('rejects an explicit scope without a leading @', () => {
+    expect(() => deriveScope('x', 'custom')).toThrow('must start with "@"');
+  });
+});
+
+describe('validateTokenConfig', () => {
+  it('passes valid values', () => {
+    expect(() =>
+      validateTokenConfig(
+        {
+          base: 'slate',
+          brand: 'blue',
+          radius: 'square',
+          borderwidth: 'normal',
+          shadow: 'quiet',
+          motion: 'snappy',
+          spacingDefault: 'default',
+        },
+        VALID_CHOICES
+      )
+    ).not.toThrow();
+  });
+
+  it('rejects an unknown value and lists valid ones', () => {
+    expect(() =>
+      validateTokenConfig({ ...DEFAULTS, radius: 'octagon' }, VALID_CHOICES)
+    ).toThrow(/Invalid --radius="octagon"\. Valid values: .*square/);
+  });
+});
+
+describe('parseExportArgs', () => {
+  it('parses name, derives scope, applies defaults and token overrides', () => {
+    const config = parseExportArgs(
+      ['--name=examlly-design-system', '--base=slate', '--radius=square'],
+      { validChoices: VALID_CHOICES }
+    );
+    expect(config).toMatchObject({
+      name: 'examlly-design-system',
+      scope: '@examlly',
+      policy: 'user',
+      version: '0.1.0',
+      out: path.join('..', 'examlly-design-system'),
+      force: false,
+    });
+    expect(config.tokenConfig.base).toBe('slate');
+    expect(config.tokenConfig.brand).toBe('black'); // default
+  });
+
+  it('requires --name', () => {
+    expect(() => parseExportArgs(['--base=slate'])).toThrow(
+      'Missing required --name'
+    );
+  });
+
+  it('validates token values against the injected choices', () => {
+    expect(() =>
+      parseExportArgs(['--name=x', '--base=chartreuse'], {
+        validChoices: VALID_CHOICES,
+      })
+    ).toThrow(/Invalid --base="chartreuse"/);
+  });
+
+  it('rejects an unknown policy', () => {
+    expect(() =>
+      parseExportArgs(['--name=x', '--policy=whatever'], {
+        validChoices: VALID_CHOICES,
+      })
+    ).toThrow(/Invalid --policy="whatever"/);
+  });
+
+  it('honors --force and an explicit --scope/--out/--version', () => {
+    const config = parseExportArgs(
+      [
+        '--name=x',
+        '--scope=@acme',
+        '--out=/tmp/out',
+        '--version=2.0.0',
+        '--force',
+      ],
+      { validChoices: VALID_CHOICES }
+    );
+    expect(config).toMatchObject({
+      scope: '@acme',
+      out: '/tmp/out',
+      version: '2.0.0',
+      force: true,
+    });
+  });
+});
+
+describe('rebrandContent', () => {
+  it('renames only the two forked packages, across file types', () => {
+    const source = [
+      "import { Button } from '@nexus_ds/react';",
+      "import { X } from '@nexus_ds/react/appearance';",
+      "@reference '@nexus_ds/tailwind';",
+      "@import '@nexus_ds/tailwind';",
+    ].join('\n');
+    const out = rebrandContent(source, '@examlly');
+    expect(out).toContain("'@examlly/react'");
+    expect(out).toContain("'@examlly/react/appearance'");
+    expect(out).toContain("@reference '@examlly/tailwind'");
+    expect(out).toContain("@import '@examlly/tailwind'");
+    expect(out).not.toContain('@nexus_ds/react');
+    expect(out).not.toContain('@nexus_ds/tailwind');
+  });
+
+  it('preserves upstream deps, the eslint-disable directive, and the nx prefix', () => {
+    const source = [
+      "import { DEFAULT } from '@nexus_ds/core';",
+      "import { nexusComponentConfig } from '@nexus_ds/eslint-plugin/config';",
+      '/* eslint-disable @nexus_ds/no-render-prop-types */',
+      "const cls = 'nx:bg-primary-background';",
+      'style: { "--nx-color-x": "red" }',
+    ].join('\n');
+    expect(rebrandContent(source, '@examlly')).toBe(source);
+  });
+});
+
+describe('transformReactPackageJson', () => {
+  const source = {
+    name: '@nexus_ds/react',
+    version: '0.0.2',
+    private: true,
+    '//': ['internal note'],
+    dependencies: {
+      '@nexus_ds/core': 'workspace:*',
+      '@nexus_ds/tailwind': 'workspace:*',
+      '@radix-ui/react-select': '^2.2.6',
+    },
+    files: ['dist'],
+  };
+
+  it('rebrands, pins core, repoints tailwind, and makes it publishable', () => {
+    const out = transformReactPackageJson(source, {
+      scope: '@examlly',
+      coreVersion: '0.1.0',
+      version: '0.1.0',
+    });
+    expect(out.name).toBe('@examlly/react');
+    expect(out.version).toBe('0.1.0');
+    expect(out.private).toBeUndefined();
+    expect(out['//']).toBeUndefined();
+    expect(out.publishConfig).toEqual({ access: 'public' });
+    expect(out.dependencies['@nexus_ds/core']).toBe('^0.1.0');
+    expect(out.dependencies['@nexus_ds/tailwind']).toBeUndefined();
+    expect(out.dependencies['@examlly/tailwind']).toBe('workspace:*');
+    expect(out.dependencies['@radix-ui/react-select']).toBe('^2.2.6');
+    expect(out.files).toEqual(['dist']);
+  });
+
+  it('does not mutate the input', () => {
+    transformReactPackageJson(source, {
+      scope: '@x',
+      coreVersion: '0.1.0',
+      version: '0.1.0',
+    });
+    expect(source.name).toBe('@nexus_ds/react');
+    expect(source.private).toBe(true);
+  });
+});
+
+describe('transformTailwindPackageJson', () => {
+  it('rebrands and makes it publishable while keeping exports', () => {
+    const out = transformTailwindPackageJson(
+      {
+        name: '@nexus_ds/tailwind',
+        version: '0.0.1',
+        private: true,
+        exports: { '.': './nexus.css' },
+        files: ['*.css'],
+      },
+      { scope: '@examlly', version: '0.1.0' }
+    );
+    expect(out.name).toBe('@examlly/tailwind');
+    expect(out.version).toBe('0.1.0');
+    expect(out.private).toBeUndefined();
+    expect(out.publishConfig).toEqual({ access: 'public' });
+    expect(out.exports).toEqual({ '.': './nexus.css' });
+    expect(out.files).toEqual(['*.css']);
+  });
+});
+
+describe('scanInternalDeps', () => {
+  it('buckets @/ imports and ignores commented lines', () => {
+    const source = [
+      "import { popoverSurfaceClassName } from '@/components/overlay-layout/overlay-layout';",
+      "import { IconCheck } from '@/lib/icons';",
+      "import { cn } from '@/lib/utils';",
+      "// import { useIsNarrow } from '@/hooks/use-narrow';",
+    ].join('\n');
+    expect(scanInternalDeps(source)).toEqual({
+      components: ['overlay-layout'],
+      lib: ['icons', 'utils'],
+      hooks: [],
+    });
+  });
+});
+
+describe('buildManifest', () => {
+  it('sorts components and records files + deps', () => {
+    const manifest = buildManifest(
+      [
+        {
+          name: 'select',
+          files: ['select.tsx'],
+          deps: {
+            components: ['overlay-layout'],
+            lib: ['icons', 'utils'],
+            hooks: [],
+          },
+        },
+        {
+          name: 'button',
+          files: ['button.tsx'],
+          deps: {
+            components: ['button-group', 'spinner'],
+            lib: ['utils'],
+            hooks: [],
+          },
+        },
+      ],
+      { version: '0.1.0' }
+    );
+    expect(Object.keys(manifest.components)).toEqual(['button', 'select']);
+    expect(manifest.version).toBe('0.1.0');
+    expect(manifest.components.select.deps.lib).toEqual(['icons', 'utils']);
+  });
+});
+
+describe('renderAppAppearanceExample', () => {
+  it('emits the real knobs for each policy from the published subentry', () => {
+    const locked = renderAppAppearanceExample('@examlly', 'locked');
+    expect(locked).toContain("from '@examlly/react/appearance'");
+    expect(locked).toContain('storageKey: false');
+    expect(locked).toContain('cookieWriteKey: false');
+
+    expect(renderAppAppearanceExample('@examlly', 'user')).toContain(
+      'storageKey: "nexus-appearance"'
+    );
+    expect(renderAppAppearanceExample('@examlly', 'tenant')).toContain(
+      'cookieWriteKey: "nexus-appearance"'
+    );
+  });
+});
+
+describe('discoverTokenChoices', () => {
+  it('discovers base/brand from semantic files and modes from primitive dirs', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nexus-export-'));
+    tempDirs.push(root);
+    const semantic = path.join(root, 'semantic');
+    const radiusDir = path.join(root, 'primitives', 'radius');
+    fs.mkdirSync(semantic, { recursive: true });
+    fs.mkdirSync(radiusDir, { recursive: true });
+    for (const f of [
+      'base-slate-light.json',
+      'base-slate-dark.json',
+      'base-stone-light.json',
+      'brands-blue-light.json',
+    ]) {
+      fs.writeFileSync(path.join(semantic, f), '{}');
+    }
+    for (const f of ['radius-square.json', 'radius-round.json']) {
+      fs.writeFileSync(path.join(radiusDir, f), '{}');
+    }
+
+    const choices = discoverTokenChoices(root);
+    expect(choices.base).toEqual(['slate', 'stone']);
+    expect(choices.brand).toEqual(['blue']);
+    expect(choices.radius).toEqual(['round', 'square']);
+  });
+});

--- a/scripts/verify-export.mjs
+++ b/scripts/verify-export.mjs
@@ -3,11 +3,12 @@
  *
  * Builds + packs the published upstream deps (`@nexus_ds/core`,
  * `@nexus_ds/eslint-plugin`) into tarballs, runs `pnpm export` into a temp
- * monorepo, redirects the two upstream deps to those tarballs via root
- * `pnpm.overrides` (leaving the real version ranges intact so `publish
- * --dry-run` validates the shipped manifest), then proves the produced repo
- * passes: install → build → lint → typecheck → publish --dry-run (both members)
- * → build-storybook → ESM smoke import → CSS token emission.
+ * monorepo, asserts the shipped upstream ranges actually resolve on npm (the
+ * tarball overrides below mask this), redirects the two upstream deps to those
+ * tarballs via root `pnpm.overrides` (leaving the real version ranges intact so
+ * `publish --dry-run` validates the shipped manifest), then proves the produced
+ * repo passes: install → build → lint → typecheck → publish --dry-run (both
+ * members) → build-storybook → ESM smoke import → CSS token emission.
  *
  * Per-step pass/fail + duration is reported; the temp dir is retained on failure.
  */
@@ -17,6 +18,8 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { KEEP_PACKAGES } from './export.mjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SCOPE = '@acme';
@@ -56,8 +59,21 @@ function exec(cmd, args, cwd) {
   return res.stdout ?? '';
 }
 
-/** Recursively find text files whose contents match `re`, relative to `root`. */
-function findMatches(root, re) {
+/** Rule ids published by @nexus_ds/eslint-plugin (each `rules/*.js` = one rule). */
+function discoverEslintRuleRefs() {
+  const rulesDir = path.join(REPO_ROOT, 'packages', 'eslint-plugin-nexus', 'src', 'rules');
+  return fs
+    .readdirSync(rulesDir)
+    .filter((file) => file.endsWith('.js'))
+    .map((file) => `@nexus_ds/${file.replace(/\.js$/, '')}`);
+}
+
+/**
+ * Find files under `root` referencing a `@nexus_ds/*` name not in `allowed`.
+ * Catches any un-forked upstream sibling (react/tailwind, or a future package),
+ * while permitting the kept published deps and the eslint-plugin rule ids.
+ */
+function findStrayNexusRefs(root, allowed) {
   const hits = [];
   const walk = (dir) => {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -67,15 +83,47 @@ function findMatches(root, re) {
           continue;
         }
         walk(full);
-      } else if (TEXT_EXTENSIONS.has(path.extname(entry.name))) {
-        if (re.test(fs.readFileSync(full, 'utf8'))) {
-          hits.push(path.relative(root, full));
-        }
+        continue;
+      }
+      if (!TEXT_EXTENSIONS.has(path.extname(entry.name))) {
+        continue;
+      }
+      const refs = fs.readFileSync(full, 'utf8').match(/@nexus_ds\/[a-zA-Z0-9._-]+/g) ?? [];
+      const bad = [...new Set(refs)].filter((ref) => !allowed.has(ref));
+      if (bad.length > 0) {
+        hits.push(`${path.relative(root, full)} (${bad.join(', ')})`);
       }
     }
   };
   walk(root);
   return hits;
+}
+
+/**
+ * Assert the produced upstream ranges resolve to a published npm version. The
+ * tarball overrides below satisfy install/publish locally, so a workspace
+ * version ahead of npm would fail a real install while this harness stayed green.
+ */
+function assertUpstreamRangesPublished(producedDir) {
+  const reactPkg = readJson(path.join(producedDir, 'packages', 'react', 'package.json'));
+  const rootPkg = readJson(path.join(producedDir, 'package.json'));
+  const ranges = {
+    '@nexus_ds/core': reactPkg.dependencies?.['@nexus_ds/core'],
+    '@nexus_ds/eslint-plugin': rootPkg.devDependencies?.['@nexus_ds/eslint-plugin'],
+  };
+  for (const [name, range] of Object.entries(ranges)) {
+    if (!range) {
+      throw new Error(`Produced manifest is missing the ${name} dependency range.`);
+    }
+    const matched = exec('npm', ['view', `${name}@${range}`, 'version'], REPO_ROOT).trim();
+    if (!matched) {
+      throw new Error(
+        `Shipped range "${name}@${range}" resolves to no published version on npm; ` +
+          `a real install would fail even though tarball overrides keep this harness green. ` +
+          `Publish ${name} at a version satisfying ${range}.`
+      );
+    }
+  }
 }
 
 function packTarball(packageDir, destDir) {
@@ -196,15 +244,17 @@ async function main() {
       )
     );
 
-    await step('rebrand audit (no stray upstream react/tailwind refs)', () => {
-      const stray = findMatches(
-        path.join(producedDir, 'packages'),
-        /@nexus_ds\/(react|tailwind)/
-      );
+    await step('rebrand audit (no un-forked @nexus_ds/* refs)', () => {
+      const allowed = new Set([...KEEP_PACKAGES, ...discoverEslintRuleRefs()]);
+      const stray = findStrayNexusRefs(path.join(producedDir, 'packages'), allowed);
       if (stray.length > 0) {
-        throw new Error(`Stray @nexus_ds/react|tailwind refs in: ${stray.join(', ')}`);
+        throw new Error(`Un-forked @nexus_ds/* refs leaked in: ${stray.join(', ')}`);
       }
     });
+
+    await step('upstream ranges resolve on npm', () =>
+      assertUpstreamRangesPublished(producedDir)
+    );
 
     await step('inject tarball overrides', () => injectOverrides(producedDir, tarballs));
     await step('pnpm install', () => exec('pnpm', ['install'], producedDir));

--- a/scripts/verify-export.mjs
+++ b/scripts/verify-export.mjs
@@ -1,0 +1,253 @@
+/**
+ * `pnpm export:verify` — acceptance harness for the standalone export (#541).
+ *
+ * Builds + packs the published upstream deps (`@nexus_ds/core`,
+ * `@nexus_ds/eslint-plugin`) into tarballs, runs `pnpm export` into a temp
+ * monorepo, redirects the two upstream deps to those tarballs via root
+ * `pnpm.overrides` (leaving the real version ranges intact so `publish
+ * --dry-run` validates the shipped manifest), then proves the produced repo
+ * passes: install → build → lint → typecheck → publish --dry-run (both members)
+ * → build-storybook → ESM smoke import → CSS token emission.
+ *
+ * Per-step pass/fail + duration is reported; the temp dir is retained on failure.
+ */
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SCOPE = '@acme';
+const NAME = 'acme-ds';
+const OFFLINE_RE =
+  /ERR_PNPM_(FETCH|META_FETCH|REGISTRIES)|ENOTFOUND|getaddrinfo|ECONNREFUSED|request to .* failed/i;
+
+const TEXT_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.css', '.json', '.md']);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function tail(text, lines = 25) {
+  return String(text ?? '')
+    .trim()
+    .split('\n')
+    .slice(-lines)
+    .join('\n');
+}
+
+/** Run a command, throwing a readable error (flagging registry/network failures). */
+function exec(cmd, args, cwd) {
+  const res = spawnSync(cmd, args, { cwd, encoding: 'utf8', env: process.env });
+  if (res.error) {
+    throw new Error(`${cmd} ${args.join(' ')} failed to spawn: ${res.error.message}`);
+  }
+  if (res.status !== 0) {
+    const combined = `${res.stdout ?? ''}\n${res.stderr ?? ''}`;
+    const offline = OFFLINE_RE.test(combined)
+      ? ' — registry/network unreachable (this harness needs an online install)'
+      : '';
+    throw new Error(
+      `${cmd} ${args.join(' ')} exited ${res.status}${offline}\n${tail(combined)}`
+    );
+  }
+  return res.stdout ?? '';
+}
+
+/** Recursively find text files whose contents match `re`, relative to `root`. */
+function findMatches(root, re) {
+  const hits = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === 'dist') {
+          continue;
+        }
+        walk(full);
+      } else if (TEXT_EXTENSIONS.has(path.extname(entry.name))) {
+        if (re.test(fs.readFileSync(full, 'utf8'))) {
+          hits.push(path.relative(root, full));
+        }
+      }
+    }
+  };
+  walk(root);
+  return hits;
+}
+
+function packTarball(packageDir, destDir) {
+  const pkg = readJson(path.join(packageDir, 'package.json'));
+  exec('pnpm', ['pack', '--pack-destination', destDir], packageDir);
+  const fileName = `${pkg.name.replace('@', '').replace('/', '-')}-${pkg.version}.tgz`;
+  const tarball = path.join(destDir, fileName);
+  if (!fs.existsSync(tarball)) {
+    throw new Error(`Expected tarball not found: ${tarball}`);
+  }
+  return { name: pkg.name, tarball };
+}
+
+/** Redirect the upstream deps to local tarballs while keeping their real ranges. */
+function injectOverrides(producedDir, tarballs) {
+  const pkgPath = path.join(producedDir, 'package.json');
+  const pkg = readJson(pkgPath);
+  pkg.pnpm ??= {};
+  pkg.pnpm.overrides ??= {};
+  for (const { name, tarball } of tarballs) {
+    pkg.pnpm.overrides[name] = `file:${tarball}`;
+  }
+  fs.writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
+/** Import the built ESM bundle (under a jsdom global) and assert the exports resolve. */
+async function smokeImport(producedDir) {
+  const { JSDOM } = await import('jsdom');
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    url: 'http://localhost/',
+  });
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  if (typeof dom.window.matchMedia !== 'function') {
+    dom.window.matchMedia = () => ({
+      matches: false,
+      media: '',
+      addEventListener() {},
+      removeEventListener() {},
+      addListener() {},
+      removeListener() {},
+      dispatchEvent() {
+        return false;
+      },
+    });
+  }
+
+  const distDir = path.join(producedDir, 'packages', 'react', 'dist');
+  const lib = await import(pathToFileURL(path.join(distDir, 'index.mjs')).href);
+  const appearance = await import(pathToFileURL(path.join(distDir, 'appearance.mjs')).href);
+
+  if (typeof lib.Button !== 'function') {
+    throw new Error('Built index.mjs did not export a `Button` component.');
+  }
+  if (typeof appearance.NexusAppearanceProvider !== 'function') {
+    throw new Error('Built appearance.mjs did not export `NexusAppearanceProvider`.');
+  }
+}
+
+/** Prove tokens emit (tailwind) and utilities build (react). */
+function assertCss(producedDir) {
+  const reactCss = path.join(producedDir, 'packages', 'react', 'dist', 'react.css');
+  const tailwindCss = path.join(producedDir, 'packages', 'tailwind', 'nexus.css');
+  if (!fs.existsSync(reactCss) || fs.statSync(reactCss).size < 500) {
+    throw new Error('Built react.css is missing or empty (no utilities generated).');
+  }
+  if (!fs.readFileSync(tailwindCss, 'utf8').includes('--nx-color-')) {
+    throw new Error('tailwind nexus.css does not emit `--nx-color-*` tokens.');
+  }
+}
+
+async function main() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'nexus-export-verify-'));
+  const producedDir = path.join(tmp, NAME);
+  const tarballDir = path.join(tmp, 'tarballs');
+  fs.mkdirSync(tarballDir, { recursive: true });
+
+  const results = [];
+  const step = async (name, fn) => {
+    const start = Date.now();
+    try {
+      await fn();
+      results.push({ name, ok: true, ms: Date.now() - start });
+      console.log(`  ✓ ${name} (${((Date.now() - start) / 1000).toFixed(1)}s)`);
+    } catch (error) {
+      results.push({ name, ok: false, ms: Date.now() - start });
+      console.log(`  ✗ ${name}\n${error.message}`);
+      throw error;
+    }
+  };
+
+  console.log(`\n🔎 export:verify → ${producedDir}\n`);
+  let failed = false;
+  try {
+    await step('build @nexus_ds/core', () =>
+      exec('pnpm', ['--filter', '@nexus_ds/core', 'build'], REPO_ROOT)
+    );
+
+    const tarballs = [];
+    await step('pack upstream deps', () => {
+      tarballs.push(packTarball(path.join(REPO_ROOT, 'packages', 'core'), tarballDir));
+      tarballs.push(
+        packTarball(path.join(REPO_ROOT, 'packages', 'eslint-plugin-nexus'), tarballDir)
+      );
+    });
+
+    await step('run pnpm export', () =>
+      exec(
+        process.execPath,
+        [
+          path.join('scripts', 'export.mjs'),
+          `--name=${NAME}`,
+          `--scope=${SCOPE}`,
+          `--out=${producedDir}`,
+          '--force',
+        ],
+        REPO_ROOT
+      )
+    );
+
+    await step('rebrand audit (no stray upstream react/tailwind refs)', () => {
+      const stray = findMatches(
+        path.join(producedDir, 'packages'),
+        /@nexus_ds\/(react|tailwind)/
+      );
+      if (stray.length > 0) {
+        throw new Error(`Stray @nexus_ds/react|tailwind refs in: ${stray.join(', ')}`);
+      }
+    });
+
+    await step('inject tarball overrides', () => injectOverrides(producedDir, tarballs));
+    await step('pnpm install', () => exec('pnpm', ['install'], producedDir));
+    await step('pnpm build', () => exec('pnpm', ['run', 'build'], producedDir));
+    await step('pnpm lint', () => exec('pnpm', ['run', 'lint'], producedDir));
+    await step('pnpm typecheck', () => exec('pnpm', ['run', 'typecheck'], producedDir));
+    await step('publish --dry-run (tailwind)', () =>
+      exec(
+        'pnpm',
+        ['--filter', `${SCOPE}/tailwind`, 'publish', '--dry-run', '--no-git-checks'],
+        producedDir
+      )
+    );
+    await step('publish --dry-run (react)', () =>
+      exec(
+        'pnpm',
+        ['--filter', `${SCOPE}/react`, 'publish', '--dry-run', '--no-git-checks'],
+        producedDir
+      )
+    );
+    await step('build-storybook', () => exec('pnpm', ['run', 'build-storybook'], producedDir));
+    await step('ESM smoke import', () => smokeImport(producedDir));
+    await step('CSS token emission', () => assertCss(producedDir));
+  } catch {
+    failed = true;
+  }
+
+  const totalMs = results.reduce((sum, r) => sum + r.ms, 0);
+  console.log('\n── Summary ──');
+  for (const r of results) {
+    console.log(`  ${r.ok ? '✓' : '✗'} ${r.name}  ${(r.ms / 1000).toFixed(1)}s`);
+  }
+  console.log(`  total ${(totalMs / 1000).toFixed(1)}s`);
+
+  if (failed) {
+    console.log(`\n✗ export:verify FAILED — temp retained at:\n  ${producedDir}\n`);
+    process.exit(1);
+  }
+  fs.rmSync(tmp, { recursive: true, force: true });
+  console.log('\n✅ export:verify PASSED\n');
+}
+
+main().catch((error) => {
+  console.error(`✗ ${error.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds `pnpm export` — a script that scaffolds a standalone, **rebranded, publish-ready design-system monorepo** from this repo, plus `pnpm export:verify`, an acceptance harness that proves the output builds/lints/typechecks/publishes.

Per the product owner's direction, the deliverable is a **monorepo fork** (not the single-package copy the issue originally described). `pnpm export --name=examlly-design-system --scope=@examlly --base=slate --radius=round` produces a pnpm workspace with two owned/publishable packages:

- **`@{scope}/tailwind`** — token CSS generated from the chosen config (`--base/--brand/--radius/--borderwidth/--shadow/--motion/--spacingDefault`) via core's `generateTailwindPackage`.
- **`@{scope}/react`** — the whole `packages/react` forked (components + appearance provider/editor + **Storybook showcase**), depending on `@{scope}/tailwind` (`workspace:*`).

Both depend on the genuinely-**published** `@nexus_ds/core` (runtime engine) + `@nexus_ds/eslint-plugin` (dev). A future `@{scope}/vue`/`@{scope}/svelte` can reuse the same token package unchanged.

### Key decisions (council-verified)
- **Provider is copy/own**, not a published dep — `@nexus_ds/react` is 404 on npm and #540 shipped it as copy/own, so the provider ships as the `./appearance` subentry of *your* published `@{scope}/react` (this makes #541's original "published provider" vision true at the produced-repo level).
- **Rebrand** is two exact string replaces (`@nexus_ds/react`, `@nexus_ds/tailwind` → scope); `@nexus_ds/core` + `@nexus_ds/eslint-plugin` and the `nx:`/`--nx-*` prefixes are preserved (core emits `--nx-*` at runtime).
- **Storybook = showcase-only** (`@storybook/addon-vitest` trimmed, no test runner) — matches the issue's "no tests in the exported surface."
- **Editor-off-`.`** deliberately excluded — react is never published, so its `.` exports are internal-only; removing the editor UI would only break the console.

## GitHub Issue

Closes #541

## Test Plan

- [x] `pnpm test:unit` — 19 unit tests over fixed fixtures (rebrand keeps core/eslint/`nx`; package.json transforms; token validation; policy wiring; manifest)
- [x] `pnpm lint` — clean
- [x] `pnpm export:verify` — full acceptance harness green end-to-end (~109s): build core → pack core+eslint-plugin → export → rebrand audit → `pnpm install` → `build` → `lint` → `typecheck` → `publish --dry-run` (both packages) → `build-storybook` → ESM smoke import (`Button` + `NexusAppearanceProvider`) → CSS token emission

🤖 Generated with [Claude Code](https://claude.com/claude-code)