### PR TITLE
feat(polish): Button scale-on-press (default-on, reduced-motion-safe) (#597)

### DIFF
--- a/docs/superpowers/plans/2026-07-02-597-button-scale-on-press.md
+++ b/docs/superpowers/plans/2026-07-02-597-button-scale-on-press.md
@@ -1,0 +1,146 @@
+# Button Scale-on-Press Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Workstream D / issue #597 — give every Button a subtle tactile shrink (`scale(0.96)`) on press, default-on, layered on top of the existing color-darken cue, suppressed under reduced motion, and excluded from the text-only `link` variant.
+
+**Architecture:** Add `nx:active:scale-[0.96]` to the `buttonVariants` base and widen the base transition to include `scale`; add `nx:motion-reduce:active:scale-100` so reduced-motion users get no shrink (there is no global motion reset). The `link` variant opts out with `nx:active:scale-100`. `scale` is a GPU-composited transform (floor-safe). Verified by class-presence stories; reduced-motion proven by a `motion-reduce` assertion.
+
+**Tech Stack:** React, Tailwind v4 (`nx:` prefix, `active:`/`motion-reduce:` variants, arbitrary `scale-[0.96]`), CVA, Storybook 10 (`storybook/test`).
+
+## Global Constraints
+
+- **Default-on** across all variants **except `link`** (text — a shrink reads wrong).
+- **Layer on top of** the existing `active:bg-*` press cue — do not replace it.
+- **Reduced motion:** `nx:motion-reduce:active:scale-100` (no global reset exists).
+- **No `transition: all`** — the base transition lists exact properties.
+- **Motion tokens:** `scale` is a transform; document the desired duration/easing-token relationship for #159 (do not invent a new scale). `nx:` prefix before every modifier; semantic tokens only.
+- **Tests are stories.** **Pre-production:** change in place. **PR:** `feat(polish): …`, base `main`, body `Closes #597`, Summary + Test Plan + polish.md evidence (incl. reduced-motion).
+
+---
+
+## File Structure
+
+- `packages/react/src/components/button/button.tsx:11` — base cva: add `active:scale-[0.96]` + reduced-motion opt-out; widen transition to include `scale`.
+- `packages/react/src/components/button/button.tsx:29` — `link` variant: opt out with `active:scale-100`.
+- `packages/react/src/components/button/Button.stories.tsx` — class-presence stories (default press + reduced-motion opt-out + link exclusion).
+
+---
+
+### Task 1: Scale-on-press on the base, opt out `link`
+
+**Files:** `button.tsx:11`, `button.tsx:29`, `Button.stories.tsx`.
+
+**Interfaces:** Consumes — nothing. Produces — nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `Button.stories.tsx` (reuse existing `Button` import + `expect` from `storybook/test`):
+
+```tsx
+export const PressScale: Story = {
+  render: () => (
+    <div>
+      <Button>Default</Button>
+      <Button variant="link">Link</Button>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const [primary, link] = canvasElement.querySelectorAll(
+      '[data-slot="button"]'
+    );
+    // Default button shrinks on press, suppressed under reduced motion.
+    await expect(primary).toHaveClass('nx:active:scale-[0.96]');
+    await expect(primary).toHaveClass('nx:motion-reduce:active:scale-100');
+    // Link opts out.
+    await expect(link).toHaveClass('nx:active:scale-100');
+  },
+};
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm test:storybook button`
+Expected: FAIL — no scale classes present yet.
+
+- [ ] **Step 3: Implement**
+
+In `packages/react/src/components/button/button.tsx`, in the base cva string (line 11), replace `nx:transition-colors` with:
+
+```
+nx:transition-[color,background-color,border-color,scale] nx:active:scale-[0.96] nx:motion-reduce:active:scale-100
+```
+
+So the relevant span of the base string changes from:
+
+```
+nx:whitespace-nowrap nx:transition-colors nx:focus-visible:outline-2
+```
+
+to:
+
+```
+nx:whitespace-nowrap nx:transition-[color,background-color,border-color,scale] nx:active:scale-[0.96] nx:motion-reduce:active:scale-100 nx:focus-visible:outline-2
+```
+
+Then, in the `link` variant (line 29), append `nx:active:scale-100` so link text does not shrink:
+
+```tsx
+        link: 'nx:border-0 nx:text-primary-subtle-foreground nx:underline-offset-4 nx:hover:underline nx:active:scale-100 nx:disabled:text-disabled-foreground nx:aria-disabled:text-disabled-foreground',
+```
+
+(CVA appends the variant class after the base, so `active:scale-100` wins over the base `active:scale-[0.96]` for `link`.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm test:storybook button`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/react/src/components/button
+git commit -m "feat(button): tactile scale-on-press (0.96), reduced-motion-safe, link excluded"
+```
+
+---
+
+### Task 2: Validate and open the PR
+
+- [ ] **Step 1:** `pnpm lint && pnpm format:check && pnpm typecheck && pnpm test:storybook` — all green. Confirm the existing Button stories still pass (the new transition list must not drop a previously-animated color state — it covers color/background-color/border-color).
+- [ ] **Step 2:** Open the PR:
+
+```bash
+git push -u origin <branch>
+gh pr create --base main \
+  --title "feat(polish): Button scale-on-press (default-on, reduced-motion-safe)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Every Button (except the text `link` variant) shrinks to `scale(0.96)` on press for tactile feedback, layered on top of the existing `active:bg-*` cue.
+- Suppressed under `prefers-reduced-motion` via `motion-reduce:active:scale-100`; base transition lists exact properties (no `transition: all`).
+
+## GitHub Issue
+Closes #597
+
+## Test Plan
+- [ ] lint / format:check / typecheck / test:storybook green
+- [ ] Story asserts `active:scale-[0.96]` + `motion-reduce:active:scale-100` on default, `active:scale-100` on link
+
+## Modern Web Guidance
+- `scale` is a GPU-composited transform (web.dev high-perf animations); floor-safe. Reduced-motion honored per MDN `prefers-reduced-motion`. Duration/easing to align with motion tokens (#159); no parallel scale introduced.
+
+## Note
+- Benchmarks (Linear/Stripe/Geist) don't scale buttons on press — this was an explicit product decision to adopt it. Sanity-check the feel in review.
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (#597):** default-on `active:scale-[0.96]` (Task 1), reduced-motion opt-out, specific transition (no `transition: all`), `link` excluded, layered on existing cue. No gaps.
+
+**Placeholder scan:** exact before/after for both the base and `link` variant; test code complete.
+
+**Type/name consistency:** `data-slot="button"` (button.tsx:195) matches; asserted classes `nx:active:scale-[0.96]`, `nx:motion-reduce:active:scale-100`, `nx:active:scale-100` are byte-identical to the impl step.

--- a/docs/superpowers/plans/2026-07-02-597-button-scale-on-press.md
+++ b/docs/superpowers/plans/2026-07-02-597-button-scale-on-press.md
@@ -14,7 +14,7 @@
 - **Layer on top of** the existing `active:bg-*` press cue — do not replace it.
 - **Reduced motion:** `nx:motion-reduce:active:scale-100` (no global reset exists).
 - **No `transition: all`** — the base transition lists exact properties.
-- **Motion tokens:** `scale` is a transform; document the desired duration/easing-token relationship for #159 (do not invent a new scale). `nx:` prefix before every modifier; semantic tokens only.
+- **Motion tokens:** the transition uses the existing token-backed default duration/easing; `scale-[0.96]` is the Button-local press distance. Do not invent a new motion scale. `nx:` prefix before every modifier; semantic tokens only.
 - **Tests are stories.** **Pre-production:** change in place. **PR:** `feat(polish): …`, base `main`, body `Closes #597`, Summary + Test Plan + polish.md evidence (incl. reduced-motion).
 
 ---
@@ -54,6 +54,7 @@ export const PressScale: Story = {
     await expect(primary).toHaveClass('nx:motion-reduce:active:scale-100');
     // Link opts out.
     await expect(link).toHaveClass('nx:active:scale-100');
+    await expect(link).not.toHaveClass('nx:active:scale-[0.96]');
   },
 };
 ```
@@ -89,7 +90,7 @@ Then, in the `link` variant (line 29), append `nx:active:scale-100` so link text
         link: 'nx:border-0 nx:text-primary-subtle-foreground nx:underline-offset-4 nx:hover:underline nx:active:scale-100 nx:disabled:text-disabled-foreground nx:aria-disabled:text-disabled-foreground',
 ```
 
-(CVA appends the variant class after the base, so `active:scale-100` wins over the base `active:scale-[0.96]` for `link`.)
+(CVA appends the variant class after the base, so `active:scale-100` wins over the base `active:scale-[0.96]` for `link`; `cn()`/tailwind-merge collapses the conflicting scale utility before the CSS cascade needs to arbitrate it.)
 
 - [ ] **Step 4: Run to verify it passes**
 
@@ -124,10 +125,10 @@ Closes #597
 
 ## Test Plan
 - [ ] lint / format:check / typecheck / test:storybook green
-- [ ] Story asserts `active:scale-[0.96]` + `motion-reduce:active:scale-100` on default, `active:scale-100` on link
+- [ ] Story asserts `active:scale-[0.96]` + `motion-reduce:active:scale-100` on default, and `active:scale-100` without `active:scale-[0.96]` on link
 
 ## Modern Web Guidance
-- `scale` is a GPU-composited transform (web.dev high-perf animations); floor-safe. Reduced-motion honored per MDN `prefers-reduced-motion`. Duration/easing to align with motion tokens (#159); no parallel scale introduced.
+- `scale` is a GPU-composited transform (web.dev high-perf animations); floor-safe. Reduced-motion honored per MDN `prefers-reduced-motion`. Uses the existing token-backed default duration/easing; no parallel motion scale introduced.
 
 ## Note
 - Benchmarks (Linear/Stripe/Geist) don't scale buttons on press — this was an explicit product decision to adopt it. Sanity-check the feel in review.

--- a/packages/react/src/components/button/Button.stories.tsx
+++ b/packages/react/src/components/button/Button.stories.tsx
@@ -480,6 +480,24 @@ export const FocusManagement: Story = {
   },
 };
 
+export const PressScale: Story = {
+  render: () => (
+    <div>
+      <Button>Default</Button>
+      <Button variant="link">Link</Button>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const [primary, link] = canvasElement.querySelectorAll(
+      '[data-slot="button"]'
+    );
+
+    await expect(primary).toHaveClass('nx:active:scale-[0.96]');
+    await expect(primary).toHaveClass('nx:motion-reduce:active:scale-100');
+    await expect(link).toHaveClass('nx:active:scale-100');
+  },
+};
+
 // ============================================
 // PROPS & ATTRIBUTES TESTS
 // ============================================

--- a/packages/react/src/components/button/Button.stories.tsx
+++ b/packages/react/src/components/button/Button.stories.tsx
@@ -495,6 +495,7 @@ export const PressScale: Story = {
     await expect(primary).toHaveClass('nx:active:scale-[0.96]');
     await expect(primary).toHaveClass('nx:motion-reduce:active:scale-100');
     await expect(link).toHaveClass('nx:active:scale-100');
+    await expect(link).not.toHaveClass('nx:active:scale-[0.96]');
   },
 };
 

--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -8,7 +8,7 @@ import { Spinner } from '@/components/spinner';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'nx:inline-flex nx:box-border nx:cursor-pointer nx:items-center nx:justify-center nx:rounded-base nx:border-default nx:border-transparent nx:whitespace-nowrap nx:transition-colors nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:pointer-events-none nx:disabled:cursor-default nx:disabled:opacity-100 nx:aria-disabled:pointer-events-none nx:aria-disabled:cursor-default nx:aria-disabled:opacity-100 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-3.5 nx:[&_svg]:shrink-0',
+  'nx:inline-flex nx:box-border nx:cursor-pointer nx:items-center nx:justify-center nx:rounded-base nx:border-default nx:border-transparent nx:whitespace-nowrap nx:transition-[color,background-color,border-color,scale] nx:active:scale-[0.96] nx:motion-reduce:active:scale-100 nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:pointer-events-none nx:disabled:cursor-default nx:disabled:opacity-100 nx:aria-disabled:pointer-events-none nx:aria-disabled:cursor-default nx:aria-disabled:opacity-100 nx:[&_svg]:pointer-events-none nx:[&_svg]:size-3.5 nx:[&_svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -26,7 +26,7 @@ const buttonVariants = cva(
           'nx:bg-secondary-background nx:text-secondary-foreground nx:hover:bg-secondary-background-hover nx:active:bg-secondary-background-active nx:disabled:bg-secondary-disabled nx:aria-disabled:bg-secondary-disabled',
         ghost:
           'nx:text-foreground nx:hover:bg-container-hover nx:active:bg-container-active nx:disabled:text-disabled-foreground nx:aria-disabled:text-disabled-foreground',
-        link: 'nx:border-0 nx:text-primary-subtle-foreground nx:underline-offset-4 nx:hover:underline nx:disabled:text-disabled-foreground nx:aria-disabled:text-disabled-foreground',
+        link: 'nx:border-0 nx:text-primary-subtle-foreground nx:underline-offset-4 nx:hover:underline nx:active:scale-100 nx:disabled:text-disabled-foreground nx:aria-disabled:text-disabled-foreground',
       },
       size: {
         sm: 'nx:h-8 nx:px-2.5 nx:gap-1 nx:typography-label-default',


### PR DESCRIPTION
## Summary

- Adds default-on `nx:active:scale-[0.96]` to Button for a tactile press response, layered on top of the existing `active:bg-*` cue.
- Replaces base `nx:transition-colors` with `nx:transition-[color,background-color,border-color,scale]` so the transition stays explicit and never becomes `transition: all`.
- Adds `nx:motion-reduce:active:scale-100` for reduced-motion suppression.
- Opts the text-only `link` variant out with `nx:active:scale-100`.
- Adds a `PressScale` Storybook play assertion covering default scale, reduced-motion override, and link exclusion, including a guard that `nx:active:scale-[0.96]` does not leak into links.

## GitHub Issue

Closes #597

## Test Plan

- [x] TDD red: `corepack pnpm test:storybook button` failed on the new `PressScale` assertions before implementation.
- [x] TDD green: `corepack pnpm test:storybook button`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm format:check`
- [x] `PATH=/private/tmp/nexus-corepack-pnpm-wrapper:$PATH corepack pnpm typecheck`
- [x] `corepack pnpm test:storybook`
- [x] `corepack pnpm audit:browser-support`
- [x] Review follow-up: `corepack pnpm format:check`
- [x] Review follow-up: `corepack pnpm test:storybook packages/react/src/components/button/Button.stories.tsx` (40 passed)
- [ ] `corepack pnpm --filter @nexus/core audit:contrast` / `audit:colorblind` - not run; no token files changed.

## polish.md Evidence

- Modern Web Guidance gate: attempted `npm_config_fetch_retries=0 npx -y modern-web-guidance@latest search "button press scale transform prefers reduced motion transition properties" --skill-version 2026_05_16-c5e7870`; sandboxed run failed with `ENOTFOUND registry.npmjs.org`, and the unsandboxed retry was rejected because it would execute an unpinned third-party package. Fallback used the repo-local Modern Web Guidance skill plus the approved Workstream D plan.
- Browser-floor decision: `scale` / transform-based press feedback and `prefers-reduced-motion` are floor-safe for the Nexus browser floor; `corepack pnpm audit:browser-support` passed.
- Reduced-motion proof: `PressScale` asserts `nx:motion-reduce:active:scale-100` on the default Button.
- No `transition: all`: base Button uses `nx:transition-[color,background-color,border-color,scale]`.
- Motion-token relationship: no new duration/easing scale was introduced; the press transform uses the existing Button transition timing. `scale-[0.96]` is intentionally Button-local.
- Benchmark note: Linear, Stripe, and Geist do not scale ordinary buttons on press; this remains an explicit Nexus product decision and should be sanity-checked in review.
