### PR TITLE
feat(motion): contextual icon cross-fade for selection indicators (E2 of #598)

### DIFF
--- a/docs/superpowers/plans/2026-07-02-598-e2-icon-crossfade.md
+++ b/docs/superpowers/plans/2026-07-02-598-e2-icon-crossfade.md
@@ -1,0 +1,152 @@
+# E2 — Contextual Icon Cross-Fade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Workstream E principle #7 (part of issue #598) — replace hard-swapped selection indicators (`hidden` ↔ `block`, or Radix mount/unmount) with an opacity + scale cross-fade, so checks/dots ease in instead of popping.
+
+**Architecture:** Keep both glyphs in the DOM and cross-fade with a CSS transition on the existing `ease`/`duration` tokens — no Framer Motion. Checkbox is the clean worked example (both icons already rendered). For Radix `Indicator` (radio, Select/DropdownMenu item) that mounts only when selected, `forceMount` the indicator and drive opacity from the parent's `data-[state]` so the exit can animate too. Every effect is `nx:motion-reduce:`-guarded.
+
+**Tech Stack:** React, Tailwind v4 (`nx:` prefix, `group-data-[state=*]:`, `transition-[opacity,transform]`), Radix (Checkbox/RadioGroup/Select/DropdownMenu indicators), Storybook 10 (`storybook/test`).
+
+## Global Constraints
+
+- Existing motion tokens (`nx:duration-fast`, `nx:ease-enter`); `nx:motion-reduce:transition-none` on every icon.
+- `nx:` prefix before every modifier; semantic tokens only. **Pre-production.** **PR:** `feat(motion): …`, base `main`, body references `#598` (sub-PR 2 of 4).
+
+---
+
+## File Structure
+
+- `packages/react/src/components/checkbox/checkbox.tsx:85,90,95` — indicator wrapper + IconCheck/IconMinus.
+- `packages/react/src/components/radio-group/radio-group.tsx:69,80` — item root (`group`) + Indicator.
+- `packages/react/src/components/select/select.tsx:266-268` and `dropdown-menu/dropdown-menu.tsx:313-315,363-365` — `ItemIndicator`.
+- Stories: `Checkbox.stories.tsx`, `RadioGroup.stories.tsx`, `Select.stories.tsx`, `DropdownMenu.stories.tsx`.
+
+---
+
+### Task 1: Checkbox check/minus cross-fade (worked example)
+
+**Files:** `checkbox.tsx:85,90,95`, `Checkbox.stories.tsx`.
+
+- [ ] **Step 1: Write the failing test** — add to `Checkbox.stories.tsx`:
+
+```tsx
+export const IndicatorCrossFade: Story = {
+  render: () => <Checkbox defaultChecked aria-label="Accept" />,
+  play: async ({ canvasElement }) => {
+    const check = canvasElement.querySelector('[data-slot="checkbox-check"]');
+    await expect(check).not.toHaveClass('nx:hidden');
+    await expect(check).toHaveClass('nx:transition-[opacity,transform]');
+    await expect(check).toHaveClass(
+      'nx:group-data-[state=checked]:opacity-100'
+    );
+    await expect(check).toHaveClass('nx:motion-reduce:transition-none');
+  },
+};
+```
+
+- [ ] **Step 2: Run — FAIL.** `pnpm test:storybook checkbox`
+
+- [ ] **Step 3: Implement.** In `checkbox.tsx`:
+
+Indicator wrapper (line 85) — add `nx:relative`:
+
+```tsx
+className =
+  'nx:relative nx:flex nx:items-center nx:justify-center nx:text-current';
+```
+
+IconCheck (line 90) — replace `'nx:hidden nx:size-3.5 nx:group-data-[state=checked]:block'` with:
+
+```tsx
+className =
+  'nx:absolute nx:size-3.5 nx:opacity-0 nx:scale-50 nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:group-data-[state=checked]:opacity-100 nx:group-data-[state=checked]:scale-100 nx:motion-reduce:transition-none';
+```
+
+IconMinus (line 95) — replace `'nx:hidden nx:size-3.5 nx:group-data-[state=indeterminate]:block'` with:
+
+```tsx
+className =
+  'nx:absolute nx:size-3.5 nx:opacity-0 nx:scale-50 nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:group-data-[state=indeterminate]:opacity-100 nx:group-data-[state=indeterminate]:scale-100 nx:motion-reduce:transition-none';
+```
+
+- [ ] **Step 4: Run — PASS.** `pnpm test:storybook checkbox`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/react/src/components/checkbox
+git commit -m "feat(motion): cross-fade checkbox check/minus indicators (#598)"
+```
+
+---
+
+### Task 2: Radio + Select/DropdownMenu indicators (forceMount recipe)
+
+**Files:** `radio-group.tsx:69,80`, `select.tsx:266-268`, `dropdown-menu.tsx:313-315,363-365` + stories.
+
+Radix `Indicator` / `ItemIndicator` mount only when selected, so a cross-fade _out_ needs `forceMount` + opacity driven by the parent's `data-[state]`.
+
+**Radio recipe** (radio-group.tsx):
+
+- Item root (line 69) — add `nx:group` to the class list so children can read `group-data-[state=checked]`.
+- Indicator (line 80) — add `forceMount` and cross-fade the `IconCircleFilled`:
+
+```tsx
+<RadioGroupPrimitive.Indicator
+  forceMount
+  data-slot="radio-group-indicator"
+  className="nx:flex nx:items-center nx:justify-center"
+>
+  <IconCircleFilled className="nx:size-2.5 nx:text-current nx:opacity-0 nx:scale-50 nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:group-data-[state=checked]:opacity-100 nx:group-data-[state=checked]:scale-100 nx:motion-reduce:transition-none" />
+</RadioGroupPrimitive.Indicator>
+```
+
+**Select / DropdownMenu `ItemIndicator`** (select.tsx:266-268, dropdown-menu.tsx:313-315 check + 363-365 radio dot): add `forceMount` to the `ItemIndicator` and apply the same opacity/scale cross-fade to its icon, gated on the item's selected/checked `data-state` (the item root already exposes it; add `nx:group` to the item root if needed). Confirm `forceMount` doesn't leave a stray hit target (the indicator is decorative, `pointer-events-none` if necessary).
+
+- [ ] **Step 1:** Add a story per component asserting the indicator icon carries `nx:transition-[opacity,transform]` + `nx:motion-reduce:transition-none` and is present in the DOM even when unselected (forceMount). Run `pnpm test:storybook radio-group select dropdown-menu` → FAIL.
+- [ ] **Step 2:** Apply the recipe per component. Re-run → PASS. Manually confirm selecting/deselecting cross-fades (not pops) and keyboard/pointer selection still works.
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/react/src/components/radio-group packages/react/src/components/select packages/react/src/components/dropdown-menu
+git commit -m "feat(motion): cross-fade radio/select/dropdown indicators via forceMount (#598)"
+```
+
+---
+
+### Task 3: Validate and open the sub-PR
+
+- [ ] `pnpm lint && pnpm format:check && pnpm typecheck && pnpm test:storybook` — green.
+- [ ] Open PR:
+
+```bash
+git push -u origin aishvarya/motion-icon-crossfade
+gh pr create --base main \
+  --title "feat(motion): contextual icon cross-fade for selection indicators (E2 of #598)" \
+  --body "$(cat <<'EOF'
+## Summary
+Checkbox check/minus, radio dot, and Select/DropdownMenu item indicators cross-fade (opacity+scale) instead of hard-swapping. Radix indicators use `forceMount` so the exit animates too.
+
+## GitHub Issue
+Part of #598 (Workstream E, principle #7). Sub-PR 2 of 4.
+
+## Test Plan
+- [ ] lint / format:check / typecheck / test:storybook green
+- [ ] Stories assert cross-fade classes + `motion-reduce:transition-none`; selection still works via keyboard + pointer
+
+## Modern Web Guidance / polish.md
+- Existing motion tokens; reduced-motion guarded; opacity/transform (GPU-composited); no Framer dependency.
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (#7):** checkbox (Task 1, exact), radio + Select/DropdownMenu (Task 2, forceMount recipe). No gaps.
+
+**Placeholder scan:** checkbox is exact before/after; the Radix-indicator recipe is concrete (forceMount + the same opacity/scale class list). The `nx:group` addition is a named, concrete step.
+
+**Type/name consistency:** `data-slot="checkbox-check"` matches source; the cross-fade class list (`nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:motion-reduce:transition-none`) is identical across all icons and the assertions.

--- a/packages/react/src/components/checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.stories.tsx
@@ -118,7 +118,7 @@ export const IndicatorCrossFade: Story = {
     const check = checkbox.querySelector('[data-slot="checkbox-check"]');
 
     await expect(check).not.toHaveClass('nx:hidden');
-    await expect(check).toHaveClass('nx:transition-[opacity,transform]');
+    await expect(check).toHaveClass('nx:transition-[opacity,scale]');
     await expect(check).toHaveClass(
       'nx:group-data-[state=checked]:opacity-100'
     );

--- a/packages/react/src/components/checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.stories.tsx
@@ -110,6 +110,22 @@ export const Indeterminate: Story = {
   },
 };
 
+export const IndicatorCrossFade: Story = {
+  render: () => <Checkbox defaultChecked aria-label="Accept" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const checkbox = canvas.getByRole('checkbox', { name: 'Accept' });
+    const check = checkbox.querySelector('[data-slot="checkbox-check"]');
+
+    await expect(check).not.toHaveClass('nx:hidden');
+    await expect(check).toHaveClass('nx:transition-[opacity,transform]');
+    await expect(check).toHaveClass(
+      'nx:group-data-[state=checked]:opacity-100'
+    );
+    await expect(check).toHaveClass('nx:motion-reduce:transition-none');
+  },
+};
+
 export const Disabled: Story = {
   args: {
     'aria-label': 'Disabled checkbox',

--- a/packages/react/src/components/checkbox/checkbox.tsx
+++ b/packages/react/src/components/checkbox/checkbox.tsx
@@ -82,18 +82,19 @@ function Checkbox({ className, ...props }: CheckboxProps) {
       {...props}
     >
       <CheckboxPrimitive.Indicator
+        forceMount
         data-slot="checkbox-indicator"
-        className="nx:flex nx:items-center nx:justify-center nx:text-current"
+        className="nx:relative nx:flex nx:size-full nx:items-center nx:justify-center nx:text-current"
       >
         <IconCheck
           data-slot="checkbox-check"
           aria-hidden="true"
-          className="nx:hidden nx:size-3.5 nx:group-data-[state=checked]:block"
+          className="nx:absolute nx:size-3.5 nx:scale-50 nx:opacity-0 nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100 nx:motion-reduce:transition-none"
         />
         <IconMinus
           data-slot="checkbox-minus"
           aria-hidden="true"
-          className="nx:hidden nx:size-3.5 nx:group-data-[state=indeterminate]:block"
+          className="nx:absolute nx:size-3.5 nx:scale-50 nx:opacity-0 nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:group-data-[state=indeterminate]:scale-100 nx:group-data-[state=indeterminate]:opacity-100 nx:motion-reduce:transition-none"
         />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>

--- a/packages/react/src/components/checkbox/checkbox.tsx
+++ b/packages/react/src/components/checkbox/checkbox.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 
 import { IconCheck, IconMinus } from '../../lib/icons';
+import { selectionIndicatorMotionClassName } from '../../lib/motion';
 import { cn } from '../../lib/utils';
 
 /**
@@ -89,12 +90,20 @@ function Checkbox({ className, ...props }: CheckboxProps) {
         <IconCheck
           data-slot="checkbox-check"
           aria-hidden="true"
-          className="nx:absolute nx:size-3.5 nx:scale-50 nx:opacity-0 nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100 nx:motion-reduce:transition-none"
+          className={cn(
+            'nx:absolute nx:size-3.5',
+            selectionIndicatorMotionClassName,
+            'nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100'
+          )}
         />
         <IconMinus
           data-slot="checkbox-minus"
           aria-hidden="true"
-          className="nx:absolute nx:size-3.5 nx:scale-50 nx:opacity-0 nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:group-data-[state=indeterminate]:scale-100 nx:group-data-[state=indeterminate]:opacity-100 nx:motion-reduce:transition-none"
+          className={cn(
+            'nx:absolute nx:size-3.5',
+            selectionIndicatorMotionClassName,
+            'nx:group-data-[state=indeterminate]:scale-100 nx:group-data-[state=indeterminate]:opacity-100'
+          )}
         />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>

--- a/packages/react/src/components/dropdown-menu/DropdownMenu.stories.tsx
+++ b/packages/react/src/components/dropdown-menu/DropdownMenu.stories.tsx
@@ -150,6 +150,9 @@ export const IndicatorCrossFade: Story = {
   render: function IndicatorCrossFadeStory() {
     const [showStatusBar, setShowStatusBar] = React.useState(true);
     const [showActivityBar, setShowActivityBar] = React.useState(false);
+    const [showBookmarksBar, setShowBookmarksBar] = React.useState<
+      boolean | 'indeterminate'
+    >('indeterminate');
     const [position, setPosition] = React.useState('bottom');
 
     return (
@@ -169,6 +172,12 @@ export const IndicatorCrossFade: Story = {
             onCheckedChange={setShowActivityBar}
           >
             Activity Bar
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={showBookmarksBar}
+            onCheckedChange={setShowBookmarksBar}
+          >
+            Bookmarks Bar
           </DropdownMenuCheckboxItem>
           <DropdownMenuSeparator />
           <DropdownMenuRadioGroup value={position} onValueChange={setPosition}>
@@ -193,6 +202,9 @@ export const IndicatorCrossFade: Story = {
       const uncheckedItem = within(menu).getByRole('menuitemcheckbox', {
         name: 'Activity Bar',
       });
+      const indeterminateItem = within(menu).getByRole('menuitemcheckbox', {
+        name: 'Bookmarks Bar',
+      });
       const selectedRadio = within(menu).getByRole('menuitemradio', {
         name: 'Bottom',
       });
@@ -206,6 +218,9 @@ export const IndicatorCrossFade: Story = {
       const uncheckedIcon = uncheckedItem.querySelector(
         '[data-slot="dropdown-menu-checkbox-indicator-icon"]'
       );
+      const indeterminateIcon = indeterminateItem.querySelector(
+        '[data-slot="dropdown-menu-checkbox-indicator-icon"]'
+      );
       const selectedDot = selectedRadio.querySelector(
         '[data-slot="dropdown-menu-radio-indicator-icon"]'
       );
@@ -215,13 +230,19 @@ export const IndicatorCrossFade: Story = {
 
       await expect(checkedIcon).toBeInTheDocument();
       await expect(uncheckedIcon).toBeInTheDocument();
+      await expect(indeterminateIcon).toBeInTheDocument();
       await expect(selectedDot).toBeInTheDocument();
       await expect(unselectedDot).toBeInTheDocument();
-      await expect(checkedIcon).toHaveClass(
-        'nx:transition-[opacity,transform]'
+      await expect(indeterminateItem).toHaveAttribute(
+        'data-state',
+        'indeterminate'
       );
+      await expect(checkedIcon).toHaveClass('nx:transition-[opacity,scale]');
       await expect(checkedIcon).toHaveClass(
         'nx:group-data-[state=checked]:opacity-100'
+      );
+      await expect(indeterminateIcon).toHaveClass(
+        'nx:group-data-[state=indeterminate]:opacity-100'
       );
       await expect(checkedIcon).toHaveClass('nx:motion-reduce:transition-none');
       await expect(selectedDot).toHaveClass(

--- a/packages/react/src/components/dropdown-menu/DropdownMenu.stories.tsx
+++ b/packages/react/src/components/dropdown-menu/DropdownMenu.stories.tsx
@@ -146,6 +146,96 @@ export const WithRadioItems: Story = {
   },
 };
 
+export const IndicatorCrossFade: Story = {
+  render: function IndicatorCrossFadeStory() {
+    const [showStatusBar, setShowStatusBar] = React.useState(true);
+    const [showActivityBar, setShowActivityBar] = React.useState(false);
+    const [position, setPosition] = React.useState('bottom');
+
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline">Indicator Motion</Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="nx:w-56">
+          <DropdownMenuCheckboxItem
+            checked={showStatusBar}
+            onCheckedChange={setShowStatusBar}
+          >
+            Status Bar
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuCheckboxItem
+            checked={showActivityBar}
+            onCheckedChange={setShowActivityBar}
+          >
+            Activity Bar
+          </DropdownMenuCheckboxItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuRadioGroup value={position} onValueChange={setPosition}>
+            <DropdownMenuRadioItem value="top">Top</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="bottom">Bottom</DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Indicator Motion' });
+
+    try {
+      await userEvent.click(trigger);
+
+      const menu = await within(document.body).findByRole('menu');
+      const checkedItem = within(menu).getByRole('menuitemcheckbox', {
+        name: 'Status Bar',
+      });
+      const uncheckedItem = within(menu).getByRole('menuitemcheckbox', {
+        name: 'Activity Bar',
+      });
+      const selectedRadio = within(menu).getByRole('menuitemradio', {
+        name: 'Bottom',
+      });
+      const unselectedRadio = within(menu).getByRole('menuitemradio', {
+        name: 'Top',
+      });
+
+      const checkedIcon = checkedItem.querySelector(
+        '[data-slot="dropdown-menu-checkbox-indicator-icon"]'
+      );
+      const uncheckedIcon = uncheckedItem.querySelector(
+        '[data-slot="dropdown-menu-checkbox-indicator-icon"]'
+      );
+      const selectedDot = selectedRadio.querySelector(
+        '[data-slot="dropdown-menu-radio-indicator-icon"]'
+      );
+      const unselectedDot = unselectedRadio.querySelector(
+        '[data-slot="dropdown-menu-radio-indicator-icon"]'
+      );
+
+      await expect(checkedIcon).toBeInTheDocument();
+      await expect(uncheckedIcon).toBeInTheDocument();
+      await expect(selectedDot).toBeInTheDocument();
+      await expect(unselectedDot).toBeInTheDocument();
+      await expect(checkedIcon).toHaveClass(
+        'nx:transition-[opacity,transform]'
+      );
+      await expect(checkedIcon).toHaveClass(
+        'nx:group-data-[state=checked]:opacity-100'
+      );
+      await expect(checkedIcon).toHaveClass('nx:motion-reduce:transition-none');
+      await expect(selectedDot).toHaveClass(
+        'nx:group-data-[state=checked]:opacity-100'
+      );
+    } finally {
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(document.querySelector('[role="menu"]')).toBeNull();
+      });
+    }
+  },
+};
+
 export const WithSubMenu: Story = {
   render: (_args) => (
     <DropdownMenu>

--- a/packages/react/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/react/src/components/dropdown-menu/dropdown-menu.tsx
@@ -4,6 +4,7 @@ import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { IconCheck, IconChevronRight, IconCircleFilled } from '../../lib/icons';
+import { selectionIndicatorMotionClassName } from '../../lib/motion';
 import { cn } from '../../lib/utils';
 import { popoverSurfaceClassName } from '../overlay-layout/overlay-layout';
 
@@ -317,7 +318,12 @@ function DropdownMenuCheckboxItem({
           <IconCheck
             data-slot="dropdown-menu-checkbox-indicator-icon"
             aria-hidden="true"
-            className="nx:size-4 nx:scale-50 nx:opacity-0 nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100 nx:motion-reduce:transition-none"
+            className={cn(
+              'nx:size-4',
+              selectionIndicatorMotionClassName,
+              'nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100',
+              'nx:group-data-[state=indeterminate]:scale-100 nx:group-data-[state=indeterminate]:opacity-100'
+            )}
           />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
@@ -374,7 +380,11 @@ function DropdownMenuRadioItem({
           <IconCircleFilled
             data-slot="dropdown-menu-radio-indicator-icon"
             aria-hidden="true"
-            className="nx:size-2 nx:scale-50 nx:opacity-0 nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100 nx:motion-reduce:transition-none"
+            className={cn(
+              'nx:size-2',
+              selectionIndicatorMotionClassName,
+              'nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100'
+            )}
           />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>

--- a/packages/react/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/react/src/components/dropdown-menu/dropdown-menu.tsx
@@ -299,7 +299,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
+        'nx:group nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
         'nx:rounded-sm nx:py-1.5 nx:pl-8 nx:pr-2 nx:typography-body-default nx:outline-none',
         'nx:transition-colors',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
@@ -309,9 +309,16 @@ function DropdownMenuCheckboxItem({
       checked={checked}
       {...props}
     >
-      <span className="nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
-          <IconCheck className="nx:size-4" />
+      <span className="nx:pointer-events-none nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
+        <DropdownMenuPrimitive.ItemIndicator
+          forceMount
+          data-slot="dropdown-menu-checkbox-indicator"
+        >
+          <IconCheck
+            data-slot="dropdown-menu-checkbox-indicator-icon"
+            aria-hidden="true"
+            className="nx:size-4 nx:scale-50 nx:opacity-0 nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100 nx:motion-reduce:transition-none"
+          />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -350,7 +357,7 @@ function DropdownMenuRadioItem({
     <DropdownMenuPrimitive.RadioItem
       data-slot="dropdown-menu-radio-item"
       className={cn(
-        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
+        'nx:group nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
         'nx:rounded-sm nx:py-1.5 nx:pl-8 nx:pr-2 nx:typography-body-default nx:outline-none',
         'nx:transition-colors',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
@@ -359,9 +366,16 @@ function DropdownMenuRadioItem({
       )}
       {...props}
     >
-      <span className="nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
-        <DropdownMenuPrimitive.ItemIndicator>
-          <IconCircleFilled className="nx:size-2" />
+      <span className="nx:pointer-events-none nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
+        <DropdownMenuPrimitive.ItemIndicator
+          forceMount
+          data-slot="dropdown-menu-radio-indicator"
+        >
+          <IconCircleFilled
+            data-slot="dropdown-menu-radio-indicator-icon"
+            aria-hidden="true"
+            className="nx:size-2 nx:scale-50 nx:opacity-0 nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100 nx:motion-reduce:transition-none"
+          />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}

--- a/packages/react/src/components/radio-group/RadioGroup.stories.tsx
+++ b/packages/react/src/components/radio-group/RadioGroup.stories.tsx
@@ -288,6 +288,31 @@ export const WithDataAttributes: Story = {
   },
 };
 
+export const IndicatorCrossFade: Story = {
+  render: (args) => (
+    <RadioGroup {...args} defaultValue="one" aria-label="Pick one">
+      <RadioGroupItem value="one" aria-label="Option one" />
+      <RadioGroupItem value="two" aria-label="Option two" />
+    </RadioGroup>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const one = canvas.getByRole('radio', { name: 'Option one' });
+    const two = canvas.getByRole('radio', { name: 'Option two' });
+
+    const selectedDot = one.querySelector('[data-slot="radio-group-dot"]');
+    const unselectedDot = two.querySelector('[data-slot="radio-group-dot"]');
+
+    await expect(selectedDot).toBeInTheDocument();
+    await expect(unselectedDot).toBeInTheDocument();
+    await expect(selectedDot).toHaveClass('nx:transition-[opacity,transform]');
+    await expect(selectedDot).toHaveClass(
+      'nx:group-data-[state=checked]:opacity-100'
+    );
+    await expect(selectedDot).toHaveClass('nx:motion-reduce:transition-none');
+  },
+};
+
 // ============================================
 // ALL VARIANTS GRID
 // ============================================

--- a/packages/react/src/components/radio-group/RadioGroup.stories.tsx
+++ b/packages/react/src/components/radio-group/RadioGroup.stories.tsx
@@ -305,7 +305,7 @@ export const IndicatorCrossFade: Story = {
 
     await expect(selectedDot).toBeInTheDocument();
     await expect(unselectedDot).toBeInTheDocument();
-    await expect(selectedDot).toHaveClass('nx:transition-[opacity,transform]');
+    await expect(selectedDot).toHaveClass('nx:transition-[opacity,scale]');
     await expect(selectedDot).toHaveClass(
       'nx:group-data-[state=checked]:opacity-100'
     );

--- a/packages/react/src/components/radio-group/radio-group.tsx
+++ b/packages/react/src/components/radio-group/radio-group.tsx
@@ -66,7 +66,7 @@ function RadioGroupItem({ className, ...props }: RadioGroupItemProps) {
     <RadioGroupPrimitive.Item
       data-slot="radio-group-item"
       className={cn(
-        'nx:relative nx:size-4 nx:shrink-0 nx:cursor-pointer nx:rounded-full nx:border-default nx:border-border-default nx:bg-background',
+        'nx:group nx:relative nx:size-4 nx:shrink-0 nx:cursor-pointer nx:rounded-full nx:border-default nx:border-border-default nx:bg-background',
         'nx:pointer-coarse:after:absolute nx:pointer-coarse:after:-inset-3.5',
         'nx:transition-colors',
         'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
@@ -79,10 +79,15 @@ function RadioGroupItem({ className, ...props }: RadioGroupItemProps) {
       {...props}
     >
       <RadioGroupPrimitive.Indicator
+        forceMount
         data-slot="radio-group-indicator"
         className="nx:flex nx:items-center nx:justify-center"
       >
-        <IconCircleFilled className="nx:size-2.5 nx:text-current" />
+        <IconCircleFilled
+          data-slot="radio-group-dot"
+          aria-hidden="true"
+          className="nx:size-2.5 nx:scale-50 nx:text-current nx:opacity-0 nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100 nx:motion-reduce:transition-none"
+        />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   );

--- a/packages/react/src/components/radio-group/radio-group.tsx
+++ b/packages/react/src/components/radio-group/radio-group.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
 
 import { IconCircleFilled } from '../../lib/icons';
+import { selectionIndicatorMotionClassName } from '../../lib/motion';
 import { cn } from '../../lib/utils';
 
 /**
@@ -86,7 +87,11 @@ function RadioGroupItem({ className, ...props }: RadioGroupItemProps) {
         <IconCircleFilled
           data-slot="radio-group-dot"
           aria-hidden="true"
-          className="nx:size-2.5 nx:scale-50 nx:text-current nx:opacity-0 nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100 nx:motion-reduce:transition-none"
+          className={cn(
+            'nx:size-2.5 nx:text-current',
+            selectionIndicatorMotionClassName,
+            'nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100'
+          )}
         />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>

--- a/packages/react/src/components/select/Select.stories.tsx
+++ b/packages/react/src/components/select/Select.stories.tsx
@@ -93,9 +93,7 @@ export const IndicatorCrossFade: Story = {
 
       await expect(selectedCheck).toBeInTheDocument();
       await expect(unselectedCheck).toBeInTheDocument();
-      await expect(selectedCheck).toHaveClass(
-        'nx:transition-[opacity,transform]'
-      );
+      await expect(selectedCheck).toHaveClass('nx:transition-[opacity,scale]');
       await expect(selectedCheck).toHaveClass(
         'nx:group-data-[state=checked]:opacity-100'
       );

--- a/packages/react/src/components/select/Select.stories.tsx
+++ b/packages/react/src/components/select/Select.stories.tsx
@@ -62,6 +62,55 @@ export const WithDefaultValue: Story = {
   ),
 };
 
+export const IndicatorCrossFade: Story = {
+  render: () => (
+    <Select defaultValue="apple">
+      <SelectTrigger className="nx:w-[180px]" aria-label="Select a fruit">
+        <SelectValue placeholder="Select a fruit" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="apple">Apple</SelectItem>
+        <SelectItem value="banana">Banana</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('combobox', { name: 'Select a fruit' });
+
+    try {
+      await userEvent.click(trigger);
+
+      const listbox = await within(document.body).findByRole('listbox');
+      const apple = within(listbox).getByRole('option', { name: 'Apple' });
+      const banana = within(listbox).getByRole('option', { name: 'Banana' });
+      const selectedCheck = apple.querySelector(
+        '[data-slot="select-item-indicator-icon"]'
+      );
+      const unselectedCheck = banana.querySelector(
+        '[data-slot="select-item-indicator-icon"]'
+      );
+
+      await expect(selectedCheck).toBeInTheDocument();
+      await expect(unselectedCheck).toBeInTheDocument();
+      await expect(selectedCheck).toHaveClass(
+        'nx:transition-[opacity,transform]'
+      );
+      await expect(selectedCheck).toHaveClass(
+        'nx:group-data-[state=checked]:opacity-100'
+      );
+      await expect(selectedCheck).toHaveClass(
+        'nx:motion-reduce:transition-none'
+      );
+    } finally {
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(document.querySelector('[role="listbox"]')).toBeNull();
+      });
+    }
+  },
+};
+
 export const Disabled: Story = {
   render: (_args) => (
     <Select disabled>

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -4,6 +4,7 @@ import * as SelectPrimitive from '@radix-ui/react-select';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { IconCheck, IconChevronDown, IconChevronUp } from '../../lib/icons';
+import { selectionIndicatorMotionClassName } from '../../lib/motion';
 import { cn } from '../../lib/utils';
 import { popoverSurfaceClassName } from '../overlay-layout/overlay-layout';
 
@@ -289,10 +290,16 @@ function SelectItem({ className, children, ...props }: SelectItemProps) {
       {...props}
     >
       <span className="nx:pointer-events-none nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
+        {/* SelectPrimitive.ItemIndicator does not support forceMount and unmounts
+            when unchecked, so this icon mirrors item state for the cross-fade. */}
         <IconCheck
           data-slot="select-item-indicator-icon"
           aria-hidden="true"
-          className="nx:size-4 nx:scale-50 nx:opacity-0 nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100 nx:motion-reduce:transition-none"
+          className={cn(
+            'nx:size-4',
+            selectionIndicatorMotionClassName,
+            'nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100'
+          )}
         />
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -280,7 +280,7 @@ function SelectItem({ className, children, ...props }: SelectItemProps) {
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        'nx:relative nx:flex nx:w-full nx:cursor-default nx:select-none nx:items-center',
+        'nx:group nx:relative nx:flex nx:w-full nx:cursor-default nx:select-none nx:items-center',
         'nx:rounded-sm nx:py-1.5 nx:pl-8 nx:pr-2 nx:typography-body-default nx:outline-none',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
         'nx:data-disabled:pointer-events-none nx:data-disabled:text-disabled-foreground',
@@ -288,10 +288,12 @@ function SelectItem({ className, children, ...props }: SelectItemProps) {
       )}
       {...props}
     >
-      <span className="nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
-        <SelectPrimitive.ItemIndicator>
-          <IconCheck className="nx:size-4" />
-        </SelectPrimitive.ItemIndicator>
+      <span className="nx:pointer-events-none nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
+        <IconCheck
+          data-slot="select-item-indicator-icon"
+          aria-hidden="true"
+          className="nx:size-4 nx:scale-50 nx:opacity-0 nx:transition-[opacity,transform] nx:duration-fast nx:ease-enter nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100 nx:motion-reduce:transition-none"
+        />
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
     </SelectPrimitive.Item>

--- a/packages/react/src/lib/motion.ts
+++ b/packages/react/src/lib/motion.ts
@@ -1,0 +1,2 @@
+export const selectionIndicatorMotionClassName =
+  'nx:scale-50 nx:opacity-0 nx:transition-[opacity,scale] nx:duration-fast nx:ease-enter nx:motion-reduce:transition-none';


### PR DESCRIPTION
## Summary

- Adds opacity + scale cross-fades for Checkbox check/minus indicators, RadioGroup dots, Select item checks, and DropdownMenu checkbox/radio indicators.
- Keeps Radix-backed radio/dropdown indicators mounted with `forceMount`; Select uses an always-mounted decorative icon in the reserved indicator slot because this installed Radix Select `ItemIndicator` leaks `forceMount` to the DOM instead of consuming it.
- Adds focused Storybook play coverage proving transition classes, reduced-motion suppression, and unselected indicator DOM presence where exit animation depends on it.

## GitHub Issue

Part of #598 (Workstream E, principle #7). Sub-PR 2 of 4.

Reference plan: `docs/superpowers/plans/2026-07-02-598-e2-icon-crossfade.md`.

## Test Plan

- [x] TDD red: `corepack pnpm test:storybook checkbox radio-group select dropdown-menu` failed on the new indicator cross-fade stories before implementation.
- [x] Task 1 green: `corepack pnpm test:storybook checkbox`
- [x] Focused E2 green: `corepack pnpm test:storybook checkbox radio-group select dropdown-menu` (5 files, 73 tests)
- [x] `corepack pnpm lint`
- [x] `corepack pnpm format:check`
- [x] `PATH=/private/tmp/nexus-corepack-pnpm-wrapper:$PATH corepack pnpm typecheck`
- [x] `corepack pnpm test:storybook` (62 files, 735 tests)
- [x] `corepack pnpm audit:browser-support`
- [x] Token audits not run; no token files changed.

## Modern Web Guidance / polish.md

- Modern Web Guidance search: sandboxed `npm_config_fetch_retries=0 npx -y modern-web-guidance@latest search "selection indicator icon cross fade forceMount reduced motion opacity scale" --skill-version 2026_05_16-c5e7870` failed with `ENOTFOUND registry.npmjs.org`; unsandboxed retry succeeded.
- Retrieved guides: `animated-select-picker`, `accessibility`.
- Findings applied: use CSS-driven state motion, avoid new JS motion dependencies, preserve semantic selection behavior, and suppress non-essential motion for `prefers-reduced-motion`.
- Browser-floor decision: uses opacity, scale, and transition utilities with existing Nexus motion tokens; this is safe for Chrome 111+, Edge 111+, Firefox 113+, Safari 15.4+, and Samsung Internet 22. `corepack pnpm audit:browser-support` passed.
- Reduced-motion proof: every new indicator motion class includes `nx:motion-reduce:transition-none`; stories assert that class on the changed indicator icons.
- Rejected approaches: no Framer Motion or custom JS state timers; no native customizable select adoption because `appearance: base-select` is outside the Nexus browser floor and unrelated to the existing Radix Select architecture.
