### PR TITLE
feat(polish): image hairline on Avatar + ItemMedia (#596)

### DIFF
--- a/apps/docs/public/themes/base-gray.css
+++ b/apps/docs/public/themes/base-gray.css
@@ -32,6 +32,7 @@ html {
   --nx-color-nav-border: var(--nx-color-gray-200);
   --nx-color-overlay: var(--nx-color-gray-a700);
   --nx-color-border-default: var(--nx-color-black-a200);
+  --nx-color-border-hairline: var(--nx-color-black-a200);
   --nx-color-border-default-alpha: var(--nx-color-gray-a200);
   --nx-color-border-active: var(--nx-color-gray-400);
   --nx-color-border-disabled: var(--nx-color-black-a200);
@@ -113,6 +114,7 @@ html.dark {
   --nx-color-nav-border: var(--nx-color-gray-800);
   --nx-color-overlay: var(--nx-color-gray-a800);
   --nx-color-border-default: var(--nx-color-white-a300);
+  --nx-color-border-hairline: var(--nx-color-white-a200);
   --nx-color-border-default-alpha: var(--nx-color-gray-a300);
   --nx-color-border-active: var(--nx-color-gray-400);
   --nx-color-border-disabled: var(--nx-color-white-a300);

--- a/apps/docs/public/themes/base-neutral.css
+++ b/apps/docs/public/themes/base-neutral.css
@@ -32,6 +32,7 @@ html {
   --nx-color-nav-border: var(--nx-color-neutral-200);
   --nx-color-overlay: var(--nx-color-neutral-a700);
   --nx-color-border-default: var(--nx-color-black-a200);
+  --nx-color-border-hairline: var(--nx-color-black-a200);
   --nx-color-border-default-alpha: var(--nx-color-neutral-a200);
   --nx-color-border-active: var(--nx-color-neutral-400);
   --nx-color-border-disabled: var(--nx-color-black-a200);
@@ -113,6 +114,7 @@ html.dark {
   --nx-color-nav-border: var(--nx-color-neutral-800);
   --nx-color-overlay: var(--nx-color-neutral-a800);
   --nx-color-border-default: var(--nx-color-white-a300);
+  --nx-color-border-hairline: var(--nx-color-white-a200);
   --nx-color-border-default-alpha: var(--nx-color-neutral-a300);
   --nx-color-border-active: var(--nx-color-neutral-400);
   --nx-color-border-disabled: var(--nx-color-white-a300);

--- a/apps/docs/public/themes/base-slate.css
+++ b/apps/docs/public/themes/base-slate.css
@@ -32,6 +32,7 @@ html {
   --nx-color-nav-border: var(--nx-color-slate-200);
   --nx-color-overlay: var(--nx-color-slate-a700);
   --nx-color-border-default: var(--nx-color-black-a200);
+  --nx-color-border-hairline: var(--nx-color-black-a200);
   --nx-color-border-default-alpha: var(--nx-color-slate-a200);
   --nx-color-border-active: var(--nx-color-slate-400);
   --nx-color-border-disabled: var(--nx-color-black-a200);
@@ -113,6 +114,7 @@ html.dark {
   --nx-color-nav-border: var(--nx-color-slate-800);
   --nx-color-overlay: var(--nx-color-slate-a800);
   --nx-color-border-default: var(--nx-color-white-a300);
+  --nx-color-border-hairline: var(--nx-color-white-a200);
   --nx-color-border-default-alpha: var(--nx-color-slate-a300);
   --nx-color-border-active: var(--nx-color-slate-400);
   --nx-color-border-disabled: var(--nx-color-white-a300);

--- a/apps/docs/public/themes/base-stone.css
+++ b/apps/docs/public/themes/base-stone.css
@@ -32,6 +32,7 @@ html {
   --nx-color-nav-border: var(--nx-color-stone-200);
   --nx-color-overlay: var(--nx-color-stone-a700);
   --nx-color-border-default: var(--nx-color-black-a200);
+  --nx-color-border-hairline: var(--nx-color-black-a200);
   --nx-color-border-default-alpha: var(--nx-color-stone-a200);
   --nx-color-border-active: var(--nx-color-stone-400);
   --nx-color-border-disabled: var(--nx-color-black-a200);
@@ -113,6 +114,7 @@ html.dark {
   --nx-color-nav-border: var(--nx-color-stone-800);
   --nx-color-overlay: var(--nx-color-stone-a800);
   --nx-color-border-default: var(--nx-color-white-a300);
+  --nx-color-border-hairline: var(--nx-color-white-a200);
   --nx-color-border-default-alpha: var(--nx-color-stone-a300);
   --nx-color-border-active: var(--nx-color-stone-400);
   --nx-color-border-disabled: var(--nx-color-white-a300);

--- a/apps/docs/public/themes/base-zinc.css
+++ b/apps/docs/public/themes/base-zinc.css
@@ -32,6 +32,7 @@ html {
   --nx-color-nav-border: var(--nx-color-zinc-200);
   --nx-color-overlay: var(--nx-color-zinc-a700);
   --nx-color-border-default: var(--nx-color-black-a200);
+  --nx-color-border-hairline: var(--nx-color-black-a200);
   --nx-color-border-default-alpha: var(--nx-color-zinc-a200);
   --nx-color-border-active: var(--nx-color-zinc-400);
   --nx-color-border-disabled: var(--nx-color-black-a200);
@@ -113,6 +114,7 @@ html.dark {
   --nx-color-nav-border: var(--nx-color-zinc-800);
   --nx-color-overlay: var(--nx-color-zinc-a800);
   --nx-color-border-default: var(--nx-color-white-a300);
+  --nx-color-border-hairline: var(--nx-color-white-a200);
   --nx-color-border-default-alpha: var(--nx-color-zinc-a300);
   --nx-color-border-active: var(--nx-color-zinc-400);
   --nx-color-border-disabled: var(--nx-color-white-a300);

--- a/apps/docs/public/themes/globals.css
+++ b/apps/docs/public/themes/globals.css
@@ -247,6 +247,10 @@
     --nx-color-border-default,
     var(--nx-color-black-a200)
   );
+  --color-border-hairline: var(
+    --nx-color-border-hairline,
+    var(--nx-color-black-a200)
+  );
   --color-border-default-alpha: var(
     --nx-color-border-default-alpha,
     var(--nx-color-slate-a200)
@@ -616,6 +620,10 @@
   --color-overlay: var(--nx-color-overlay, var(--nx-color-slate-a700));
   --color-border-default: var(
     --nx-color-border-default,
+    var(--nx-color-black-a200)
+  );
+  --color-border-hairline: var(
+    --nx-color-border-hairline,
     var(--nx-color-black-a200)
   );
   --color-border-default-alpha: var(

--- a/docs/superpowers/plans/2026-07-02-596-image-outlines.md
+++ b/docs/superpowers/plans/2026-07-02-596-image-outlines.md
@@ -4,15 +4,15 @@
 
 **Goal:** Workstream B / issue #596 — give Avatar and ItemMedia images a subtle 1px inset hairline so they don't blend into the surface, using a floor-safe Root `::after` pseudo-element (never `outline` on the element, never inset shadow on the `<img>`).
 
-**Architecture:** Add an inset hairline via `::after` on the component root (a non-replaced element): `after:inset-0 after:rounded-[inherit] after:outline after:outline-1 after:-outline-offset-1` in **pure black @10% (light) / pure white @10% (dark)** — a tinted token would read as dirt on the edge. The Root `::after` follows the border radius (circle + rounded) and paints reliably across the whole floor, unlike `outline` on the element (rectangular < Safari 16.4) or inset `box-shadow` on a replaced `<img>` (often non-painting). Verified by class-presence + visual stories.
+**Architecture:** Add an inset hairline via `::after` on the component root (a non-replaced element): `after:inset-0 after:rounded-[inherit] after:outline after:outline-1 after:-outline-offset-1` in **pure black @9.4% (light) / pure white @9.4% (dark)** via the existing primitive-layer alpha variables `--nx-color-black-a200` and `--nx-color-white-a200` — a tinted token would read as dirt on the edge. The Root `::after` follows the border radius (circle + rounded) and paints reliably across the whole floor, unlike `outline` on the element (rectangular < Safari 16.4) or inset `box-shadow` on a replaced `<img>` (often non-painting). Verified by computed `::after` outline-color assertions + visual stories.
 
 **Tech Stack:** React, Tailwind v4 (`nx:` prefix, `after:` variant, `-outline-offset`), Radix Avatar, Storybook 10 (`storybook/test`).
 
 ## Global Constraints
 
-- **Pure black/white only** for the hairline (`black/10` light, `white/10` dark). This is the one sanctioned `nx:dark:` case on a raw primitive (per components.md). Do **not** use a tinted border token.
+- **Pure black/white alpha only** for the hairline via `--nx-color-black-a200` in light mode and `--nx-color-white-a200` in dark mode. Do **not** use Tailwind palette classes like `outline-black/10` / `outline-white/10`; `nexus.css` resets `--color-*` primitives to `initial`, so those classes do not emit the intended color. Do **not** use a tinted border token.
 - **Floor-safe technique:** Root `::after`, not element `outline`, not `<img>` inset shadow.
-- **`nx:` prefix before every modifier;** semantic tokens elsewhere; `pnpm lint` (eslint-plugin-nexus) may flag the raw `black`/`white` — if so, add a scoped `eslint-disable` with a reason (see Task 1 Step 4).
+- **`nx:` prefix before every modifier;** semantic tokens elsewhere; the hairline references in-system primitive-layer CSS variables with scoped arbitrary values.
 - **Tests are stories.** **Pre-production:** change in place. **PR:** `feat(polish): …`, base `main`, body `Closes #596`, Summary + Test Plan + polish.md evidence (incl. light/dark + circle/rounded + Safari-floor visual check).
 
 ---
@@ -20,9 +20,9 @@
 ## File Structure
 
 - `packages/react/src/components/avatar/avatar.tsx:8` — add the `::after` hairline to `avatarVariants` base.
-- `packages/react/src/components/avatar/Avatar.stories.tsx` — class-presence + light/dark visual story.
+- `packages/react/src/components/avatar/Avatar.stories.tsx` — computed `::after` outline-color + light/dark visual story.
 - `packages/react/src/components/item/item.tsx:134` — add the `::after` hairline to the `image` variant of `itemMediaVariants`.
-- `packages/react/src/components/item/Item.stories.tsx` — class-presence story on ItemMedia image.
+- `packages/react/src/components/item/Item.stories.tsx` — computed `::after` outline-color story on ItemMedia image.
 
 ---
 
@@ -34,7 +34,7 @@
 
 - [ ] **Step 1: Write the failing test**
 
-Add to `Avatar.stories.tsx` (reuse existing `Avatar`, `AvatarImage`, `AvatarFallback` imports + `expect` from `storybook/test`):
+Add to `Avatar.stories.tsx` (reuse existing `Avatar`, `AvatarImage`, `AvatarFallback` imports + `expect` from `storybook/test`; assert computed `::after` output rather than class presence):
 
 ```tsx
 export const ImageHairline: Story = {
@@ -45,8 +45,7 @@ export const ImageHairline: Story = {
   ),
   play: async ({ canvasElement }) => {
     const root = canvasElement.querySelector('[data-slot="avatar"]');
-    await expect(root).toHaveClass('nx:after:outline-black/10');
-    await expect(root).toHaveClass('nx:dark:after:outline-white/10');
+    expectAvatarHairline(root, '--nx-color-black-a200');
   },
 };
 ```
@@ -68,7 +67,7 @@ to:
 
 ```ts
 const avatarVariants = cva(
-  'nx:relative nx:flex nx:shrink-0 nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-black/10 nx:dark:after:outline-white/10',
+  'nx:relative nx:flex nx:shrink-0 nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-[var(--nx-color-black-a200)] nx:dark:after:outline-[var(--nx-color-white-a200)]',
   {
 ```
 
@@ -77,19 +76,13 @@ const avatarVariants = cva(
 - [ ] **Step 4: Run to verify it passes + lint**
 
 Run: `pnpm test:storybook avatar && pnpm lint`
-Expected: story PASS. If `pnpm lint` flags `nx:after:outline-black/10` / `nx:dark:after:outline-white/10` as a raw primitive, add this directly above `const avatarVariants = cva(` and re-run lint:
-
-```ts
-// eslint-disable-next-line @nexus/no-raw-primitives -- image hairline requires pure black/white; a tinted token reads as dirt on the edge (#596)
-```
-
-(Use the exact rule id `pnpm lint` reports. Avatar already carries one such coded exception, so this pattern is precedented.)
+Expected: story PASS. The test must verify `getComputedStyle(root, '::after').outlineColor` resolves to `--nx-color-black-a200` in light mode and `--nx-color-white-a200` in dark mode; class-presence alone is insufficient because stripped Tailwind palette classes can stay present while emitting no color.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add packages/react/src/components/avatar
-git commit -m "feat(avatar): subtle image hairline via root ::after (black/10, white/10 dark)"
+git commit -m "feat(avatar): subtle image hairline via root ::after"
 ```
 
 ---
@@ -118,8 +111,7 @@ export const MediaImageHairline: Story = {
   ),
   play: async ({ canvasElement }) => {
     const media = canvasElement.querySelector('[data-slot="item-media"]');
-    await expect(media).toHaveClass('nx:after:outline-black/10');
-    await expect(media).toHaveClass('nx:dark:after:outline-white/10');
+    expectMediaHairline(media);
   },
 };
 ```
@@ -144,7 +136,7 @@ to:
 
 ```ts
         image:
-          'nx:relative nx:size-10 nx:overflow-hidden nx:rounded-sm nx:[&_img]:size-full nx:[&_img]:object-cover nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-black/10 nx:dark:after:outline-white/10',
+          'nx:relative nx:size-10 nx:overflow-hidden nx:rounded-sm nx:[&_img]:size-full nx:[&_img]:object-cover nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-[var(--nx-color-black-a200)] nx:dark:after:outline-[var(--nx-color-white-a200)]',
 ```
 
 (The wrapper is `overflow-hidden`; the inset `::after` at `-outline-offset-1` renders 1px inside the edge, within the clip.)
@@ -152,13 +144,13 @@ to:
 - [ ] **Step 4: Run to verify it passes**
 
 Run: `pnpm test:storybook item && pnpm lint`
-Expected: PASS (add the same scoped `eslint-disable` above `const itemMediaVariants = cva(` if lint flags the primitive).
+Expected: PASS; the story must assert the computed `::after` outline, not only the wrapper class string.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add packages/react/src/components/item
-git commit -m "feat(item): image-media hairline via ::after (black/10, white/10 dark)"
+git commit -m "feat(item): image-media hairline via ::after"
 ```
 
 ---
@@ -175,7 +167,7 @@ gh pr create --base main \
   --title "feat(polish): subtle image hairline on Avatar + ItemMedia" \
   --body "$(cat <<'EOF'
 ## Summary
-- Avatar and ItemMedia images gain a 1px inset hairline (black/10 light, white/10 dark) via a Root `::after`, so images don't blend into the surface.
+- Avatar and ItemMedia images gain a 1px inset hairline (`--nx-color-black-a200` light, `--nx-color-white-a200` dark) via a Root `::after`, so images don't blend into the surface.
 - Floor-safe: Root `::after` follows the radius on circle + rounded and paints across the whole floor (unlike element `outline` < Safari 16.4 or inset shadow on a replaced `<img>`).
 
 ## GitHub Issue
@@ -183,10 +175,12 @@ Closes #596
 
 ## Test Plan
 - [ ] lint / format:check / typecheck / test:storybook green
-- [ ] Class-presence stories; visual check light/dark + circle/rounded + Safari floor
+- [ ] Computed `::after` outline-color stories; visual check light/dark + circle/rounded + Safari floor
 
 ## Modern Web Guidance
-- `::after` + `-outline-offset` universally supported; pure black/white avoids tinted-edge "dirt"; `nx:dark:` on a raw primitive is the one sanctioned primitive case (components.md).
+- Search query: `image outline pseudo-element inset hairline border radius CSS`.
+- NPX was unavailable/rejected in the implementation environment, so the fallback path is the repo-local Modern Web Guidance skill plus the approved plan and the Nexus browser floor.
+- `::after`, `outline`, `outline-offset`, `inset: 0`, `border-radius: inherit`, and CSS custom properties are floor-safe here; pure black/white alpha variables avoid tinted-edge "dirt" while staying inside the Nexus token layer.
 EOF
 )"
 ```
@@ -195,8 +189,8 @@ EOF
 
 ## Self-Review
 
-**Spec coverage (#596):** Avatar hairline (Task 1) + ItemMedia hairline (Task 2), both via Root `::after`, pure black/white, floor-safe. No gaps.
+**Spec coverage (#596):** Avatar hairline (Task 1) + ItemMedia hairline (Task 2), both via Root `::after`, pure black/white alpha variables, floor-safe.
 
-**Placeholder scan:** exact before/after cva strings; test code complete. The lint-disable step names a concrete conditional and the exact reason; the ItemMedia `data-slot` verification is a one-line confirm, not deferred logic.
+**Placeholder scan:** exact before/after cva strings; test code complete. The ItemMedia `data-slot` verification is a one-line confirm, not deferred logic.
 
-**Type/name consistency:** `data-slot="avatar"` (avatar.tsx:116) matches; the hairline class list is byte-identical between Avatar and ItemMedia impl steps and their assertions.
+**Type/name consistency:** `data-slot="avatar"` and `data-slot="item-media"` match the story selectors; the hairline class list is byte-identical between Avatar and ItemMedia implementation steps, and stories assert the computed pseudo-element result.

--- a/docs/superpowers/plans/2026-07-02-596-image-outlines.md
+++ b/docs/superpowers/plans/2026-07-02-596-image-outlines.md
@@ -4,15 +4,15 @@
 
 **Goal:** Workstream B / issue #596 — give Avatar and ItemMedia images a subtle 1px inset hairline so they don't blend into the surface, using a floor-safe Root `::after` pseudo-element (never `outline` on the element, never inset shadow on the `<img>`).
 
-**Architecture:** Add an inset hairline via `::after` on the component root (a non-replaced element): `after:inset-0 after:rounded-[inherit] after:outline after:outline-1 after:-outline-offset-1` in **pure black @9.4% (light) / pure white @9.4% (dark)** via the existing primitive-layer alpha variables `--nx-color-black-a200` and `--nx-color-white-a200` — a tinted token would read as dirt on the edge. The Root `::after` follows the border radius (circle + rounded) and paints reliably across the whole floor, unlike `outline` on the element (rectangular < Safari 16.4) or inset `box-shadow` on a replaced `<img>` (often non-painting). Verified by computed `::after` outline-color assertions + visual stories.
+**Architecture:** Add an inset hairline via `::after` on the component root (a non-replaced element): `after:inset-0 after:rounded-[inherit] after:outline after:outline-1 after:-outline-offset-1` using the semantic `border-hairline` color. That semantic resolves to pure black @9.4% in light mode and pure white @9.4% in dark mode — a tinted token would read as dirt on the edge. The Root `::after` follows the border radius (circle + rounded) and paints reliably across the whole floor, unlike `outline` on the element (rectangular < Safari 16.4) or inset `box-shadow` on a replaced `<img>` (often non-painting). Verified by computed `::after` outline-color assertions + visual stories.
 
 **Tech Stack:** React, Tailwind v4 (`nx:` prefix, `after:` variant, `-outline-offset`), Radix Avatar, Storybook 10 (`storybook/test`).
 
 ## Global Constraints
 
-- **Pure black/white alpha only** for the hairline via `--nx-color-black-a200` in light mode and `--nx-color-white-a200` in dark mode. Do **not** use Tailwind palette classes like `outline-black/10` / `outline-white/10`; `nexus.css` resets `--color-*` primitives to `initial`, so those classes do not emit the intended color. Do **not** use a tinted border token.
+- **Pure black/white alpha only** for the hairline via semantic `--nx-color-border-hairline`. Do **not** use Tailwind palette classes like `outline-black/10` / `outline-white/10`; `nexus.css` resets `--color-*` primitives to `initial`, so those classes do not emit the intended color. Do **not** use a tinted border token.
 - **Floor-safe technique:** Root `::after`, not element `outline`, not `<img>` inset shadow.
-- **`nx:` prefix before every modifier;** semantic tokens elsewhere; the hairline references in-system primitive-layer CSS variables with scoped arbitrary values.
+- **`nx:` prefix before every modifier;** use `nx:after:outline-border-hairline` for the hairline colour.
 - **Tests are stories.** **Pre-production:** change in place. **PR:** `feat(polish): …`, base `main`, body `Closes #596`, Summary + Test Plan + polish.md evidence (incl. light/dark + circle/rounded + Safari-floor visual check).
 
 ---
@@ -45,7 +45,7 @@ export const ImageHairline: Story = {
   ),
   play: async ({ canvasElement }) => {
     const root = canvasElement.querySelector('[data-slot="avatar"]');
-    expectAvatarHairline(root, '--nx-color-black-a200');
+    expectAvatarHairline(root);
   },
 };
 ```
@@ -67,7 +67,7 @@ to:
 
 ```ts
 const avatarVariants = cva(
-  'nx:relative nx:flex nx:shrink-0 nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-[var(--nx-color-black-a200)] nx:dark:after:outline-[var(--nx-color-white-a200)]',
+  'nx:relative nx:flex nx:shrink-0 nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-border-hairline',
   {
 ```
 
@@ -76,7 +76,7 @@ const avatarVariants = cva(
 - [ ] **Step 4: Run to verify it passes + lint**
 
 Run: `pnpm test:storybook avatar && pnpm lint`
-Expected: story PASS. The test must verify `getComputedStyle(root, '::after').outlineColor` resolves to `--nx-color-black-a200` in light mode and `--nx-color-white-a200` in dark mode; class-presence alone is insufficient because stripped Tailwind palette classes can stay present while emitting no color.
+Expected: story PASS. The test must verify `getComputedStyle(root, '::after').outlineColor` resolves to `--nx-color-border-hairline`; class-presence alone is insufficient because stripped Tailwind palette classes can stay present while emitting no color.
 
 - [ ] **Step 5: Commit**
 
@@ -136,7 +136,7 @@ to:
 
 ```ts
         image:
-          'nx:relative nx:size-10 nx:overflow-hidden nx:rounded-sm nx:[&_img]:size-full nx:[&_img]:object-cover nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-[var(--nx-color-black-a200)] nx:dark:after:outline-[var(--nx-color-white-a200)]',
+          'nx:relative nx:size-10 nx:overflow-hidden nx:rounded-sm nx:[&_img]:size-full nx:[&_img]:object-cover nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-border-hairline',
 ```
 
 (The wrapper is `overflow-hidden`; the inset `::after` at `-outline-offset-1` renders 1px inside the edge, within the clip.)
@@ -167,7 +167,7 @@ gh pr create --base main \
   --title "feat(polish): subtle image hairline on Avatar + ItemMedia" \
   --body "$(cat <<'EOF'
 ## Summary
-- Avatar and ItemMedia images gain a 1px inset hairline (`--nx-color-black-a200` light, `--nx-color-white-a200` dark) via a Root `::after`, so images don't blend into the surface.
+- Avatar and ItemMedia images gain a 1px inset hairline (`--nx-color-border-hairline`) via a Root `::after`, so images don't blend into the surface.
 - Floor-safe: Root `::after` follows the radius on circle + rounded and paints across the whole floor (unlike element `outline` < Safari 16.4 or inset shadow on a replaced `<img>`).
 
 ## GitHub Issue
@@ -180,7 +180,7 @@ Closes #596
 ## Modern Web Guidance
 - Search query: `image outline pseudo-element inset hairline border radius CSS`.
 - NPX was unavailable/rejected in the implementation environment, so the fallback path is the repo-local Modern Web Guidance skill plus the approved plan and the Nexus browser floor.
-- `::after`, `outline`, `outline-offset`, `inset: 0`, `border-radius: inherit`, and CSS custom properties are floor-safe here; pure black/white alpha variables avoid tinted-edge "dirt" while staying inside the Nexus token layer.
+- `::after`, `outline`, `outline-offset`, `inset: 0`, `border-radius: inherit`, and CSS custom properties are floor-safe here; `border-hairline` formalizes the pure black/white alpha edge inside the Nexus token layer.
 EOF
 )"
 ```
@@ -189,7 +189,7 @@ EOF
 
 ## Self-Review
 
-**Spec coverage (#596):** Avatar hairline (Task 1) + ItemMedia hairline (Task 2), both via Root `::after`, pure black/white alpha variables, floor-safe.
+**Spec coverage (#596):** Avatar hairline (Task 1) + ItemMedia hairline (Task 2), both via Root `::after`, semantic `border-hairline`, floor-safe.
 
 **Placeholder scan:** exact before/after cva strings; test code complete. The ItemMedia `data-slot` verification is a one-line confirm, not deferred logic.
 

--- a/docs/superpowers/plans/2026-07-02-596-image-outlines.md
+++ b/docs/superpowers/plans/2026-07-02-596-image-outlines.md
@@ -1,0 +1,202 @@
+# Image Outlines Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Workstream B / issue #596 — give Avatar and ItemMedia images a subtle 1px inset hairline so they don't blend into the surface, using a floor-safe Root `::after` pseudo-element (never `outline` on the element, never inset shadow on the `<img>`).
+
+**Architecture:** Add an inset hairline via `::after` on the component root (a non-replaced element): `after:inset-0 after:rounded-[inherit] after:outline after:outline-1 after:-outline-offset-1` in **pure black @10% (light) / pure white @10% (dark)** — a tinted token would read as dirt on the edge. The Root `::after` follows the border radius (circle + rounded) and paints reliably across the whole floor, unlike `outline` on the element (rectangular < Safari 16.4) or inset `box-shadow` on a replaced `<img>` (often non-painting). Verified by class-presence + visual stories.
+
+**Tech Stack:** React, Tailwind v4 (`nx:` prefix, `after:` variant, `-outline-offset`), Radix Avatar, Storybook 10 (`storybook/test`).
+
+## Global Constraints
+
+- **Pure black/white only** for the hairline (`black/10` light, `white/10` dark). This is the one sanctioned `nx:dark:` case on a raw primitive (per components.md). Do **not** use a tinted border token.
+- **Floor-safe technique:** Root `::after`, not element `outline`, not `<img>` inset shadow.
+- **`nx:` prefix before every modifier;** semantic tokens elsewhere; `pnpm lint` (eslint-plugin-nexus) may flag the raw `black`/`white` — if so, add a scoped `eslint-disable` with a reason (see Task 1 Step 4).
+- **Tests are stories.** **Pre-production:** change in place. **PR:** `feat(polish): …`, base `main`, body `Closes #596`, Summary + Test Plan + polish.md evidence (incl. light/dark + circle/rounded + Safari-floor visual check).
+
+---
+
+## File Structure
+
+- `packages/react/src/components/avatar/avatar.tsx:8` — add the `::after` hairline to `avatarVariants` base.
+- `packages/react/src/components/avatar/Avatar.stories.tsx` — class-presence + light/dark visual story.
+- `packages/react/src/components/item/item.tsx:134` — add the `::after` hairline to the `image` variant of `itemMediaVariants`.
+- `packages/react/src/components/item/Item.stories.tsx` — class-presence story on ItemMedia image.
+
+---
+
+### Task 1: Avatar image hairline
+
+**Files:** `avatar.tsx:8`, `Avatar.stories.tsx`.
+
+**Interfaces:** Consumes — nothing. Produces — nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Avatar.stories.tsx` (reuse existing `Avatar`, `AvatarImage`, `AvatarFallback` imports + `expect` from `storybook/test`):
+
+```tsx
+export const ImageHairline: Story = {
+  render: () => (
+    <Avatar>
+      <AvatarFallback>JD</AvatarFallback>
+    </Avatar>
+  ),
+  play: async ({ canvasElement }) => {
+    const root = canvasElement.querySelector('[data-slot="avatar"]');
+    await expect(root).toHaveClass('nx:after:outline-black/10');
+    await expect(root).toHaveClass('nx:dark:after:outline-white/10');
+  },
+};
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm test:storybook avatar`
+Expected: FAIL — the avatar root has no `::after` hairline.
+
+- [ ] **Step 3: Implement**
+
+In `packages/react/src/components/avatar/avatar.tsx`, change the base string at line 8 from:
+
+```ts
+const avatarVariants = cva('nx:relative nx:flex nx:shrink-0', {
+```
+
+to:
+
+```ts
+const avatarVariants = cva(
+  'nx:relative nx:flex nx:shrink-0 nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-black/10 nx:dark:after:outline-white/10',
+  {
+```
+
+(Root is already `nx:relative`, so the `::after` positions correctly. It rings the whole avatar including the fallback tile — the intended consistent edge.)
+
+- [ ] **Step 4: Run to verify it passes + lint**
+
+Run: `pnpm test:storybook avatar && pnpm lint`
+Expected: story PASS. If `pnpm lint` flags `nx:after:outline-black/10` / `nx:dark:after:outline-white/10` as a raw primitive, add this directly above `const avatarVariants = cva(` and re-run lint:
+
+```ts
+// eslint-disable-next-line @nexus/no-raw-primitives -- image hairline requires pure black/white; a tinted token reads as dirt on the edge (#596)
+```
+
+(Use the exact rule id `pnpm lint` reports. Avatar already carries one such coded exception, so this pattern is precedented.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/react/src/components/avatar
+git commit -m "feat(avatar): subtle image hairline via root ::after (black/10, white/10 dark)"
+```
+
+---
+
+### Task 2: ItemMedia image hairline
+
+**Files:** `item.tsx:134`, `Item.stories.tsx`.
+
+**Interfaces:** Consumes — nothing. Produces — nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Item.stories.tsx` (reuse existing `Item`, `ItemMedia` imports + `expect`):
+
+```tsx
+export const MediaImageHairline: Story = {
+  render: () => (
+    <Item>
+      <ItemMedia variant="image">
+        <img
+          src="data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA="
+          alt=""
+        />
+      </ItemMedia>
+    </Item>
+  ),
+  play: async ({ canvasElement }) => {
+    const media = canvasElement.querySelector('[data-slot="item-media"]');
+    await expect(media).toHaveClass('nx:after:outline-black/10');
+    await expect(media).toHaveClass('nx:dark:after:outline-white/10');
+  },
+};
+```
+
+(Confirm the `data-slot` ItemMedia sets — adjust the selector if it differs, e.g. `[data-slot="item-media"]`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm test:storybook item`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `packages/react/src/components/item/item.tsx`, change the `image` variant at line 134 from:
+
+```ts
+        image:
+          'nx:size-10 nx:overflow-hidden nx:rounded-sm nx:[&_img]:size-full nx:[&_img]:object-cover',
+```
+
+to:
+
+```ts
+        image:
+          'nx:relative nx:size-10 nx:overflow-hidden nx:rounded-sm nx:[&_img]:size-full nx:[&_img]:object-cover nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-black/10 nx:dark:after:outline-white/10',
+```
+
+(The wrapper is `overflow-hidden`; the inset `::after` at `-outline-offset-1` renders 1px inside the edge, within the clip.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm test:storybook item && pnpm lint`
+Expected: PASS (add the same scoped `eslint-disable` above `const itemMediaVariants = cva(` if lint flags the primitive).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/react/src/components/item
+git commit -m "feat(item): image-media hairline via ::after (black/10, white/10 dark)"
+```
+
+---
+
+### Task 3: Validate and open the PR
+
+- [ ] **Step 1:** `pnpm lint && pnpm format:check && pnpm typecheck && pnpm test:storybook` — all green.
+- [ ] **Step 2:** Visually confirm the hairline in Storybook on **light + dark** surfaces and **circle + rounded** avatars, and (if available) a Safari-15.4 check that the ring follows the radius.
+- [ ] **Step 3:** Open the PR:
+
+```bash
+git push -u origin <branch>
+gh pr create --base main \
+  --title "feat(polish): subtle image hairline on Avatar + ItemMedia" \
+  --body "$(cat <<'EOF'
+## Summary
+- Avatar and ItemMedia images gain a 1px inset hairline (black/10 light, white/10 dark) via a Root `::after`, so images don't blend into the surface.
+- Floor-safe: Root `::after` follows the radius on circle + rounded and paints across the whole floor (unlike element `outline` < Safari 16.4 or inset shadow on a replaced `<img>`).
+
+## GitHub Issue
+Closes #596
+
+## Test Plan
+- [ ] lint / format:check / typecheck / test:storybook green
+- [ ] Class-presence stories; visual check light/dark + circle/rounded + Safari floor
+
+## Modern Web Guidance
+- `::after` + `-outline-offset` universally supported; pure black/white avoids tinted-edge "dirt"; `nx:dark:` on a raw primitive is the one sanctioned primitive case (components.md).
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (#596):** Avatar hairline (Task 1) + ItemMedia hairline (Task 2), both via Root `::after`, pure black/white, floor-safe. No gaps.
+
+**Placeholder scan:** exact before/after cva strings; test code complete. The lint-disable step names a concrete conditional and the exact reason; the ItemMedia `data-slot` verification is a one-line confirm, not deferred logic.
+
+**Type/name consistency:** `data-slot="avatar"` (avatar.tsx:116) matches; the hairline class list is byte-identical between Avatar and ItemMedia impl steps and their assertions.

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -243,7 +243,7 @@ describe('generateTailwindPackage', () => {
     const themeBlock = extractBlock(nexusCSS, '@theme inline');
     const colorLines = themeColorLines(themeBlock);
 
-    expect(colorLines).toHaveLength(105);
+    expect(colorLines).toHaveLength(106);
 
     for (const [, name, value] of colorLines) {
       expect(compactCss(value), `--color-${name}`).toMatch(

--- a/packages/core/src/lib/derive-theme.test.ts
+++ b/packages/core/src/lib/derive-theme.test.ts
@@ -35,7 +35,7 @@ function hOf(oklchStr: string | undefined): number {
 const toRgb = converter('rgb');
 const oklabDelta = differenceEuclidean('oklab');
 const COLORBLIND_DELTA_E = 0.02;
-const RUNTIME_SEMANTIC_COLOR_COUNT = 105;
+const RUNTIME_SEMANTIC_COLOR_COUNT = 106;
 const VISION_TYPES = [
   'normal',
   'deuteranopia',
@@ -638,6 +638,10 @@ describe('alpha and translucent colors', () => {
       'oklch(0.1448 0 0 / 0.0941)'
     );
     expect(dark['--nx-color-border-default']).toBe('oklch(1 0 0 / 0.1882)');
+    expect(light['--nx-color-border-hairline']).toBe(
+      'oklch(0.1448 0 0 / 0.0941)'
+    );
+    expect(dark['--nx-color-border-hairline']).toBe('oklch(1 0 0 / 0.0941)');
     expect(light['--nx-color-border-disabled']).toBe(
       'oklch(0.1448 0 0 / 0.0941)'
     );
@@ -682,6 +686,12 @@ describe('alpha and translucent colors', () => {
     );
     expect(at(100).dark['--nx-color-border-default-alpha']).toBe(
       'oklch(0.13 0.0400 264.7 / 0.2337)'
+    );
+    expect(at(100).light['--nx-color-border-hairline']).toBe(
+      'oklch(0.1448 0 0 / 0.0941)'
+    );
+    expect(at(100).dark['--nx-color-border-hairline']).toBe(
+      'oklch(1 0 0 / 0.0941)'
     );
     // contrast 30 exercises the sub-anchor lerp branch + toFixed rounding —
     // every assertion above is an endpoint (0/100) or the c===60 early return.

--- a/packages/core/src/lib/derive-theme.ts
+++ b/packages/core/src/lib/derive-theme.ts
@@ -531,6 +531,7 @@ function deriveAlpha(
     '--nx-color-popover-alpha': dark
       ? toneInk(0.7529)
       : 'oklch(1 0 0 / 0.7529)',
+    '--nx-color-border-hairline': contrastInk(0.0941),
     '--nx-color-border-default': contrastInk(profile.borderAlpha),
     '--nx-color-border-disabled': contrastInk(profile.borderAlpha),
   };

--- a/packages/core/src/lib/tone-parity.test.ts
+++ b/packages/core/src/lib/tone-parity.test.ts
@@ -86,6 +86,7 @@ const CONTRAST_INK_TOKENS = new Set([
   'nav-foreground',
   'nav-muted-foreground',
   'border-default',
+  'border-hairline',
   'border-disabled',
 ]);
 const FIXED_WHITE_TOKENS = new Set(['control-thumb']);

--- a/packages/core/tokens/semantic/base-gray-dark.json
+++ b/packages/core/tokens/semantic/base-gray-dark.json
@@ -126,6 +126,10 @@
       "$value": "{white.a300}",
       "$type": "color"
     },
+    "hairline": {
+      "$value": "{white.a200}",
+      "$type": "color"
+    },
     "default-alpha": {
       "$value": "{gray.a300}",
       "$type": "color"

--- a/packages/core/tokens/semantic/base-gray-light.json
+++ b/packages/core/tokens/semantic/base-gray-light.json
@@ -126,6 +126,10 @@
       "$value": "{black.a200}",
       "$type": "color"
     },
+    "hairline": {
+      "$value": "{black.a200}",
+      "$type": "color"
+    },
     "default-alpha": {
       "$value": "{gray.a200}",
       "$type": "color"

--- a/packages/core/tokens/semantic/base-neutral-dark.json
+++ b/packages/core/tokens/semantic/base-neutral-dark.json
@@ -126,6 +126,10 @@
       "$value": "{white.a300}",
       "$type": "color"
     },
+    "hairline": {
+      "$value": "{white.a200}",
+      "$type": "color"
+    },
     "default-alpha": {
       "$value": "{neutral.a300}",
       "$type": "color"

--- a/packages/core/tokens/semantic/base-neutral-light.json
+++ b/packages/core/tokens/semantic/base-neutral-light.json
@@ -126,6 +126,10 @@
       "$value": "{black.a200}",
       "$type": "color"
     },
+    "hairline": {
+      "$value": "{black.a200}",
+      "$type": "color"
+    },
     "default-alpha": {
       "$value": "{neutral.a200}",
       "$type": "color"

--- a/packages/core/tokens/semantic/base-slate-dark.json
+++ b/packages/core/tokens/semantic/base-slate-dark.json
@@ -126,6 +126,10 @@
       "$value": "{white.a300}",
       "$type": "color"
     },
+    "hairline": {
+      "$value": "{white.a200}",
+      "$type": "color"
+    },
     "default-alpha": {
       "$value": "{slate.a300}",
       "$type": "color"

--- a/packages/core/tokens/semantic/base-slate-light.json
+++ b/packages/core/tokens/semantic/base-slate-light.json
@@ -126,6 +126,10 @@
       "$value": "{black.a200}",
       "$type": "color"
     },
+    "hairline": {
+      "$value": "{black.a200}",
+      "$type": "color"
+    },
     "default-alpha": {
       "$value": "{slate.a200}",
       "$type": "color"

--- a/packages/core/tokens/semantic/base-stone-dark.json
+++ b/packages/core/tokens/semantic/base-stone-dark.json
@@ -126,6 +126,10 @@
       "$value": "{white.a300}",
       "$type": "color"
     },
+    "hairline": {
+      "$value": "{white.a200}",
+      "$type": "color"
+    },
     "default-alpha": {
       "$value": "{stone.a300}",
       "$type": "color"

--- a/packages/core/tokens/semantic/base-stone-light.json
+++ b/packages/core/tokens/semantic/base-stone-light.json
@@ -126,6 +126,10 @@
       "$value": "{black.a200}",
       "$type": "color"
     },
+    "hairline": {
+      "$value": "{black.a200}",
+      "$type": "color"
+    },
     "default-alpha": {
       "$value": "{stone.a200}",
       "$type": "color"

--- a/packages/core/tokens/semantic/base-zinc-dark.json
+++ b/packages/core/tokens/semantic/base-zinc-dark.json
@@ -126,6 +126,10 @@
       "$value": "{white.a300}",
       "$type": "color"
     },
+    "hairline": {
+      "$value": "{white.a200}",
+      "$type": "color"
+    },
     "default-alpha": {
       "$value": "{zinc.a300}",
       "$type": "color"

--- a/packages/core/tokens/semantic/base-zinc-light.json
+++ b/packages/core/tokens/semantic/base-zinc-light.json
@@ -126,6 +126,10 @@
       "$value": "{black.a200}",
       "$type": "color"
     },
+    "hairline": {
+      "$value": "{black.a200}",
+      "$type": "color"
+    },
     "default-alpha": {
       "$value": "{zinc.a200}",
       "$type": "color"

--- a/packages/react/src/components/avatar/Avatar.stories.tsx
+++ b/packages/react/src/components/avatar/Avatar.stories.tsx
@@ -67,6 +67,34 @@ const WIDE_AVATAR_URL = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(`
   </svg>
 `)}`;
 
+function resolveCssColor(element: Element, color: string) {
+  const probe = element.ownerDocument.createElement('span');
+  probe.style.color = color;
+  element.ownerDocument.body.append(probe);
+  const resolved = getComputedStyle(probe).color;
+  probe.remove();
+  return resolved;
+}
+
+function expectAvatarHairline(
+  element: Element | null,
+  token: '--nx-color-black-a200' | '--nx-color-white-a200'
+) {
+  if (!element) throw new Error('avatar root not found');
+
+  const rootStyles = getComputedStyle(element.ownerDocument.documentElement);
+  const expectedColor = resolveCssColor(
+    element,
+    rootStyles.getPropertyValue(token).trim()
+  );
+  const afterStyles = getComputedStyle(element, '::after');
+
+  expect(afterStyles.outlineStyle).toBe('solid');
+  expect(afterStyles.outlineWidth).toBe('1px');
+  expect(afterStyles.outlineOffset).toBe('-1px');
+  expect(afterStyles.outlineColor).toBe(expectedColor);
+}
+
 function avatarLabel(size: (typeof AVATAR_SIZES)[number]) {
   if (size === '2xs') return '2X';
   if (size === 'xs') return 'XS';
@@ -159,10 +187,10 @@ export const ImageHairline: Story = {
       return img;
     });
 
-    await expect(root).toHaveClass('nx:after:outline-black/10');
-    await expect(root).toHaveClass('nx:dark:after:outline-white/10');
-    await expect(root).toHaveClass('nx:after:-outline-offset-1');
-    await expect(image).not.toHaveClass('nx:after:outline-black/10');
+    expectAvatarHairline(root, '--nx-color-black-a200');
+    await expect(image).not.toHaveClass(
+      'nx:after:outline-[var(--nx-color-black-a200)]'
+    );
   },
 };
 
@@ -189,6 +217,15 @@ export const ImageHairlineLightDark: Story = {
       </div>
     </div>
   ),
+  play: async ({ canvasElement }) => {
+    const avatars = canvasElement.querySelectorAll('[data-slot="avatar"]');
+
+    await expect(avatars).toHaveLength(4);
+    expectAvatarHairline(avatars.item(0), '--nx-color-black-a200');
+    expectAvatarHairline(avatars.item(1), '--nx-color-black-a200');
+    expectAvatarHairline(avatars.item(2), '--nx-color-white-a200');
+    expectAvatarHairline(avatars.item(3), '--nx-color-white-a200');
+  },
 };
 
 export const WithFallback: Story = {

--- a/packages/react/src/components/avatar/Avatar.stories.tsx
+++ b/packages/react/src/components/avatar/Avatar.stories.tsx
@@ -144,6 +144,53 @@ export const DefaultDataAttributes: Story = {
   },
 };
 
+export const ImageHairline: Story = {
+  render: () => (
+    <Avatar>
+      <AvatarImage src={AVATAR_URL} alt="Ada Lovelace" />
+      <AvatarFallback>AL</AvatarFallback>
+    </Avatar>
+  ),
+  play: async ({ canvasElement }) => {
+    const root = canvasElement.querySelector('[data-slot="avatar"]');
+    const image = await waitFor(() => {
+      const img = canvasElement.querySelector('[data-slot="avatar-image"]');
+      if (!img) throw new Error('avatar image has not mounted yet');
+      return img;
+    });
+
+    await expect(root).toHaveClass('nx:after:outline-black/10');
+    await expect(root).toHaveClass('nx:dark:after:outline-white/10');
+    await expect(root).toHaveClass('nx:after:-outline-offset-1');
+    await expect(image).not.toHaveClass('nx:after:outline-black/10');
+  },
+};
+
+export const ImageHairlineLightDark: Story = {
+  render: () => (
+    <div className="nx:grid nx:grid-cols-2 nx:gap-4">
+      <div className="nx:flex nx:items-center nx:gap-3 nx:rounded-md nx:bg-background nx:p-4">
+        <Avatar>
+          <AvatarImage src={AVATAR_URL} alt="Ada Lovelace" />
+          <AvatarFallback>AL</AvatarFallback>
+        </Avatar>
+        <Avatar shape="rounded">
+          <AvatarFallback>JD</AvatarFallback>
+        </Avatar>
+      </div>
+      <div className="dark nx:flex nx:items-center nx:gap-3 nx:rounded-md nx:bg-background nx:p-4">
+        <Avatar>
+          <AvatarImage src={AVATAR_URL} alt="Ada Lovelace" />
+          <AvatarFallback>AL</AvatarFallback>
+        </Avatar>
+        <Avatar shape="rounded">
+          <AvatarFallback>JD</AvatarFallback>
+        </Avatar>
+      </div>
+    </div>
+  ),
+};
+
 export const WithFallback: Story = {
   render: (_args) => (
     <Avatar role="img" aria-label="Ada Lovelace">

--- a/packages/react/src/components/avatar/Avatar.stories.tsx
+++ b/packages/react/src/components/avatar/Avatar.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { IconUser } from '@tabler/icons-react';
 import { expect, waitFor, within } from 'storybook/test';
 
+import { expectInsetOutlinePseudoElement } from '../../stories/support/pseudo-element-style';
+
 import {
   Avatar,
   AvatarFallback,
@@ -67,32 +69,14 @@ const WIDE_AVATAR_URL = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(`
   </svg>
 `)}`;
 
-function resolveCssColor(element: Element, color: string) {
-  const probe = element.ownerDocument.createElement('span');
-  probe.style.color = color;
-  element.ownerDocument.body.append(probe);
-  const resolved = getComputedStyle(probe).color;
-  probe.remove();
-  return resolved;
-}
-
 function expectAvatarHairline(
   element: Element | null,
-  token: '--nx-color-black-a200' | '--nx-color-white-a200'
+  missingMessage = 'avatar root not found'
 ) {
-  if (!element) throw new Error('avatar root not found');
-
-  const rootStyles = getComputedStyle(element.ownerDocument.documentElement);
-  const expectedColor = resolveCssColor(
-    element,
-    rootStyles.getPropertyValue(token).trim()
-  );
-  const afterStyles = getComputedStyle(element, '::after');
-
-  expect(afterStyles.outlineStyle).toBe('solid');
-  expect(afterStyles.outlineWidth).toBe('1px');
-  expect(afterStyles.outlineOffset).toBe('-1px');
-  expect(afterStyles.outlineColor).toBe(expectedColor);
+  expectInsetOutlinePseudoElement(element, {
+    token: '--nx-color-border-hairline',
+    missingMessage,
+  });
 }
 
 function avatarLabel(size: (typeof AVATAR_SIZES)[number]) {
@@ -187,10 +171,8 @@ export const ImageHairline: Story = {
       return img;
     });
 
-    expectAvatarHairline(root, '--nx-color-black-a200');
-    await expect(image).not.toHaveClass(
-      'nx:after:outline-[var(--nx-color-black-a200)]'
-    );
+    expectAvatarHairline(root);
+    await expect(image).not.toHaveClass('nx:after:outline-border-hairline');
   },
 };
 
@@ -221,10 +203,10 @@ export const ImageHairlineLightDark: Story = {
     const avatars = canvasElement.querySelectorAll('[data-slot="avatar"]');
 
     await expect(avatars).toHaveLength(4);
-    expectAvatarHairline(avatars.item(0), '--nx-color-black-a200');
-    expectAvatarHairline(avatars.item(1), '--nx-color-black-a200');
-    expectAvatarHairline(avatars.item(2), '--nx-color-white-a200');
-    expectAvatarHairline(avatars.item(3), '--nx-color-white-a200');
+    expectAvatarHairline(avatars.item(0));
+    expectAvatarHairline(avatars.item(1));
+    expectAvatarHairline(avatars.item(2));
+    expectAvatarHairline(avatars.item(3));
   },
 };
 

--- a/packages/react/src/components/avatar/avatar.tsx
+++ b/packages/react/src/components/avatar/avatar.tsx
@@ -5,29 +5,32 @@ import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
 
-const avatarVariants = cva('nx:relative nx:flex nx:shrink-0', {
-  variants: {
-    size: {
-      '2xs': 'nx:size-5 nx:text-[0.625rem]',
-      xs: 'nx:size-6 nx:text-[0.6875rem]',
-      sm: 'nx:size-8 nx:text-[0.75rem]',
-      md: 'nx:size-10 nx:text-[1rem]',
-      lg: 'nx:size-12 nx:text-[1.125rem]',
-      xl: 'nx:size-14 nx:text-[1.25rem]',
-      '2xl': 'nx:size-16 nx:text-[1.5rem]',
-      '3xl': 'nx:size-20 nx:text-[1.875rem]',
-      '4xl': 'nx:size-24 nx:text-[2.25rem]',
+const avatarVariants = cva(
+  'nx:relative nx:flex nx:shrink-0 nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-black/10 nx:dark:after:outline-white/10',
+  {
+    variants: {
+      size: {
+        '2xs': 'nx:size-5 nx:text-[0.625rem]',
+        xs: 'nx:size-6 nx:text-[0.6875rem]',
+        sm: 'nx:size-8 nx:text-[0.75rem]',
+        md: 'nx:size-10 nx:text-[1rem]',
+        lg: 'nx:size-12 nx:text-[1.125rem]',
+        xl: 'nx:size-14 nx:text-[1.25rem]',
+        '2xl': 'nx:size-16 nx:text-[1.5rem]',
+        '3xl': 'nx:size-20 nx:text-[1.875rem]',
+        '4xl': 'nx:size-24 nx:text-[2.25rem]',
+      },
+      shape: {
+        circle: 'nx:rounded-full',
+        rounded: 'nx:rounded-lg',
+      },
     },
-    shape: {
-      circle: 'nx:rounded-full',
-      rounded: 'nx:rounded-lg',
+    defaultVariants: {
+      size: 'md',
+      shape: 'circle',
     },
-  },
-  defaultVariants: {
-    size: 'md',
-    shape: 'circle',
-  },
-});
+  }
+);
 
 type AvatarGroupContextValue = Pick<
   VariantProps<typeof avatarVariants>,

--- a/packages/react/src/components/avatar/avatar.tsx
+++ b/packages/react/src/components/avatar/avatar.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const avatarVariants = cva(
-  'nx:relative nx:flex nx:shrink-0 nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-[var(--nx-color-black-a200)] nx:dark:after:outline-[var(--nx-color-white-a200)]',
+  'nx:relative nx:flex nx:shrink-0 nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-border-hairline',
   {
     variants: {
       size: {

--- a/packages/react/src/components/avatar/avatar.tsx
+++ b/packages/react/src/components/avatar/avatar.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const avatarVariants = cva(
-  'nx:relative nx:flex nx:shrink-0 nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-black/10 nx:dark:after:outline-white/10',
+  'nx:relative nx:flex nx:shrink-0 nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-[var(--nx-color-black-a200)] nx:dark:after:outline-[var(--nx-color-white-a200)]',
   {
     variants: {
       size: {

--- a/packages/react/src/components/item/Item.stories.tsx
+++ b/packages/react/src/components/item/Item.stories.tsx
@@ -115,6 +115,28 @@ export const Media: Story = {
   ),
 };
 
+export const MediaImageHairline: Story = {
+  render: () => (
+    <Item>
+      <ItemMedia variant="image">
+        <img
+          src="data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA="
+          alt=""
+        />
+      </ItemMedia>
+    </Item>
+  ),
+  play: async ({ canvasElement }) => {
+    const media = canvasElement.querySelector('[data-slot="item-media"]');
+    const image = canvasElement.querySelector('img');
+
+    await expect(media).toHaveClass('nx:after:outline-black/10');
+    await expect(media).toHaveClass('nx:dark:after:outline-white/10');
+    await expect(media).toHaveClass('nx:after:-outline-offset-1');
+    await expect(image).not.toHaveClass('nx:after:outline-black/10');
+  },
+};
+
 // A grouped list divided by separators.
 export const Grouped: Story = {
   render: () => (

--- a/packages/react/src/components/item/Item.stories.tsx
+++ b/packages/react/src/components/item/Item.stories.tsx
@@ -27,6 +27,31 @@ type Story = StoryObj<typeof Item>;
 const THUMB =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Crect width='40' height='40' fill='%23999'/%3E%3C/svg%3E";
 
+function resolveCssColor(element: Element, color: string) {
+  const probe = element.ownerDocument.createElement('span');
+  probe.style.color = color;
+  element.ownerDocument.body.append(probe);
+  const resolved = getComputedStyle(probe).color;
+  probe.remove();
+  return resolved;
+}
+
+function expectMediaHairline(element: Element | null) {
+  if (!element) throw new Error('item media not found');
+
+  const rootStyles = getComputedStyle(element.ownerDocument.documentElement);
+  const expectedColor = resolveCssColor(
+    element,
+    rootStyles.getPropertyValue('--nx-color-black-a200').trim()
+  );
+  const afterStyles = getComputedStyle(element, '::after');
+
+  expect(afterStyles.outlineStyle).toBe('solid');
+  expect(afterStyles.outlineWidth).toBe('1px');
+  expect(afterStyles.outlineOffset).toBe('-1px');
+  expect(afterStyles.outlineColor).toBe(expectedColor);
+}
+
 // A standard row: icon media, title + description, and a trailing action.
 export const Default: Story = {
   render: () => (
@@ -130,10 +155,10 @@ export const MediaImageHairline: Story = {
     const media = canvasElement.querySelector('[data-slot="item-media"]');
     const image = canvasElement.querySelector('img');
 
-    await expect(media).toHaveClass('nx:after:outline-black/10');
-    await expect(media).toHaveClass('nx:dark:after:outline-white/10');
-    await expect(media).toHaveClass('nx:after:-outline-offset-1');
-    await expect(image).not.toHaveClass('nx:after:outline-black/10');
+    expectMediaHairline(media);
+    await expect(image).not.toHaveClass(
+      'nx:after:outline-[var(--nx-color-black-a200)]'
+    );
   },
 };
 

--- a/packages/react/src/components/item/Item.stories.tsx
+++ b/packages/react/src/components/item/Item.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { IconFile } from '@tabler/icons-react';
 import { expect, within } from 'storybook/test';
 
+import { expectInsetOutlinePseudoElement } from '../../stories/support/pseudo-element-style';
 import { Button } from '../button';
 
 import {
@@ -27,29 +28,11 @@ type Story = StoryObj<typeof Item>;
 const THUMB =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Crect width='40' height='40' fill='%23999'/%3E%3C/svg%3E";
 
-function resolveCssColor(element: Element, color: string) {
-  const probe = element.ownerDocument.createElement('span');
-  probe.style.color = color;
-  element.ownerDocument.body.append(probe);
-  const resolved = getComputedStyle(probe).color;
-  probe.remove();
-  return resolved;
-}
-
 function expectMediaHairline(element: Element | null) {
-  if (!element) throw new Error('item media not found');
-
-  const rootStyles = getComputedStyle(element.ownerDocument.documentElement);
-  const expectedColor = resolveCssColor(
-    element,
-    rootStyles.getPropertyValue('--nx-color-black-a200').trim()
-  );
-  const afterStyles = getComputedStyle(element, '::after');
-
-  expect(afterStyles.outlineStyle).toBe('solid');
-  expect(afterStyles.outlineWidth).toBe('1px');
-  expect(afterStyles.outlineOffset).toBe('-1px');
-  expect(afterStyles.outlineColor).toBe(expectedColor);
+  expectInsetOutlinePseudoElement(element, {
+    token: '--nx-color-border-hairline',
+    missingMessage: 'item media not found',
+  });
 }
 
 // A standard row: icon media, title + description, and a trailing action.
@@ -156,9 +139,7 @@ export const MediaImageHairline: Story = {
     const image = canvasElement.querySelector('img');
 
     expectMediaHairline(media);
-    await expect(image).not.toHaveClass(
-      'nx:after:outline-[var(--nx-color-black-a200)]'
-    );
+    await expect(image).not.toHaveClass('nx:after:outline-border-hairline');
   },
 };
 

--- a/packages/react/src/components/item/item.tsx
+++ b/packages/react/src/components/item/item.tsx
@@ -131,7 +131,7 @@ const itemMediaVariants = cva(
         default: 'nx:bg-transparent',
         icon: 'nx:size-8 nx:rounded-sm nx:border-default nx:border-border-default nx:bg-muted nx:[&_svg]:size-4',
         image:
-          'nx:size-10 nx:overflow-hidden nx:rounded-sm nx:[&_img]:size-full nx:[&_img]:object-cover',
+          'nx:relative nx:size-10 nx:overflow-hidden nx:rounded-sm nx:[&_img]:size-full nx:[&_img]:object-cover nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-black/10 nx:dark:after:outline-white/10',
       },
     },
     defaultVariants: {

--- a/packages/react/src/components/item/item.tsx
+++ b/packages/react/src/components/item/item.tsx
@@ -131,7 +131,7 @@ const itemMediaVariants = cva(
         default: 'nx:bg-transparent',
         icon: 'nx:size-8 nx:rounded-sm nx:border-default nx:border-border-default nx:bg-muted nx:[&_svg]:size-4',
         image:
-          'nx:relative nx:size-10 nx:overflow-hidden nx:rounded-sm nx:[&_img]:size-full nx:[&_img]:object-cover nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-[var(--nx-color-black-a200)] nx:dark:after:outline-[var(--nx-color-white-a200)]',
+          'nx:relative nx:size-10 nx:overflow-hidden nx:rounded-sm nx:[&_img]:size-full nx:[&_img]:object-cover nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-border-hairline',
       },
     },
     defaultVariants: {

--- a/packages/react/src/components/item/item.tsx
+++ b/packages/react/src/components/item/item.tsx
@@ -131,7 +131,7 @@ const itemMediaVariants = cva(
         default: 'nx:bg-transparent',
         icon: 'nx:size-8 nx:rounded-sm nx:border-default nx:border-border-default nx:bg-muted nx:[&_svg]:size-4',
         image:
-          'nx:relative nx:size-10 nx:overflow-hidden nx:rounded-sm nx:[&_img]:size-full nx:[&_img]:object-cover nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-black/10 nx:dark:after:outline-white/10',
+          'nx:relative nx:size-10 nx:overflow-hidden nx:rounded-sm nx:[&_img]:size-full nx:[&_img]:object-cover nx:after:pointer-events-none nx:after:absolute nx:after:inset-0 nx:after:rounded-[inherit] nx:after:outline nx:after:outline-1 nx:after:-outline-offset-1 nx:after:outline-[var(--nx-color-black-a200)] nx:dark:after:outline-[var(--nx-color-white-a200)]',
       },
     },
     defaultVariants: {

--- a/packages/react/src/stories/support/pseudo-element-style.ts
+++ b/packages/react/src/stories/support/pseudo-element-style.ts
@@ -1,0 +1,34 @@
+import { expect } from 'storybook/test';
+
+function resolveCssColor(element: Element, color: string) {
+  const probe = element.ownerDocument.createElement('span');
+  probe.style.color = color;
+  element.ownerDocument.body.append(probe);
+  const resolved = getComputedStyle(probe).color;
+  probe.remove();
+  return resolved;
+}
+
+export function expectInsetOutlinePseudoElement(
+  element: Element | null,
+  {
+    token,
+    missingMessage = 'element not found',
+  }: {
+    token: string;
+    missingMessage?: string;
+  }
+) {
+  if (!element) throw new Error(missingMessage);
+
+  const expectedColor = resolveCssColor(
+    element,
+    getComputedStyle(element).getPropertyValue(token).trim()
+  );
+  const afterStyles = getComputedStyle(element, '::after');
+
+  expect(afterStyles.outlineStyle).toBe('solid');
+  expect(afterStyles.outlineWidth).toBe('1px');
+  expect(afterStyles.outlineOffset).toBe('-1px');
+  expect(afterStyles.outlineColor).toBe(expectedColor);
+}

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -242,6 +242,10 @@
     --nx-color-border-default,
     var(--nx-color-black-a200)
   );
+  --color-border-hairline: var(
+    --nx-color-border-hairline,
+    var(--nx-color-black-a200)
+  );
   --color-border-default-alpha: var(
     --nx-color-border-default-alpha,
     var(--nx-color-stone-a200)
@@ -633,6 +637,10 @@
     --nx-color-border-default,
     var(--nx-color-black-a200)
   );
+  --color-border-hairline: var(
+    --nx-color-border-hairline,
+    var(--nx-color-black-a200)
+  );
   --color-border-default-alpha: var(
     --nx-color-border-default-alpha,
     var(--nx-color-stone-a200)
@@ -955,6 +963,7 @@
   --nx-color-nav-border: var(--nx-color-stone-800);
   --nx-color-overlay: var(--nx-color-stone-a800);
   --nx-color-border-default: var(--nx-color-white-a300);
+  --nx-color-border-hairline: var(--nx-color-white-a200);
   --nx-color-border-default-alpha: var(--nx-color-stone-a300);
   --nx-color-border-active: var(--nx-color-stone-400);
   --nx-color-border-disabled: var(--nx-color-white-a300);


### PR DESCRIPTION
## Summary

- Formalizes the Avatar and ItemMedia image edge as a semantic `border-hairline` color token, backed by pure black alpha in light mode and pure white alpha in dark mode.
- Keeps the floor-safe root/wrapper `::after` technique and switches both components to `nx:after:outline-border-hairline`.
- Extracts the duplicated story assertion code into a shared pseudo-element helper, with computed `::after` checks for outline style, width, offset, and resolved token color.
- Updates the seeded plan wording to match the final semantic-token implementation.

## GitHub Issue

Closes #596

## Review Fixes

- Addresses Principal Architect review 4629160218: removes the dead Tailwind palette hairline path and formalizes the edge as a semantic token instead of component-level primitive vars.
- Addresses SDE2 review 4629160425: verifies the actual rendered `::after` outline color instead of class presence.
- Addresses the optional SDE2 follow-up: removes duplicated `resolveCssColor` logic from Avatar and Item stories.
- Addresses the optional Architect follow-up: adds `border-hairline` as a semantic token and generated Tailwind utility.

## Test Plan

- [x] `corepack pnpm test packages/core/src/lib/derive-theme.test.ts packages/core/src/lib/tone-parity.test.ts packages/core/scripts/__tests__/generate-tailwind-package.test.js` (192 passed)
- [x] `corepack pnpm test:storybook packages/react/src/components/avatar/Avatar.stories.tsx packages/react/src/components/item/Item.stories.tsx` (42 passed)
- [x] `corepack pnpm lint`
- [x] `corepack pnpm format:check`
- [x] `PATH=/private/tmp/nexus-corepack-pnpm-wrapper:$PATH corepack pnpm typecheck`
- [x] `corepack pnpm test:storybook` (734 passed; chart stories still emit existing Recharts zero-size stderr warnings)
- [x] `corepack pnpm audit:browser-support`
- [x] `corepack pnpm audit:contrast`
- [x] `corepack pnpm --filter @nexus_ds/core audit:colorblind`
- [x] `corepack pnpm tokens:tailwind`
- [x] `corepack pnpm tokens:modular`
- [x] `corepack pnpm --filter @nexus_ds/core audit:class-refs`
- [x] `corepack pnpm audit:mode-codenames`
- [x] `corepack pnpm audit:mode-distinctness`
- [ ] Safari manual visual recapture not run in this environment; computed light/dark pseudo-element assertions and browser-support audit passed.

## polish.md Evidence

- Modern Web Guidance gate: attempted `npm_config_fetch_retries=0 npx -y modern-web-guidance@latest search "image outline pseudo-element inset hairline border radius CSS" --skill-version 2026_05_16-c5e7870`; the unsandboxed retry was rejected by the safety reviewer because unpinned third-party `npx` execution can run arbitrary external code. Fallback used the repo-local Modern Web Guidance skill plus the approved plan and Nexus browser floor.
- Browser-floor decision: kept the hairline on the root/wrapper `::after` using `outline`, `outline-offset`, `inset: 0`, `border-radius: inherit`, and CSS custom properties. These are floor-safe for Chrome/Edge 111+, Firefox 113+, Safari 15.4+, and Samsung Internet 22+; `audit:browser-support` passed.
- Rendered-result proof: Avatar and Item stories now assert `getComputedStyle(element, "::after")` for solid 1px inset outline and resolved `--nx-color-border-hairline`, including scoped dark-mode containers.
- Reduced motion proof: not applicable; this workstream adds no motion or animation.
