### PR TITLE
docs(motion): E1 interruptible overlay open/close plan (E1 of #598)

### DIFF
--- a/docs/superpowers/plans/2026-07-02-598-e1-overlay-interruptible.md
+++ b/docs/superpowers/plans/2026-07-02-598-e1-overlay-interruptible.md
@@ -9,9 +9,14 @@ teardown. Radix Presence is animation-gated (`animationName` /
 `animationend`), while this work removes the keyframes that currently provide
 both the enter 0% frame and the exit unmount delay. The spike must first add a
 small Nexus transition-presence helper that uses `forceMount`, owns the visual
-motion state, waits for `transitionend`, and gates closed content from pointer
-and focus access. Only after Popover proves that helper should the recipe fan
-out to other surfaces.
+motion state, waits for `transitionend`, and gates exiting content from pointer
+and focus access. Teardown means **full unmount** of the Radix
+portal/content/overlay subtree after the exit transition completes; a mounted
+but visually hidden/deactivated subtree is not an acceptable closed state
+because modal Radix side effects such as scroll lock, outside hiding, and focus
+scope are Presence-gated. The precursor PR must prove the helper on both
+Popover (non-modal positioning surface) and Dialog (modal side-effect surface)
+before any recipe fans out to other overlays.
 
 **Tech Stack:** React, Tailwind v4 (`nx:` prefix, data-attribute variants,
 individual transform-property transitions), Radix primitives with `forceMount`,
@@ -30,14 +35,25 @@ these surfaces), Storybook 10 (`storybook/test`).
 - **Radix `Presence` is not the transition teardown mechanism** - every
   converted Presence-backed surface needs `forceMount` plus Nexus-owned
   transitionend teardown.
+- **Teardown means full unmount** - after the visible exit transition ends, the
+  helper must unmount the Radix portal/content/overlay subtree. Do not keep a
+  closed modal subtree mounted as `aria-hidden`, pointer-blocked, or otherwise
+  "deactivated"; that leaves modal side effects alive.
+- **Split precursor from fan-out** - the first implementation PR is the shared
+  helper plus Popover and Dialog spikes only. Remaining overlay surfaces move in
+  follow-up PRs after the modal and non-modal contracts are proven.
 - **No `@starting-style` for this work** - it is below the Nexus browser floor.
 - Tailwind v4 scale/translate utilities emit individual transform properties.
   Use `nx:transition-[opacity,scale]` for fade+scale surfaces and
   `nx:transition-[opacity,translate]` (or `opacity,scale,translate` where both
   are used) for directional slide surfaces. Do **not** use
   `transition-[opacity,transform]` for `scale-95`.
-- Closed/closing content must be gated: no pointer interaction, no focusable
-  descendants reachable by Tab, and hidden from assistive tech while closed.
+- Exiting content must be gated: no pointer interaction and no focusable
+  descendants reachable by Tab while the exit is in progress. Do not create a
+  visible semantic node that is also `aria-hidden`. If a visual-only exit shell
+  is used, the semantic Radix subtree must already be unmounted and the shell
+  must be non-focusable, `aria-hidden`, and pointer-events-none. Do not rely on
+  `inert` unless the PR names a Safari 15.4-safe fallback.
 - `nx:` prefix before every modifier; semantic tokens only. **Pre-production.** **PR:** `feat(motion): …`, base `main`, body references `#598` (this is sub-PR 1 of 4).
 
 ---
@@ -54,7 +70,10 @@ these surfaces), Storybook 10 (`storybook/test`).
 - `packages/react/src/components/hover-card/hover-card.tsx:95`
 - `packages/react/src/components/tooltip/tooltip.tsx:82,83`
 - `packages/react/src/components/sheet/sheet.tsx:80,102` — scrim opacity + panel slide from edge
-- `packages/react/src/components/drawer/drawer.tsx:72` — Vaul owns runtime transitions; verify and leave out of scope unless evidence says Nexus owns the close transition
+- `packages/react/src/components/drawer/drawer.tsx:72` — Nexus owns this scrim
+  recipe; Vaul owns the drawer primitive/panel lifecycle. Verify the Nexus
+  scrim keyframes separately and leave Vaul panel lifecycle out of scope unless
+  evidence proves Nexus-owned close timing controls interruptibility.
 - `packages/react/src/components/navigation-menu/navigation-menu.tsx:186,195,235,303`
 
 ---
@@ -73,12 +92,11 @@ Required assertions:
 - the panel has no `animate-in` / `animate-out` keyframe utilities;
 - computed `transition-property` includes `opacity` and `scale`;
 - closing leaves the panel mounted long enough to observe the visible exit
-  state (`opacity < 1` or equivalent closed-state class + computed opacity);
+  state (`opacity < 1` or equivalent exiting-state class + computed opacity);
 - a close interrupted by a re-open cancels stale teardown and leaves the panel
   present/open;
-- final `transitionend` removes or fully deactivates the panel according to the
-  helper contract;
-- the closed/closing state blocks pointer interaction and keyboard focus.
+- final `transitionend` fully unmounts the Radix portal/content subtree;
+- the exiting state blocks pointer interaction and keyboard focus.
 
 ```tsx
 export const InterruptibleOpenClose: Story = {
@@ -116,13 +134,17 @@ export const InterruptibleOpenClose: Story = {
     await expect(panel).toHaveStyle({ pointerEvents: 'none' });
 
     await userEvent.click(trigger);
+    const reopenedContent = await within(document.body).findByText('Content');
+    const reopenedPanel = reopenedContent.closest(
+      '[data-slot="popover-content"]'
+    )!;
     await waitFor(() =>
-      expect(panel).toHaveAttribute('data-motion-state', 'open')
+      expect(reopenedPanel).toHaveAttribute('data-motion-state', 'open')
     );
-    await expect(panel).toBeVisible();
+    await expect(reopenedPanel).toBeVisible();
 
     await userEvent.keyboard('{Escape}');
-    panel.dispatchEvent(
+    reopenedPanel.dispatchEvent(
       new TransitionEvent('transitionend', {
         bubbles: true,
         propertyName: 'opacity',
@@ -158,11 +180,13 @@ Implementation requirements:
   animation frame. This replaces the keyframe 0% frame without using
   `@starting-style`.
 - On close, set the motion state to closed, wait for `transitionend` from the
-  animated property (`opacity` for fade+scale), then tear down. Ignore stale
-  transitionend events after an interrupted reopen.
-- Closed/closing content gets `aria-hidden`, no pointer interaction, and focus
-  gating. If the implementation uses `inert`, first verify Safari 15.4 support
-  or provide a fallback because `inert` may sit outside the Nexus floor.
+  animated property (`opacity` for fade+scale), then fully unmount the Radix
+  portal/content subtree. Ignore stale transitionend events after an interrupted
+  reopen.
+- Exiting content gets no pointer interaction and focus gating. Do not add
+  `aria-hidden` to a still-visible semantic content node. If the implementation
+  uses `inert`, first verify Safari 15.4 support or provide a fallback because
+  `inert` may sit outside the Nexus floor.
 
 Popover class recipe:
 
@@ -209,16 +233,87 @@ git commit -m "feat(motion): interruptible transitions for Popover open/close (#
 
 ---
 
-### Task 2: Apply the verified recipe to the remaining surfaces
+### Task 2: Add the Dialog modal spike gate before fan-out
+
+**Files:** `overlay-layout.ts`, `dialog.tsx`, `Dialog.stories.tsx`, and the
+shared transition-presence helper from Task 1.
+
+Popover proves the non-modal positioning case only. It does not exercise
+Dialog's modal Radix path, including scroll lock, outside `aria-hidden`
+management, or focus return. Do not fan out to any other surface until Dialog
+proves the helper releases those modal side effects by fully unmounting after
+exit.
+
+Required assertions:
+
+- opening Dialog renders content and overlay visibly;
+- closing leaves content/overlay mounted long enough to observe the visible exit
+  state;
+- no still-visible Dialog content node is marked `aria-hidden`;
+- a close interrupted by a re-open cancels stale teardown; re-query the content
+  node after the re-open before asserting or dispatching `transitionend`;
+- final `transitionend` fully unmounts the current Dialog content and overlay;
+- after final unmount, body scroll lock is released, outside `aria-hidden`
+  mutations are cleaned up, and focus returns to the trigger.
+
+- [ ] **Step 1:** Write the failing Dialog story/play-fn for the assertions
+      above. Run `pnpm test:storybook dialog` -> FAIL.
+- [ ] **Step 2:** Apply the helper to Dialog/AlertDialog layout content and
+      scrim. Use `nx:transition-[opacity,scale]` for content and
+      `nx:transition-opacity` for scrim. Preserve existing open/close
+      duration/ease tokens. Run `pnpm test:storybook dialog` -> PASS.
+- [ ] **Step 3:** Commit the modal proof separately:
+
+```bash
+git add packages/react/src/components/dialog packages/react/src/components/overlay-layout
+git commit -m "feat(motion): prove modal overlay transition teardown (#598)"
+```
+
+---
+
+### Task 3: Validate and open the precursor sub-PR
+
+- [ ] `pnpm lint && pnpm format:check && pnpm typecheck && pnpm test:storybook` — all green.
+- [ ] Open PR:
+
+```bash
+git push -u origin aishvarya/motion-overlay-interruptible
+gh pr create --base main \
+  --title "feat(motion): prove interruptible overlay transition teardown (E1 of #598)" \
+  --body "$(cat <<'EOF'
+## Summary
+Introduce the Nexus transition-presence helper and prove interruptible open/close on Popover and Dialog before fan-out. The helper uses `forceMount` only during visible exit, then fully unmounts the Radix portal/content/overlay subtree so modal side effects release naturally. Loading/height keyframes untouched.
+
+## GitHub Issue
+Part of #598 (Workstream E, principle #4). Sub-PR 1 of 4.
+
+## Test Plan
+- [ ] lint / format:check / typecheck / test:storybook green
+- [ ] Popover spike proves forceMount + Nexus transitionend teardown + exiting-state gating
+- [ ] Dialog spike proves full unmount releases scroll lock, outside aria-hidden cleanup, and focus return
+- [ ] Popover/Dialog play-fns: no `animate-in` / `animate-out` class, `motion-reduce:transition-none` present, computed transition-property matches opacity/scale, exit visibly paints, interruption cancels stale teardown
+
+## Modern Web Guidance / polish.md
+- Existing `nx:duration-*` / `nx:ease-*` tokens (no parallel scale); reduced-motion guarded; opacity plus individual scale/translate properties only. Radix Presence is animation-gated, so CSS-transition teardown is owned by the Nexus helper. Visible semantic nodes are not marked aria-hidden; inert is avoided unless a Safari 15.4 fallback is named.
+EOF
+)"
+```
+
+---
+
+### Task 4: Apply the verified recipe to remaining surfaces in follow-up PRs
 
 **Files:** each surface in File Structure above (except Popover).
 
-Do not fan out until Task 1 proves the helper with tests. For each surface,
-move from Radix/animation-state classes to the shared transition-presence
-contract, then adapt only the visual recipe.
+Do not fan out until Tasks 1-3 land the precursor PR with non-modal and modal
+tests. For each follow-up surface, move from Radix/animation-state classes to
+the shared transition-presence contract, then adapt only the visual recipe.
 
-- **Popover-family fade+scale surfaces** (`overlay-layout.ts:48`,
-  dropdown-menu, context-menu, menubar, select, hover-card): use
+- **Dialog/AlertDialog content** (`overlay-layout.ts:48`): use the
+  modal-proven helper, `nx:transition-[opacity,scale]`, preserved open/close
+  duration/ease tokens, and full unmount after exit.
+- **Popover-family fade+scale surfaces** (dropdown-menu, context-menu, menubar,
+  select, hover-card): use
   `nx:transition-[opacity,scale]`, closed opacity/scale, preserved open/close
   duration/ease tokens, and closed pointer/focus gating.
 - **Dialog/AlertDialog scrim** (`overlay-layout.ts:59`): opacity only. Use
@@ -231,9 +326,11 @@ contract, then adapt only the visual recipe.
   translate. Tailwind v4 translate utilities emit the individual `translate`
   property, so the panel transition property must include `translate`, not only
   `transform`.
-- **Drawer** (`drawer.tsx:72`): Vaul owns the drawer runtime transition model.
-  Keep Drawer out of this PR unless the spike proves a Nexus-owned keyframe is
-  actually controlling its interruptibility; if excluded, say so in the PR body.
+- **Drawer** (`drawer.tsx:72`): Nexus owns the scrim recipe at this line; Vaul
+  owns the drawer primitive/panel lifecycle. Verify the Nexus scrim keyframes
+  independently. Keep Vaul panel lifecycle out of this PR unless evidence proves
+  Nexus-owned close timing controls interruptibility; if excluded, say so in the
+  PR body.
 - **NavigationMenu** (`navigation-menu.tsx:186,195,235,303`): convert viewport
   and inline flyout recipes separately. Preserve any directional motion by
   translating it to `translate` states rather than dropping it.
@@ -245,9 +342,9 @@ contract, then adapt only the visual recipe.
       interruption cancels stale teardown. Run `pnpm test:storybook <surface>`
       -> FAIL.
 - [ ] **Step 2:** Apply the helper and the surface-specific recipe. Re-run ->
-      PASS. Manually confirm pointer/focus gating in the closed/closing state.
-- [ ] **Step 3:** Commit per surface or in small logical groups (e.g. helper +
-      Popover, popover-family, panels, navigation-menu):
+      PASS. Manually confirm pointer/focus gating in the exiting state.
+- [ ] **Step 3:** Commit per surface or in small logical groups (e.g.
+      popover-family, panels, navigation-menu):
 
 ```bash
 git add packages/react/src/components/<surface>
@@ -256,39 +353,10 @@ git commit -m "feat(motion): interruptible transitions for <surface> open/close 
 
 ---
 
-### Task 3: Validate and open the sub-PR
-
-- [ ] `pnpm lint && pnpm format:check && pnpm typecheck && pnpm test:storybook` — all green.
-- [ ] Open PR:
-
-```bash
-git push -u origin aishvarya/motion-overlay-interruptible
-gh pr create --base main \
-  --title "feat(motion): interruptible overlay open/close transitions (E1 of #598)" \
-  --body "$(cat <<'EOF'
-## Summary
-Convert overlay open/close from tw-animate-css keyframes to interruptible `data-[state]` transitions across the popover family, tooltip, sheet, drawer, and navigation-menu. Rapid open/close now retargets instead of replaying. Loading/height keyframes untouched.
-
-## GitHub Issue
-Part of #598 (Workstream E, principle #4). Sub-PR 1 of 4.
-
-## Test Plan
-- [ ] lint / format:check / typecheck / test:storybook green
-- [ ] Popover spike proves forceMount + Nexus transitionend teardown + closed-state gating
-- [ ] Per-surface play-fn: no `animate-in` / `animate-out` class, `motion-reduce:transition-none` present, computed transition-property matches opacity/scale/translate, exit visibly paints, interruption cancels stale teardown
-
-## Modern Web Guidance / polish.md
-- Existing `nx:duration-*` / `nx:ease-*` tokens (no parallel scale); reduced-motion guarded; opacity plus individual scale/translate properties only. Radix Presence is animation-gated, so CSS-transition teardown is owned by the Nexus helper.
-EOF
-)"
-```
-
----
-
 ## Self-Review
 
-**Spec coverage (#4):** all `data-[state=open]:animate-in/out` surfaces enumerated; helper + recipe proven on Popover (Task 1) then applied per-surface (Task 2). Loading/height keyframes explicitly excluded. Drawer/Vaul flagged for exclusion unless verification proves Nexus owns its transition.
+**Spec coverage (#4):** all `data-[state=open]:animate-in/out` surfaces enumerated; helper + recipe proven on Popover (Task 1) and Dialog (Task 2) before the precursor PR opens (Task 3) and before any follow-up fan-out (Task 4). Loading/height keyframes explicitly excluded. Drawer split is sharpened: Nexus owns the scrim recipe, while Vaul panel lifecycle remains out of scope unless evidence proves Nexus-owned close timing controls interruptibility.
 
-**Placeholder scan:** the Popover recipe is concrete (exact REMOVE/ADD class lists), while remaining surfaces are grouped by motion shape: fade+scale, opacity-only scrim, or directional translate. The "spike then apply" structure is deliberate because Radix Presence cannot be trusted for transition teardown.
+**Placeholder scan:** the Popover recipe is concrete (exact REMOVE/ADD class lists), Dialog has a required modal side-effect spike, and remaining surfaces are grouped by motion shape: fade+scale, opacity-only scrim, or directional translate. The "precursor then fan-out" structure is deliberate because Radix Presence cannot be trusted for transition teardown.
 
 **Type/name consistency:** `data-slot="popover-content"`, `data-motion-state`, computed `transition-property`, and `motion-reduce:transition-none` are aligned between the implementation recipe and the assertions. `scale-95` maps to `scale`, not `transform`, under Tailwind v4.

--- a/docs/superpowers/plans/2026-07-02-598-e1-overlay-interruptible.md
+++ b/docs/superpowers/plans/2026-07-02-598-e1-overlay-interruptible.md
@@ -4,16 +4,40 @@
 
 **Goal:** Workstream E principle #4 (part of issue #598) — convert the overlay open/close animations from tw-animate-css **keyframes** (`animate-in` / `animate-out`) to **interruptible CSS transitions** on `data-[state]`, so rapid open/close retargets instead of replaying a fixed timeline.
 
-**Architecture:** Radix sets `data-state="open|closed"` and (via `Presence`) keeps the node mounted until the exit animation/transition ends. Replace `data-[state=open]:animate-in … fade-in-0 zoom-in-95 (slide-*)` / `data-[state=closed]:animate-out …` with a **state-driven transition**: a rest state (`opacity-100 scale-100`), a closed state (`data-[state=closed]:opacity-0 data-[state=closed]:scale-95` + slide for panels), `transition-[opacity,transform]` on the existing `nx:duration-*` / `nx:ease-*` tokens, and `nx:motion-reduce:transition-none`. This is **spike-driven**: prove the recipe + Radix `Presence` exit-before-unmount on ONE surface, then apply it to the rest.
+**Architecture:** Do **not** rely on Radix `Presence` for CSS-transition
+teardown. Radix Presence is animation-gated (`animationName` /
+`animationend`), while this work removes the keyframes that currently provide
+both the enter 0% frame and the exit unmount delay. The spike must first add a
+small Nexus transition-presence helper that uses `forceMount`, owns the visual
+motion state, waits for `transitionend`, and gates closed content from pointer
+and focus access. Only after Popover proves that helper should the recipe fan
+out to other surfaces.
 
-**Tech Stack:** React, Tailwind v4 (`nx:` prefix, `data-[state=*]:` + `transition-*`), Radix `Presence`, tw-animate-css (removing its keyframe utilities from these surfaces), Storybook 10 (`storybook/test`).
+**Tech Stack:** React, Tailwind v4 (`nx:` prefix, data-attribute variants,
+individual transform-property transitions), Radix primitives with `forceMount`,
+a Nexus transitionend helper, tw-animate-css (removing keyframe utilities from
+these surfaces), Storybook 10 (`storybook/test`).
 
 ## Global Constraints
 
-- **Existing motion tokens only** (`nx:duration-fast|default`, `nx:ease-enter|exit|move`) — no new scale.
+- **Existing motion tokens only** (`nx:duration-fast|default|slow`,
+  `nx:ease-enter|exit|move`) - no new scale.
+- Preserve each surface's existing timing semantics unless the PR explicitly
+  justifies a change. Do not silently collapse `duration-slow/default` plus
+  `ease-enter/exit` into one `duration-fast ease-move` recipe.
 - **`nx:motion-reduce:transition-none`** on every converted surface.
 - **Loading/height keyframes stay keyframes** — do NOT touch spinner, skeleton, accordion, collapsible, progress-indeterminate, caret-blink.
-- **Radix `Presence` must still unmount on close** — the closed-state transition must actually run before unmount (`forceMount` only if a surface needs it).
+- **Radix `Presence` is not the transition teardown mechanism** - every
+  converted Presence-backed surface needs `forceMount` plus Nexus-owned
+  transitionend teardown.
+- **No `@starting-style` for this work** - it is below the Nexus browser floor.
+- Tailwind v4 scale/translate utilities emit individual transform properties.
+  Use `nx:transition-[opacity,scale]` for fade+scale surfaces and
+  `nx:transition-[opacity,translate]` (or `opacity,scale,translate` where both
+  are used) for directional slide surfaces. Do **not** use
+  `transition-[opacity,transform]` for `scale-95`.
+- Closed/closing content must be gated: no pointer interaction, no focusable
+  descendants reachable by Tab, and hidden from assistive tech while closed.
 - `nx:` prefix before every modifier; semantic tokens only. **Pre-production.** **PR:** `feat(motion): …`, base `main`, body references `#598` (this is sub-PR 1 of 4).
 
 ---
@@ -21,24 +45,40 @@
 ## File Structure (surfaces carrying `data-[state=open]:animate-in / animate-out`)
 
 - `packages/react/src/components/popover/popover.tsx:77` — **spike surface**
-- `packages/react/src/components/overlay-layout/overlay-layout.ts:48,59` — Dialog/AlertDialog content + shared popover recipe
+- `packages/react/src/components/overlay-layout/overlay-layout.ts:48` — Dialog/AlertDialog content: fade + scale
+- `packages/react/src/components/overlay-layout/overlay-layout.ts:59` — Dialog/AlertDialog scrim: opacity only, no scale
 - `packages/react/src/components/dropdown-menu/dropdown-menu.tsx:135`
 - `packages/react/src/components/context-menu/context-menu.tsx:135`
 - `packages/react/src/components/menubar/menubar.tsx:183,240`
 - `packages/react/src/components/select/select.tsx:170`
 - `packages/react/src/components/hover-card/hover-card.tsx:95`
 - `packages/react/src/components/tooltip/tooltip.tsx:82,83`
-- `packages/react/src/components/sheet/sheet.tsx:80,102` — panels (slide from edge)
-- `packages/react/src/components/drawer/drawer.tsx:72` — Vaul (may already use its own transitions; verify)
+- `packages/react/src/components/sheet/sheet.tsx:80,102` — scrim opacity + panel slide from edge
+- `packages/react/src/components/drawer/drawer.tsx:72` — Vaul owns runtime transitions; verify and leave out of scope unless evidence says Nexus owns the close transition
 - `packages/react/src/components/navigation-menu/navigation-menu.tsx:186,195,235,303`
 
 ---
 
 ### Task 1: Spike + verify the recipe on Popover
 
-**Files:** `popover.tsx` (around :77) + `Popover.stories.tsx`.
+**Files:** `popover.tsx` (around :77), `Popover.stories.tsx`, and a shared
+helper if the spike proves the pattern belongs outside Popover.
 
-- [ ] **Step 1: Write the failing/verifying test** — a play fn that opens then closes the popover and asserts the content unmounts after the transition (proves Radix `Presence` still tears down):
+- [ ] **Step 1: Write the failing tests** - cover the behavior the PR exists to
+      deliver, not only class-string cleanup.
+
+Required assertions:
+
+- opening renders content visibly;
+- the panel has no `animate-in` / `animate-out` keyframe utilities;
+- computed `transition-property` includes `opacity` and `scale`;
+- closing leaves the panel mounted long enough to observe the visible exit
+  state (`opacity < 1` or equivalent closed-state class + computed opacity);
+- a close interrupted by a re-open cancels stale teardown and leaves the panel
+  present/open;
+- final `transitionend` removes or fully deactivates the panel according to the
+  helper contract;
+- the closed/closing state blocks pointer interaction and keyboard focus.
 
 ```tsx
 export const InterruptibleOpenClose: Story = {
@@ -50,14 +90,44 @@ export const InterruptibleOpenClose: Story = {
   ),
   play: async ({ canvasElement }) => {
     const trigger = within(canvasElement).getByText('Open');
+
     await userEvent.click(trigger);
     const content = await within(document.body).findByText('Content');
-    await expect(content).toBeVisible();
-    // No animate-in keyframe utility remains on the content.
     const panel = content.closest('[data-slot="popover-content"]')!;
+
+    await expect(content).toBeVisible();
     await expect(panel).not.toHaveClass('nx:data-[state=open]:animate-in');
+    await expect(panel).not.toHaveClass('nx:data-[state=closed]:animate-out');
     await expect(panel).toHaveClass('nx:motion-reduce:transition-none');
+
+    const openTransition = getComputedStyle(panel).transitionProperty;
+    await expect(openTransition).toContain('opacity');
+    await expect(openTransition).toContain('scale');
+
     await userEvent.keyboard('{Escape}');
+
+    // The exit must paint while still mounted; eventual teardown alone is not
+    // enough evidence for interruptibility.
+    await waitFor(() => {
+      expect(panel).toHaveAttribute('data-motion-state', 'closed');
+      expect(Number(getComputedStyle(panel).opacity)).toBeLessThan(1);
+    });
+
+    await expect(panel).toHaveStyle({ pointerEvents: 'none' });
+
+    await userEvent.click(trigger);
+    await waitFor(() =>
+      expect(panel).toHaveAttribute('data-motion-state', 'open')
+    );
+    await expect(panel).toBeVisible();
+
+    await userEvent.keyboard('{Escape}');
+    panel.dispatchEvent(
+      new TransitionEvent('transitionend', {
+        bubbles: true,
+        propertyName: 'opacity',
+      })
+    );
     await waitForElementToBeRemoved(() =>
       document.body.querySelector('[data-slot="popover-content"]')
     );
@@ -65,28 +135,70 @@ export const InterruptibleOpenClose: Story = {
 };
 ```
 
-(Import `within`, `userEvent`, `expect`, `waitForElementToBeRemoved` from `storybook/test`.)
+(Import `within`, `userEvent`, `expect`, `waitFor`, and
+`waitForElementToBeRemoved` from `storybook/test`.)
 
 - [ ] **Step 2: Run — verify it fails**
 
-Run: `pnpm test:storybook popover` → FAIL (content still uses `animate-in`).
+Run: `pnpm test:storybook popover` -> FAIL for the real gaps: keyframe classes
+are still present, computed transition properties are absent/wrong, and exit
+teardown is still Presence animation-gated.
 
-- [ ] **Step 3: Implement the recipe on Popover** — in `popover.tsx`, read the content's full animate composition (the `animate-in/out` at :77 plus its neighbouring `fade-in-0 zoom-in-95 …` / `fade-out-0 zoom-out-95 …` classes) and replace the keyframe set with the transition equivalent. Recipe:
+- [ ] **Step 3: Implement the transition-presence helper on Popover first.**
+      This is not a class-only swap.
+
+Implementation requirements:
+
+- Make Popover root state observable to content. Preserve controlled and
+  uncontrolled root usage.
+- `PopoverContent` uses `forceMount` so Radix does not remove the node before
+  the exit transition paints.
+- Add a Nexus-owned motion state, e.g. `data-motion-state="open|closed"`.
+  Enter must mount/prepare in the closed state, then flip to open on the next
+  animation frame. This replaces the keyframe 0% frame without using
+  `@starting-style`.
+- On close, set the motion state to closed, wait for `transitionend` from the
+  animated property (`opacity` for fade+scale), then tear down. Ignore stale
+  transitionend events after an interrupted reopen.
+- Closed/closing content gets `aria-hidden`, no pointer interaction, and focus
+  gating. If the implementation uses `inert`, first verify Safari 15.4 support
+  or provide a fallback because `inert` may sit outside the Nexus floor.
+
+Popover class recipe:
 
 ```
 REMOVE:  nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out
          nx:data-[state=open]:fade-in-0  nx:data-[state=closed]:fade-out-0
          nx:data-[state=open]:zoom-in-95 nx:data-[state=closed]:zoom-out-95
-ADD:     nx:transition-[opacity,transform] nx:duration-fast nx:ease-move
+         nx:data-[state=open]:duration-default nx:data-[state=open]:ease-enter
+         nx:data-[state=closed]:duration-fast nx:data-[state=closed]:ease-exit
+         nx:data-[side=bottom]:slide-in-from-top-2
+         nx:data-[side=left]:slide-in-from-right-2
+         nx:data-[side=right]:slide-in-from-left-2
+         nx:data-[side=top]:slide-in-from-bottom-2
+         nx:motion-reduce:data-[state=open]:animate-none
+         nx:motion-reduce:data-[state=closed]:animate-none
+ADD:     nx:transition-[opacity,scale]
          nx:motion-reduce:transition-none
-         nx:data-[state=closed]:opacity-0 nx:data-[state=closed]:scale-95
+         nx:data-[motion-state=open]:duration-default
+         nx:data-[motion-state=open]:ease-enter
+         nx:data-[motion-state=closed]:duration-fast
+         nx:data-[motion-state=closed]:ease-exit
+         nx:data-[motion-state=closed]:opacity-0
+         nx:data-[motion-state=closed]:scale-95
+         nx:data-[motion-state=closed]:pointer-events-none
 ```
 
-(Base is implicitly `opacity-100 scale-100`. The transition interpolates both ways and is interruptible.)
+Base is `opacity-100 scale-100`. Do not carry over Popover's directional
+`slide-in-from-*` classes unless the spike also models them as transitionable
+`translate` states; otherwise they silently disappear and change the entrance
+motion.
 
-- [ ] **Step 4: Run — verify it passes + manually confirm** the open/close feels right and that clicking-open-then-away mid-animation retargets smoothly.
+- [ ] **Step 4: Run — verify it passes + manually confirm** open, close,
+      close-then-reopen mid-exit, and Escape/click-away. Confirm the panel does
+      not accept pointer/focus while closing.
 
-Run: `pnpm test:storybook popover` → PASS.
+Run: `pnpm test:storybook popover` -> PASS.
 
 - [ ] **Step 5: Commit**
 
@@ -101,16 +213,41 @@ git commit -m "feat(motion): interruptible transitions for Popover open/close (#
 
 **Files:** each surface in File Structure above (except Popover).
 
-For **each** surface: apply the same recipe as Task 1 Step 3, adapting the direction —
+Do not fan out until Task 1 proves the helper with tests. For each surface,
+move from Radix/animation-state classes to the shared transition-presence
+contract, then adapt only the visual recipe.
 
-- **Menus/popover-family** (overlay-layout.ts:48,59; dropdown-menu:135; context-menu:135; menubar:183,240; select:170; hover-card:95): fade + zoom → `transition-[opacity,transform]` + `data-[state=closed]:opacity-0 data-[state=closed]:scale-95`.
-- **Tooltip** (tooltip.tsx:82,83): the enter is unconditional `animate-in fade-in-0 zoom-in-95`; convert to `transition-[opacity,transform] data-[state=closed]:opacity-0 data-[state=closed]:scale-95` with a base open state.
-- **Sheet** (sheet.tsx:80,102) and **Drawer** (drawer.tsx:72): these SLIDE from an edge. Keep the slide but make it a transition: `transition-transform data-[state=closed]:translate-x-full` (per side) instead of `slide-out-to-*`. Vaul (Drawer) may already animate via its own runtime CSS — verify before changing; if Vaul owns it, leave Drawer out of scope and note it.
-- **NavigationMenu** (navigation-menu.tsx:186,195,235,303): convert its viewport/flyout animate set the same way.
+- **Popover-family fade+scale surfaces** (`overlay-layout.ts:48`,
+  dropdown-menu, context-menu, menubar, select, hover-card): use
+  `nx:transition-[opacity,scale]`, closed opacity/scale, preserved open/close
+  duration/ease tokens, and closed pointer/focus gating.
+- **Dialog/AlertDialog scrim** (`overlay-layout.ts:59`): opacity only. Use
+  `nx:transition-opacity` plus closed opacity. Do **not** add `scale-95` to a
+  full-bleed scrim.
+- **Tooltip** (`tooltip.tsx:82,83`): convert the unconditional enter keyframes
+  and closed keyframes to the same helper-backed fade+scale recipe. Verify
+  tooltip delay/escape behavior still works.
+- **Sheet** (`sheet.tsx:80,102`): scrim is opacity only; panel uses directional
+  translate. Tailwind v4 translate utilities emit the individual `translate`
+  property, so the panel transition property must include `translate`, not only
+  `transform`.
+- **Drawer** (`drawer.tsx:72`): Vaul owns the drawer runtime transition model.
+  Keep Drawer out of this PR unless the spike proves a Nexus-owned keyframe is
+  actually controlling its interruptibility; if excluded, say so in the PR body.
+- **NavigationMenu** (`navigation-menu.tsx:186,195,235,303`): convert viewport
+  and inline flyout recipes separately. Preserve any directional motion by
+  translating it to `translate` states rather than dropping it.
 
-- [ ] **Step 1:** For each surface, add a play-fn (mirroring Task 1) asserting the `animate-in` keyframe class is gone, `motion-reduce:transition-none` is present, and the content unmounts on close. Run `pnpm test:storybook <surface>` → FAIL.
-- [ ] **Step 2:** Apply the recipe. Re-run → PASS. Manually confirm Radix `Presence` still tears down each surface (add `forceMount` only if a surface fails to unmount).
-- [ ] **Step 3:** Commit per surface or in small logical groups (e.g. one commit for the popover-family, one for panels, one for navigation-menu):
+- [ ] **Step 1:** For each surface, add or update a play-fn that asserts no
+      `animate-in` / `animate-out` class remains, `motion-reduce:transition-none`
+      is present, computed `transition-property` matches the used individual
+      properties (`opacity`, `scale`, `translate`), the exit visibly paints, and
+      interruption cancels stale teardown. Run `pnpm test:storybook <surface>`
+      -> FAIL.
+- [ ] **Step 2:** Apply the helper and the surface-specific recipe. Re-run ->
+      PASS. Manually confirm pointer/focus gating in the closed/closing state.
+- [ ] **Step 3:** Commit per surface or in small logical groups (e.g. helper +
+      Popover, popover-family, panels, navigation-menu):
 
 ```bash
 git add packages/react/src/components/<surface>
@@ -137,10 +274,11 @@ Part of #598 (Workstream E, principle #4). Sub-PR 1 of 4.
 
 ## Test Plan
 - [ ] lint / format:check / typecheck / test:storybook green
-- [ ] Per-surface play-fn: no `animate-in` class, `motion-reduce:transition-none` present, content unmounts on close (Radix Presence)
+- [ ] Popover spike proves forceMount + Nexus transitionend teardown + closed-state gating
+- [ ] Per-surface play-fn: no `animate-in` / `animate-out` class, `motion-reduce:transition-none` present, computed transition-property matches opacity/scale/translate, exit visibly paints, interruption cancels stale teardown
 
 ## Modern Web Guidance / polish.md
-- Existing `nx:duration-*` / `nx:ease-*` tokens (no parallel scale); reduced-motion guarded; opacity/transform only (GPU-composited). Radix `Presence` exit-before-unmount verified per surface.
+- Existing `nx:duration-*` / `nx:ease-*` tokens (no parallel scale); reduced-motion guarded; opacity plus individual scale/translate properties only. Radix Presence is animation-gated, so CSS-transition teardown is owned by the Nexus helper.
 EOF
 )"
 ```
@@ -149,8 +287,8 @@ EOF
 
 ## Self-Review
 
-**Spec coverage (#4):** all `data-[state=open]:animate-in/out` surfaces enumerated; recipe proven on Popover (Task 1) then applied per-surface (Task 2). Loading/height keyframes explicitly excluded. Drawer/Vaul flagged for verification.
+**Spec coverage (#4):** all `data-[state=open]:animate-in/out` surfaces enumerated; helper + recipe proven on Popover (Task 1) then applied per-surface (Task 2). Loading/height keyframes explicitly excluded. Drawer/Vaul flagged for exclusion unless verification proves Nexus owns its transition.
 
-**Placeholder scan:** the recipe is concrete (exact REMOVE/ADD class lists); the "spike then apply" structure is deliberate for genuinely per-surface work, not a placeholder. Each surface has an explicit file:line and the same recipe.
+**Placeholder scan:** the Popover recipe is concrete (exact REMOVE/ADD class lists), while remaining surfaces are grouped by motion shape: fade+scale, opacity-only scrim, or directional translate. The "spike then apply" structure is deliberate because Radix Presence cannot be trusted for transition teardown.
 
-**Type/name consistency:** `data-slot="popover-content"` and the `data-[state=closed]` / `motion-reduce:transition-none` classes are identical between the impl recipe and the assertions.
+**Type/name consistency:** `data-slot="popover-content"`, `data-motion-state`, computed `transition-property`, and `motion-reduce:transition-none` are aligned between the implementation recipe and the assertions. `scale-95` maps to `scale`, not `transform`, under Tailwind v4.

--- a/docs/superpowers/plans/2026-07-02-598-e1-overlay-interruptible.md
+++ b/docs/superpowers/plans/2026-07-02-598-e1-overlay-interruptible.md
@@ -1,0 +1,156 @@
+# E1 — Interruptible Overlay Open/Close Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Workstream E principle #4 (part of issue #598) — convert the overlay open/close animations from tw-animate-css **keyframes** (`animate-in` / `animate-out`) to **interruptible CSS transitions** on `data-[state]`, so rapid open/close retargets instead of replaying a fixed timeline.
+
+**Architecture:** Radix sets `data-state="open|closed"` and (via `Presence`) keeps the node mounted until the exit animation/transition ends. Replace `data-[state=open]:animate-in … fade-in-0 zoom-in-95 (slide-*)` / `data-[state=closed]:animate-out …` with a **state-driven transition**: a rest state (`opacity-100 scale-100`), a closed state (`data-[state=closed]:opacity-0 data-[state=closed]:scale-95` + slide for panels), `transition-[opacity,transform]` on the existing `nx:duration-*` / `nx:ease-*` tokens, and `nx:motion-reduce:transition-none`. This is **spike-driven**: prove the recipe + Radix `Presence` exit-before-unmount on ONE surface, then apply it to the rest.
+
+**Tech Stack:** React, Tailwind v4 (`nx:` prefix, `data-[state=*]:` + `transition-*`), Radix `Presence`, tw-animate-css (removing its keyframe utilities from these surfaces), Storybook 10 (`storybook/test`).
+
+## Global Constraints
+
+- **Existing motion tokens only** (`nx:duration-fast|default`, `nx:ease-enter|exit|move`) — no new scale.
+- **`nx:motion-reduce:transition-none`** on every converted surface.
+- **Loading/height keyframes stay keyframes** — do NOT touch spinner, skeleton, accordion, collapsible, progress-indeterminate, caret-blink.
+- **Radix `Presence` must still unmount on close** — the closed-state transition must actually run before unmount (`forceMount` only if a surface needs it).
+- `nx:` prefix before every modifier; semantic tokens only. **Pre-production.** **PR:** `feat(motion): …`, base `main`, body references `#598` (this is sub-PR 1 of 4).
+
+---
+
+## File Structure (surfaces carrying `data-[state=open]:animate-in / animate-out`)
+
+- `packages/react/src/components/popover/popover.tsx:77` — **spike surface**
+- `packages/react/src/components/overlay-layout/overlay-layout.ts:48,59` — Dialog/AlertDialog content + shared popover recipe
+- `packages/react/src/components/dropdown-menu/dropdown-menu.tsx:135`
+- `packages/react/src/components/context-menu/context-menu.tsx:135`
+- `packages/react/src/components/menubar/menubar.tsx:183,240`
+- `packages/react/src/components/select/select.tsx:170`
+- `packages/react/src/components/hover-card/hover-card.tsx:95`
+- `packages/react/src/components/tooltip/tooltip.tsx:82,83`
+- `packages/react/src/components/sheet/sheet.tsx:80,102` — panels (slide from edge)
+- `packages/react/src/components/drawer/drawer.tsx:72` — Vaul (may already use its own transitions; verify)
+- `packages/react/src/components/navigation-menu/navigation-menu.tsx:186,195,235,303`
+
+---
+
+### Task 1: Spike + verify the recipe on Popover
+
+**Files:** `popover.tsx` (around :77) + `Popover.stories.tsx`.
+
+- [ ] **Step 1: Write the failing/verifying test** — a play fn that opens then closes the popover and asserts the content unmounts after the transition (proves Radix `Presence` still tears down):
+
+```tsx
+export const InterruptibleOpenClose: Story = {
+  render: () => (
+    <Popover>
+      <PopoverTrigger>Open</PopoverTrigger>
+      <PopoverContent>Content</PopoverContent>
+    </Popover>
+  ),
+  play: async ({ canvasElement }) => {
+    const trigger = within(canvasElement).getByText('Open');
+    await userEvent.click(trigger);
+    const content = await within(document.body).findByText('Content');
+    await expect(content).toBeVisible();
+    // No animate-in keyframe utility remains on the content.
+    const panel = content.closest('[data-slot="popover-content"]')!;
+    await expect(panel).not.toHaveClass('nx:data-[state=open]:animate-in');
+    await expect(panel).toHaveClass('nx:motion-reduce:transition-none');
+    await userEvent.keyboard('{Escape}');
+    await waitForElementToBeRemoved(() =>
+      document.body.querySelector('[data-slot="popover-content"]')
+    );
+  },
+};
+```
+
+(Import `within`, `userEvent`, `expect`, `waitForElementToBeRemoved` from `storybook/test`.)
+
+- [ ] **Step 2: Run — verify it fails**
+
+Run: `pnpm test:storybook popover` → FAIL (content still uses `animate-in`).
+
+- [ ] **Step 3: Implement the recipe on Popover** — in `popover.tsx`, read the content's full animate composition (the `animate-in/out` at :77 plus its neighbouring `fade-in-0 zoom-in-95 …` / `fade-out-0 zoom-out-95 …` classes) and replace the keyframe set with the transition equivalent. Recipe:
+
+```
+REMOVE:  nx:data-[state=open]:animate-in nx:data-[state=closed]:animate-out
+         nx:data-[state=open]:fade-in-0  nx:data-[state=closed]:fade-out-0
+         nx:data-[state=open]:zoom-in-95 nx:data-[state=closed]:zoom-out-95
+ADD:     nx:transition-[opacity,transform] nx:duration-fast nx:ease-move
+         nx:motion-reduce:transition-none
+         nx:data-[state=closed]:opacity-0 nx:data-[state=closed]:scale-95
+```
+
+(Base is implicitly `opacity-100 scale-100`. The transition interpolates both ways and is interruptible.)
+
+- [ ] **Step 4: Run — verify it passes + manually confirm** the open/close feels right and that clicking-open-then-away mid-animation retargets smoothly.
+
+Run: `pnpm test:storybook popover` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/react/src/components/popover
+git commit -m "feat(motion): interruptible transitions for Popover open/close (#598)"
+```
+
+---
+
+### Task 2: Apply the verified recipe to the remaining surfaces
+
+**Files:** each surface in File Structure above (except Popover).
+
+For **each** surface: apply the same recipe as Task 1 Step 3, adapting the direction —
+
+- **Menus/popover-family** (overlay-layout.ts:48,59; dropdown-menu:135; context-menu:135; menubar:183,240; select:170; hover-card:95): fade + zoom → `transition-[opacity,transform]` + `data-[state=closed]:opacity-0 data-[state=closed]:scale-95`.
+- **Tooltip** (tooltip.tsx:82,83): the enter is unconditional `animate-in fade-in-0 zoom-in-95`; convert to `transition-[opacity,transform] data-[state=closed]:opacity-0 data-[state=closed]:scale-95` with a base open state.
+- **Sheet** (sheet.tsx:80,102) and **Drawer** (drawer.tsx:72): these SLIDE from an edge. Keep the slide but make it a transition: `transition-transform data-[state=closed]:translate-x-full` (per side) instead of `slide-out-to-*`. Vaul (Drawer) may already animate via its own runtime CSS — verify before changing; if Vaul owns it, leave Drawer out of scope and note it.
+- **NavigationMenu** (navigation-menu.tsx:186,195,235,303): convert its viewport/flyout animate set the same way.
+
+- [ ] **Step 1:** For each surface, add a play-fn (mirroring Task 1) asserting the `animate-in` keyframe class is gone, `motion-reduce:transition-none` is present, and the content unmounts on close. Run `pnpm test:storybook <surface>` → FAIL.
+- [ ] **Step 2:** Apply the recipe. Re-run → PASS. Manually confirm Radix `Presence` still tears down each surface (add `forceMount` only if a surface fails to unmount).
+- [ ] **Step 3:** Commit per surface or in small logical groups (e.g. one commit for the popover-family, one for panels, one for navigation-menu):
+
+```bash
+git add packages/react/src/components/<surface>
+git commit -m "feat(motion): interruptible transitions for <surface> open/close (#598)"
+```
+
+---
+
+### Task 3: Validate and open the sub-PR
+
+- [ ] `pnpm lint && pnpm format:check && pnpm typecheck && pnpm test:storybook` — all green.
+- [ ] Open PR:
+
+```bash
+git push -u origin aishvarya/motion-overlay-interruptible
+gh pr create --base main \
+  --title "feat(motion): interruptible overlay open/close transitions (E1 of #598)" \
+  --body "$(cat <<'EOF'
+## Summary
+Convert overlay open/close from tw-animate-css keyframes to interruptible `data-[state]` transitions across the popover family, tooltip, sheet, drawer, and navigation-menu. Rapid open/close now retargets instead of replaying. Loading/height keyframes untouched.
+
+## GitHub Issue
+Part of #598 (Workstream E, principle #4). Sub-PR 1 of 4.
+
+## Test Plan
+- [ ] lint / format:check / typecheck / test:storybook green
+- [ ] Per-surface play-fn: no `animate-in` class, `motion-reduce:transition-none` present, content unmounts on close (Radix Presence)
+
+## Modern Web Guidance / polish.md
+- Existing `nx:duration-*` / `nx:ease-*` tokens (no parallel scale); reduced-motion guarded; opacity/transform only (GPU-composited). Radix `Presence` exit-before-unmount verified per surface.
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (#4):** all `data-[state=open]:animate-in/out` surfaces enumerated; recipe proven on Popover (Task 1) then applied per-surface (Task 2). Loading/height keyframes explicitly excluded. Drawer/Vaul flagged for verification.
+
+**Placeholder scan:** the recipe is concrete (exact REMOVE/ADD class lists); the "spike then apply" structure is deliberate for genuinely per-surface work, not a placeholder. Each surface has an explicit file:line and the same recipe.
+
+**Type/name consistency:** `data-slot="popover-content"` and the `data-[state=closed]` / `motion-reduce:transition-none` classes are identical between the impl recipe and the assertions.

--- a/docs/superpowers/plans/2026-07-02-598-e1-overlay-interruptible.md
+++ b/docs/superpowers/plans/2026-07-02-598-e1-overlay-interruptible.md
@@ -132,6 +132,8 @@ export const InterruptibleOpenClose: Story = {
     });
 
     await expect(panel).toHaveStyle({ pointerEvents: 'none' });
+    await userEvent.tab();
+    await expect(panel).not.toContainElement(document.activeElement);
 
     await userEvent.click(trigger);
     const reopenedContent = await within(document.body).findByText('Content');
@@ -247,6 +249,12 @@ exit.
 Required assertions:
 
 - opening Dialog renders content and overlay visibly;
+- Dialog content and scrim have no `animate-in` / `animate-out` keyframe
+  utilities;
+- Dialog content and scrim include `nx:motion-reduce:transition-none`;
+- computed `transition-property` includes `opacity` and `scale` for content;
+- computed `transition-property` includes `opacity` for the scrim, and the scrim
+  recipe does not add scale;
 - closing leaves content/overlay mounted long enough to observe the visible exit
   state;
 - no still-visible Dialog content node is marked `aria-hidden`;
@@ -255,6 +263,9 @@ Required assertions:
 - final `transitionend` fully unmounts the current Dialog content and overlay;
 - after final unmount, body scroll lock is released, outside `aria-hidden`
   mutations are cleaned up, and focus returns to the trigger.
+- focus gating is evidenced either by an automated Tab assertion while exiting
+  or, if the portal/focus trap makes that unstable in Storybook, by an explicit
+  manual focus-gating checklist item in the PR body.
 
 - [ ] **Step 1:** Write the failing Dialog story/play-fn for the assertions
       above. Run `pnpm test:storybook dialog` -> FAIL.
@@ -292,6 +303,7 @@ Part of #598 (Workstream E, principle #4). Sub-PR 1 of 4.
 - [ ] Popover spike proves forceMount + Nexus transitionend teardown + exiting-state gating
 - [ ] Dialog spike proves full unmount releases scroll lock, outside aria-hidden cleanup, and focus return
 - [ ] Popover/Dialog play-fns: no `animate-in` / `animate-out` class, `motion-reduce:transition-none` present, computed transition-property matches opacity/scale, exit visibly paints, interruption cancels stale teardown
+- [ ] Exiting-state focus gating covered by automated Tab assertions or called out as a manual focus-gating checklist where Storybook focus-trap behavior is unstable
 
 ## Modern Web Guidance / polish.md
 - Existing `nx:duration-*` / `nx:ease-*` tokens (no parallel scale); reduced-motion guarded; opacity plus individual scale/translate properties only. Radix Presence is animation-gated, so CSS-transition teardown is owned by the Nexus helper. Visible semantic nodes are not marked aria-hidden; inert is avoided unless a Safari 15.4 fallback is named.
@@ -303,22 +315,17 @@ EOF
 
 ### Task 4: Apply the verified recipe to remaining surfaces in follow-up PRs
 
-**Files:** each surface in File Structure above (except Popover).
+**Files:** each surface in File Structure above (except Popover and
+Dialog/AlertDialog).
 
 Do not fan out until Tasks 1-3 land the precursor PR with non-modal and modal
 tests. For each follow-up surface, move from Radix/animation-state classes to
 the shared transition-presence contract, then adapt only the visual recipe.
 
-- **Dialog/AlertDialog content** (`overlay-layout.ts:48`): use the
-  modal-proven helper, `nx:transition-[opacity,scale]`, preserved open/close
-  duration/ease tokens, and full unmount after exit.
 - **Popover-family fade+scale surfaces** (dropdown-menu, context-menu, menubar,
   select, hover-card): use
   `nx:transition-[opacity,scale]`, closed opacity/scale, preserved open/close
   duration/ease tokens, and closed pointer/focus gating.
-- **Dialog/AlertDialog scrim** (`overlay-layout.ts:59`): opacity only. Use
-  `nx:transition-opacity` plus closed opacity. Do **not** add `scale-95` to a
-  full-bleed scrim.
 - **Tooltip** (`tooltip.tsx:82,83`): convert the unconditional enter keyframes
   and closed keyframes to the same helper-backed fade+scale recipe. Verify
   tooltip delay/escape behavior still works.


### PR DESCRIPTION
## Summary
TDD plan for Workstream E principle #4 (interruptible overlay open/close). NOTE: the implementation branch `aishvarya/motion-overlay-interruptible` is already held by a Codex worktree for the #4 work — this `-plan` branch is the plan's reference home. Codex reads the plan from here.

## GitHub Issue
Part of #598 (Workstream E, principle #4). Plan for sub-PR 1 of 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9PUqK3zh6ETEmjGfki1JA