### PR TITLE
feat(react): polish slider value display

### DIFF
--- a/packages/react/src/components/slider/Slider.stories.tsx
+++ b/packages/react/src/components/slider/Slider.stories.tsx
@@ -22,8 +22,8 @@ const withSliderWidth: Decorator = (Story, context) => {
 
 function FluidSliderShowcase({ children }: { children: React.ReactNode }) {
   return (
-    <div className="nx:w-[42rem] nx:max-w-[calc(100vw-3rem)] nx:rounded-md nx:bg-background nx:px-11 nx:py-12 nx:text-foreground">
-      <div className="nx:flex nx:w-full nx:flex-col nx:gap-6">{children}</div>
+    <div className="nx:w-[35rem] nx:max-w-[calc(100vw-3rem)] nx:bg-background nx:px-6 nx:py-8 nx:text-foreground">
+      <div className="nx:flex nx:w-full nx:flex-col nx:gap-5">{children}</div>
     </div>
   );
 }
@@ -415,7 +415,7 @@ export const AllVariants: Story = {
   },
   render: () => (
     <FluidSliderShowcase>
-      <div className="nx:grid nx:grid-cols-[3rem_minmax(0,1fr)] nx:items-center nx:gap-x-6 nx:gap-y-5">
+      <div className="nx:grid nx:grid-cols-[3rem_minmax(0,1fr)] nx:items-center nx:gap-x-5 nx:gap-y-8">
         <span className="nx:tabular-nums nx:typography-label-default nx:text-muted-foreground">
           50
         </span>
@@ -433,7 +433,7 @@ export const AllVariants: Story = {
           aria-label="Stepped volume"
         />
       </div>
-      <div className="nx:pt-5">
+      <div className="nx:pt-4">
         <SliderComfortable
           defaultValue={2}
           min={0}

--- a/packages/react/src/components/slider/Slider.stories.tsx
+++ b/packages/react/src/components/slider/Slider.stories.tsx
@@ -20,33 +20,11 @@ const withSliderWidth: Decorator = (Story, context) => {
   );
 };
 
-const fluidSliderVariables: React.CSSProperties &
-  Record<`--${string}`, string> = {
-  '--slider-showcase-bg': '#0e0e0e',
-  '--slider-showcase-muted': '#8c8c8c',
-  '--slider-track': '#242424',
-  '--slider-range': '#3a3a3a',
-  '--slider-border': 'rgba(255,255,255,.09)',
-  '--slider-pip': '#5c5c5c',
-  '--slider-thumb': '#ffffff',
-  '--slider-thumb-border': 'rgba(0,0,0,.04)',
-  '--slider-tooltip-bg': '#f2f2f0',
-  '--slider-tooltip-fg': '#171717',
-  '--slider-comfortable-track': '#1a1a1a',
-  '--slider-comfortable-range': '#2c2c2c',
-  '--slider-comfortable-border': 'rgba(255,255,255,.09)',
-  '--slider-comfortable-pip': '#5c5c5c',
-  '--slider-comfortable-caret': '#cfcfcf',
-  '--slider-comfortable-label': '#d4d4d4',
-  '--slider-comfortable-muted': '#8c8c8c',
-};
-
 function FluidSliderShowcase({ children }: { children: React.ReactNode }) {
   return (
     <div
       data-slider-showcase
-      style={fluidSliderVariables}
-      className="nx:w-[35rem] nx:max-w-[calc(100vw-3rem)] nx:bg-(--slider-showcase-bg) nx:px-6 nx:py-8 nx:text-foreground"
+      className="nx:w-[35rem] nx:max-w-[calc(100vw-3rem)] nx:bg-background nx:px-6 nx:py-8 nx:text-foreground"
     >
       <div className="nx:flex nx:w-full nx:flex-col nx:gap-5">{children}</div>
     </div>
@@ -441,11 +419,11 @@ export const AllVariants: Story = {
   render: () => (
     <FluidSliderShowcase>
       <div className="nx:grid nx:grid-cols-[3rem_minmax(0,1fr)] nx:items-center nx:gap-x-5 nx:gap-y-8">
-        <span className="nx:tabular-nums nx:typography-label-default nx:text-(--slider-showcase-muted)">
+        <span className="nx:tabular-nums nx:typography-label-default nx:text-muted-foreground">
           50
         </span>
         <Slider defaultValue={[50]} max={100} step={1} aria-label="Single" />
-        <span className="nx:tabular-nums nx:typography-label-default nx:text-(--slider-showcase-muted)">
+        <span className="nx:tabular-nums nx:typography-label-default nx:text-muted-foreground">
           50
         </span>
         <Slider

--- a/packages/react/src/components/slider/Slider.stories.tsx
+++ b/packages/react/src/components/slider/Slider.stories.tsx
@@ -1,20 +1,37 @@
 import * as React from 'react';
 
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { Slider, SliderComfortable } from './slider';
 
+const darkGlobals = { mode: 'dark' } as const;
+
+const withSliderWidth: Decorator = (Story, context) => {
+  const sliderWidth =
+    typeof context.parameters.sliderWidth === 'string'
+      ? context.parameters.sliderWidth
+      : 'nx:w-64';
+
+  return (
+    <div className={sliderWidth}>
+      <Story />
+    </div>
+  );
+};
+
+function FluidSliderShowcase({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="nx:w-[42rem] nx:max-w-[calc(100vw-3rem)] nx:rounded-md nx:bg-background nx:px-11 nx:py-12 nx:text-foreground">
+      <div className="nx:flex nx:w-full nx:flex-col nx:gap-6">{children}</div>
+    </div>
+  );
+}
+
 const meta: Meta<typeof Slider> = {
   title: 'Components/Slider',
   component: Slider,
-  decorators: [
-    (Story) => (
-      <div className="nx:w-64">
-        <Story />
-      </div>
-    ),
-  ],
+  decorators: [withSliderWidth],
 };
 
 export default meta;
@@ -229,15 +246,16 @@ export const Invalid: Story = {
 type ComfortableStory = StoryObj<typeof SliderComfortable>;
 
 const comfortableDecorators = [
-  (Story: React.ComponentType) => (
-    <div className="nx:w-72">
+  ((Story) => (
+    <div className="nx:w-[36rem] nx:max-w-[calc(100vw-3rem)]">
       <Story />
     </div>
-  ),
+  )) satisfies Decorator,
 ];
 
 // Pip mode creates a discrete settings-row selector.
 export const Comfortable: ComfortableStory = {
+  globals: darkGlobals,
   decorators: comfortableDecorators,
   render: function ComfortableStory() {
     const [value, setValue] = React.useState(2);
@@ -257,6 +275,7 @@ export const Comfortable: ComfortableStory = {
 
 // Scrubber mode keeps the larger row but drops discrete pips.
 export const ComfortableScrubber: ComfortableStory = {
+  globals: darkGlobals,
   decorators: comfortableDecorators,
   render: function ComfortableScrubberStory() {
     const [value, setValue] = React.useState(50);
@@ -278,6 +297,7 @@ export const ComfortableScrubber: ComfortableStory = {
 
 // Comfortable sliders also accept display formatters.
 export const ComfortableFormat: ComfortableStory = {
+  globals: darkGlobals,
   decorators: comfortableDecorators,
   render: function ComfortableFormatStory() {
     const [value, setValue] = React.useState(2);
@@ -299,6 +319,7 @@ export const ComfortableFormat: ComfortableStory = {
 
 // Disabled comfortable sliders keep their row mounted but inert.
 export const ComfortableDisabled: ComfortableStory = {
+  globals: darkGlobals,
   decorators: comfortableDecorators,
   render: () => (
     <SliderComfortable
@@ -323,6 +344,7 @@ export const ComfortableDisabled: ComfortableStory = {
 // Arrow keys operate the comfortable slider through Radix semantics.
 export const ComfortableKeyboardInteraction: ComfortableStory = {
   args: { onValueChange: fn() },
+  globals: darkGlobals,
   decorators: comfortableDecorators,
   render: (args) => (
     <SliderComfortable
@@ -348,6 +370,7 @@ export const ComfortableKeyboardInteraction: ComfortableStory = {
 
 // Comfortable data slots identify the row, track, range, thumb, label, and value.
 export const ComfortableWithDataAttributes: ComfortableStory = {
+  globals: darkGlobals,
   decorators: comfortableDecorators,
   render: () => (
     <SliderComfortable
@@ -386,32 +409,39 @@ export const ComfortableWithDataAttributes: ComfortableStory = {
 
 // Compact and comfortable slider examples. Reused by the per-base variant generator.
 export const AllVariants: Story = {
+  globals: darkGlobals,
+  parameters: {
+    sliderWidth: 'nx:w-auto',
+  },
   render: () => (
-    <div className="nx:flex nx:w-72 nx:flex-col nx:gap-8">
-      <Slider defaultValue={[50]} max={100} step={1} aria-label="Single" />
-      <Slider
-        defaultValue={[25, 75]}
-        max={100}
-        step={1}
-        showValue
-        valuePosition="right"
-        aria-label="Range"
-      />
-      <Slider
-        defaultValue={[40]}
-        max={100}
-        step={10}
-        showSteps
-        aria-label="Steps"
-      />
-      <Slider disabled defaultValue={[40]} max={100} aria-label="Disabled" />
-      <SliderComfortable
-        defaultValue={2}
-        min={0}
-        max={4}
-        step={1}
-        label="Roundness"
-      />
+    <FluidSliderShowcase>
+      <div className="nx:grid nx:grid-cols-[3rem_minmax(0,1fr)] nx:items-center nx:gap-x-6 nx:gap-y-5">
+        <span className="nx:tabular-nums nx:typography-label-default nx:text-muted-foreground">
+          50
+        </span>
+        <Slider defaultValue={[50]} max={100} step={1} aria-label="Single" />
+        <span className="nx:tabular-nums nx:typography-label-default nx:text-muted-foreground">
+          50
+        </span>
+        <Slider
+          defaultValue={[70]}
+          max={100}
+          step={10}
+          showSteps
+          showValue
+          valuePosition="tooltip"
+          aria-label="Stepped volume"
+        />
+      </div>
+      <div className="nx:pt-5">
+        <SliderComfortable
+          defaultValue={2}
+          min={0}
+          max={4}
+          step={1}
+          label="Roundness"
+        />
+      </div>
       <SliderComfortable
         variant="scrubber"
         defaultValue={50}
@@ -421,6 +451,6 @@ export const AllVariants: Story = {
         label="Volume"
         formatValue={(nextValue) => `${nextValue}%`}
       />
-    </div>
+    </FluidSliderShowcase>
   ),
 };

--- a/packages/react/src/components/slider/Slider.stories.tsx
+++ b/packages/react/src/components/slider/Slider.stories.tsx
@@ -5,8 +5,6 @@ import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { Slider, SliderComfortable } from './slider';
 
-const darkGlobals = { mode: 'dark' } as const;
-
 const withSliderWidth: Decorator = (Story, context) => {
   const sliderWidth =
     typeof context.parameters.sliderWidth === 'string'
@@ -258,7 +256,6 @@ const comfortableDecorators = [
 
 // Pip mode creates a discrete settings-row selector.
 export const Comfortable: ComfortableStory = {
-  globals: darkGlobals,
   decorators: comfortableDecorators,
   render: function ComfortableStory() {
     const [value, setValue] = React.useState(2);
@@ -278,7 +275,6 @@ export const Comfortable: ComfortableStory = {
 
 // Scrubber mode keeps the larger row but drops discrete pips.
 export const ComfortableScrubber: ComfortableStory = {
-  globals: darkGlobals,
   decorators: comfortableDecorators,
   render: function ComfortableScrubberStory() {
     const [value, setValue] = React.useState(50);
@@ -300,7 +296,6 @@ export const ComfortableScrubber: ComfortableStory = {
 
 // Comfortable sliders also accept display formatters.
 export const ComfortableFormat: ComfortableStory = {
-  globals: darkGlobals,
   decorators: comfortableDecorators,
   render: function ComfortableFormatStory() {
     const [value, setValue] = React.useState(2);
@@ -322,7 +317,6 @@ export const ComfortableFormat: ComfortableStory = {
 
 // Disabled comfortable sliders keep their row mounted but inert.
 export const ComfortableDisabled: ComfortableStory = {
-  globals: darkGlobals,
   decorators: comfortableDecorators,
   render: () => (
     <SliderComfortable
@@ -347,7 +341,6 @@ export const ComfortableDisabled: ComfortableStory = {
 // Arrow keys operate the comfortable slider through Radix semantics.
 export const ComfortableKeyboardInteraction: ComfortableStory = {
   args: { onValueChange: fn() },
-  globals: darkGlobals,
   decorators: comfortableDecorators,
   render: (args) => (
     <SliderComfortable
@@ -373,7 +366,6 @@ export const ComfortableKeyboardInteraction: ComfortableStory = {
 
 // Comfortable data slots identify the row, track, range, thumb, label, and value.
 export const ComfortableWithDataAttributes: ComfortableStory = {
-  globals: darkGlobals,
   decorators: comfortableDecorators,
   render: () => (
     <SliderComfortable
@@ -412,7 +404,6 @@ export const ComfortableWithDataAttributes: ComfortableStory = {
 
 // Compact and comfortable slider examples. Reused by the per-base variant generator.
 export const AllVariants: Story = {
-  globals: darkGlobals,
   parameters: {
     sliderWidth: 'nx:w-auto',
   },
@@ -456,4 +447,9 @@ export const AllVariants: Story = {
       />
     </FluidSliderShowcase>
   ),
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.ownerDocument.documentElement).not.toHaveClass(
+      'dark'
+    );
+  },
 };

--- a/packages/react/src/components/slider/Slider.stories.tsx
+++ b/packages/react/src/components/slider/Slider.stories.tsx
@@ -1,7 +1,9 @@
+import * as React from 'react';
+
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, fn, userEvent, within } from 'storybook/test';
 
-import { Slider } from './slider';
+import { Slider, SliderComfortable } from './slider';
 
 const meta: Meta<typeof Slider> = {
   title: 'Components/Slider',
@@ -40,8 +42,72 @@ export const Range: Story = {
 // Larger step increments snap the thumb.
 export const Steps: Story = {
   render: () => (
-    <Slider defaultValue={[40]} max={100} step={10} aria-label="Brightness" />
+    <Slider
+      defaultValue={[40]}
+      max={100}
+      step={10}
+      showSteps
+      aria-label="Brightness"
+    />
   ),
+};
+
+// The current value can sit beside the track.
+export const ValueDisplay: Story = {
+  render: function ValueDisplayStory() {
+    const [value, setValue] = React.useState([40]);
+
+    return (
+      <Slider
+        value={value}
+        onValueChange={setValue}
+        max={100}
+        step={1}
+        showValue
+        valuePosition="right"
+        label="Volume"
+      />
+    );
+  },
+};
+
+// Formatters keep the control numeric while displaying domain units.
+export const Format: Story = {
+  render: function FormatStory() {
+    const [value, setValue] = React.useState([75]);
+
+    return (
+      <Slider
+        value={value}
+        onValueChange={setValue}
+        max={100}
+        step={5}
+        showValue
+        valuePosition="bottom"
+        label="Opacity"
+        formatValue={(nextValue) => `${nextValue}%`}
+      />
+    );
+  },
+};
+
+// Tooltip values appear above the thumb on hover or keyboard focus.
+export const TooltipValue: Story = {
+  render: function TooltipValueStory() {
+    const [value, setValue] = React.useState([60]);
+
+    return (
+      <Slider
+        value={value}
+        onValueChange={setValue}
+        max={100}
+        step={1}
+        showValue
+        valuePosition="tooltip"
+        aria-label="Volume"
+      />
+    );
+  },
 };
 
 // Vertical orientation.
@@ -86,7 +152,14 @@ export const KeyboardInteraction: Story = {
 // A disabled slider does not respond to interaction.
 export const Disabled: Story = {
   render: () => (
-    <Slider disabled defaultValue={[50]} max={100} aria-label="Volume" />
+    <Slider
+      disabled
+      defaultValue={[50]}
+      max={100}
+      showValue
+      valuePosition="right"
+      aria-label="Volume"
+    />
   ),
   play: async ({ canvasElement }) => {
     const slider = canvasElement.querySelector('[data-slot="slider"]');
@@ -153,17 +226,201 @@ export const Invalid: Story = {
   },
 };
 
+type ComfortableStory = StoryObj<typeof SliderComfortable>;
+
+const comfortableDecorators = [
+  (Story: React.ComponentType) => (
+    <div className="nx:w-72">
+      <Story />
+    </div>
+  ),
+];
+
+// Pip mode creates a discrete settings-row selector.
+export const Comfortable: ComfortableStory = {
+  decorators: comfortableDecorators,
+  render: function ComfortableStory() {
+    const [value, setValue] = React.useState(2);
+
+    return (
+      <SliderComfortable
+        value={value}
+        onValueChange={setValue}
+        min={0}
+        max={4}
+        step={1}
+        label="Roundness"
+      />
+    );
+  },
+};
+
+// Scrubber mode keeps the larger row but drops discrete pips.
+export const ComfortableScrubber: ComfortableStory = {
+  decorators: comfortableDecorators,
+  render: function ComfortableScrubberStory() {
+    const [value, setValue] = React.useState(50);
+
+    return (
+      <SliderComfortable
+        variant="scrubber"
+        value={value}
+        onValueChange={setValue}
+        min={0}
+        max={100}
+        step={1}
+        label="Volume"
+        formatValue={(nextValue) => `${nextValue}%`}
+      />
+    );
+  },
+};
+
+// Comfortable sliders also accept display formatters.
+export const ComfortableFormat: ComfortableStory = {
+  decorators: comfortableDecorators,
+  render: function ComfortableFormatStory() {
+    const [value, setValue] = React.useState(2);
+    const qualityLabels = ['Low', 'Medium', 'High'];
+
+    return (
+      <SliderComfortable
+        value={value}
+        onValueChange={setValue}
+        min={1}
+        max={3}
+        step={1}
+        label="Quality"
+        formatValue={(nextValue) => qualityLabels[nextValue - 1] ?? 'Medium'}
+      />
+    );
+  },
+};
+
+// Disabled comfortable sliders keep their row mounted but inert.
+export const ComfortableDisabled: ComfortableStory = {
+  decorators: comfortableDecorators,
+  render: () => (
+    <SliderComfortable
+      disabled
+      defaultValue={2}
+      min={0}
+      max={4}
+      step={1}
+      label="Roundness"
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    await expect(
+      canvasElement.querySelector('[data-slot="slider-comfortable"]')
+    ).toHaveAttribute('data-disabled');
+    await expect(
+      canvasElement.querySelector('[data-slot="slider-comfortable-track"]')
+    ).toHaveClass('nx:bg-disabled');
+  },
+};
+
+// Arrow keys operate the comfortable slider through Radix semantics.
+export const ComfortableKeyboardInteraction: ComfortableStory = {
+  args: { onValueChange: fn() },
+  decorators: comfortableDecorators,
+  render: (args) => (
+    <SliderComfortable
+      defaultValue={2}
+      min={0}
+      max={4}
+      step={1}
+      label="Roundness"
+      onValueChange={args.onValueChange}
+    />
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const thumb = canvas.getByRole('slider');
+    await expect(thumb).toHaveAttribute('aria-valuenow', '2');
+    await userEvent.tab();
+    await expect(thumb).toHaveFocus();
+    await userEvent.keyboard('{ArrowRight}');
+    await expect(thumb).toHaveAttribute('aria-valuenow', '3');
+    await expect(args.onValueChange).toHaveBeenCalledWith(3);
+  },
+};
+
+// Comfortable data slots identify the row, track, range, thumb, label, and value.
+export const ComfortableWithDataAttributes: ComfortableStory = {
+  decorators: comfortableDecorators,
+  render: () => (
+    <SliderComfortable
+      defaultValue={2}
+      min={0}
+      max={4}
+      step={1}
+      label="Roundness"
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    await expect(
+      canvasElement.querySelector('[data-slot="slider-comfortable"]')
+    ).toHaveAttribute('data-variant', 'pips');
+    await expect(
+      canvasElement.querySelector('[data-slot="slider-comfortable-track"]')
+    ).toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-slot="slider-comfortable-range"]')
+    ).toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-slot="slider-comfortable-thumb"]')
+    ).toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-slot="slider-comfortable-label"]')
+    ).toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('[data-slot="slider-comfortable-value"]')
+    ).toBeInTheDocument();
+  },
+};
+
 // ============================================
 // ALL VARIANTS GRID
 // ============================================
 
-// Single, range, and disabled sliders. Reused by the per-base variant generator.
+// Compact and comfortable slider examples. Reused by the per-base variant generator.
 export const AllVariants: Story = {
   render: () => (
-    <div className="nx:flex nx:w-64 nx:flex-col nx:gap-8">
+    <div className="nx:flex nx:w-72 nx:flex-col nx:gap-8">
       <Slider defaultValue={[50]} max={100} step={1} aria-label="Single" />
-      <Slider defaultValue={[25, 75]} max={100} step={1} aria-label="Range" />
+      <Slider
+        defaultValue={[25, 75]}
+        max={100}
+        step={1}
+        showValue
+        valuePosition="right"
+        aria-label="Range"
+      />
+      <Slider
+        defaultValue={[40]}
+        max={100}
+        step={10}
+        showSteps
+        aria-label="Steps"
+      />
       <Slider disabled defaultValue={[40]} max={100} aria-label="Disabled" />
+      <SliderComfortable
+        defaultValue={2}
+        min={0}
+        max={4}
+        step={1}
+        label="Roundness"
+      />
+      <SliderComfortable
+        variant="scrubber"
+        defaultValue={50}
+        min={0}
+        max={100}
+        step={1}
+        label="Volume"
+        formatValue={(nextValue) => `${nextValue}%`}
+      />
     </div>
   ),
 };

--- a/packages/react/src/components/slider/Slider.stories.tsx
+++ b/packages/react/src/components/slider/Slider.stories.tsx
@@ -20,9 +20,34 @@ const withSliderWidth: Decorator = (Story, context) => {
   );
 };
 
+const fluidSliderVariables: React.CSSProperties &
+  Record<`--${string}`, string> = {
+  '--slider-showcase-bg': '#0e0e0e',
+  '--slider-showcase-muted': '#8c8c8c',
+  '--slider-track': '#242424',
+  '--slider-range': '#3a3a3a',
+  '--slider-border': 'rgba(255,255,255,.09)',
+  '--slider-pip': '#5c5c5c',
+  '--slider-thumb': '#ffffff',
+  '--slider-thumb-border': 'rgba(0,0,0,.04)',
+  '--slider-tooltip-bg': '#f2f2f0',
+  '--slider-tooltip-fg': '#171717',
+  '--slider-comfortable-track': '#1a1a1a',
+  '--slider-comfortable-range': '#2c2c2c',
+  '--slider-comfortable-border': 'rgba(255,255,255,.09)',
+  '--slider-comfortable-pip': '#5c5c5c',
+  '--slider-comfortable-caret': '#cfcfcf',
+  '--slider-comfortable-label': '#d4d4d4',
+  '--slider-comfortable-muted': '#8c8c8c',
+};
+
 function FluidSliderShowcase({ children }: { children: React.ReactNode }) {
   return (
-    <div className="nx:w-[35rem] nx:max-w-[calc(100vw-3rem)] nx:bg-background nx:px-6 nx:py-8 nx:text-foreground">
+    <div
+      data-slider-showcase
+      style={fluidSliderVariables}
+      className="nx:w-[35rem] nx:max-w-[calc(100vw-3rem)] nx:bg-(--slider-showcase-bg) nx:px-6 nx:py-8 nx:text-foreground"
+    >
       <div className="nx:flex nx:w-full nx:flex-col nx:gap-5">{children}</div>
     </div>
   );
@@ -416,11 +441,11 @@ export const AllVariants: Story = {
   render: () => (
     <FluidSliderShowcase>
       <div className="nx:grid nx:grid-cols-[3rem_minmax(0,1fr)] nx:items-center nx:gap-x-5 nx:gap-y-8">
-        <span className="nx:tabular-nums nx:typography-label-default nx:text-muted-foreground">
+        <span className="nx:tabular-nums nx:typography-label-default nx:text-(--slider-showcase-muted)">
           50
         </span>
         <Slider defaultValue={[50]} max={100} step={1} aria-label="Single" />
-        <span className="nx:tabular-nums nx:typography-label-default nx:text-muted-foreground">
+        <span className="nx:tabular-nums nx:typography-label-default nx:text-(--slider-showcase-muted)">
           50
         </span>
         <Slider

--- a/packages/react/src/components/slider/slider.tsx
+++ b/packages/react/src/components/slider/slider.tsx
@@ -372,7 +372,7 @@ function SliderComfortable({
       step={step}
       disabled={disabled}
       className={cn(
-        'nx:group/slider-comfortable nx:relative nx:flex nx:h-6 nx:w-full nx:cursor-pointer nx:select-none nx:items-center nx:touch-pan-y nx:data-disabled:cursor-default',
+        'nx:group/slider-comfortable nx:relative nx:flex nx:h-8 nx:w-full nx:cursor-pointer nx:select-none nx:items-center nx:touch-pan-y nx:data-disabled:cursor-default',
         disabled && 'nx:pointer-events-none',
         className
       )}
@@ -381,7 +381,7 @@ function SliderComfortable({
       <SliderPrimitive.Track
         data-slot="slider-comfortable-track"
         className={cn(
-          'nx:relative nx:h-6 nx:w-full nx:overflow-hidden nx:rounded-lg nx:border-default nx:border-border-default nx:bg-control-background nx:text-foreground nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none',
+          'nx:relative nx:h-8 nx:w-full nx:overflow-hidden nx:rounded-lg nx:border-default nx:border-border-default nx:bg-control-background nx:text-foreground nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none',
           disabled &&
             'nx:border-border-disabled nx:bg-disabled nx:text-disabled-foreground'
         )}

--- a/packages/react/src/components/slider/slider.tsx
+++ b/packages/react/src/components/slider/slider.tsx
@@ -235,7 +235,7 @@ function Slider({
     >
       <SliderPrimitive.Track
         data-slot="slider-track"
-        className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:border-default nx:border-border-default nx:bg-control-background nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-7 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-7"
+        className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:border-default nx:border-border-default nx:bg-control-background nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-2 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-2"
       >
         {stepValues.map((stepValue) => (
           <span
@@ -372,7 +372,7 @@ function SliderComfortable({
       step={step}
       disabled={disabled}
       className={cn(
-        'nx:group/slider-comfortable nx:relative nx:flex nx:h-12 nx:w-full nx:cursor-pointer nx:select-none nx:items-center nx:touch-pan-y nx:data-disabled:cursor-default',
+        'nx:group/slider-comfortable nx:relative nx:flex nx:h-10 nx:w-full nx:cursor-pointer nx:select-none nx:items-center nx:touch-pan-y nx:data-disabled:cursor-default',
         disabled && 'nx:pointer-events-none',
         className
       )}
@@ -381,7 +381,7 @@ function SliderComfortable({
       <SliderPrimitive.Track
         data-slot="slider-comfortable-track"
         className={cn(
-          'nx:relative nx:h-12 nx:w-full nx:overflow-hidden nx:rounded-lg nx:border-default nx:border-border-default nx:bg-control-background nx:text-foreground nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none',
+          'nx:relative nx:h-10 nx:w-full nx:overflow-hidden nx:rounded-lg nx:border-default nx:border-border-default nx:bg-control-background nx:text-foreground nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none',
           disabled &&
             'nx:border-border-disabled nx:bg-disabled nx:text-disabled-foreground'
         )}

--- a/packages/react/src/components/slider/slider.tsx
+++ b/packages/react/src/components/slider/slider.tsx
@@ -235,7 +235,7 @@ function Slider({
     >
       <SliderPrimitive.Track
         data-slot="slider-track"
-        className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:border-default nx:border-border-default nx:bg-control-background nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-2 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-2"
+        className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:border-default nx:border-border-default nx:bg-control-background nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-3 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-3"
       >
         {stepValues.map((stepValue) => (
           <span
@@ -372,7 +372,7 @@ function SliderComfortable({
       step={step}
       disabled={disabled}
       className={cn(
-        'nx:group/slider-comfortable nx:relative nx:flex nx:h-10 nx:w-full nx:cursor-pointer nx:select-none nx:items-center nx:touch-pan-y nx:data-disabled:cursor-default',
+        'nx:group/slider-comfortable nx:relative nx:flex nx:h-6 nx:w-full nx:cursor-pointer nx:select-none nx:items-center nx:touch-pan-y nx:data-disabled:cursor-default',
         disabled && 'nx:pointer-events-none',
         className
       )}
@@ -381,7 +381,7 @@ function SliderComfortable({
       <SliderPrimitive.Track
         data-slot="slider-comfortable-track"
         className={cn(
-          'nx:relative nx:h-10 nx:w-full nx:overflow-hidden nx:rounded-lg nx:border-default nx:border-border-default nx:bg-control-background nx:text-foreground nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none',
+          'nx:relative nx:h-6 nx:w-full nx:overflow-hidden nx:rounded-lg nx:border-default nx:border-border-default nx:bg-control-background nx:text-foreground nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none',
           disabled &&
             'nx:border-border-disabled nx:bg-disabled nx:text-disabled-foreground'
         )}

--- a/packages/react/src/components/slider/slider.tsx
+++ b/packages/react/src/components/slider/slider.tsx
@@ -235,14 +235,14 @@ function Slider({
     >
       <SliderPrimitive.Track
         data-slot="slider-track"
-        className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:border-default nx:border-border-default nx:bg-control-background nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-7 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-7"
+        className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:border-default nx:border-(--slider-border,var(--nx-color-border-default-alpha)) nx:bg-(--slider-track,var(--nx-color-control-background)) nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-7 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-7"
       >
         {stepValues.map((stepValue) => (
           <span
             aria-hidden="true"
             data-slot="slider-step"
             key={stepValue}
-            className="nx:pointer-events-none nx:absolute nx:top-1/2 nx:size-1 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-control-thumb nx:opacity-60 nx:data-[orientation=vertical]:left-1/2 nx:data-[orientation=vertical]:top-auto nx:data-[orientation=vertical]:-translate-x-1/2 nx:data-[orientation=vertical]:translate-y-1/2"
+            className="nx:pointer-events-none nx:absolute nx:top-1/2 nx:size-1 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-(--slider-pip,var(--nx-color-control-thumb)) nx:opacity-60 nx:data-[orientation=vertical]:left-1/2 nx:data-[orientation=vertical]:top-auto nx:data-[orientation=vertical]:-translate-x-1/2 nx:data-[orientation=vertical]:translate-y-1/2"
             style={
               orientation === 'vertical'
                 ? { bottom: `${getValuePercent(stepValue, min, max)}%` }
@@ -252,7 +252,7 @@ function Slider({
         ))}
         <SliderPrimitive.Range
           data-slot="slider-range"
-          className="nx:pointer-events-none nx:absolute nx:bg-control-background-hover nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-full nx:data-[orientation=vertical]:w-full"
+          className="nx:pointer-events-none nx:absolute nx:bg-(--slider-range,var(--nx-color-control-background-hover)) nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-full nx:data-[orientation=vertical]:w-full"
         />
       </SliderPrimitive.Track>
       {Array.from({ length: values.length }, (_, index) => (
@@ -271,12 +271,12 @@ function Slider({
           aria-labelledby={ariaLabelledby}
           aria-invalid={ariaInvalid}
           aria-valuetext={formatValue(values[index] ?? values[0] ?? min)}
-          className="nx:relative nx:z-30 nx:block nx:size-5 nx:shrink-0 nx:cursor-grab nx:rounded-full nx:border-default nx:border-border-default nx:bg-control-thumb nx:transition-[background-color,border-color,transform] nx:duration-fast nx:after:absolute nx:after:-inset-3 nx:after:cursor-grab nx:after:content-[''] nx:hover:scale-105 nx:active:cursor-grabbing nx:active:after:cursor-grabbing nx:motion-reduce:transition-none nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:cursor-not-allowed nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-disabled:after:cursor-not-allowed nx:aria-invalid:focus-visible:outline-focus-error"
+          className="nx:relative nx:z-30 nx:block nx:size-5 nx:shrink-0 nx:cursor-grab nx:rounded-full nx:border-default nx:border-(--slider-thumb-border,var(--nx-color-border-default)) nx:bg-(--slider-thumb,var(--nx-color-control-thumb)) nx:transition-[background-color,border-color,transform] nx:duration-fast nx:after:absolute nx:after:-inset-3 nx:after:cursor-grab nx:after:content-[''] nx:hover:scale-105 nx:active:cursor-grabbing nx:active:after:cursor-grabbing nx:motion-reduce:transition-none nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:cursor-not-allowed nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-disabled:after:cursor-not-allowed nx:aria-invalid:focus-visible:outline-focus-error"
         >
           {showValue && valuePosition === 'tooltip' ? (
             <span
               data-slot="slider-tooltip"
-              className="nx:pointer-events-none nx:absolute nx:bottom-full nx:left-1/2 nx:mb-4 nx:-translate-x-1/2 nx:rounded-lg nx:bg-foreground nx:px-3 nx:py-1.5 nx:tabular-nums nx:typography-label-default nx:text-background nx:opacity-0 nx:transition-opacity nx:duration-fast nx:before:absolute nx:before:left-1/2 nx:before:top-full nx:before:size-2 nx:before:-translate-x-1/2 nx:before:-translate-y-1/2 nx:before:rotate-45 nx:before:bg-foreground nx:before:content-[''] nx:motion-reduce:transition-none nx:group-hover/slider:opacity-100 nx:group-focus-within/slider:opacity-100"
+              className="nx:pointer-events-none nx:absolute nx:bottom-full nx:left-1/2 nx:mb-4 nx:-translate-x-1/2 nx:rounded-lg nx:bg-(--slider-tooltip-bg,var(--nx-color-foreground)) nx:px-3 nx:py-1.5 nx:tabular-nums nx:typography-label-default nx:text-(--slider-tooltip-fg,var(--nx-color-background)) nx:opacity-0 nx:transition-opacity nx:duration-fast nx:before:absolute nx:before:left-1/2 nx:before:top-full nx:before:size-2 nx:before:-translate-x-1/2 nx:before:-translate-y-1/2 nx:before:rotate-45 nx:before:bg-(--slider-tooltip-bg,var(--nx-color-foreground)) nx:before:content-[''] nx:motion-reduce:transition-none nx:group-hover/slider:opacity-100 nx:group-focus-within/slider:opacity-100"
             >
               {formatValue(values[index] ?? values[0] ?? min)}
             </span>
@@ -381,8 +381,7 @@ function SliderComfortable({
       <SliderPrimitive.Track
         data-slot="slider-comfortable-track"
         className={cn(
-          'nx:relative nx:h-12 nx:w-full nx:overflow-hidden nx:rounded-lg nx:border-default nx:border-border-default nx:bg-control-background nx:text-foreground nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none',
-          'nx:text-foreground',
+          'nx:relative nx:h-12 nx:w-full nx:overflow-hidden nx:rounded-lg nx:border-default nx:border-(--slider-comfortable-border,var(--nx-color-border-default-alpha)) nx:bg-(--slider-comfortable-track,var(--nx-color-control-background)) nx:text-(--slider-comfortable-label,var(--nx-color-foreground)) nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none',
           disabled &&
             'nx:border-border-disabled nx:bg-disabled nx:text-disabled-foreground'
         )}
@@ -393,8 +392,9 @@ function SliderComfortable({
             data-slot="slider-comfortable-pip"
             key={pipValue}
             className={cn(
-              'nx:pointer-events-none nx:absolute nx:top-1/2 nx:size-1 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-muted-foreground nx:opacity-50',
-              pipValue === currentValue && 'nx:bg-foreground nx:opacity-90'
+              'nx:pointer-events-none nx:absolute nx:top-1/2 nx:size-1 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-(--slider-comfortable-pip,var(--nx-color-muted-foreground)) nx:opacity-50',
+              pipValue === currentValue &&
+                'nx:bg-(--slider-comfortable-caret,var(--nx-color-foreground)) nx:opacity-90'
             )}
             style={{ left: `${getValuePercent(pipValue, min, max)}%` }}
           />
@@ -402,7 +402,7 @@ function SliderComfortable({
         <SliderPrimitive.Range
           data-slot="slider-comfortable-range"
           className={cn(
-            'nx:pointer-events-none nx:absolute nx:inset-y-0 nx:left-0 nx:min-w-36 nx:bg-control-background-hover',
+            'nx:pointer-events-none nx:absolute nx:inset-y-0 nx:left-0 nx:min-w-36 nx:bg-(--slider-comfortable-range,var(--nx-color-control-background-hover))',
             disabled && 'nx:bg-disabled'
           )}
         />
@@ -414,7 +414,7 @@ function SliderComfortable({
           ) : null}
           <span
             data-slot="slider-comfortable-value"
-            className="nx:ml-auto nx:shrink-0 nx:tabular-nums nx:text-muted-foreground"
+            className="nx:ml-auto nx:shrink-0 nx:tabular-nums nx:text-(--slider-comfortable-muted,var(--nx-color-muted-foreground))"
           >
             {formatValue(currentValue)}
           </span>
@@ -425,12 +425,12 @@ function SliderComfortable({
         aria-label={ariaLabel ?? label}
         aria-labelledby={ariaLabelledby}
         aria-valuetext={formatValue(currentValue)}
-        className="nx:relative nx:z-40 nx:block nx:h-5 nx:w-0.5 nx:shrink-0 nx:cursor-grab nx:rounded-full nx:bg-foreground nx:transition-[background-color,transform] nx:duration-fast nx:after:absolute nx:after:-inset-5 nx:after:cursor-grab nx:after:content-[''] nx:hover:scale-y-110 nx:active:cursor-grabbing nx:active:after:cursor-grabbing nx:motion-reduce:transition-none nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:cursor-not-allowed nx:data-disabled:bg-disabled-foreground nx:data-disabled:after:cursor-not-allowed"
+        className="nx:relative nx:z-40 nx:block nx:h-5 nx:w-0.5 nx:shrink-0 nx:cursor-grab nx:rounded-full nx:bg-(--slider-comfortable-caret,var(--nx-color-foreground)) nx:transition-[background-color,transform] nx:duration-fast nx:after:absolute nx:after:-inset-5 nx:after:cursor-grab nx:after:content-[''] nx:hover:scale-y-110 nx:active:cursor-grabbing nx:active:after:cursor-grabbing nx:motion-reduce:transition-none nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:cursor-not-allowed nx:data-disabled:bg-disabled-foreground nx:data-disabled:after:cursor-not-allowed"
       >
         {!disabled ? (
           <span
             data-slot="slider-comfortable-tooltip"
-            className="nx:pointer-events-none nx:absolute nx:bottom-full nx:left-1/2 nx:mb-3 nx:-translate-x-1/2 nx:rounded-lg nx:bg-foreground nx:px-3 nx:py-1.5 nx:tabular-nums nx:typography-label-default nx:text-background nx:opacity-0 nx:shadow-sm nx:transition-opacity nx:duration-fast nx:before:absolute nx:before:left-1/2 nx:before:top-full nx:before:size-2 nx:before:-translate-x-1/2 nx:before:-translate-y-1/2 nx:before:rotate-45 nx:before:bg-foreground nx:before:content-[''] nx:motion-reduce:transition-none nx:group-hover/slider-comfortable:opacity-100 nx:group-focus-within/slider-comfortable:opacity-100"
+            className="nx:pointer-events-none nx:absolute nx:bottom-full nx:left-1/2 nx:mb-3 nx:-translate-x-1/2 nx:rounded-lg nx:bg-(--slider-tooltip-bg,var(--nx-color-foreground)) nx:px-3 nx:py-1.5 nx:tabular-nums nx:typography-label-default nx:text-(--slider-tooltip-fg,var(--nx-color-background)) nx:opacity-0 nx:shadow-sm nx:transition-opacity nx:duration-fast nx:before:absolute nx:before:left-1/2 nx:before:top-full nx:before:size-2 nx:before:-translate-x-1/2 nx:before:-translate-y-1/2 nx:before:rotate-45 nx:before:bg-(--slider-tooltip-bg,var(--nx-color-foreground)) nx:before:content-[''] nx:motion-reduce:transition-none nx:group-hover/slider-comfortable:opacity-100 nx:group-focus-within/slider-comfortable:opacity-100"
           >
             {formatValue(currentValue)}
           </span>

--- a/packages/react/src/components/slider/slider.tsx
+++ b/packages/react/src/components/slider/slider.tsx
@@ -4,6 +4,8 @@ import * as SliderPrimitive from '@radix-ui/react-slider';
 
 import { cn } from '@/lib/utils';
 
+type SliderValuePosition = 'left' | 'right' | 'top' | 'bottom' | 'tooltip';
+
 /**
  * SliderProps
  *
@@ -11,14 +13,159 @@ import { cn } from '@/lib/utils';
  */
 interface SliderProps extends React.ComponentProps<
   typeof SliderPrimitive.Root
-> {}
+> {
+  /**
+   * Render step markers along the track.
+   *
+   * @default false
+   * @example
+   * ```tsx
+   * <Slider defaultValue={[50]} step={10} showSteps aria-label="Volume" />
+   * ```
+   */
+  showSteps?: boolean;
+  /**
+   * Render the current value beside, above, below, or above the thumb.
+   *
+   * @default false
+   * @example
+   * ```tsx
+   * <Slider value={[value]} showValue valuePosition="right" />
+   * ```
+   */
+  showValue?: boolean;
+  /**
+   * Where the value display appears when `showValue` is true.
+   *
+   * @default "left"
+   */
+  valuePosition?: SliderValuePosition;
+  /**
+   * Formats visible value labels and slider `aria-valuetext`.
+   *
+   * @default String
+   */
+  formatValue?: (value: number) => string;
+  /**
+   * Visible value prefix and accessible-name fallback.
+   */
+  label?: string;
+}
+
+interface SliderComfortableProps extends Omit<
+  React.ComponentProps<typeof SliderPrimitive.Root>,
+  'value' | 'defaultValue' | 'onValueChange' | 'orientation'
+> {
+  /**
+   * Controlled scalar value.
+   */
+  value?: number;
+  /**
+   * Initial scalar value for uncontrolled usage.
+   *
+   * @default min
+   */
+  defaultValue?: number;
+  /**
+   * Called with the scalar value whenever the slider changes.
+   */
+  onValueChange?: (value: number) => void;
+  /**
+   * Comfortable visual treatment.
+   *
+   * @default "pips"
+   */
+  variant?: 'pips' | 'scrubber';
+  /**
+   * Label shown inside the comfortable slider row.
+   */
+  label?: string;
+  /**
+   * Formats the visible value and slider `aria-valuetext`.
+   *
+   * @default String
+   */
+  formatValue?: (value: number) => string;
+}
+
+function getInitialSliderValues({
+  value,
+  defaultValue,
+  min,
+  max,
+}: {
+  value?: number[];
+  defaultValue?: number[];
+  min: number;
+  max: number;
+}) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (Array.isArray(defaultValue)) {
+    return defaultValue;
+  }
+
+  return [min, max];
+}
+
+function getStepValues(min: number, max: number, step: number) {
+  if (step <= 0 || max <= min) {
+    return [];
+  }
+
+  const count = Math.floor((max - min) / step);
+
+  return Array.from({ length: count + 1 }, (_, index) => {
+    const value = min + index * step;
+
+    return Math.min(value, max);
+  });
+}
+
+function getValuePercent(value: number, min: number, max: number) {
+  if (max === min) {
+    return 0;
+  }
+
+  return ((value - min) / (max - min)) * 100;
+}
+
+function SliderValueDisplay({
+  values,
+  label,
+  formatValue,
+}: {
+  values: number[];
+  label?: string;
+  formatValue: (value: number) => string;
+}) {
+  const firstValue = values[0] ?? 0;
+  const secondValue = values[1] ?? firstValue;
+  const formattedValue =
+    values.length > 1
+      ? `${formatValue(firstValue)} - ${formatValue(secondValue)}`
+      : formatValue(firstValue);
+
+  return (
+    <span
+      data-slot="slider-value"
+      className="nx:shrink-0 nx:select-none nx:tabular-nums nx:typography-label-small nx:text-muted-foreground"
+    >
+      {label ? `${label}: ` : null}
+      {formattedValue}
+    </span>
+  );
+}
 
 /**
  * Slider
  *
  * A value / range slider built on Radix Slider. Renders one thumb per value, so
  * a single `defaultValue={[50]}` is a value slider and `defaultValue={[25, 75]}`
- * is a range slider. Supports steps, keyboard, and vertical orientation.
+ * is a range slider. Supports step markers, value display, keyboard, and
+ * vertical orientation.
  *
  * @example
  * ```tsx
@@ -30,30 +177,58 @@ function Slider({
   className,
   defaultValue,
   value,
+  onValueChange,
   min = 0,
   max = 100,
+  step = 1,
+  orientation = 'horizontal',
+  showSteps = false,
+  showValue = false,
+  valuePosition = 'left',
+  formatValue = String,
+  label,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledby,
   'aria-invalid': ariaInvalid,
   ...props
 }: SliderProps) {
-  // Derive the thumb count from the controlled/uncontrolled value; fall back to
-  // a two-thumb range spanning the track when neither is provided.
-  const values = Array.isArray(value)
-    ? value
-    : Array.isArray(defaultValue)
-      ? defaultValue
-      : [min, max];
+  const isControlled = Array.isArray(value);
+  const [uncontrolledValues, setUncontrolledValues] = React.useState(() =>
+    getInitialSliderValues({ value, defaultValue, min, max })
+  );
+  const values = isControlled ? value : uncontrolledValues;
+  const stepValues = showSteps ? getStepValues(min, max, step) : [];
+  const showStaticValue = showValue && valuePosition !== 'tooltip';
+  const valueDisplay = showStaticValue ? (
+    <SliderValueDisplay
+      values={values}
+      label={label}
+      formatValue={formatValue}
+    />
+  ) : null;
 
-  return (
+  const handleValueChange = React.useCallback(
+    (nextValues: number[]) => {
+      if (!isControlled) {
+        setUncontrolledValues(nextValues);
+      }
+
+      onValueChange?.(nextValues);
+    },
+    [isControlled, onValueChange]
+  );
+
+  const slider = (
     <SliderPrimitive.Root
       data-slot="slider"
-      defaultValue={defaultValue}
-      value={value}
+      value={values}
+      onValueChange={handleValueChange}
       min={min}
       max={max}
+      step={step}
+      orientation={orientation}
       className={cn(
-        'nx:relative nx:flex nx:w-full nx:touch-none nx:items-center nx:select-none nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:min-h-44 nx:data-[orientation=vertical]:w-auto nx:data-[orientation=vertical]:flex-col',
+        'nx:group/slider nx:relative nx:flex nx:w-full nx:select-none nx:items-center nx:data-[orientation=horizontal]:touch-pan-y nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:min-h-44 nx:data-[orientation=vertical]:w-auto nx:data-[orientation=vertical]:touch-pan-x nx:data-[orientation=vertical]:flex-col',
         className
       )}
       {...props}
@@ -62,9 +237,22 @@ function Slider({
         data-slot="slider-track"
         className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:bg-control-background nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-1.5 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-1.5"
       >
+        {stepValues.map((stepValue) => (
+          <span
+            aria-hidden="true"
+            data-slot="slider-step"
+            key={stepValue}
+            className="nx:pointer-events-none nx:absolute nx:top-1/2 nx:z-10 nx:size-1 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-control-thumb nx:opacity-70 nx:data-[orientation=vertical]:left-1/2 nx:data-[orientation=vertical]:top-auto nx:data-[orientation=vertical]:-translate-x-1/2 nx:data-[orientation=vertical]:translate-y-1/2"
+            style={
+              orientation === 'vertical'
+                ? { bottom: `${getValuePercent(stepValue, min, max)}%` }
+                : { left: `${getValuePercent(stepValue, min, max)}%` }
+            }
+          />
+        ))}
         <SliderPrimitive.Range
           data-slot="slider-range"
-          className="nx:absolute nx:bg-primary-background nx:data-disabled:bg-primary-disabled nx:data-[orientation=horizontal]:h-full nx:data-[orientation=vertical]:w-full"
+          className="nx:absolute nx:z-20 nx:bg-primary-background nx:data-disabled:bg-primary-disabled nx:data-[orientation=horizontal]:h-full nx:data-[orientation=vertical]:w-full"
         />
       </SliderPrimitive.Track>
       {Array.from({ length: values.length }, (_, index) => (
@@ -74,14 +262,179 @@ function Slider({
           // Radix puts role="slider" on the thumb, not the role-less Root span:
           // forward the thumb-owned ARIA here (naming + invalid state) so it lands
           // on the right element and stays off the Root, where it'd be prohibited.
-          aria-label={ariaLabel}
+          aria-label={
+            ariaLabel ??
+            (label && values.length > 1
+              ? `${label} ${index === 0 ? 'minimum' : 'maximum'}`
+              : label)
+          }
           aria-labelledby={ariaLabelledby}
           aria-invalid={ariaInvalid}
-          className="nx:block nx:size-4 nx:shrink-0 nx:rounded-full nx:border-default nx:border-border-primary nx:bg-background nx:transition-colors nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:aria-invalid:focus-visible:outline-focus-error"
-        />
+          aria-valuetext={formatValue(values[index] ?? values[0] ?? min)}
+          className="nx:relative nx:z-30 nx:block nx:size-4 nx:shrink-0 nx:rounded-full nx:border-default nx:border-border-primary nx:bg-background nx:transition-colors nx:after:absolute nx:after:-inset-3 nx:after:content-[''] nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:aria-invalid:focus-visible:outline-focus-error"
+        >
+          {showValue && valuePosition === 'tooltip' ? (
+            <span
+              data-slot="slider-tooltip"
+              className="nx:pointer-events-none nx:absolute nx:bottom-full nx:left-1/2 nx:mb-2 nx:-translate-x-1/2 nx:rounded-md nx:bg-popover nx:px-2 nx:py-1 nx:tabular-nums nx:typography-label-small nx:text-popover-foreground nx:opacity-0 nx:shadow-sm nx:transition-opacity nx:duration-fast nx:motion-reduce:transition-none nx:group-hover/slider:opacity-100 nx:group-focus-within/slider:opacity-100"
+            >
+              {formatValue(values[index] ?? values[0] ?? min)}
+            </span>
+          ) : null}
+        </SliderPrimitive.Thumb>
       ))}
+    </SliderPrimitive.Root>
+  );
+
+  if (!showStaticValue) {
+    return slider;
+  }
+
+  return (
+    <div
+      data-slot="slider-field"
+      data-value-position={valuePosition}
+      className={cn(
+        'nx:flex nx:gap-3',
+        valuePosition === 'top' || valuePosition === 'bottom'
+          ? 'nx:flex-col'
+          : 'nx:items-center',
+        valuePosition === 'right' && 'nx:flex-row',
+        valuePosition === 'bottom' && 'nx:flex-col'
+      )}
+    >
+      {(valuePosition === 'left' || valuePosition === 'top') && valueDisplay}
+      {slider}
+      {(valuePosition === 'right' || valuePosition === 'bottom') &&
+        valueDisplay}
+    </div>
+  );
+}
+
+/**
+ * SliderComfortable
+ *
+ * A roomier settings-row slider inspired by the Fluid Functionalism comfortable
+ * examples. It uses the existing Radix slider primitive, keeps the value scalar,
+ * and renders either a discrete pip rail or a continuous scrubber row.
+ *
+ * @example
+ * ```tsx
+ * <SliderComfortable label="Roundness" defaultValue={2} min={0} max={4} />
+ * <SliderComfortable variant="scrubber" label="Volume" defaultValue={50} />
+ * ```
+ */
+function SliderComfortable({
+  className,
+  value,
+  defaultValue,
+  onValueChange,
+  min = 0,
+  max = 100,
+  step = 1,
+  variant = 'pips',
+  label,
+  formatValue = String,
+  disabled,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
+  ...props
+}: SliderComfortableProps) {
+  const isControlled = typeof value === 'number';
+  const [uncontrolledValue, setUncontrolledValue] = React.useState(
+    defaultValue ?? min
+  );
+  const currentValue = isControlled ? value : uncontrolledValue;
+  const values = [currentValue];
+  const pipValues = variant === 'pips' ? getStepValues(min, max, step) : [];
+
+  const handleValueChange = React.useCallback(
+    (nextValues: number[]) => {
+      const nextValue = nextValues[0] ?? min;
+
+      if (!isControlled) {
+        setUncontrolledValue(nextValue);
+      }
+
+      onValueChange?.(nextValue);
+    },
+    [isControlled, min, onValueChange]
+  );
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider-comfortable"
+      data-variant={variant}
+      value={values}
+      onValueChange={handleValueChange}
+      min={min}
+      max={max}
+      step={step}
+      disabled={disabled}
+      className={cn(
+        'nx:group/slider-comfortable nx:relative nx:flex nx:h-8 nx:w-full nx:select-none nx:items-center nx:touch-pan-y',
+        disabled && 'nx:pointer-events-none',
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-comfortable-track"
+        className={cn(
+          'nx:relative nx:h-8 nx:w-full nx:overflow-hidden nx:rounded-md nx:border-default nx:border-border-default nx:bg-container nx:text-muted-foreground nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none',
+          'nx:group-hover/slider-comfortable:text-foreground nx:group-focus-within/slider-comfortable:text-foreground',
+          disabled &&
+            'nx:border-border-disabled nx:bg-disabled nx:text-disabled-foreground'
+        )}
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-comfortable-range"
+          className={cn(
+            'nx:absolute nx:inset-y-0 nx:left-0 nx:z-10 nx:bg-primary-subtle',
+            disabled && 'nx:bg-primary-disabled'
+          )}
+        />
+        {pipValues.map((pipValue) => (
+          <span
+            aria-hidden="true"
+            data-slot="slider-comfortable-pip"
+            key={pipValue}
+            className={cn(
+              'nx:pointer-events-none nx:absolute nx:top-1/2 nx:z-20 nx:size-1.5 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-current nx:opacity-40',
+              pipValue === currentValue && 'nx:opacity-100'
+            )}
+            style={{ left: `${getValuePercent(pipValue, min, max)}%` }}
+          />
+        ))}
+        <span className="nx:pointer-events-none nx:absolute nx:inset-0 nx:z-30 nx:flex nx:items-center nx:gap-3 nx:px-3 nx:typography-label-small">
+          {label ? (
+            <span data-slot="slider-comfortable-label" className="nx:truncate">
+              {label}
+            </span>
+          ) : null}
+          <span
+            data-slot="slider-comfortable-value"
+            className="nx:ml-auto nx:shrink-0 nx:tabular-nums"
+          >
+            {formatValue(currentValue)}
+          </span>
+        </span>
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb
+        data-slot="slider-comfortable-thumb"
+        aria-label={ariaLabel ?? label}
+        aria-labelledby={ariaLabelledby}
+        aria-valuetext={formatValue(currentValue)}
+        className="nx:relative nx:z-40 nx:block nx:h-4 nx:w-0.5 nx:shrink-0 nx:rounded-full nx:bg-foreground nx:transition-[height,background-color] nx:duration-fast nx:after:absolute nx:after:-inset-4 nx:after:content-[''] nx:motion-reduce:transition-none nx:group-hover/slider-comfortable:h-5 nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:bg-disabled-foreground"
+      />
     </SliderPrimitive.Root>
   );
 }
 
-export { Slider, type SliderProps };
+export {
+  Slider,
+  SliderComfortable,
+  type SliderComfortableProps,
+  type SliderProps,
+  type SliderValuePosition,
+};

--- a/packages/react/src/components/slider/slider.tsx
+++ b/packages/react/src/components/slider/slider.tsx
@@ -151,7 +151,7 @@ function SliderValueDisplay({
   return (
     <span
       data-slot="slider-value"
-      className="nx:shrink-0 nx:select-none nx:tabular-nums nx:typography-label-small nx:text-muted-foreground"
+      className="nx:shrink-0 nx:select-none nx:tabular-nums nx:typography-label-default nx:text-muted-foreground"
     >
       {label ? `${label}: ` : null}
       {formattedValue}
@@ -235,14 +235,14 @@ function Slider({
     >
       <SliderPrimitive.Track
         data-slot="slider-track"
-        className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:bg-control-background nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-2 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-2"
+        className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:border-default nx:border-border-default nx:bg-control-background nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-7 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-7"
       >
         {stepValues.map((stepValue) => (
           <span
             aria-hidden="true"
             data-slot="slider-step"
             key={stepValue}
-            className="nx:pointer-events-none nx:absolute nx:top-1/2 nx:z-10 nx:size-1 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-control-thumb nx:opacity-70 nx:data-[orientation=vertical]:left-1/2 nx:data-[orientation=vertical]:top-auto nx:data-[orientation=vertical]:-translate-x-1/2 nx:data-[orientation=vertical]:translate-y-1/2"
+            className="nx:pointer-events-none nx:absolute nx:top-1/2 nx:size-1 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-control-thumb nx:opacity-60 nx:data-[orientation=vertical]:left-1/2 nx:data-[orientation=vertical]:top-auto nx:data-[orientation=vertical]:-translate-x-1/2 nx:data-[orientation=vertical]:translate-y-1/2"
             style={
               orientation === 'vertical'
                 ? { bottom: `${getValuePercent(stepValue, min, max)}%` }
@@ -252,7 +252,7 @@ function Slider({
         ))}
         <SliderPrimitive.Range
           data-slot="slider-range"
-          className="nx:pointer-events-none nx:absolute nx:z-20 nx:bg-control-background-hover nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-full nx:data-[orientation=vertical]:w-full"
+          className="nx:pointer-events-none nx:absolute nx:bg-control-background-hover nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-full nx:data-[orientation=vertical]:w-full"
         />
       </SliderPrimitive.Track>
       {Array.from({ length: values.length }, (_, index) => (
@@ -271,12 +271,12 @@ function Slider({
           aria-labelledby={ariaLabelledby}
           aria-invalid={ariaInvalid}
           aria-valuetext={formatValue(values[index] ?? values[0] ?? min)}
-          className="nx:relative nx:z-30 nx:block nx:size-5 nx:shrink-0 nx:cursor-grab nx:rounded-full nx:border-default nx:border-border-default nx:bg-control-thumb nx:shadow-sm nx:transition-[background-color,border-color,transform] nx:duration-fast nx:after:absolute nx:after:-inset-3 nx:after:cursor-grab nx:after:content-[''] nx:active:cursor-grabbing nx:active:after:cursor-grabbing nx:motion-reduce:transition-none nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:cursor-not-allowed nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-disabled:after:cursor-not-allowed nx:aria-invalid:focus-visible:outline-focus-error"
+          className="nx:relative nx:z-30 nx:block nx:size-5 nx:shrink-0 nx:cursor-grab nx:rounded-full nx:border-default nx:border-border-default nx:bg-control-thumb nx:transition-[background-color,border-color,transform] nx:duration-fast nx:after:absolute nx:after:-inset-3 nx:after:cursor-grab nx:after:content-[''] nx:hover:scale-105 nx:active:cursor-grabbing nx:active:after:cursor-grabbing nx:motion-reduce:transition-none nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:cursor-not-allowed nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-disabled:after:cursor-not-allowed nx:aria-invalid:focus-visible:outline-focus-error"
         >
           {showValue && valuePosition === 'tooltip' ? (
             <span
               data-slot="slider-tooltip"
-              className="nx:pointer-events-none nx:absolute nx:bottom-full nx:left-1/2 nx:mb-3 nx:-translate-x-1/2 nx:rounded-lg nx:bg-foreground nx:px-2.5 nx:py-1 nx:tabular-nums nx:typography-label-small nx:text-background nx:opacity-0 nx:shadow-sm nx:transition-opacity nx:duration-fast nx:before:absolute nx:before:left-1/2 nx:before:top-full nx:before:size-2 nx:before:-translate-x-1/2 nx:before:-translate-y-1/2 nx:before:rotate-45 nx:before:bg-foreground nx:before:content-[''] nx:motion-reduce:transition-none nx:group-hover/slider:opacity-100 nx:group-focus-within/slider:opacity-100"
+              className="nx:pointer-events-none nx:absolute nx:bottom-full nx:left-1/2 nx:mb-4 nx:-translate-x-1/2 nx:rounded-lg nx:bg-foreground nx:px-3 nx:py-1.5 nx:tabular-nums nx:typography-label-default nx:text-background nx:opacity-0 nx:transition-opacity nx:duration-fast nx:before:absolute nx:before:left-1/2 nx:before:top-full nx:before:size-2 nx:before:-translate-x-1/2 nx:before:-translate-y-1/2 nx:before:rotate-45 nx:before:bg-foreground nx:before:content-[''] nx:motion-reduce:transition-none nx:group-hover/slider:opacity-100 nx:group-focus-within/slider:opacity-100"
             >
               {formatValue(values[index] ?? values[0] ?? min)}
             </span>
@@ -295,7 +295,7 @@ function Slider({
       data-slot="slider-field"
       data-value-position={valuePosition}
       className={cn(
-        'nx:flex nx:gap-3',
+        'nx:flex nx:gap-4',
         valuePosition === 'top' || valuePosition === 'bottom'
           ? 'nx:flex-col'
           : 'nx:items-center',
@@ -372,7 +372,7 @@ function SliderComfortable({
       step={step}
       disabled={disabled}
       className={cn(
-        'nx:group/slider-comfortable nx:relative nx:flex nx:h-16 nx:w-full nx:cursor-pointer nx:select-none nx:items-center nx:touch-pan-y nx:data-disabled:cursor-default',
+        'nx:group/slider-comfortable nx:relative nx:flex nx:h-12 nx:w-full nx:cursor-pointer nx:select-none nx:items-center nx:touch-pan-y nx:data-disabled:cursor-default',
         disabled && 'nx:pointer-events-none',
         className
       )}
@@ -381,32 +381,32 @@ function SliderComfortable({
       <SliderPrimitive.Track
         data-slot="slider-comfortable-track"
         className={cn(
-          'nx:relative nx:h-16 nx:w-full nx:overflow-hidden nx:rounded-md nx:border-default nx:border-border-default nx:bg-background nx:text-foreground nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none',
+          'nx:relative nx:h-12 nx:w-full nx:overflow-hidden nx:rounded-lg nx:border-default nx:border-border-default nx:bg-control-background nx:text-foreground nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none',
           'nx:text-foreground',
           disabled &&
             'nx:border-border-disabled nx:bg-disabled nx:text-disabled-foreground'
         )}
       >
-        <SliderPrimitive.Range
-          data-slot="slider-comfortable-range"
-          className={cn(
-            'nx:pointer-events-none nx:absolute nx:inset-y-0 nx:left-0 nx:z-10 nx:bg-control-background',
-            disabled && 'nx:bg-disabled'
-          )}
-        />
         {pipValues.map((pipValue) => (
           <span
             aria-hidden="true"
             data-slot="slider-comfortable-pip"
             key={pipValue}
             className={cn(
-              'nx:pointer-events-none nx:absolute nx:top-1/2 nx:z-20 nx:size-2 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-muted-foreground nx:opacity-50',
+              'nx:pointer-events-none nx:absolute nx:top-1/2 nx:size-1 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-muted-foreground nx:opacity-50',
               pipValue === currentValue && 'nx:bg-foreground nx:opacity-90'
             )}
             style={{ left: `${getValuePercent(pipValue, min, max)}%` }}
           />
         ))}
-        <span className="nx:pointer-events-none nx:absolute nx:inset-0 nx:z-30 nx:flex nx:items-center nx:gap-4 nx:px-5 nx:typography-label-default">
+        <SliderPrimitive.Range
+          data-slot="slider-comfortable-range"
+          className={cn(
+            'nx:pointer-events-none nx:absolute nx:inset-y-0 nx:left-0 nx:min-w-36 nx:bg-control-background-hover',
+            disabled && 'nx:bg-disabled'
+          )}
+        />
+        <span className="nx:pointer-events-none nx:absolute nx:inset-0 nx:flex nx:items-center nx:gap-4 nx:px-5 nx:typography-label-default">
           {label ? (
             <span data-slot="slider-comfortable-label" className="nx:truncate">
               {label}
@@ -414,7 +414,7 @@ function SliderComfortable({
           ) : null}
           <span
             data-slot="slider-comfortable-value"
-            className="nx:ml-auto nx:shrink-0 nx:tabular-nums"
+            className="nx:ml-auto nx:shrink-0 nx:tabular-nums nx:text-muted-foreground"
           >
             {formatValue(currentValue)}
           </span>
@@ -425,7 +425,7 @@ function SliderComfortable({
         aria-label={ariaLabel ?? label}
         aria-labelledby={ariaLabelledby}
         aria-valuetext={formatValue(currentValue)}
-        className="nx:relative nx:z-40 nx:block nx:h-8 nx:w-1 nx:shrink-0 nx:cursor-grab nx:rounded-full nx:bg-foreground nx:transition-[height,background-color] nx:duration-fast nx:after:absolute nx:after:-inset-5 nx:after:cursor-grab nx:after:content-[''] nx:active:cursor-grabbing nx:active:after:cursor-grabbing nx:motion-reduce:transition-none nx:group-hover/slider-comfortable:h-9 nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:cursor-not-allowed nx:data-disabled:bg-disabled-foreground nx:data-disabled:after:cursor-not-allowed"
+        className="nx:relative nx:z-40 nx:block nx:h-5 nx:w-0.5 nx:shrink-0 nx:cursor-grab nx:rounded-full nx:bg-foreground nx:transition-[background-color,transform] nx:duration-fast nx:after:absolute nx:after:-inset-5 nx:after:cursor-grab nx:after:content-[''] nx:hover:scale-y-110 nx:active:cursor-grabbing nx:active:after:cursor-grabbing nx:motion-reduce:transition-none nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:cursor-not-allowed nx:data-disabled:bg-disabled-foreground nx:data-disabled:after:cursor-not-allowed"
       >
         {!disabled ? (
           <span

--- a/packages/react/src/components/slider/slider.tsx
+++ b/packages/react/src/components/slider/slider.tsx
@@ -235,14 +235,14 @@ function Slider({
     >
       <SliderPrimitive.Track
         data-slot="slider-track"
-        className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:border-default nx:border-(--slider-border,var(--nx-color-border-default-alpha)) nx:bg-(--slider-track,var(--nx-color-control-background)) nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-7 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-7"
+        className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:border-default nx:border-border-default nx:bg-control-background nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-7 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-7"
       >
         {stepValues.map((stepValue) => (
           <span
             aria-hidden="true"
             data-slot="slider-step"
             key={stepValue}
-            className="nx:pointer-events-none nx:absolute nx:top-1/2 nx:size-1 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-(--slider-pip,var(--nx-color-control-thumb)) nx:opacity-60 nx:data-[orientation=vertical]:left-1/2 nx:data-[orientation=vertical]:top-auto nx:data-[orientation=vertical]:-translate-x-1/2 nx:data-[orientation=vertical]:translate-y-1/2"
+            className="nx:pointer-events-none nx:absolute nx:top-1/2 nx:size-1 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-muted-foreground nx:opacity-60 nx:data-[orientation=vertical]:left-1/2 nx:data-[orientation=vertical]:top-auto nx:data-[orientation=vertical]:-translate-x-1/2 nx:data-[orientation=vertical]:translate-y-1/2"
             style={
               orientation === 'vertical'
                 ? { bottom: `${getValuePercent(stepValue, min, max)}%` }
@@ -252,7 +252,7 @@ function Slider({
         ))}
         <SliderPrimitive.Range
           data-slot="slider-range"
-          className="nx:pointer-events-none nx:absolute nx:bg-(--slider-range,var(--nx-color-control-background-hover)) nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-full nx:data-[orientation=vertical]:w-full"
+          className="nx:pointer-events-none nx:absolute nx:bg-control-background-hover nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-full nx:data-[orientation=vertical]:w-full"
         />
       </SliderPrimitive.Track>
       {Array.from({ length: values.length }, (_, index) => (
@@ -271,12 +271,12 @@ function Slider({
           aria-labelledby={ariaLabelledby}
           aria-invalid={ariaInvalid}
           aria-valuetext={formatValue(values[index] ?? values[0] ?? min)}
-          className="nx:relative nx:z-30 nx:block nx:size-5 nx:shrink-0 nx:cursor-grab nx:rounded-full nx:border-default nx:border-(--slider-thumb-border,var(--nx-color-border-default)) nx:bg-(--slider-thumb,var(--nx-color-control-thumb)) nx:transition-[background-color,border-color,transform] nx:duration-fast nx:after:absolute nx:after:-inset-3 nx:after:cursor-grab nx:after:content-[''] nx:hover:scale-105 nx:active:cursor-grabbing nx:active:after:cursor-grabbing nx:motion-reduce:transition-none nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:cursor-not-allowed nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-disabled:after:cursor-not-allowed nx:aria-invalid:focus-visible:outline-focus-error"
+          className="nx:relative nx:z-30 nx:block nx:size-5 nx:shrink-0 nx:cursor-grab nx:rounded-full nx:border-default nx:border-border-default nx:bg-control-thumb nx:transition-[background-color,border-color,transform] nx:duration-fast nx:after:absolute nx:after:-inset-3 nx:after:cursor-grab nx:after:content-[''] nx:hover:scale-105 nx:active:cursor-grabbing nx:active:after:cursor-grabbing nx:motion-reduce:transition-none nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:cursor-not-allowed nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-disabled:after:cursor-not-allowed nx:aria-invalid:focus-visible:outline-focus-error"
         >
           {showValue && valuePosition === 'tooltip' ? (
             <span
               data-slot="slider-tooltip"
-              className="nx:pointer-events-none nx:absolute nx:bottom-full nx:left-1/2 nx:mb-4 nx:-translate-x-1/2 nx:rounded-lg nx:bg-(--slider-tooltip-bg,var(--nx-color-foreground)) nx:px-3 nx:py-1.5 nx:tabular-nums nx:typography-label-default nx:text-(--slider-tooltip-fg,var(--nx-color-background)) nx:opacity-0 nx:transition-opacity nx:duration-fast nx:before:absolute nx:before:left-1/2 nx:before:top-full nx:before:size-2 nx:before:-translate-x-1/2 nx:before:-translate-y-1/2 nx:before:rotate-45 nx:before:bg-(--slider-tooltip-bg,var(--nx-color-foreground)) nx:before:content-[''] nx:motion-reduce:transition-none nx:group-hover/slider:opacity-100 nx:group-focus-within/slider:opacity-100"
+              className="nx:pointer-events-none nx:absolute nx:bottom-full nx:left-1/2 nx:mb-4 nx:-translate-x-1/2 nx:rounded-lg nx:bg-popover nx:px-3 nx:py-1.5 nx:tabular-nums nx:typography-label-default nx:text-popover-foreground nx:opacity-0 nx:transition-opacity nx:duration-fast nx:before:absolute nx:before:left-1/2 nx:before:top-full nx:before:size-2 nx:before:-translate-x-1/2 nx:before:-translate-y-1/2 nx:before:rotate-45 nx:before:bg-popover nx:before:content-[''] nx:motion-reduce:transition-none nx:group-hover/slider:opacity-100 nx:group-focus-within/slider:opacity-100"
             >
               {formatValue(values[index] ?? values[0] ?? min)}
             </span>
@@ -381,7 +381,7 @@ function SliderComfortable({
       <SliderPrimitive.Track
         data-slot="slider-comfortable-track"
         className={cn(
-          'nx:relative nx:h-12 nx:w-full nx:overflow-hidden nx:rounded-lg nx:border-default nx:border-(--slider-comfortable-border,var(--nx-color-border-default-alpha)) nx:bg-(--slider-comfortable-track,var(--nx-color-control-background)) nx:text-(--slider-comfortable-label,var(--nx-color-foreground)) nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none',
+          'nx:relative nx:h-12 nx:w-full nx:overflow-hidden nx:rounded-lg nx:border-default nx:border-border-default nx:bg-control-background nx:text-foreground nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none',
           disabled &&
             'nx:border-border-disabled nx:bg-disabled nx:text-disabled-foreground'
         )}
@@ -392,9 +392,8 @@ function SliderComfortable({
             data-slot="slider-comfortable-pip"
             key={pipValue}
             className={cn(
-              'nx:pointer-events-none nx:absolute nx:top-1/2 nx:size-1 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-(--slider-comfortable-pip,var(--nx-color-muted-foreground)) nx:opacity-50',
-              pipValue === currentValue &&
-                'nx:bg-(--slider-comfortable-caret,var(--nx-color-foreground)) nx:opacity-90'
+              'nx:pointer-events-none nx:absolute nx:top-1/2 nx:size-1 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-muted-foreground nx:opacity-50',
+              pipValue === currentValue && 'nx:bg-control-thumb nx:opacity-90'
             )}
             style={{ left: `${getValuePercent(pipValue, min, max)}%` }}
           />
@@ -402,7 +401,7 @@ function SliderComfortable({
         <SliderPrimitive.Range
           data-slot="slider-comfortable-range"
           className={cn(
-            'nx:pointer-events-none nx:absolute nx:inset-y-0 nx:left-0 nx:min-w-36 nx:bg-(--slider-comfortable-range,var(--nx-color-control-background-hover))',
+            'nx:pointer-events-none nx:absolute nx:inset-y-0 nx:left-0 nx:min-w-36 nx:bg-control-background-hover',
             disabled && 'nx:bg-disabled'
           )}
         />
@@ -414,7 +413,7 @@ function SliderComfortable({
           ) : null}
           <span
             data-slot="slider-comfortable-value"
-            className="nx:ml-auto nx:shrink-0 nx:tabular-nums nx:text-(--slider-comfortable-muted,var(--nx-color-muted-foreground))"
+            className="nx:ml-auto nx:shrink-0 nx:tabular-nums nx:text-muted-foreground"
           >
             {formatValue(currentValue)}
           </span>
@@ -425,12 +424,12 @@ function SliderComfortable({
         aria-label={ariaLabel ?? label}
         aria-labelledby={ariaLabelledby}
         aria-valuetext={formatValue(currentValue)}
-        className="nx:relative nx:z-40 nx:block nx:h-5 nx:w-0.5 nx:shrink-0 nx:cursor-grab nx:rounded-full nx:bg-(--slider-comfortable-caret,var(--nx-color-foreground)) nx:transition-[background-color,transform] nx:duration-fast nx:after:absolute nx:after:-inset-5 nx:after:cursor-grab nx:after:content-[''] nx:hover:scale-y-110 nx:active:cursor-grabbing nx:active:after:cursor-grabbing nx:motion-reduce:transition-none nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:cursor-not-allowed nx:data-disabled:bg-disabled-foreground nx:data-disabled:after:cursor-not-allowed"
+        className="nx:relative nx:z-40 nx:block nx:h-5 nx:w-0.5 nx:shrink-0 nx:cursor-grab nx:rounded-full nx:bg-control-thumb nx:transition-[background-color,transform] nx:duration-fast nx:after:absolute nx:after:-inset-5 nx:after:cursor-grab nx:after:content-[''] nx:hover:scale-y-110 nx:active:cursor-grabbing nx:active:after:cursor-grabbing nx:motion-reduce:transition-none nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:cursor-not-allowed nx:data-disabled:bg-disabled-foreground nx:data-disabled:after:cursor-not-allowed"
       >
         {!disabled ? (
           <span
             data-slot="slider-comfortable-tooltip"
-            className="nx:pointer-events-none nx:absolute nx:bottom-full nx:left-1/2 nx:mb-3 nx:-translate-x-1/2 nx:rounded-lg nx:bg-(--slider-tooltip-bg,var(--nx-color-foreground)) nx:px-3 nx:py-1.5 nx:tabular-nums nx:typography-label-default nx:text-(--slider-tooltip-fg,var(--nx-color-background)) nx:opacity-0 nx:shadow-sm nx:transition-opacity nx:duration-fast nx:before:absolute nx:before:left-1/2 nx:before:top-full nx:before:size-2 nx:before:-translate-x-1/2 nx:before:-translate-y-1/2 nx:before:rotate-45 nx:before:bg-(--slider-tooltip-bg,var(--nx-color-foreground)) nx:before:content-[''] nx:motion-reduce:transition-none nx:group-hover/slider-comfortable:opacity-100 nx:group-focus-within/slider-comfortable:opacity-100"
+            className="nx:pointer-events-none nx:absolute nx:bottom-full nx:left-1/2 nx:mb-3 nx:-translate-x-1/2 nx:rounded-lg nx:bg-popover nx:px-3 nx:py-1.5 nx:tabular-nums nx:typography-label-default nx:text-popover-foreground nx:opacity-0 nx:shadow-sm nx:transition-opacity nx:duration-fast nx:before:absolute nx:before:left-1/2 nx:before:top-full nx:before:size-2 nx:before:-translate-x-1/2 nx:before:-translate-y-1/2 nx:before:rotate-45 nx:before:bg-popover nx:before:content-[''] nx:motion-reduce:transition-none nx:group-hover/slider-comfortable:opacity-100 nx:group-focus-within/slider-comfortable:opacity-100"
           >
             {formatValue(currentValue)}
           </span>

--- a/packages/react/src/components/slider/slider.tsx
+++ b/packages/react/src/components/slider/slider.tsx
@@ -228,14 +228,14 @@ function Slider({
       step={step}
       orientation={orientation}
       className={cn(
-        'nx:group/slider nx:relative nx:flex nx:w-full nx:select-none nx:items-center nx:data-[orientation=horizontal]:touch-pan-y nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:min-h-44 nx:data-[orientation=vertical]:w-auto nx:data-[orientation=vertical]:touch-pan-x nx:data-[orientation=vertical]:flex-col',
+        'nx:group/slider nx:relative nx:flex nx:w-full nx:cursor-pointer nx:select-none nx:items-center nx:data-disabled:cursor-default nx:data-[orientation=horizontal]:touch-pan-y nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:min-h-44 nx:data-[orientation=vertical]:w-auto nx:data-[orientation=vertical]:touch-pan-x nx:data-[orientation=vertical]:flex-col',
         className
       )}
       {...props}
     >
       <SliderPrimitive.Track
         data-slot="slider-track"
-        className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:bg-control-background nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-1.5 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-1.5"
+        className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:bg-control-background nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-2 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-2"
       >
         {stepValues.map((stepValue) => (
           <span
@@ -252,7 +252,7 @@ function Slider({
         ))}
         <SliderPrimitive.Range
           data-slot="slider-range"
-          className="nx:absolute nx:z-20 nx:bg-primary-background nx:data-disabled:bg-primary-disabled nx:data-[orientation=horizontal]:h-full nx:data-[orientation=vertical]:w-full"
+          className="nx:pointer-events-none nx:absolute nx:z-20 nx:bg-control-background-hover nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-full nx:data-[orientation=vertical]:w-full"
         />
       </SliderPrimitive.Track>
       {Array.from({ length: values.length }, (_, index) => (
@@ -271,12 +271,12 @@ function Slider({
           aria-labelledby={ariaLabelledby}
           aria-invalid={ariaInvalid}
           aria-valuetext={formatValue(values[index] ?? values[0] ?? min)}
-          className="nx:relative nx:z-30 nx:block nx:size-4 nx:shrink-0 nx:rounded-full nx:border-default nx:border-border-primary nx:bg-background nx:transition-colors nx:after:absolute nx:after:-inset-3 nx:after:content-[''] nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:aria-invalid:focus-visible:outline-focus-error"
+          className="nx:relative nx:z-30 nx:block nx:size-5 nx:shrink-0 nx:cursor-grab nx:rounded-full nx:border-default nx:border-border-default nx:bg-control-thumb nx:shadow-sm nx:transition-[background-color,border-color,transform] nx:duration-fast nx:after:absolute nx:after:-inset-3 nx:after:cursor-grab nx:after:content-[''] nx:active:cursor-grabbing nx:active:after:cursor-grabbing nx:motion-reduce:transition-none nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:cursor-not-allowed nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-disabled:after:cursor-not-allowed nx:aria-invalid:focus-visible:outline-focus-error"
         >
           {showValue && valuePosition === 'tooltip' ? (
             <span
               data-slot="slider-tooltip"
-              className="nx:pointer-events-none nx:absolute nx:bottom-full nx:left-1/2 nx:mb-2 nx:-translate-x-1/2 nx:rounded-md nx:bg-popover nx:px-2 nx:py-1 nx:tabular-nums nx:typography-label-small nx:text-popover-foreground nx:opacity-0 nx:shadow-sm nx:transition-opacity nx:duration-fast nx:motion-reduce:transition-none nx:group-hover/slider:opacity-100 nx:group-focus-within/slider:opacity-100"
+              className="nx:pointer-events-none nx:absolute nx:bottom-full nx:left-1/2 nx:mb-3 nx:-translate-x-1/2 nx:rounded-lg nx:bg-foreground nx:px-2.5 nx:py-1 nx:tabular-nums nx:typography-label-small nx:text-background nx:opacity-0 nx:shadow-sm nx:transition-opacity nx:duration-fast nx:before:absolute nx:before:left-1/2 nx:before:top-full nx:before:size-2 nx:before:-translate-x-1/2 nx:before:-translate-y-1/2 nx:before:rotate-45 nx:before:bg-foreground nx:before:content-[''] nx:motion-reduce:transition-none nx:group-hover/slider:opacity-100 nx:group-focus-within/slider:opacity-100"
             >
               {formatValue(values[index] ?? values[0] ?? min)}
             </span>
@@ -372,7 +372,7 @@ function SliderComfortable({
       step={step}
       disabled={disabled}
       className={cn(
-        'nx:group/slider-comfortable nx:relative nx:flex nx:h-8 nx:w-full nx:select-none nx:items-center nx:touch-pan-y',
+        'nx:group/slider-comfortable nx:relative nx:flex nx:h-16 nx:w-full nx:cursor-pointer nx:select-none nx:items-center nx:touch-pan-y nx:data-disabled:cursor-default',
         disabled && 'nx:pointer-events-none',
         className
       )}
@@ -381,8 +381,8 @@ function SliderComfortable({
       <SliderPrimitive.Track
         data-slot="slider-comfortable-track"
         className={cn(
-          'nx:relative nx:h-8 nx:w-full nx:overflow-hidden nx:rounded-md nx:border-default nx:border-border-default nx:bg-container nx:text-muted-foreground nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none',
-          'nx:group-hover/slider-comfortable:text-foreground nx:group-focus-within/slider-comfortable:text-foreground',
+          'nx:relative nx:h-16 nx:w-full nx:overflow-hidden nx:rounded-md nx:border-default nx:border-border-default nx:bg-background nx:text-foreground nx:transition-colors nx:duration-fast nx:motion-reduce:transition-none',
+          'nx:text-foreground',
           disabled &&
             'nx:border-border-disabled nx:bg-disabled nx:text-disabled-foreground'
         )}
@@ -390,8 +390,8 @@ function SliderComfortable({
         <SliderPrimitive.Range
           data-slot="slider-comfortable-range"
           className={cn(
-            'nx:absolute nx:inset-y-0 nx:left-0 nx:z-10 nx:bg-primary-subtle',
-            disabled && 'nx:bg-primary-disabled'
+            'nx:pointer-events-none nx:absolute nx:inset-y-0 nx:left-0 nx:z-10 nx:bg-control-background',
+            disabled && 'nx:bg-disabled'
           )}
         />
         {pipValues.map((pipValue) => (
@@ -400,13 +400,13 @@ function SliderComfortable({
             data-slot="slider-comfortable-pip"
             key={pipValue}
             className={cn(
-              'nx:pointer-events-none nx:absolute nx:top-1/2 nx:z-20 nx:size-1.5 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-current nx:opacity-40',
-              pipValue === currentValue && 'nx:opacity-100'
+              'nx:pointer-events-none nx:absolute nx:top-1/2 nx:z-20 nx:size-2 nx:-translate-x-1/2 nx:-translate-y-1/2 nx:rounded-full nx:bg-muted-foreground nx:opacity-50',
+              pipValue === currentValue && 'nx:bg-foreground nx:opacity-90'
             )}
             style={{ left: `${getValuePercent(pipValue, min, max)}%` }}
           />
         ))}
-        <span className="nx:pointer-events-none nx:absolute nx:inset-0 nx:z-30 nx:flex nx:items-center nx:gap-3 nx:px-3 nx:typography-label-small">
+        <span className="nx:pointer-events-none nx:absolute nx:inset-0 nx:z-30 nx:flex nx:items-center nx:gap-4 nx:px-5 nx:typography-label-default">
           {label ? (
             <span data-slot="slider-comfortable-label" className="nx:truncate">
               {label}
@@ -425,8 +425,17 @@ function SliderComfortable({
         aria-label={ariaLabel ?? label}
         aria-labelledby={ariaLabelledby}
         aria-valuetext={formatValue(currentValue)}
-        className="nx:relative nx:z-40 nx:block nx:h-4 nx:w-0.5 nx:shrink-0 nx:rounded-full nx:bg-foreground nx:transition-[height,background-color] nx:duration-fast nx:after:absolute nx:after:-inset-4 nx:after:content-[''] nx:motion-reduce:transition-none nx:group-hover/slider-comfortable:h-5 nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:bg-disabled-foreground"
-      />
+        className="nx:relative nx:z-40 nx:block nx:h-8 nx:w-1 nx:shrink-0 nx:cursor-grab nx:rounded-full nx:bg-foreground nx:transition-[height,background-color] nx:duration-fast nx:after:absolute nx:after:-inset-5 nx:after:cursor-grab nx:after:content-[''] nx:active:cursor-grabbing nx:active:after:cursor-grabbing nx:motion-reduce:transition-none nx:group-hover/slider-comfortable:h-9 nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:data-disabled:cursor-not-allowed nx:data-disabled:bg-disabled-foreground nx:data-disabled:after:cursor-not-allowed"
+      >
+        {!disabled ? (
+          <span
+            data-slot="slider-comfortable-tooltip"
+            className="nx:pointer-events-none nx:absolute nx:bottom-full nx:left-1/2 nx:mb-3 nx:-translate-x-1/2 nx:rounded-lg nx:bg-foreground nx:px-3 nx:py-1.5 nx:tabular-nums nx:typography-label-default nx:text-background nx:opacity-0 nx:shadow-sm nx:transition-opacity nx:duration-fast nx:before:absolute nx:before:left-1/2 nx:before:top-full nx:before:size-2 nx:before:-translate-x-1/2 nx:before:-translate-y-1/2 nx:before:rotate-45 nx:before:bg-foreground nx:before:content-[''] nx:motion-reduce:transition-none nx:group-hover/slider-comfortable:opacity-100 nx:group-focus-within/slider-comfortable:opacity-100"
+          >
+            {formatValue(currentValue)}
+          </span>
+        ) : null}
+      </SliderPrimitive.Thumb>
     </SliderPrimitive.Root>
   );
 }

--- a/packages/react/src/components/slider/slider.tsx
+++ b/packages/react/src/components/slider/slider.tsx
@@ -235,7 +235,7 @@ function Slider({
     >
       <SliderPrimitive.Track
         data-slot="slider-track"
-        className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:border-default nx:border-border-default nx:bg-control-background nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-3 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-3"
+        className="nx:relative nx:grow nx:overflow-hidden nx:rounded-full nx:border-default nx:border-border-default nx:bg-control-background nx:data-disabled:border-border-disabled nx:data-disabled:bg-disabled nx:data-[orientation=horizontal]:h-4 nx:data-[orientation=horizontal]:w-full nx:data-[orientation=vertical]:h-full nx:data-[orientation=vertical]:w-4"
       >
         {stepValues.map((stepValue) => (
           <span


### PR DESCRIPTION
## Summary

- Adds Fluid-inspired value display options to the existing Radix-backed Slider.
- Adds step pips, tooltip values, formatted labels, and the polished SliderComfortable variant.
- Expands Slider Storybook coverage with the new examples and interaction checks.

## GitHub Issue

Not linked.

## Test Plan

- [x] `./node_modules/.bin/eslint packages/react/src/components/slider/slider.tsx packages/react/src/components/slider/Slider.stories.tsx`
- [x] `./node_modules/.bin/tsc --noEmit --pretty false --project packages/react/tsconfig.json`
- [x] `./node_modules/.bin/prettier --check packages/react/src/components/slider/slider.tsx packages/react/src/components/slider/Slider.stories.tsx`
- [x] `./node_modules/.bin/vitest run --project=storybook packages/react/src/components/slider/Slider.stories.tsx`
