### PR TITLE
[codex] Add data table recipe and reuse console helpers

### DIFF
--- a/apps/console/src/components/data-pager.tsx
+++ b/apps/console/src/components/data-pager.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 import { Button } from '@nexus_ds/react';
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 
@@ -5,28 +7,30 @@ interface DataPagerProps {
   /** 0-based page index. */
   page: number;
   pageCount: number;
-  /** Total filtered row count, summarised on the left. */
+  /** Total filtered row count, shown on the left when `summary` is omitted. */
   total: number;
+  /** Overrides the left summary text, such as a selection count. */
+  summary?: ReactNode;
   onPrev: () => void;
   onNext: () => void;
 }
 
 /**
- * The prev/next pager for the mobile card lists — mirrors the pager built into
- * {@link DataTable} (row count, "Page X of Y", bounded chevrons) so the table
- * (≥lg) and card (<lg) views read consistently.
+ * The shared prev/next pager for the console's table and card-list views: row
+ * count or a caller summary, "Page X of Y", and bounded chevrons.
  */
 export function DataPager({
   page,
   pageCount,
   total,
+  summary,
   onPrev,
   onNext,
 }: DataPagerProps) {
   return (
     <div className="nx:flex nx:items-center nx:justify-between nx:gap-4">
       <p className="nx:text-muted-foreground nx:typography-body-default">
-        {total} row(s)
+        {summary ?? `${total} row(s)`}
       </p>
       <div className="nx:flex nx:items-center nx:gap-3">
         <span className="nx:text-muted-foreground nx:typography-label-default">

--- a/apps/console/src/components/data-table.tsx
+++ b/apps/console/src/components/data-table.tsx
@@ -1,10 +1,6 @@
 import { useState } from 'react';
 
 import {
-  Button,
-  InputGroup,
-  InputGroupAddon,
-  InputGroupInput,
   Table,
   TableBody,
   TableCell,
@@ -12,11 +8,6 @@ import {
   TableHeader,
   TableRow,
 } from '@nexus_ds/react';
-import {
-  IconChevronLeft,
-  IconChevronRight,
-  IconSearch,
-} from '@tabler/icons-react';
 import {
   type ColumnDef,
   type ColumnFiltersState,
@@ -28,6 +19,9 @@ import {
   type SortingState,
   useReactTable,
 } from '@tanstack/react-table';
+
+import { DataPager } from './data-pager';
+import { FilterInput } from './filter-input';
 
 /**
  * Generic, app-level data table — the canonical recipe of headless
@@ -88,17 +82,11 @@ export function DataTable<TData>({
   return (
     <div className="nx:space-y-4">
       {filterControl && (
-        <InputGroup className="nx:max-w-xs">
-          <InputGroupAddon>
-            <IconSearch />
-          </InputGroupAddon>
-          <InputGroupInput
-            placeholder={filterPlaceholder ?? 'Filter…'}
-            value={(filterControl.getFilterValue() as string) ?? ''}
-            onChange={(e) => filterControl.setFilterValue(e.target.value)}
-            aria-label={filterPlaceholder ?? 'Filter'}
-          />
-        </InputGroup>
+        <FilterInput
+          value={(filterControl.getFilterValue() as string) ?? ''}
+          onChange={(value) => filterControl.setFilterValue(value)}
+          placeholder={filterPlaceholder}
+        />
       )}
 
       <div className="nx:border-border-default nx:overflow-hidden nx:rounded-md nx:border-default">
@@ -150,37 +138,18 @@ export function DataTable<TData>({
         </Table>
       </div>
 
-      {/* App-local pager — the polished @nexus_ds/react Pagination is tracked in #281. */}
-      <div className="nx:flex nx:items-center nx:justify-between nx:gap-4">
-        <p className="nx:text-muted-foreground nx:typography-body-default">
-          {enableSelection
+      <DataPager
+        page={pageIndex}
+        pageCount={Math.max(table.getPageCount(), 1)}
+        total={totalCount}
+        summary={
+          enableSelection
             ? `${selectedCount} of ${totalCount} row(s) selected.`
-            : `${totalCount} row(s)`}
-        </p>
-        <div className="nx:flex nx:items-center nx:gap-3">
-          <span className="nx:text-muted-foreground nx:typography-label-default">
-            Page {pageIndex + 1} of {Math.max(table.getPageCount(), 1)}
-          </span>
-          <Button
-            variant="outline"
-            size="icon-sm"
-            onClick={() => table.previousPage()}
-            disabled={!table.getCanPreviousPage()}
-            aria-label="Previous page"
-          >
-            <IconChevronLeft />
-          </Button>
-          <Button
-            variant="outline"
-            size="icon-sm"
-            onClick={() => table.nextPage()}
-            disabled={!table.getCanNextPage()}
-            aria-label="Next page"
-          >
-            <IconChevronRight />
-          </Button>
-        </div>
-      </div>
+            : undefined
+        }
+        onPrev={() => table.previousPage()}
+        onNext={() => table.nextPage()}
+      />
     </div>
   );
 }

--- a/apps/console/src/components/filter-input.tsx
+++ b/apps/console/src/components/filter-input.tsx
@@ -8,14 +8,13 @@ interface FilterInputProps {
 }
 
 /**
- * The search box that filters the mobile card lists — mirrors the filter box
- * built into {@link DataTable} so the table (≥lg) and card (<lg) views share one
- * look. Controlled: the parent owns the query string.
+ * The shared search box for the console's table and card-list views. Controlled:
+ * the parent owns the query string.
  */
 export function FilterInput({
   value,
   onChange,
-  placeholder = 'Filter…',
+  placeholder,
 }: FilterInputProps) {
   return (
     <InputGroup className="nx:max-w-xs">
@@ -23,10 +22,10 @@ export function FilterInput({
         <IconSearch />
       </InputGroupAddon>
       <InputGroupInput
-        placeholder={placeholder}
+        placeholder={placeholder ?? 'Filter…'}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        aria-label={placeholder}
+        aria-label={placeholder ?? 'Filter'}
       />
     </InputGroup>
   );

--- a/packages/react/src/components/table/Table.stories.tsx
+++ b/packages/react/src/components/table/Table.stories.tsx
@@ -3,11 +3,18 @@ import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent } from 'storybook/test';
 
-import { IconChevronDown, IconChevronUp } from '@/lib/icons';
+import {
+  IconChevronDown,
+  IconChevronLeft,
+  IconChevronRight,
+  IconChevronUp,
+  IconSearch,
+} from '@/lib/icons';
 
 import { Button } from '../button';
 import { Checkbox } from '../checkbox';
 import { Hide } from '../hide';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '../input-group';
 import { Show } from '../show';
 
 import {
@@ -471,9 +478,9 @@ export const SemanticScope: Story = {
   },
 };
 
-// A sorted column reads as active: TableHead emphasizes its text (muted →
+// A sorted column reads as active: TableHead emphasizes its text (muted to
 // foreground) when it carries aria-sort="ascending"/"descending", but not for a
-// merely-sortable "none". The interactive sort control is a recipe (SortableHeader).
+// merely-sortable "none". The interactive sort control is a recipe.
 export const AriaSortIndicator: Story = {
   render: () => (
     <Table>
@@ -505,8 +512,6 @@ export const AriaSortIndicator: Story = {
     await expect(none).toBeInTheDocument();
     await expect(desc).toBeInTheDocument();
 
-    // Smoke check that the emphasis utility ships on the head (it's on the cva
-    // base, so every <th> carries it — the aria-sort attr selects which renders).
     await expect(asc).toHaveClass(
       'nx:[&[aria-sort=ascending]]:text-foreground'
     );
@@ -1250,6 +1255,194 @@ export const LiveRegionAnnouncements: Story = {
   },
 };
 
-// The full sort/filter/paginate DataTable recipe — TanStack Table wired over
-// these primitives — lives at apps/console/src/components/data-table.tsx (the
-// logic engine stays a consumer dependency, out of the published bundle).
+// Canonical product-table recipe: filter + sortable header + row selection +
+// pagination + empty state, assembled over the Table primitives. State is plain
+// useState (TanStack Table in production; see the console adapter note below);
+// no @tanstack/react-table dependency enters the package.
+interface RecipeRow {
+  invoice: string;
+  status: string;
+  amount: number;
+}
+
+const recipeRows: RecipeRow[] = [
+  { invoice: 'INV-001', status: 'Paid', amount: 250 },
+  { invoice: 'INV-002', status: 'Pending', amount: 150 },
+  { invoice: 'INV-003', status: 'Unpaid', amount: 350 },
+  { invoice: 'INV-004', status: 'Paid', amount: 450 },
+  { invoice: 'INV-005', status: 'Pending', amount: 550 },
+  { invoice: 'INV-006', status: 'Paid', amount: 200 },
+  { invoice: 'INV-007', status: 'Unpaid', amount: 300 },
+];
+
+const RECIPE_PAGE_SIZE = 3;
+const formatRecipeAmount = (amount: number) => `$${amount.toFixed(2)}`;
+
+function DataTableRecipeDemo() {
+  const [query, setQuery] = useState('');
+  const [sort, setSort] = useState<'asc' | 'desc'>('asc');
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [page, setPage] = useState(0);
+
+  const ariaSort = sort === 'asc' ? 'ascending' : 'descending';
+  const SortIcon = sort === 'asc' ? IconChevronUp : IconChevronDown;
+  const filtered = recipeRows
+    .filter((row) => row.invoice.toLowerCase().includes(query.toLowerCase()))
+    .sort((a, b) =>
+      sort === 'asc' ? a.amount - b.amount : b.amount - a.amount
+    );
+  const pageCount = Math.max(1, Math.ceil(filtered.length / RECIPE_PAGE_SIZE));
+  const safePage = Math.min(page, pageCount - 1);
+  const pageRows = filtered.slice(
+    safePage * RECIPE_PAGE_SIZE,
+    safePage * RECIPE_PAGE_SIZE + RECIPE_PAGE_SIZE
+  );
+
+  function changeQuery(value: string) {
+    setQuery(value);
+    setPage(0);
+  }
+
+  function toggleRow(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <div className="nx:space-y-4">
+      <InputGroup className="nx:max-w-xs">
+        <InputGroupAddon>
+          <IconSearch />
+        </InputGroupAddon>
+        <InputGroupInput
+          placeholder="Filter by invoice..."
+          value={query}
+          onChange={(e) => changeQuery(e.target.value)}
+          aria-label="Filter by invoice"
+        />
+      </InputGroup>
+
+      <div className="nx:overflow-hidden nx:rounded-md nx:border-default nx:border-border-default">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>
+                <span className="nx:sr-only">Select</span>
+              </TableHead>
+              <TableHead>Invoice</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead aria-sort={ariaSort} className="nx:text-right">
+                <button
+                  type="button"
+                  onClick={() => setSort((s) => (s === 'asc' ? 'desc' : 'asc'))}
+                  className="nx:ml-auto nx:inline-flex nx:items-center nx:gap-1 nx:typography-label-default nx:text-inherit nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
+                >
+                  Amount
+                  <SortIcon className="nx:size-4" aria-hidden />
+                </button>
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {pageRows.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={4}
+                  className="nx:py-8 nx:text-center nx:text-muted-foreground"
+                >
+                  No results.
+                </TableCell>
+              </TableRow>
+            ) : (
+              pageRows.map((row) => (
+                <TableRow
+                  key={row.invoice}
+                  data-state={
+                    selected.has(row.invoice) ? 'selected' : undefined
+                  }
+                >
+                  <TableCell>
+                    <Checkbox
+                      checked={selected.has(row.invoice)}
+                      onCheckedChange={() => toggleRow(row.invoice)}
+                      aria-label={`Select ${row.invoice}`}
+                    />
+                  </TableCell>
+                  <TableRowHeader>{row.invoice}</TableRowHeader>
+                  <TableCell>{row.status}</TableCell>
+                  <TableCell className="nx:text-right nx:tabular-nums">
+                    {formatRecipeAmount(row.amount)}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="nx:flex nx:items-center nx:justify-between nx:gap-4">
+        <p className="nx:text-muted-foreground nx:typography-body-default">
+          {selected.size > 0
+            ? `${selected.size} of ${filtered.length} row(s) selected.`
+            : `${filtered.length} row(s)`}
+        </p>
+        <div className="nx:flex nx:items-center nx:gap-3">
+          <span className="nx:text-muted-foreground nx:typography-label-default">
+            Page {safePage + 1} of {pageCount}
+          </span>
+          <Button
+            variant="outline"
+            size="icon-sm"
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={safePage === 0}
+            aria-label="Previous page"
+          >
+            <IconChevronLeft />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon-sm"
+            onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+            disabled={safePage >= pageCount - 1}
+            aria-label="Next page"
+          >
+            <IconChevronRight />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const DataTableRecipe: Story = {
+  render: () => <DataTableRecipeDemo />,
+  play: async ({ canvasElement }) => {
+    const filter = canvasElement.querySelector(
+      '[aria-label="Filter by invoice"]'
+    ) as HTMLInputElement;
+    await userEvent.type(filter, 'INV-002');
+    await expect(canvasElement).toHaveTextContent('1 row(s)');
+    await userEvent.clear(filter);
+    await expect(canvasElement).toHaveTextContent('7 row(s)');
+
+    const amountHeader = canvasElement.querySelector('[aria-sort]');
+    await expect(amountHeader).toHaveAttribute('aria-sort', 'ascending');
+    await userEvent.click(canvasElement.querySelector('th button') as Element);
+    await expect(amountHeader).toHaveAttribute('aria-sort', 'descending');
+
+    await userEvent.click(
+      canvasElement.querySelector('tbody [role="checkbox"]') as Element
+    );
+    await expect(canvasElement).toHaveTextContent('1 of 7 row(s) selected.');
+  },
+};
+
+// DataTableRecipe (above) shows the assembled shell: filter, sortable header,
+// selection, pagination, empty state, over these primitives with plain state.
+// The production version wires TanStack Table over the same markup and lives at
+// apps/console/src/components/data-table.tsx (the engine stays a consumer
+// dependency, out of the published bundle).


### PR DESCRIPTION
## Summary

- Add a recipes-first DataTableRecipe Storybook example over the published Nexus Table primitives, using plain React state and keeping TanStack out of @nexus/react.
- Refactor the console DataTable to consume the shared FilterInput and DataPager helpers instead of duplicating desktop filter/pager markup.
- Let DataPager accept an optional summary so the desktop table can preserve the selected-row summary while card lists keep the default row count.

## Why

Issue #582 reframes DataTable work as a recipe-first path: document the shell pattern in Nexus, avoid a new shipped composite API, and reduce the real console duplication by inverting the dependency onto existing helpers.

## Validation

- corepack pnpm --filter @nexus/core build
- corepack pnpm --filter @nexus/react build
- corepack pnpm --filter @nexus/react typecheck
- corepack pnpm --filter @nexus/console typecheck
- corepack pnpm lint
- corepack pnpm format:check
- corepack pnpm size-limit (@nexus/react ESM 90.17 kB / 95 kB, CSS 15.53 kB / 30 kB)
- corepack pnpm --filter @nexus/console build (passes with the existing Vite large chunk warning)
- corepack pnpm exec vitest run --project=storybook packages/react/src/components/table/Table.stories.tsx (28/28)
- Perturbation check: temporarily broke the recipe filter, confirmed the Storybook play test failed, restored it, and reran green
- git diff --check