### PR TITLE
feat(motion): stop avatar fallback mount-fade on page load (E4 of #598)

### DIFF
--- a/packages/react/src/components/avatar/Avatar.stories.tsx
+++ b/packages/react/src/components/avatar/Avatar.stories.tsx
@@ -647,6 +647,8 @@ export const FallbackDataAttributes: Story = {
     const avatar = canvas.getByRole('img', { name: 'Ada Byron' });
 
     await expect(fallback).toBeInTheDocument();
+    await expect(fallback).not.toHaveClass('nx:animate-in');
+    await expect(fallback).not.toHaveClass('nx:fade-in-0');
     await expect(avatar).toHaveAttribute('data-slot', 'avatar');
   },
 };

--- a/packages/react/src/components/avatar/avatar.tsx
+++ b/packages/react/src/components/avatar/avatar.tsx
@@ -200,7 +200,6 @@ function AvatarFallback({ className, ...props }: AvatarFallbackProps) {
       data-slot="avatar-fallback"
       className={cn(
         'nx:flex nx:size-full nx:items-center nx:justify-center nx:rounded-[inherit] nx:bg-muted nx:text-foreground nx:font-medium nx:leading-none',
-        'nx:animate-in nx:fade-in-0 nx:duration-fast nx:ease-enter nx:motion-reduce:animate-none',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

- Removes the `AvatarFallback` mount fade so initials render immediately on first page paint — the actual #13 "skip animation on load" target (the fallback renders on mount, so its `animate-in` fired on every page load).
- Leaves `AvatarImage` on its existing `animate-in` one-liner. Radix mounts the `<img>` only once the image resolves (`Avatar.Image` renders `null` until `loaded`), so that keyframe already fires on genuine load — not on page-mount — and needs no change. No state / `data-state` / `requestAnimationFrame` rebuild.
- Adds a regression guard to `FallbackDataAttributes` asserting the fallback carries no `nx:animate-in` / `nx:fade-in-0` (re-adding the fade fails the story).

## GitHub Issue

Closes #598 (final sub-PR of Workstream E, principle #13). Merge LAST.

## Test Plan

- [ ] `pnpm lint && pnpm format:check && pnpm typecheck`
- [ ] `pnpm test:storybook` — Avatar stories green; `FallbackDataAttributes` guards the fade removal

_(Validated by CI on this push; the fix is a 2-file, +2/-1 change with no new tokens or motion scale.)_

## Motion / polish.md

- No motion-token or reduced-motion change. `AvatarImage` keeps `nx:motion-reduce:animate-none`; the fallback simply drops its fade line. No new duration/easing scale, no `@starting-style`, nothing outside the browser floor.
