### PR TITLE
feat(polish): typography base polish

### DIFF
--- a/apps/docs/public/themes/typography-utilities.css
+++ b/apps/docs/public/themes/typography-utilities.css
@@ -6,6 +6,7 @@
   font-weight: var(--nx-typography-weight-semibold);
   line-height: var(--nx-typography-line-height-3xl);
   letter-spacing: var(--nx-typography-letterspacing-normal);
+  text-wrap: balance;
 }
 
 @utility typography-heading-medium {
@@ -14,6 +15,7 @@
   font-weight: var(--nx-typography-weight-semibold);
   line-height: var(--nx-typography-line-height-2xl);
   letter-spacing: var(--nx-typography-letterspacing-normal);
+  text-wrap: balance;
 }
 
 @utility typography-heading-small {
@@ -22,6 +24,7 @@
   font-weight: var(--nx-typography-weight-semibold);
   line-height: var(--nx-typography-line-height-xl);
   letter-spacing: var(--nx-typography-letterspacing-normal);
+  text-wrap: balance;
 }
 
 @utility typography-heading-xsmall {
@@ -30,6 +33,7 @@
   font-weight: var(--nx-typography-weight-semibold);
   line-height: var(--nx-typography-line-height-lg);
   letter-spacing: var(--nx-typography-letterspacing-normal);
+  text-wrap: balance;
 }
 
 @utility typography-body-default {

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -398,6 +398,14 @@ describe('generateTailwindPackage', () => {
     expect(typographyCSS).not.toMatch(/line-height: auto/);
   });
 
+  it('emits balanced wrapping on heading typography utilities', () => {
+    const block = extractBlock(
+      typographyCSS,
+      '@utility typography-heading-large'
+    );
+    expect(block).toMatch(/text-wrap: balance;/);
+  });
+
   it('emits typography-shortcut from the shortcut composite token', () => {
     const block = extractBlock(typographyCSS, '@utility typography-shortcut');
     expect(block).toMatch(

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -696,6 +696,10 @@ export function generateTypographyUtilitiesCSS(tokensDir, primitiveMap) {
       css += `  letter-spacing: ${resolveTypographyProperty(value.letterSpacing, primitiveMap)};\n`;
     }
 
+    if (token.path[0] === 'heading') {
+      css += `  text-wrap: balance;\n`;
+    }
+
     if (token.path[0] === 'body') {
       // orphan/widow protection for multi-line copy
       css += `  text-wrap: pretty;\n`;

--- a/packages/core/src/lib/appearance-model.test.ts
+++ b/packages/core/src/lib/appearance-model.test.ts
@@ -318,6 +318,22 @@ describe('appearancePrefsToCss', () => {
     expect(css).toContain('-webkit-font-smoothing: antialiased');
   });
 
+  it('pairs -moz-osx-font-smoothing with the -webkit property', () => {
+    const on = appearancePrefsToCss({
+      ...prefs,
+      fontSmoothing: true,
+    });
+    expect(on).toContain('-webkit-font-smoothing: antialiased');
+    expect(on).toContain('-moz-osx-font-smoothing: grayscale');
+
+    const off = appearancePrefsToCss({
+      ...prefs,
+      fontSmoothing: false,
+    });
+    expect(off).toContain('-webkit-font-smoothing: auto');
+    expect(off).toContain('-moz-osx-font-smoothing: auto');
+  });
+
   it('keeps default runtime typography variables in parity with generated tokens', () => {
     const generatedCss = readFileSync(
       resolve(process.cwd(), 'packages/tailwind/variables.css'),

--- a/packages/core/src/lib/appearance-model.ts
+++ b/packages/core/src/lib/appearance-model.ts
@@ -341,7 +341,7 @@ export function appearancePrefsToCss(prefs: NexusAppearancePrefs): string {
 ${typographyScaleVariables(uiPx)}
 }`,
     `code, pre, .nx\\:font-mono, .nx\\:typography-code-block, .nx\\:typography-code-inline { font-size: ${codePx}px; }`,
-    `html { -webkit-font-smoothing: ${prefs.fontSmoothing ? 'antialiased' : 'auto'}; }`,
+    `html { -webkit-font-smoothing: ${prefs.fontSmoothing ? 'antialiased' : 'auto'}; -moz-osx-font-smoothing: ${prefs.fontSmoothing ? 'grayscale' : 'auto'}; }`,
   ];
   if (prefs.pointerCursors) {
     blocks.push(

--- a/packages/react/src/components/chart/Chart.stories.tsx
+++ b/packages/react/src/components/chart/Chart.stories.tsx
@@ -202,6 +202,43 @@ export const WithDataAttributes: Story = {
   },
 };
 
+export const AxisTicksTabular: Story = {
+  render: () => (
+    <div className="nx:w-[600px] nx:max-w-full">
+      <ChartContainer config={config}>
+        <LineChart
+          accessibilityLayer
+          data={data}
+          margin={{ left: 12, right: 12 }}
+        >
+          <CartesianGrid vertical={false} />
+          <XAxis
+            dataKey="month"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            tickFormatter={shortMonth}
+          />
+          <Line
+            dataKey="desktop"
+            type="natural"
+            stroke="var(--color-desktop)"
+            strokeWidth={2}
+            dot={false}
+          />
+        </LineChart>
+      </ChartContainer>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const chart = canvasElement.querySelector('[data-slot="chart"]');
+
+    await expect(chart).toHaveClass(
+      'nx:[&_.recharts-cartesian-axis-tick_text]:tabular-nums'
+    );
+  },
+};
+
 export const DynamicStyleGuard: Story = {
   render: () => (
     <div className="nx:w-[600px] nx:max-w-full">

--- a/packages/react/src/components/chart/chart.tsx
+++ b/packages/react/src/components/chart/chart.tsx
@@ -72,7 +72,7 @@ function ChartContainer({
         data-slot="chart"
         data-chart={chartId}
         className={cn(
-          "nx:flex nx:aspect-video nx:justify-center nx:typography-body-small nx:[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground nx:[&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border-default nx:[&_.recharts-curve.recharts-tooltip-cursor]:stroke-border-default nx:[&_.recharts-dot[stroke='#fff']]:stroke-transparent nx:[&_.recharts-layer]:outline-hidden nx:[&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border-default nx:[&_.recharts-radial-bar-background-sector]:fill-muted nx:[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted nx:[&_.recharts-reference-line_[stroke='#ccc']]:stroke-border-default nx:[&_.recharts-sector]:outline-hidden nx:[&_.recharts-sector[stroke='#fff']]:stroke-transparent nx:[&_.recharts-surface]:outline-hidden",
+          "nx:flex nx:aspect-video nx:justify-center nx:typography-body-small nx:[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground nx:[&_.recharts-cartesian-axis-tick_text]:tabular-nums nx:[&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border-default nx:[&_.recharts-curve.recharts-tooltip-cursor]:stroke-border-default nx:[&_.recharts-dot[stroke='#fff']]:stroke-transparent nx:[&_.recharts-layer]:outline-hidden nx:[&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border-default nx:[&_.recharts-radial-bar-background-sector]:fill-muted nx:[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted nx:[&_.recharts-reference-line_[stroke='#ccc']]:stroke-border-default nx:[&_.recharts-sector]:outline-hidden nx:[&_.recharts-sector[stroke='#fff']]:stroke-transparent nx:[&_.recharts-surface]:outline-hidden",
           className
         )}
         style={chartStyle}

--- a/packages/react/src/components/input-otp/InputOtp.stories.tsx
+++ b/packages/react/src/components/input-otp/InputOtp.stories.tsx
@@ -132,6 +132,27 @@ export const ClickInteraction: Story = {
   },
 };
 
+export const TransitionScoped: Story = {
+  render: () => (
+    <InputOTP maxLength={4} aria-label="One-time password">
+      <InputOTPGroup>
+        <InputOTPSlot index={0} />
+        <InputOTPSlot index={1} />
+        <InputOTPSlot index={2} />
+        <InputOTPSlot index={3} />
+      </InputOTPGroup>
+    </InputOTP>
+  ),
+  play: async ({ canvasElement }) => {
+    const slot = canvasElement.querySelector('[data-slot="input-otp-slot"]');
+
+    await expect(slot).not.toHaveClass('nx:transition-all');
+    await expect(slot).toHaveClass(
+      'nx:transition-[color,background-color,border-color]'
+    );
+  },
+};
+
 export const KeyboardInteraction: Story = {
   play: async ({ canvasElement, args }) => {
     const input = canvasElement.querySelector<HTMLInputElement>(

--- a/packages/react/src/components/input-otp/input-otp.tsx
+++ b/packages/react/src/components/input-otp/input-otp.tsx
@@ -120,7 +120,7 @@ function InputOTPSlot({ index, className, ...props }: InputOTPSlotProps) {
         'nx:relative nx:flex nx:size-10 nx:items-center nx:justify-center',
         'nx:border-y-default nx:border-r-default nx:border-border-default',
         'nx:group-has-[:disabled]/input-otp:border-border-disabled nx:group-has-[:disabled]/input-otp:bg-disabled nx:group-has-[:disabled]/input-otp:text-disabled-foreground',
-        'nx:bg-background nx:text-foreground nx:typography-body-small nx:transition-all nx:duration-fast nx:motion-reduce:transition-none',
+        'nx:bg-background nx:text-foreground nx:typography-body-small nx:transition-[color,background-color,border-color] nx:duration-fast nx:motion-reduce:transition-none',
         'nx:first:rounded-l-md nx:first:border-l-default nx:last:rounded-r-md',
         'nx:data-[active=true]:z-10 nx:data-[active=true]:outline-2 nx:data-[active=true]:outline-focus-default nx:data-[active=true]:outline-offset-(--focus-offset)',
         className

--- a/packages/react/src/components/progress/Progress.stories.tsx
+++ b/packages/react/src/components/progress/Progress.stories.tsx
@@ -123,7 +123,7 @@ export const AllVariants: Story = {
     <div className="nx:flex nx:flex-col nx:gap-6">
       {[0, 25, 50, 75, 100].map((pct) => (
         <div key={pct} className="nx:flex nx:flex-col nx:gap-2">
-          <span className="nx:typography-label-default nx:text-muted-foreground">
+          <span className="nx:typography-label-default nx:tabular-nums nx:text-muted-foreground">
             {pct}%
           </span>
           <Progress value={pct} aria-label={`${pct}% complete`} />

--- a/packages/react/src/stories/Typography.stories.tsx
+++ b/packages/react/src/stories/Typography.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect } from 'storybook/test';
 
 import {
   tokenValue,
@@ -342,4 +343,27 @@ export const CompositeUtilities: Story = {
       ))}
     </div>
   ),
+};
+
+export const HeadingsBalance: Story = {
+  render: () => (
+    <h2
+      data-testid="balanced-heading"
+      className="nx:typography-heading-large"
+      style={{ inlineSize: '18rem' }}
+    >
+      A deliberately long heading that wraps onto multiple lines
+    </h2>
+  ),
+  play: async ({ canvasElement }) => {
+    const heading = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="balanced-heading"]'
+    );
+    const style = getComputedStyle(heading!);
+    const wrap =
+      style.getPropertyValue('text-wrap-style') ||
+      style.getPropertyValue('text-wrap');
+
+    await expect(wrap).toContain('balance');
+  },
 };

--- a/packages/tailwind/typography-utilities.css
+++ b/packages/tailwind/typography-utilities.css
@@ -6,6 +6,7 @@
   font-weight: var(--nx-typography-weight-semibold);
   line-height: var(--nx-typography-line-height-3xl);
   letter-spacing: var(--nx-typography-letterspacing-normal);
+  text-wrap: balance;
 }
 
 @utility typography-heading-medium {
@@ -14,6 +15,7 @@
   font-weight: var(--nx-typography-weight-semibold);
   line-height: var(--nx-typography-line-height-2xl);
   letter-spacing: var(--nx-typography-letterspacing-normal);
+  text-wrap: balance;
 }
 
 @utility typography-heading-small {
@@ -22,6 +24,7 @@
   font-weight: var(--nx-typography-weight-semibold);
   line-height: var(--nx-typography-line-height-xl);
   letter-spacing: var(--nx-typography-letterspacing-normal);
+  text-wrap: balance;
 }
 
 @utility typography-heading-xsmall {
@@ -30,6 +33,7 @@
   font-weight: var(--nx-typography-weight-semibold);
   line-height: var(--nx-typography-line-height-lg);
   letter-spacing: var(--nx-typography-letterspacing-normal);
+  text-wrap: balance;
 }
 
 @utility typography-body-default {


### PR DESCRIPTION
## Summary

- Add `text-wrap: balance` to the four `typography-heading-*` utilities and prove it with a Typography story computed-style assertion.
- Pair `-moz-osx-font-smoothing` with the existing `-webkit-font-smoothing` emission in `appearancePrefsToCss`.
- Add `tabular-nums` to Recharts cartesian axis ticks and the Progress percentage demo readout.
- Replace the InputOTP slot `transition-all` with an explicit color/background/border transition and story coverage.

## GitHub Issue

Closes #594

## Test Plan

- [x] `corepack pnpm lint`
- [x] `corepack pnpm format:check`
- [x] `PATH=/private/tmp/nexus-corepack-pnpm-wrapper:$PATH corepack pnpm typecheck` - 7/7 Turbo tasks passed; wrapper keeps child tasks on repo-pinned pnpm 10.12.1.
- [x] `corepack pnpm test:unit` - 39 files / 715 tests passed.
- [x] `corepack pnpm audit:browser-support`
- [x] `corepack pnpm test:storybook` - 62 files / 734 tests passed.

## Polish Evidence

- Modern Web Guidance: attempted `npx -y modern-web-guidance@latest search "text-wrap balance font smoothing tabular nums CSS transitions React Tailwind component typography" --skill-version 2026_05_16-c5e7870`; sandboxed run failed with `ENOTFOUND registry.npmjs.org`, and the escalated public-registry package execution was rejected by policy. Per `polish.md`, used the repo-local guide `.agents/skills/modern-web-guidance/guides/user-experience/improve-text-layout-and-legibility.md` plus `.agents/skills/modern-web-guidance/guides/css/css.md`.
- Browser-floor decision: `text-wrap: balance` is below the Nexus floor for Safari 15.4 and Firefox 113, so this PR treats it as progressive enhancement only. Unsupported browsers ignore the declaration and keep normal wrapping. `tabular-nums`, font smoothing declarations, and explicit CSS transition properties do not require new fallbacks for the stated floor.
- Fallback / progressive enhancement: headings remain readable with default wrapping where `text-wrap: balance` is unsupported; no behavior depends on support.
- Reduced motion: this workstream introduces no new motion; the existing InputOTP `nx:motion-reduce:transition-none` guard remains in place and the new transition is scoped away from `transition-all`.
- Rejected approaches: did not apply `text-wrap: balance` globally, did not add `tabular-nums` to `TableCell`, did not add any token or API, and did not keep `transition-all`.
- Deliberately left out: optional tabular-number polish for date-picker / pagination / avatar counts from the source spec remains outside this scoped #594 PR.
