### PR TITLE
fix(storybook): keep story wrapper transparent

### DIFF
--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -225,7 +225,7 @@ const AppearanceDecorator: Decorator = (Story, context) => {
       onStateChange={handleStateChange}
     >
       <div
-        className={`nx:flex nx:items-center nx:justify-center nx:bg-background nx:text-foreground ${isDocs ? 'nx:py-12' : 'nx:min-h-svh'}`}
+        className={`nx:flex nx:items-center nx:justify-center nx:text-foreground ${isDocs ? 'nx:py-12' : 'nx:min-h-svh'}`}
       >
         <Story />
       </div>
@@ -263,11 +263,11 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
-    // Disable Storybook's built-in background selector
-    // Theme switching is handled by the decorator which applies
-    // nx:bg-background class that uses CSS variables
+    // Disable Storybook's built-in background selector. The imported consumer
+    // CSS still owns the iframe body background for theme parity; the per-story
+    // wrapper stays transparent so components do not get an extra surface.
     backgrounds: { disable: true },
-    // Use fullscreen layout so our theme wrapper fills the entire canvas
+    // Use fullscreen layout so our theme wrapper owns alignment and min-height
     layout: 'fullscreen',
     viewport: {
       options: {


### PR DESCRIPTION
## Summary

- Removes the `nx:bg-background` utility from the global Storybook story wrapper.
- Keeps the appearance provider, text color, alignment, docs padding, and fullscreen layout behavior intact.
- Clarifies that the iframe body background remains owned by imported consumer CSS, while the per-story wrapper stays transparent.

## GitHub Issue

Not linked.

## Test Plan

- [x] `git diff --check`
- [x] `corepack pnpm --filter @nexus_ds/core build`
- [x] Live Storybook DOM check against `components-button--default`: wrapper background was `rgba(0, 0, 0, 0)` and `nx:bg-background` was absent.

Note: `corepack pnpm --filter @nexus_ds/react typecheck` did not complete in this fresh worktree because the local dependency install state left `@storybook/react` unresolved to TypeScript; the failure was unrelated to the preview diff.
