### PR TITLE
fix(tokens): restore static semantic color output

### DIFF
--- a/apps/docs/public/themes/globals.css
+++ b/apps/docs/public/themes/globals.css
@@ -31,6 +31,109 @@
   --shadow-*: initial;
   --breakpoint-*: initial;
 
+  /* Semantic tokens */
+  --color-background: var(--nx-color-white-base);
+  --color-foreground: var(--nx-color-black-a900);
+  --color-background-hover: var(--nx-color-slate-50);
+  --color-background-hover-alpha: var(--nx-color-slate-a100);
+  --color-background-active: var(--nx-color-slate-100);
+  --color-muted: var(--nx-color-slate-50);
+  --color-muted-foreground: var(--nx-color-black-a600);
+  --color-muted-foreground-subtle: var(--nx-color-black-a500);
+  --color-disabled: var(--nx-color-slate-50);
+  --color-disabled-foreground: var(--nx-color-slate-400);
+  --color-container: var(--nx-color-white-base);
+  --color-container-foreground: var(--nx-color-slate-900);
+  --color-container-hover: var(--nx-color-slate-50);
+  --color-container-active: var(--nx-color-slate-100);
+  --color-popover: var(--nx-color-white-base);
+  --color-popover-foreground: var(--nx-color-slate-900);
+  --color-popover-hover: var(--nx-color-slate-50);
+  --color-popover-active: var(--nx-color-slate-50);
+  --color-popover-alpha: var(--nx-color-white-a700);
+  --color-popover-backdrop: var(--nx-color-slate-a900);
+  --color-control-background: var(--nx-color-slate-100);
+  --color-control-background-hover: var(--nx-color-slate-200);
+  --color-control-thumb: var(--nx-color-white-base);
+  --color-nav-background: var(--nx-color-slate-100);
+  --color-nav-foreground: var(--nx-color-slate-900);
+  --color-nav-muted-foreground: var(--nx-color-slate-600);
+  --color-nav-item-hover: var(--nx-color-slate-200);
+  --color-nav-item-active: var(--nx-color-slate-200);
+  --color-nav-border: var(--nx-color-slate-200);
+  --color-overlay: var(--nx-color-slate-a700);
+  --color-border-default: var(--nx-color-black-a200);
+  --color-border-hairline: var(--nx-color-black-a200);
+  --color-border-default-alpha: var(--nx-color-slate-a200);
+  --color-border-active: var(--nx-color-slate-400);
+  --color-border-disabled: var(--nx-color-black-a200);
+  --color-border-warning: var(--nx-color-orange-200);
+  --color-border-warning-active: var(--nx-color-orange-400);
+  --color-border-success: var(--nx-color-green-200);
+  --color-border-success-active: var(--nx-color-green-400);
+  --color-border-error: var(--nx-color-red-200);
+  --color-border-error-active: var(--nx-color-red-400);
+  --color-border-information: var(--nx-color-blue-200);
+  --color-border-information-active: var(--nx-color-blue-400);
+  --color-error-background: var(--nx-color-red-600);
+  --color-error-foreground: var(--nx-color-white-base);
+  --color-error-background-hover: var(--nx-color-red-700);
+  --color-error-background-active: var(--nx-color-red-800);
+  --color-error-disabled: var(--nx-color-red-300);
+  --color-error-subtle: var(--nx-color-red-50);
+  --color-error-subtle-foreground: var(--nx-color-red-600);
+  --color-error-subtle-hover: var(--nx-color-red-100);
+  --color-error-subtle-active: var(--nx-color-red-200);
+  --color-success-background: var(--nx-color-green-600);
+  --color-success-foreground: var(--nx-color-white-base);
+  --color-success-background-hover: var(--nx-color-green-700);
+  --color-success-background-active: var(--nx-color-green-800);
+  --color-success-disabled: var(--nx-color-green-300);
+  --color-success-subtle: var(--nx-color-green-50);
+  --color-success-subtle-foreground: var(--nx-color-green-700);
+  --color-success-subtle-hover: var(--nx-color-green-100);
+  --color-success-subtle-active: var(--nx-color-green-200);
+  --color-information-background: var(--nx-color-blue-600);
+  --color-information-foreground: var(--nx-color-white-base);
+  --color-information-background-hover: var(--nx-color-blue-700);
+  --color-information-background-active: var(--nx-color-blue-800);
+  --color-information-disabled: var(--nx-color-blue-300);
+  --color-information-subtle: var(--nx-color-blue-50);
+  --color-information-subtle-foreground: var(--nx-color-blue-600);
+  --color-information-subtle-hover: var(--nx-color-blue-100);
+  --color-information-subtle-active: var(--nx-color-blue-200);
+  --color-warning-background: var(--nx-color-orange-600);
+  --color-warning-foreground: var(--nx-color-white-base);
+  --color-warning-background-hover: var(--nx-color-orange-700);
+  --color-warning-background-active: var(--nx-color-orange-800);
+  --color-warning-disabled: var(--nx-color-orange-300);
+  --color-warning-subtle: var(--nx-color-orange-50);
+  --color-warning-subtle-foreground: var(--nx-color-orange-600);
+  --color-warning-subtle-hover: var(--nx-color-orange-100);
+  --color-warning-subtle-active: var(--nx-color-orange-200);
+  --color-primary-background: var(--nx-color-blue-600);
+  --color-primary-background-active: var(--nx-color-blue-800);
+  --color-primary-foreground: var(--nx-color-white-base);
+  --color-primary-background-hover: var(--nx-color-blue-700);
+  --color-primary-disabled: var(--nx-color-blue-300);
+  --color-primary-subtle: var(--nx-color-blue-50);
+  --color-primary-subtle-foreground: var(--nx-color-blue-600);
+  --color-primary-subtle-hover: var(--nx-color-blue-100);
+  --color-primary-subtle-active: var(--nx-color-blue-200);
+  --color-secondary-background: var(--nx-color-neutral-100);
+  --color-secondary-foreground: var(--nx-color-neutral-900);
+  --color-secondary-background-hover: var(--nx-color-neutral-200);
+  --color-secondary-background-active: var(--nx-color-neutral-300);
+  --color-secondary-disabled: var(--nx-color-neutral-50);
+  --color-secondary-subtle: var(--nx-color-neutral-100);
+  --color-secondary-subtle-foreground: var(--nx-color-neutral-600);
+  --color-secondary-subtle-hover: var(--nx-color-neutral-200);
+  --color-secondary-subtle-active: var(--nx-color-neutral-300);
+  --color-border-primary: var(--nx-color-blue-200);
+  --color-border-primary-active: var(--nx-color-blue-400);
+  --color-focus-default: var(--nx-focus-color-default);
+  --color-focus-error: var(--nx-focus-color-error);
+
   /* Spacing tokens */
   --spacing-0: 0px;
   --spacing-1: 4px;
@@ -143,756 +246,6 @@
   --breakpoint-lg: 64rem;
   --breakpoint-xl: 80rem;
   --breakpoint-2xl: 96rem;
-}
-
-@theme inline {
-  /* Semantic tokens */
-  --color-background: var(--nx-color-background, var(--nx-color-white-base));
-  --color-foreground: var(--nx-color-foreground, var(--nx-color-black-a900));
-  --color-background-hover: var(
-    --nx-color-background-hover,
-    var(--nx-color-slate-50)
-  );
-  --color-background-hover-alpha: var(
-    --nx-color-background-hover-alpha,
-    var(--nx-color-slate-a100)
-  );
-  --color-background-active: var(
-    --nx-color-background-active,
-    var(--nx-color-slate-100)
-  );
-  --color-muted: var(--nx-color-muted, var(--nx-color-slate-50));
-  --color-muted-foreground: var(
-    --nx-color-muted-foreground,
-    var(--nx-color-black-a600)
-  );
-  --color-muted-foreground-subtle: var(
-    --nx-color-muted-foreground-subtle,
-    var(--nx-color-black-a500)
-  );
-  --color-disabled: var(--nx-color-disabled, var(--nx-color-slate-50));
-  --color-disabled-foreground: var(
-    --nx-color-disabled-foreground,
-    var(--nx-color-slate-400)
-  );
-  --color-container: var(--nx-color-container, var(--nx-color-white-base));
-  --color-container-foreground: var(
-    --nx-color-container-foreground,
-    var(--nx-color-slate-900)
-  );
-  --color-container-hover: var(
-    --nx-color-container-hover,
-    var(--nx-color-slate-50)
-  );
-  --color-container-active: var(
-    --nx-color-container-active,
-    var(--nx-color-slate-100)
-  );
-  --color-popover: var(--nx-color-popover, var(--nx-color-white-base));
-  --color-popover-foreground: var(
-    --nx-color-popover-foreground,
-    var(--nx-color-slate-900)
-  );
-  --color-popover-hover: var(
-    --nx-color-popover-hover,
-    var(--nx-color-slate-50)
-  );
-  --color-popover-active: var(
-    --nx-color-popover-active,
-    var(--nx-color-slate-50)
-  );
-  --color-popover-alpha: var(
-    --nx-color-popover-alpha,
-    var(--nx-color-white-a700)
-  );
-  --color-popover-backdrop: var(
-    --nx-color-popover-backdrop,
-    var(--nx-color-slate-a900)
-  );
-  --color-control-background: var(
-    --nx-color-control-background,
-    var(--nx-color-slate-100)
-  );
-  --color-control-background-hover: var(
-    --nx-color-control-background-hover,
-    var(--nx-color-slate-200)
-  );
-  --color-control-thumb: var(
-    --nx-color-control-thumb,
-    var(--nx-color-white-base)
-  );
-  --color-nav-background: var(
-    --nx-color-nav-background,
-    var(--nx-color-slate-100)
-  );
-  --color-nav-foreground: var(
-    --nx-color-nav-foreground,
-    var(--nx-color-slate-900)
-  );
-  --color-nav-muted-foreground: var(
-    --nx-color-nav-muted-foreground,
-    var(--nx-color-slate-600)
-  );
-  --color-nav-item-hover: var(
-    --nx-color-nav-item-hover,
-    var(--nx-color-slate-200)
-  );
-  --color-nav-item-active: var(
-    --nx-color-nav-item-active,
-    var(--nx-color-slate-200)
-  );
-  --color-nav-border: var(--nx-color-nav-border, var(--nx-color-slate-200));
-  --color-overlay: var(--nx-color-overlay, var(--nx-color-slate-a700));
-  --color-border-default: var(
-    --nx-color-border-default,
-    var(--nx-color-black-a200)
-  );
-  --color-border-hairline: var(
-    --nx-color-border-hairline,
-    var(--nx-color-black-a200)
-  );
-  --color-border-default-alpha: var(
-    --nx-color-border-default-alpha,
-    var(--nx-color-slate-a200)
-  );
-  --color-border-active: var(
-    --nx-color-border-active,
-    var(--nx-color-slate-400)
-  );
-  --color-border-disabled: var(
-    --nx-color-border-disabled,
-    var(--nx-color-black-a200)
-  );
-  --color-border-warning: var(
-    --nx-color-border-warning,
-    var(--nx-color-orange-200)
-  );
-  --color-border-warning-active: var(
-    --nx-color-border-warning-active,
-    var(--nx-color-orange-400)
-  );
-  --color-border-success: var(
-    --nx-color-border-success,
-    var(--nx-color-green-200)
-  );
-  --color-border-success-active: var(
-    --nx-color-border-success-active,
-    var(--nx-color-green-400)
-  );
-  --color-border-error: var(--nx-color-border-error, var(--nx-color-red-200));
-  --color-border-error-active: var(
-    --nx-color-border-error-active,
-    var(--nx-color-red-400)
-  );
-  --color-border-information: var(
-    --nx-color-border-information,
-    var(--nx-color-blue-200)
-  );
-  --color-border-information-active: var(
-    --nx-color-border-information-active,
-    var(--nx-color-blue-400)
-  );
-  --color-error-background: var(
-    --nx-color-error-background,
-    var(--nx-color-red-600)
-  );
-  --color-error-foreground: var(
-    --nx-color-error-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-error-background-hover: var(
-    --nx-color-error-background-hover,
-    var(--nx-color-red-700)
-  );
-  --color-error-background-active: var(
-    --nx-color-error-background-active,
-    var(--nx-color-red-800)
-  );
-  --color-error-disabled: var(
-    --nx-color-error-disabled,
-    var(--nx-color-red-300)
-  );
-  --color-error-subtle: var(--nx-color-error-subtle, var(--nx-color-red-50));
-  --color-error-subtle-foreground: var(
-    --nx-color-error-subtle-foreground,
-    var(--nx-color-red-600)
-  );
-  --color-error-subtle-hover: var(
-    --nx-color-error-subtle-hover,
-    var(--nx-color-red-100)
-  );
-  --color-error-subtle-active: var(
-    --nx-color-error-subtle-active,
-    var(--nx-color-red-200)
-  );
-  --color-success-background: var(
-    --nx-color-success-background,
-    var(--nx-color-green-600)
-  );
-  --color-success-foreground: var(
-    --nx-color-success-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-success-background-hover: var(
-    --nx-color-success-background-hover,
-    var(--nx-color-green-700)
-  );
-  --color-success-background-active: var(
-    --nx-color-success-background-active,
-    var(--nx-color-green-800)
-  );
-  --color-success-disabled: var(
-    --nx-color-success-disabled,
-    var(--nx-color-green-300)
-  );
-  --color-success-subtle: var(
-    --nx-color-success-subtle,
-    var(--nx-color-green-50)
-  );
-  --color-success-subtle-foreground: var(
-    --nx-color-success-subtle-foreground,
-    var(--nx-color-green-700)
-  );
-  --color-success-subtle-hover: var(
-    --nx-color-success-subtle-hover,
-    var(--nx-color-green-100)
-  );
-  --color-success-subtle-active: var(
-    --nx-color-success-subtle-active,
-    var(--nx-color-green-200)
-  );
-  --color-information-background: var(
-    --nx-color-information-background,
-    var(--nx-color-blue-600)
-  );
-  --color-information-foreground: var(
-    --nx-color-information-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-information-background-hover: var(
-    --nx-color-information-background-hover,
-    var(--nx-color-blue-700)
-  );
-  --color-information-background-active: var(
-    --nx-color-information-background-active,
-    var(--nx-color-blue-800)
-  );
-  --color-information-disabled: var(
-    --nx-color-information-disabled,
-    var(--nx-color-blue-300)
-  );
-  --color-information-subtle: var(
-    --nx-color-information-subtle,
-    var(--nx-color-blue-50)
-  );
-  --color-information-subtle-foreground: var(
-    --nx-color-information-subtle-foreground,
-    var(--nx-color-blue-600)
-  );
-  --color-information-subtle-hover: var(
-    --nx-color-information-subtle-hover,
-    var(--nx-color-blue-100)
-  );
-  --color-information-subtle-active: var(
-    --nx-color-information-subtle-active,
-    var(--nx-color-blue-200)
-  );
-  --color-warning-background: var(
-    --nx-color-warning-background,
-    var(--nx-color-orange-600)
-  );
-  --color-warning-foreground: var(
-    --nx-color-warning-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-warning-background-hover: var(
-    --nx-color-warning-background-hover,
-    var(--nx-color-orange-700)
-  );
-  --color-warning-background-active: var(
-    --nx-color-warning-background-active,
-    var(--nx-color-orange-800)
-  );
-  --color-warning-disabled: var(
-    --nx-color-warning-disabled,
-    var(--nx-color-orange-300)
-  );
-  --color-warning-subtle: var(
-    --nx-color-warning-subtle,
-    var(--nx-color-orange-50)
-  );
-  --color-warning-subtle-foreground: var(
-    --nx-color-warning-subtle-foreground,
-    var(--nx-color-orange-600)
-  );
-  --color-warning-subtle-hover: var(
-    --nx-color-warning-subtle-hover,
-    var(--nx-color-orange-100)
-  );
-  --color-warning-subtle-active: var(
-    --nx-color-warning-subtle-active,
-    var(--nx-color-orange-200)
-  );
-  --color-primary-background: var(
-    --nx-color-primary-background,
-    var(--nx-color-blue-600)
-  );
-  --color-primary-background-active: var(
-    --nx-color-primary-background-active,
-    var(--nx-color-blue-800)
-  );
-  --color-primary-foreground: var(
-    --nx-color-primary-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-primary-background-hover: var(
-    --nx-color-primary-background-hover,
-    var(--nx-color-blue-700)
-  );
-  --color-primary-disabled: var(
-    --nx-color-primary-disabled,
-    var(--nx-color-blue-300)
-  );
-  --color-primary-subtle: var(
-    --nx-color-primary-subtle,
-    var(--nx-color-blue-50)
-  );
-  --color-primary-subtle-foreground: var(
-    --nx-color-primary-subtle-foreground,
-    var(--nx-color-blue-600)
-  );
-  --color-primary-subtle-hover: var(
-    --nx-color-primary-subtle-hover,
-    var(--nx-color-blue-100)
-  );
-  --color-primary-subtle-active: var(
-    --nx-color-primary-subtle-active,
-    var(--nx-color-blue-200)
-  );
-  --color-secondary-background: var(
-    --nx-color-secondary-background,
-    var(--nx-color-neutral-100)
-  );
-  --color-secondary-foreground: var(
-    --nx-color-secondary-foreground,
-    var(--nx-color-neutral-900)
-  );
-  --color-secondary-background-hover: var(
-    --nx-color-secondary-background-hover,
-    var(--nx-color-neutral-200)
-  );
-  --color-secondary-background-active: var(
-    --nx-color-secondary-background-active,
-    var(--nx-color-neutral-300)
-  );
-  --color-secondary-disabled: var(
-    --nx-color-secondary-disabled,
-    var(--nx-color-neutral-50)
-  );
-  --color-secondary-subtle: var(
-    --nx-color-secondary-subtle,
-    var(--nx-color-neutral-100)
-  );
-  --color-secondary-subtle-foreground: var(
-    --nx-color-secondary-subtle-foreground,
-    var(--nx-color-neutral-600)
-  );
-  --color-secondary-subtle-hover: var(
-    --nx-color-secondary-subtle-hover,
-    var(--nx-color-neutral-200)
-  );
-  --color-secondary-subtle-active: var(
-    --nx-color-secondary-subtle-active,
-    var(--nx-color-neutral-300)
-  );
-  --color-border-primary: var(
-    --nx-color-border-primary,
-    var(--nx-color-blue-200)
-  );
-  --color-border-primary-active: var(
-    --nx-color-border-primary-active,
-    var(--nx-color-blue-400)
-  );
-  --color-focus-default: var(
-    --nx-color-focus-default,
-    var(--nx-focus-color-default)
-  );
-  --color-focus-error: var(--nx-color-focus-error, var(--nx-focus-color-error));
-}
-
-/* ===== RUNTIME COLOR ALIASES ===== */
-:root {
-  --color-background: var(--nx-color-background, var(--nx-color-white-base));
-  --color-foreground: var(--nx-color-foreground, var(--nx-color-black-a900));
-  --color-background-hover: var(
-    --nx-color-background-hover,
-    var(--nx-color-slate-50)
-  );
-  --color-background-hover-alpha: var(
-    --nx-color-background-hover-alpha,
-    var(--nx-color-slate-a100)
-  );
-  --color-background-active: var(
-    --nx-color-background-active,
-    var(--nx-color-slate-100)
-  );
-  --color-muted: var(--nx-color-muted, var(--nx-color-slate-50));
-  --color-muted-foreground: var(
-    --nx-color-muted-foreground,
-    var(--nx-color-black-a600)
-  );
-  --color-muted-foreground-subtle: var(
-    --nx-color-muted-foreground-subtle,
-    var(--nx-color-black-a500)
-  );
-  --color-disabled: var(--nx-color-disabled, var(--nx-color-slate-50));
-  --color-disabled-foreground: var(
-    --nx-color-disabled-foreground,
-    var(--nx-color-slate-400)
-  );
-  --color-container: var(--nx-color-container, var(--nx-color-white-base));
-  --color-container-foreground: var(
-    --nx-color-container-foreground,
-    var(--nx-color-slate-900)
-  );
-  --color-container-hover: var(
-    --nx-color-container-hover,
-    var(--nx-color-slate-50)
-  );
-  --color-container-active: var(
-    --nx-color-container-active,
-    var(--nx-color-slate-100)
-  );
-  --color-popover: var(--nx-color-popover, var(--nx-color-white-base));
-  --color-popover-foreground: var(
-    --nx-color-popover-foreground,
-    var(--nx-color-slate-900)
-  );
-  --color-popover-hover: var(
-    --nx-color-popover-hover,
-    var(--nx-color-slate-50)
-  );
-  --color-popover-active: var(
-    --nx-color-popover-active,
-    var(--nx-color-slate-50)
-  );
-  --color-popover-alpha: var(
-    --nx-color-popover-alpha,
-    var(--nx-color-white-a700)
-  );
-  --color-popover-backdrop: var(
-    --nx-color-popover-backdrop,
-    var(--nx-color-slate-a900)
-  );
-  --color-control-background: var(
-    --nx-color-control-background,
-    var(--nx-color-slate-100)
-  );
-  --color-control-background-hover: var(
-    --nx-color-control-background-hover,
-    var(--nx-color-slate-200)
-  );
-  --color-control-thumb: var(
-    --nx-color-control-thumb,
-    var(--nx-color-white-base)
-  );
-  --color-nav-background: var(
-    --nx-color-nav-background,
-    var(--nx-color-slate-100)
-  );
-  --color-nav-foreground: var(
-    --nx-color-nav-foreground,
-    var(--nx-color-slate-900)
-  );
-  --color-nav-muted-foreground: var(
-    --nx-color-nav-muted-foreground,
-    var(--nx-color-slate-600)
-  );
-  --color-nav-item-hover: var(
-    --nx-color-nav-item-hover,
-    var(--nx-color-slate-200)
-  );
-  --color-nav-item-active: var(
-    --nx-color-nav-item-active,
-    var(--nx-color-slate-200)
-  );
-  --color-nav-border: var(--nx-color-nav-border, var(--nx-color-slate-200));
-  --color-overlay: var(--nx-color-overlay, var(--nx-color-slate-a700));
-  --color-border-default: var(
-    --nx-color-border-default,
-    var(--nx-color-black-a200)
-  );
-  --color-border-hairline: var(
-    --nx-color-border-hairline,
-    var(--nx-color-black-a200)
-  );
-  --color-border-default-alpha: var(
-    --nx-color-border-default-alpha,
-    var(--nx-color-slate-a200)
-  );
-  --color-border-active: var(
-    --nx-color-border-active,
-    var(--nx-color-slate-400)
-  );
-  --color-border-disabled: var(
-    --nx-color-border-disabled,
-    var(--nx-color-black-a200)
-  );
-  --color-border-warning: var(
-    --nx-color-border-warning,
-    var(--nx-color-orange-200)
-  );
-  --color-border-warning-active: var(
-    --nx-color-border-warning-active,
-    var(--nx-color-orange-400)
-  );
-  --color-border-success: var(
-    --nx-color-border-success,
-    var(--nx-color-green-200)
-  );
-  --color-border-success-active: var(
-    --nx-color-border-success-active,
-    var(--nx-color-green-400)
-  );
-  --color-border-error: var(--nx-color-border-error, var(--nx-color-red-200));
-  --color-border-error-active: var(
-    --nx-color-border-error-active,
-    var(--nx-color-red-400)
-  );
-  --color-border-information: var(
-    --nx-color-border-information,
-    var(--nx-color-blue-200)
-  );
-  --color-border-information-active: var(
-    --nx-color-border-information-active,
-    var(--nx-color-blue-400)
-  );
-  --color-error-background: var(
-    --nx-color-error-background,
-    var(--nx-color-red-600)
-  );
-  --color-error-foreground: var(
-    --nx-color-error-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-error-background-hover: var(
-    --nx-color-error-background-hover,
-    var(--nx-color-red-700)
-  );
-  --color-error-background-active: var(
-    --nx-color-error-background-active,
-    var(--nx-color-red-800)
-  );
-  --color-error-disabled: var(
-    --nx-color-error-disabled,
-    var(--nx-color-red-300)
-  );
-  --color-error-subtle: var(--nx-color-error-subtle, var(--nx-color-red-50));
-  --color-error-subtle-foreground: var(
-    --nx-color-error-subtle-foreground,
-    var(--nx-color-red-600)
-  );
-  --color-error-subtle-hover: var(
-    --nx-color-error-subtle-hover,
-    var(--nx-color-red-100)
-  );
-  --color-error-subtle-active: var(
-    --nx-color-error-subtle-active,
-    var(--nx-color-red-200)
-  );
-  --color-success-background: var(
-    --nx-color-success-background,
-    var(--nx-color-green-600)
-  );
-  --color-success-foreground: var(
-    --nx-color-success-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-success-background-hover: var(
-    --nx-color-success-background-hover,
-    var(--nx-color-green-700)
-  );
-  --color-success-background-active: var(
-    --nx-color-success-background-active,
-    var(--nx-color-green-800)
-  );
-  --color-success-disabled: var(
-    --nx-color-success-disabled,
-    var(--nx-color-green-300)
-  );
-  --color-success-subtle: var(
-    --nx-color-success-subtle,
-    var(--nx-color-green-50)
-  );
-  --color-success-subtle-foreground: var(
-    --nx-color-success-subtle-foreground,
-    var(--nx-color-green-700)
-  );
-  --color-success-subtle-hover: var(
-    --nx-color-success-subtle-hover,
-    var(--nx-color-green-100)
-  );
-  --color-success-subtle-active: var(
-    --nx-color-success-subtle-active,
-    var(--nx-color-green-200)
-  );
-  --color-information-background: var(
-    --nx-color-information-background,
-    var(--nx-color-blue-600)
-  );
-  --color-information-foreground: var(
-    --nx-color-information-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-information-background-hover: var(
-    --nx-color-information-background-hover,
-    var(--nx-color-blue-700)
-  );
-  --color-information-background-active: var(
-    --nx-color-information-background-active,
-    var(--nx-color-blue-800)
-  );
-  --color-information-disabled: var(
-    --nx-color-information-disabled,
-    var(--nx-color-blue-300)
-  );
-  --color-information-subtle: var(
-    --nx-color-information-subtle,
-    var(--nx-color-blue-50)
-  );
-  --color-information-subtle-foreground: var(
-    --nx-color-information-subtle-foreground,
-    var(--nx-color-blue-600)
-  );
-  --color-information-subtle-hover: var(
-    --nx-color-information-subtle-hover,
-    var(--nx-color-blue-100)
-  );
-  --color-information-subtle-active: var(
-    --nx-color-information-subtle-active,
-    var(--nx-color-blue-200)
-  );
-  --color-warning-background: var(
-    --nx-color-warning-background,
-    var(--nx-color-orange-600)
-  );
-  --color-warning-foreground: var(
-    --nx-color-warning-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-warning-background-hover: var(
-    --nx-color-warning-background-hover,
-    var(--nx-color-orange-700)
-  );
-  --color-warning-background-active: var(
-    --nx-color-warning-background-active,
-    var(--nx-color-orange-800)
-  );
-  --color-warning-disabled: var(
-    --nx-color-warning-disabled,
-    var(--nx-color-orange-300)
-  );
-  --color-warning-subtle: var(
-    --nx-color-warning-subtle,
-    var(--nx-color-orange-50)
-  );
-  --color-warning-subtle-foreground: var(
-    --nx-color-warning-subtle-foreground,
-    var(--nx-color-orange-600)
-  );
-  --color-warning-subtle-hover: var(
-    --nx-color-warning-subtle-hover,
-    var(--nx-color-orange-100)
-  );
-  --color-warning-subtle-active: var(
-    --nx-color-warning-subtle-active,
-    var(--nx-color-orange-200)
-  );
-  --color-primary-background: var(
-    --nx-color-primary-background,
-    var(--nx-color-blue-600)
-  );
-  --color-primary-background-active: var(
-    --nx-color-primary-background-active,
-    var(--nx-color-blue-800)
-  );
-  --color-primary-foreground: var(
-    --nx-color-primary-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-primary-background-hover: var(
-    --nx-color-primary-background-hover,
-    var(--nx-color-blue-700)
-  );
-  --color-primary-disabled: var(
-    --nx-color-primary-disabled,
-    var(--nx-color-blue-300)
-  );
-  --color-primary-subtle: var(
-    --nx-color-primary-subtle,
-    var(--nx-color-blue-50)
-  );
-  --color-primary-subtle-foreground: var(
-    --nx-color-primary-subtle-foreground,
-    var(--nx-color-blue-600)
-  );
-  --color-primary-subtle-hover: var(
-    --nx-color-primary-subtle-hover,
-    var(--nx-color-blue-100)
-  );
-  --color-primary-subtle-active: var(
-    --nx-color-primary-subtle-active,
-    var(--nx-color-blue-200)
-  );
-  --color-secondary-background: var(
-    --nx-color-secondary-background,
-    var(--nx-color-neutral-100)
-  );
-  --color-secondary-foreground: var(
-    --nx-color-secondary-foreground,
-    var(--nx-color-neutral-900)
-  );
-  --color-secondary-background-hover: var(
-    --nx-color-secondary-background-hover,
-    var(--nx-color-neutral-200)
-  );
-  --color-secondary-background-active: var(
-    --nx-color-secondary-background-active,
-    var(--nx-color-neutral-300)
-  );
-  --color-secondary-disabled: var(
-    --nx-color-secondary-disabled,
-    var(--nx-color-neutral-50)
-  );
-  --color-secondary-subtle: var(
-    --nx-color-secondary-subtle,
-    var(--nx-color-neutral-100)
-  );
-  --color-secondary-subtle-foreground: var(
-    --nx-color-secondary-subtle-foreground,
-    var(--nx-color-neutral-600)
-  );
-  --color-secondary-subtle-hover: var(
-    --nx-color-secondary-subtle-hover,
-    var(--nx-color-neutral-200)
-  );
-  --color-secondary-subtle-active: var(
-    --nx-color-secondary-subtle-active,
-    var(--nx-color-neutral-300)
-  );
-  --color-border-primary: var(
-    --nx-color-border-primary,
-    var(--nx-color-blue-200)
-  );
-  --color-border-primary-active: var(
-    --nx-color-border-primary-active,
-    var(--nx-color-blue-400)
-  );
-  --color-focus-default: var(
-    --nx-color-focus-default,
-    var(--nx-focus-color-default)
-  );
-  --color-focus-error: var(--nx-color-focus-error, var(--nx-focus-color-error));
 }
 
 /* ===== RUNTIME DIMENSION TOKENS ===== */

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -110,10 +110,6 @@ function cssDeclarations(block) {
   );
 }
 
-function themeColorLines(themeBlock) {
-  return [...themeBlock.matchAll(/--color-([a-z0-9-]+):\s*([^;]+);/g)];
-}
-
 function compactCss(value) {
   return value.replace(/\s+/g, ' ').trim();
 }
@@ -226,12 +222,12 @@ describe('generateTailwindPackage', () => {
   // vars referenced only via arbitrary utilities, #506). The count guard also
   // catches duplicate emission via the dimension scan (the --breakpoint-* trap).
   it('promotes focus colours to --color-* and emits --focus-offset once at :root; no focus box-shadow', () => {
-    const themeBlock = compactCss(extractBlock(nexusCSS, '@theme inline'));
+    const themeBlock = extractBlock(nexusCSS, '@theme');
     expect(themeBlock).toMatch(
-      /--color-focus-default: var\(\s*--nx-color-focus-default,\s*var\(--nx-focus-color-default\)\s*\);/
+      /--color-focus-default: var\(--nx-focus-color-default\);/
     );
     expect(themeBlock).toMatch(
-      /--color-focus-error: var\(\s*--nx-color-focus-error,\s*var\(--nx-focus-color-error\)\s*\);/
+      /--color-focus-error: var\(--nx-focus-color-error\);/
     );
     expect(nexusCSS.match(/--focus-offset:/g)).toHaveLength(1);
     expect(themeBlock).not.toMatch(/--focus-offset/);
@@ -239,29 +235,7 @@ describe('generateTailwindPackage', () => {
     expect(nexusCSS).not.toMatch(/--shadow-focus-/);
   });
 
-  it('bridges every semantic color utility to its runtime override with a static fallback', () => {
-    const themeBlock = extractBlock(nexusCSS, '@theme inline');
-    const colorLines = themeColorLines(themeBlock);
-
-    expect(colorLines).toHaveLength(106);
-
-    for (const [, name, value] of colorLines) {
-      expect(compactCss(value), `--color-${name}`).toMatch(
-        new RegExp(`^var\\(\\s*--nx-color-${name},\\s*.+\\)$`)
-      );
-    }
-  });
-
-  it('aliases semantic colors at :root for non-utility CSS consumers', () => {
-    expect(nexusCSS).toMatch(
-      /:root\s*\{[\s\S]*--color-background:\s*var\(--nx-color-background,\s*var\(--nx-color-white-base\)\);[\s\S]*\}/
-    );
-    expect(nexusCSS).toMatch(
-      /:root\s*\{[\s\S]*--color-focus-default:\s*var\(\s*--nx-color-focus-default,\s*var\(--nx-focus-color-default\)\s*\);[\s\S]*\}/
-    );
-  });
-
-  it('compiles semantic color utilities through the bridged theme variables', async () => {
+  it('compiles semantic color utilities through prefixed theme variables', async () => {
     const css = compactCss(
       await compileGeneratedTailwind(distDir, [
         'nx:bg-background',
@@ -269,12 +243,8 @@ describe('generateTailwindPackage', () => {
       ])
     );
 
-    expect(css).toMatch(
-      /background-color:\s*var\(--nx-color-background,\s*var\(--nx-color-white-base\)\);/
-    );
-    expect(css).toMatch(
-      /outline-color:\s*var\(\s*--nx-color-focus-default,\s*var\(--nx-focus-color-default\)\s*\);/
-    );
+    expect(css).toMatch(/background-color:\s*var\(--nx-color-background\);/);
+    expect(css).toMatch(/outline-color:\s*var\(--nx-color-focus-default\);/);
   });
 
   // Every var(--nx-shadow-*) or var(--nx-focus-*) ref in nexus.css must have a
@@ -323,12 +293,12 @@ describe('generateTailwindPackage', () => {
   });
 
   it('emits chart.categorical tokens in @theme (light) and .dark (dark override)', () => {
-    const themeBlock = compactCss(extractBlock(nexusCSS, '@theme inline'));
+    const themeBlock = extractBlock(nexusCSS, '@theme');
     expect(themeBlock).toMatch(
-      /--color-chart-categorical-1: var\(\s*--nx-color-chart-categorical-1,\s*var\(--nx-color-teal-600\)\s*\);/
+      /--color-chart-categorical-1: var\(--nx-color-teal-600\);/
     );
     expect(themeBlock).toMatch(
-      /--color-chart-categorical-5: var\(\s*--nx-color-chart-categorical-5,\s*var\(--nx-color-indigo-600\)\s*\);/
+      /--color-chart-categorical-5: var\(--nx-color-indigo-600\);/
     );
 
     const darkBlock = extractBlock(nexusCSS, '.dark');

--- a/packages/core/scripts/generate-tailwind-package.js
+++ b/packages/core/scripts/generate-tailwind-package.js
@@ -500,9 +500,8 @@ function generateNexusCSS(
 /* Auto-generated - DO NOT EDIT */
 /* Uses nx: prefix for all utility classes */
 /*
- * Uses @theme for static scales and @theme inline for semantic colours so
- * generated utilities can fall back statically while accepting runtime
- * --nx-color-* overrides from NexusAppearanceProvider.
+ * Uses @theme (not inline) so utilities reference CSS variables
+ * that can be overridden by .dark selector for theme switching.
  */
 
 `;

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -1890,6 +1890,14 @@ export function generateThemeCSS(config) {
   css += `  --shadow-*: initial;\n`;
   css += `  --breakpoint-*: initial;\n\n`;
 
+  // Semantic colour tokens (dimensions like --focus-offset emit at :root)
+  if (semanticTokens.length > 0) {
+    css += `  /* Semantic tokens */\n`;
+    for (const token of semanticTokens) {
+      css += `  --${token.cssName}: ${token.value};\n`;
+    }
+  }
+
   // Spacing tokens (numeric default baseline — see generateSpacingModesCSS for
   // per-mode overrides emitted outside @theme).
   if (spacingTokens.length > 0) {
@@ -1950,30 +1958,6 @@ export function generateThemeCSS(config) {
   }
 
   css += `}\n`;
-
-  // Semantic colour utilities need their fallback expression inlined into the
-  // generated utility, otherwise Tailwind's `prefix(nx)` rewrites the @theme
-  // variable to the same `--nx-color-*` name that the runtime provider owns.
-  if (semanticTokens.length > 0) {
-    css += `\n@theme inline {\n`;
-    css += `  /* Semantic tokens */\n`;
-    for (const token of semanticTokens) {
-      const value = token.cssName.startsWith('color-')
-        ? `var(--nx-${token.cssName}, ${token.value})`
-        : token.value;
-      css += `  --${token.cssName}: ${value};\n`;
-    }
-    css += `}\n`;
-
-    css += `\n/* ===== RUNTIME COLOR ALIASES ===== */\n`;
-    css += `:root {\n`;
-    for (const token of semanticTokens.filter((token) =>
-      token.cssName.startsWith('color-')
-    )) {
-      css += `  --${token.cssName}: var(--nx-${token.cssName}, ${token.value});\n`;
-    }
-    css += `}\n`;
-  }
 
   // Dark mode block (if provided)
   if (darkSemanticTokens.length > 0) {

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -2,9 +2,8 @@
 /* Auto-generated - DO NOT EDIT */
 /* Uses nx: prefix for all utility classes */
 /*
- * Uses @theme for static scales and @theme inline for semantic colours so
- * generated utilities can fall back statically while accepting runtime
- * --nx-color-* overrides from NexusAppearanceProvider.
+ * Uses @theme (not inline) so utilities reference CSS variables
+ * that can be overridden by .dark selector for theme switching.
  */
 
 @import 'tailwindcss' prefix(nx);
@@ -25,6 +24,114 @@
   --radius-*: initial;
   --shadow-*: initial;
   --breakpoint-*: initial;
+
+  /* Semantic tokens */
+  --color-background: var(--nx-color-white-base);
+  --color-foreground: var(--nx-color-black-a900);
+  --color-background-hover: var(--nx-color-stone-50);
+  --color-background-hover-alpha: var(--nx-color-stone-a100);
+  --color-background-active: var(--nx-color-stone-100);
+  --color-muted: var(--nx-color-stone-50);
+  --color-muted-foreground: var(--nx-color-black-a600);
+  --color-muted-foreground-subtle: var(--nx-color-black-a500);
+  --color-disabled: var(--nx-color-stone-50);
+  --color-disabled-foreground: var(--nx-color-stone-400);
+  --color-container: var(--nx-color-white-base);
+  --color-container-foreground: var(--nx-color-stone-950);
+  --color-container-hover: var(--nx-color-stone-50);
+  --color-container-active: var(--nx-color-stone-100);
+  --color-popover: var(--nx-color-white-base);
+  --color-popover-foreground: var(--nx-color-stone-950);
+  --color-popover-hover: var(--nx-color-stone-50);
+  --color-popover-active: var(--nx-color-stone-50);
+  --color-popover-alpha: var(--nx-color-white-a700);
+  --color-popover-backdrop: var(--nx-color-stone-a900);
+  --color-control-background: var(--nx-color-stone-100);
+  --color-control-background-hover: var(--nx-color-stone-200);
+  --color-control-thumb: var(--nx-color-white-base);
+  --color-nav-background: var(--nx-color-stone-100);
+  --color-nav-foreground: var(--nx-color-stone-900);
+  --color-nav-muted-foreground: var(--nx-color-stone-600);
+  --color-nav-item-hover: var(--nx-color-stone-200);
+  --color-nav-item-active: var(--nx-color-stone-200);
+  --color-nav-border: var(--nx-color-stone-200);
+  --color-overlay: var(--nx-color-stone-a700);
+  --color-border-default: var(--nx-color-black-a200);
+  --color-border-hairline: var(--nx-color-black-a200);
+  --color-border-default-alpha: var(--nx-color-stone-a200);
+  --color-border-active: var(--nx-color-stone-400);
+  --color-border-disabled: var(--nx-color-black-a200);
+  --color-border-warning: var(--nx-color-orange-200);
+  --color-border-warning-active: var(--nx-color-orange-400);
+  --color-border-success: var(--nx-color-green-200);
+  --color-border-success-active: var(--nx-color-green-400);
+  --color-border-error: var(--nx-color-red-200);
+  --color-border-error-active: var(--nx-color-red-400);
+  --color-border-information: var(--nx-color-blue-200);
+  --color-border-information-active: var(--nx-color-blue-400);
+  --color-error-background: var(--nx-color-red-600);
+  --color-error-foreground: var(--nx-color-white-base);
+  --color-error-background-hover: var(--nx-color-red-700);
+  --color-error-background-active: var(--nx-color-red-800);
+  --color-error-disabled: var(--nx-color-red-300);
+  --color-error-subtle: var(--nx-color-red-50);
+  --color-error-subtle-foreground: var(--nx-color-red-600);
+  --color-error-subtle-hover: var(--nx-color-red-100);
+  --color-error-subtle-active: var(--nx-color-red-200);
+  --color-success-background: var(--nx-color-green-600);
+  --color-success-foreground: var(--nx-color-white-base);
+  --color-success-background-hover: var(--nx-color-green-700);
+  --color-success-background-active: var(--nx-color-green-800);
+  --color-success-disabled: var(--nx-color-green-300);
+  --color-success-subtle: var(--nx-color-green-50);
+  --color-success-subtle-foreground: var(--nx-color-green-700);
+  --color-success-subtle-hover: var(--nx-color-green-100);
+  --color-success-subtle-active: var(--nx-color-green-200);
+  --color-information-background: var(--nx-color-blue-600);
+  --color-information-foreground: var(--nx-color-white-base);
+  --color-information-background-hover: var(--nx-color-blue-700);
+  --color-information-background-active: var(--nx-color-blue-800);
+  --color-information-disabled: var(--nx-color-blue-300);
+  --color-information-subtle: var(--nx-color-blue-50);
+  --color-information-subtle-foreground: var(--nx-color-blue-600);
+  --color-information-subtle-hover: var(--nx-color-blue-100);
+  --color-information-subtle-active: var(--nx-color-blue-200);
+  --color-warning-background: var(--nx-color-orange-600);
+  --color-warning-foreground: var(--nx-color-white-base);
+  --color-warning-background-hover: var(--nx-color-orange-700);
+  --color-warning-background-active: var(--nx-color-orange-800);
+  --color-warning-disabled: var(--nx-color-orange-300);
+  --color-warning-subtle: var(--nx-color-orange-50);
+  --color-warning-subtle-foreground: var(--nx-color-orange-600);
+  --color-warning-subtle-hover: var(--nx-color-orange-100);
+  --color-warning-subtle-active: var(--nx-color-orange-200);
+  --color-primary-background: var(--nx-color-black-base);
+  --color-primary-background-active: var(--nx-color-neutral-950);
+  --color-primary-foreground: var(--nx-color-white-base);
+  --color-primary-background-hover: var(--nx-color-neutral-900);
+  --color-primary-disabled: var(--nx-color-neutral-300);
+  --color-primary-subtle: var(--nx-color-neutral-50);
+  --color-primary-subtle-foreground: var(--nx-color-black-base);
+  --color-primary-subtle-hover: var(--nx-color-neutral-100);
+  --color-primary-subtle-active: var(--nx-color-neutral-200);
+  --color-secondary-background: var(--nx-color-neutral-100);
+  --color-secondary-foreground: var(--nx-color-neutral-900);
+  --color-secondary-background-hover: var(--nx-color-neutral-200);
+  --color-secondary-background-active: var(--nx-color-neutral-300);
+  --color-secondary-disabled: var(--nx-color-neutral-50);
+  --color-secondary-subtle: var(--nx-color-neutral-100);
+  --color-secondary-subtle-foreground: var(--nx-color-neutral-600);
+  --color-secondary-subtle-hover: var(--nx-color-neutral-200);
+  --color-secondary-subtle-active: var(--nx-color-neutral-300);
+  --color-border-primary: var(--nx-color-neutral-200);
+  --color-border-primary-active: var(--nx-color-neutral-400);
+  --color-chart-categorical-1: var(--nx-color-teal-600);
+  --color-chart-categorical-2: var(--nx-color-lime-700);
+  --color-chart-categorical-3: var(--nx-color-orange-600);
+  --color-chart-categorical-4: var(--nx-color-rose-600);
+  --color-chart-categorical-5: var(--nx-color-indigo-600);
+  --color-focus-default: var(--nx-focus-color-default);
+  --color-focus-error: var(--nx-focus-color-error);
 
   /* Spacing tokens */
   --spacing-0: 0px;
@@ -138,796 +245,6 @@
   --breakpoint-lg: 64rem;
   --breakpoint-xl: 80rem;
   --breakpoint-2xl: 96rem;
-}
-
-@theme inline {
-  /* Semantic tokens */
-  --color-background: var(--nx-color-background, var(--nx-color-white-base));
-  --color-foreground: var(--nx-color-foreground, var(--nx-color-black-a900));
-  --color-background-hover: var(
-    --nx-color-background-hover,
-    var(--nx-color-stone-50)
-  );
-  --color-background-hover-alpha: var(
-    --nx-color-background-hover-alpha,
-    var(--nx-color-stone-a100)
-  );
-  --color-background-active: var(
-    --nx-color-background-active,
-    var(--nx-color-stone-100)
-  );
-  --color-muted: var(--nx-color-muted, var(--nx-color-stone-50));
-  --color-muted-foreground: var(
-    --nx-color-muted-foreground,
-    var(--nx-color-black-a600)
-  );
-  --color-muted-foreground-subtle: var(
-    --nx-color-muted-foreground-subtle,
-    var(--nx-color-black-a500)
-  );
-  --color-disabled: var(--nx-color-disabled, var(--nx-color-stone-50));
-  --color-disabled-foreground: var(
-    --nx-color-disabled-foreground,
-    var(--nx-color-stone-400)
-  );
-  --color-container: var(--nx-color-container, var(--nx-color-white-base));
-  --color-container-foreground: var(
-    --nx-color-container-foreground,
-    var(--nx-color-stone-950)
-  );
-  --color-container-hover: var(
-    --nx-color-container-hover,
-    var(--nx-color-stone-50)
-  );
-  --color-container-active: var(
-    --nx-color-container-active,
-    var(--nx-color-stone-100)
-  );
-  --color-popover: var(--nx-color-popover, var(--nx-color-white-base));
-  --color-popover-foreground: var(
-    --nx-color-popover-foreground,
-    var(--nx-color-stone-950)
-  );
-  --color-popover-hover: var(
-    --nx-color-popover-hover,
-    var(--nx-color-stone-50)
-  );
-  --color-popover-active: var(
-    --nx-color-popover-active,
-    var(--nx-color-stone-50)
-  );
-  --color-popover-alpha: var(
-    --nx-color-popover-alpha,
-    var(--nx-color-white-a700)
-  );
-  --color-popover-backdrop: var(
-    --nx-color-popover-backdrop,
-    var(--nx-color-stone-a900)
-  );
-  --color-control-background: var(
-    --nx-color-control-background,
-    var(--nx-color-stone-100)
-  );
-  --color-control-background-hover: var(
-    --nx-color-control-background-hover,
-    var(--nx-color-stone-200)
-  );
-  --color-control-thumb: var(
-    --nx-color-control-thumb,
-    var(--nx-color-white-base)
-  );
-  --color-nav-background: var(
-    --nx-color-nav-background,
-    var(--nx-color-stone-100)
-  );
-  --color-nav-foreground: var(
-    --nx-color-nav-foreground,
-    var(--nx-color-stone-900)
-  );
-  --color-nav-muted-foreground: var(
-    --nx-color-nav-muted-foreground,
-    var(--nx-color-stone-600)
-  );
-  --color-nav-item-hover: var(
-    --nx-color-nav-item-hover,
-    var(--nx-color-stone-200)
-  );
-  --color-nav-item-active: var(
-    --nx-color-nav-item-active,
-    var(--nx-color-stone-200)
-  );
-  --color-nav-border: var(--nx-color-nav-border, var(--nx-color-stone-200));
-  --color-overlay: var(--nx-color-overlay, var(--nx-color-stone-a700));
-  --color-border-default: var(
-    --nx-color-border-default,
-    var(--nx-color-black-a200)
-  );
-  --color-border-hairline: var(
-    --nx-color-border-hairline,
-    var(--nx-color-black-a200)
-  );
-  --color-border-default-alpha: var(
-    --nx-color-border-default-alpha,
-    var(--nx-color-stone-a200)
-  );
-  --color-border-active: var(
-    --nx-color-border-active,
-    var(--nx-color-stone-400)
-  );
-  --color-border-disabled: var(
-    --nx-color-border-disabled,
-    var(--nx-color-black-a200)
-  );
-  --color-border-warning: var(
-    --nx-color-border-warning,
-    var(--nx-color-orange-200)
-  );
-  --color-border-warning-active: var(
-    --nx-color-border-warning-active,
-    var(--nx-color-orange-400)
-  );
-  --color-border-success: var(
-    --nx-color-border-success,
-    var(--nx-color-green-200)
-  );
-  --color-border-success-active: var(
-    --nx-color-border-success-active,
-    var(--nx-color-green-400)
-  );
-  --color-border-error: var(--nx-color-border-error, var(--nx-color-red-200));
-  --color-border-error-active: var(
-    --nx-color-border-error-active,
-    var(--nx-color-red-400)
-  );
-  --color-border-information: var(
-    --nx-color-border-information,
-    var(--nx-color-blue-200)
-  );
-  --color-border-information-active: var(
-    --nx-color-border-information-active,
-    var(--nx-color-blue-400)
-  );
-  --color-error-background: var(
-    --nx-color-error-background,
-    var(--nx-color-red-600)
-  );
-  --color-error-foreground: var(
-    --nx-color-error-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-error-background-hover: var(
-    --nx-color-error-background-hover,
-    var(--nx-color-red-700)
-  );
-  --color-error-background-active: var(
-    --nx-color-error-background-active,
-    var(--nx-color-red-800)
-  );
-  --color-error-disabled: var(
-    --nx-color-error-disabled,
-    var(--nx-color-red-300)
-  );
-  --color-error-subtle: var(--nx-color-error-subtle, var(--nx-color-red-50));
-  --color-error-subtle-foreground: var(
-    --nx-color-error-subtle-foreground,
-    var(--nx-color-red-600)
-  );
-  --color-error-subtle-hover: var(
-    --nx-color-error-subtle-hover,
-    var(--nx-color-red-100)
-  );
-  --color-error-subtle-active: var(
-    --nx-color-error-subtle-active,
-    var(--nx-color-red-200)
-  );
-  --color-success-background: var(
-    --nx-color-success-background,
-    var(--nx-color-green-600)
-  );
-  --color-success-foreground: var(
-    --nx-color-success-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-success-background-hover: var(
-    --nx-color-success-background-hover,
-    var(--nx-color-green-700)
-  );
-  --color-success-background-active: var(
-    --nx-color-success-background-active,
-    var(--nx-color-green-800)
-  );
-  --color-success-disabled: var(
-    --nx-color-success-disabled,
-    var(--nx-color-green-300)
-  );
-  --color-success-subtle: var(
-    --nx-color-success-subtle,
-    var(--nx-color-green-50)
-  );
-  --color-success-subtle-foreground: var(
-    --nx-color-success-subtle-foreground,
-    var(--nx-color-green-700)
-  );
-  --color-success-subtle-hover: var(
-    --nx-color-success-subtle-hover,
-    var(--nx-color-green-100)
-  );
-  --color-success-subtle-active: var(
-    --nx-color-success-subtle-active,
-    var(--nx-color-green-200)
-  );
-  --color-information-background: var(
-    --nx-color-information-background,
-    var(--nx-color-blue-600)
-  );
-  --color-information-foreground: var(
-    --nx-color-information-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-information-background-hover: var(
-    --nx-color-information-background-hover,
-    var(--nx-color-blue-700)
-  );
-  --color-information-background-active: var(
-    --nx-color-information-background-active,
-    var(--nx-color-blue-800)
-  );
-  --color-information-disabled: var(
-    --nx-color-information-disabled,
-    var(--nx-color-blue-300)
-  );
-  --color-information-subtle: var(
-    --nx-color-information-subtle,
-    var(--nx-color-blue-50)
-  );
-  --color-information-subtle-foreground: var(
-    --nx-color-information-subtle-foreground,
-    var(--nx-color-blue-600)
-  );
-  --color-information-subtle-hover: var(
-    --nx-color-information-subtle-hover,
-    var(--nx-color-blue-100)
-  );
-  --color-information-subtle-active: var(
-    --nx-color-information-subtle-active,
-    var(--nx-color-blue-200)
-  );
-  --color-warning-background: var(
-    --nx-color-warning-background,
-    var(--nx-color-orange-600)
-  );
-  --color-warning-foreground: var(
-    --nx-color-warning-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-warning-background-hover: var(
-    --nx-color-warning-background-hover,
-    var(--nx-color-orange-700)
-  );
-  --color-warning-background-active: var(
-    --nx-color-warning-background-active,
-    var(--nx-color-orange-800)
-  );
-  --color-warning-disabled: var(
-    --nx-color-warning-disabled,
-    var(--nx-color-orange-300)
-  );
-  --color-warning-subtle: var(
-    --nx-color-warning-subtle,
-    var(--nx-color-orange-50)
-  );
-  --color-warning-subtle-foreground: var(
-    --nx-color-warning-subtle-foreground,
-    var(--nx-color-orange-600)
-  );
-  --color-warning-subtle-hover: var(
-    --nx-color-warning-subtle-hover,
-    var(--nx-color-orange-100)
-  );
-  --color-warning-subtle-active: var(
-    --nx-color-warning-subtle-active,
-    var(--nx-color-orange-200)
-  );
-  --color-primary-background: var(
-    --nx-color-primary-background,
-    var(--nx-color-black-base)
-  );
-  --color-primary-background-active: var(
-    --nx-color-primary-background-active,
-    var(--nx-color-neutral-950)
-  );
-  --color-primary-foreground: var(
-    --nx-color-primary-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-primary-background-hover: var(
-    --nx-color-primary-background-hover,
-    var(--nx-color-neutral-900)
-  );
-  --color-primary-disabled: var(
-    --nx-color-primary-disabled,
-    var(--nx-color-neutral-300)
-  );
-  --color-primary-subtle: var(
-    --nx-color-primary-subtle,
-    var(--nx-color-neutral-50)
-  );
-  --color-primary-subtle-foreground: var(
-    --nx-color-primary-subtle-foreground,
-    var(--nx-color-black-base)
-  );
-  --color-primary-subtle-hover: var(
-    --nx-color-primary-subtle-hover,
-    var(--nx-color-neutral-100)
-  );
-  --color-primary-subtle-active: var(
-    --nx-color-primary-subtle-active,
-    var(--nx-color-neutral-200)
-  );
-  --color-secondary-background: var(
-    --nx-color-secondary-background,
-    var(--nx-color-neutral-100)
-  );
-  --color-secondary-foreground: var(
-    --nx-color-secondary-foreground,
-    var(--nx-color-neutral-900)
-  );
-  --color-secondary-background-hover: var(
-    --nx-color-secondary-background-hover,
-    var(--nx-color-neutral-200)
-  );
-  --color-secondary-background-active: var(
-    --nx-color-secondary-background-active,
-    var(--nx-color-neutral-300)
-  );
-  --color-secondary-disabled: var(
-    --nx-color-secondary-disabled,
-    var(--nx-color-neutral-50)
-  );
-  --color-secondary-subtle: var(
-    --nx-color-secondary-subtle,
-    var(--nx-color-neutral-100)
-  );
-  --color-secondary-subtle-foreground: var(
-    --nx-color-secondary-subtle-foreground,
-    var(--nx-color-neutral-600)
-  );
-  --color-secondary-subtle-hover: var(
-    --nx-color-secondary-subtle-hover,
-    var(--nx-color-neutral-200)
-  );
-  --color-secondary-subtle-active: var(
-    --nx-color-secondary-subtle-active,
-    var(--nx-color-neutral-300)
-  );
-  --color-border-primary: var(
-    --nx-color-border-primary,
-    var(--nx-color-neutral-200)
-  );
-  --color-border-primary-active: var(
-    --nx-color-border-primary-active,
-    var(--nx-color-neutral-400)
-  );
-  --color-chart-categorical-1: var(
-    --nx-color-chart-categorical-1,
-    var(--nx-color-teal-600)
-  );
-  --color-chart-categorical-2: var(
-    --nx-color-chart-categorical-2,
-    var(--nx-color-lime-700)
-  );
-  --color-chart-categorical-3: var(
-    --nx-color-chart-categorical-3,
-    var(--nx-color-orange-600)
-  );
-  --color-chart-categorical-4: var(
-    --nx-color-chart-categorical-4,
-    var(--nx-color-rose-600)
-  );
-  --color-chart-categorical-5: var(
-    --nx-color-chart-categorical-5,
-    var(--nx-color-indigo-600)
-  );
-  --color-focus-default: var(
-    --nx-color-focus-default,
-    var(--nx-focus-color-default)
-  );
-  --color-focus-error: var(--nx-color-focus-error, var(--nx-focus-color-error));
-}
-
-/* ===== RUNTIME COLOR ALIASES ===== */
-:root {
-  --color-background: var(--nx-color-background, var(--nx-color-white-base));
-  --color-foreground: var(--nx-color-foreground, var(--nx-color-black-a900));
-  --color-background-hover: var(
-    --nx-color-background-hover,
-    var(--nx-color-stone-50)
-  );
-  --color-background-hover-alpha: var(
-    --nx-color-background-hover-alpha,
-    var(--nx-color-stone-a100)
-  );
-  --color-background-active: var(
-    --nx-color-background-active,
-    var(--nx-color-stone-100)
-  );
-  --color-muted: var(--nx-color-muted, var(--nx-color-stone-50));
-  --color-muted-foreground: var(
-    --nx-color-muted-foreground,
-    var(--nx-color-black-a600)
-  );
-  --color-muted-foreground-subtle: var(
-    --nx-color-muted-foreground-subtle,
-    var(--nx-color-black-a500)
-  );
-  --color-disabled: var(--nx-color-disabled, var(--nx-color-stone-50));
-  --color-disabled-foreground: var(
-    --nx-color-disabled-foreground,
-    var(--nx-color-stone-400)
-  );
-  --color-container: var(--nx-color-container, var(--nx-color-white-base));
-  --color-container-foreground: var(
-    --nx-color-container-foreground,
-    var(--nx-color-stone-950)
-  );
-  --color-container-hover: var(
-    --nx-color-container-hover,
-    var(--nx-color-stone-50)
-  );
-  --color-container-active: var(
-    --nx-color-container-active,
-    var(--nx-color-stone-100)
-  );
-  --color-popover: var(--nx-color-popover, var(--nx-color-white-base));
-  --color-popover-foreground: var(
-    --nx-color-popover-foreground,
-    var(--nx-color-stone-950)
-  );
-  --color-popover-hover: var(
-    --nx-color-popover-hover,
-    var(--nx-color-stone-50)
-  );
-  --color-popover-active: var(
-    --nx-color-popover-active,
-    var(--nx-color-stone-50)
-  );
-  --color-popover-alpha: var(
-    --nx-color-popover-alpha,
-    var(--nx-color-white-a700)
-  );
-  --color-popover-backdrop: var(
-    --nx-color-popover-backdrop,
-    var(--nx-color-stone-a900)
-  );
-  --color-control-background: var(
-    --nx-color-control-background,
-    var(--nx-color-stone-100)
-  );
-  --color-control-background-hover: var(
-    --nx-color-control-background-hover,
-    var(--nx-color-stone-200)
-  );
-  --color-control-thumb: var(
-    --nx-color-control-thumb,
-    var(--nx-color-white-base)
-  );
-  --color-nav-background: var(
-    --nx-color-nav-background,
-    var(--nx-color-stone-100)
-  );
-  --color-nav-foreground: var(
-    --nx-color-nav-foreground,
-    var(--nx-color-stone-900)
-  );
-  --color-nav-muted-foreground: var(
-    --nx-color-nav-muted-foreground,
-    var(--nx-color-stone-600)
-  );
-  --color-nav-item-hover: var(
-    --nx-color-nav-item-hover,
-    var(--nx-color-stone-200)
-  );
-  --color-nav-item-active: var(
-    --nx-color-nav-item-active,
-    var(--nx-color-stone-200)
-  );
-  --color-nav-border: var(--nx-color-nav-border, var(--nx-color-stone-200));
-  --color-overlay: var(--nx-color-overlay, var(--nx-color-stone-a700));
-  --color-border-default: var(
-    --nx-color-border-default,
-    var(--nx-color-black-a200)
-  );
-  --color-border-hairline: var(
-    --nx-color-border-hairline,
-    var(--nx-color-black-a200)
-  );
-  --color-border-default-alpha: var(
-    --nx-color-border-default-alpha,
-    var(--nx-color-stone-a200)
-  );
-  --color-border-active: var(
-    --nx-color-border-active,
-    var(--nx-color-stone-400)
-  );
-  --color-border-disabled: var(
-    --nx-color-border-disabled,
-    var(--nx-color-black-a200)
-  );
-  --color-border-warning: var(
-    --nx-color-border-warning,
-    var(--nx-color-orange-200)
-  );
-  --color-border-warning-active: var(
-    --nx-color-border-warning-active,
-    var(--nx-color-orange-400)
-  );
-  --color-border-success: var(
-    --nx-color-border-success,
-    var(--nx-color-green-200)
-  );
-  --color-border-success-active: var(
-    --nx-color-border-success-active,
-    var(--nx-color-green-400)
-  );
-  --color-border-error: var(--nx-color-border-error, var(--nx-color-red-200));
-  --color-border-error-active: var(
-    --nx-color-border-error-active,
-    var(--nx-color-red-400)
-  );
-  --color-border-information: var(
-    --nx-color-border-information,
-    var(--nx-color-blue-200)
-  );
-  --color-border-information-active: var(
-    --nx-color-border-information-active,
-    var(--nx-color-blue-400)
-  );
-  --color-error-background: var(
-    --nx-color-error-background,
-    var(--nx-color-red-600)
-  );
-  --color-error-foreground: var(
-    --nx-color-error-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-error-background-hover: var(
-    --nx-color-error-background-hover,
-    var(--nx-color-red-700)
-  );
-  --color-error-background-active: var(
-    --nx-color-error-background-active,
-    var(--nx-color-red-800)
-  );
-  --color-error-disabled: var(
-    --nx-color-error-disabled,
-    var(--nx-color-red-300)
-  );
-  --color-error-subtle: var(--nx-color-error-subtle, var(--nx-color-red-50));
-  --color-error-subtle-foreground: var(
-    --nx-color-error-subtle-foreground,
-    var(--nx-color-red-600)
-  );
-  --color-error-subtle-hover: var(
-    --nx-color-error-subtle-hover,
-    var(--nx-color-red-100)
-  );
-  --color-error-subtle-active: var(
-    --nx-color-error-subtle-active,
-    var(--nx-color-red-200)
-  );
-  --color-success-background: var(
-    --nx-color-success-background,
-    var(--nx-color-green-600)
-  );
-  --color-success-foreground: var(
-    --nx-color-success-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-success-background-hover: var(
-    --nx-color-success-background-hover,
-    var(--nx-color-green-700)
-  );
-  --color-success-background-active: var(
-    --nx-color-success-background-active,
-    var(--nx-color-green-800)
-  );
-  --color-success-disabled: var(
-    --nx-color-success-disabled,
-    var(--nx-color-green-300)
-  );
-  --color-success-subtle: var(
-    --nx-color-success-subtle,
-    var(--nx-color-green-50)
-  );
-  --color-success-subtle-foreground: var(
-    --nx-color-success-subtle-foreground,
-    var(--nx-color-green-700)
-  );
-  --color-success-subtle-hover: var(
-    --nx-color-success-subtle-hover,
-    var(--nx-color-green-100)
-  );
-  --color-success-subtle-active: var(
-    --nx-color-success-subtle-active,
-    var(--nx-color-green-200)
-  );
-  --color-information-background: var(
-    --nx-color-information-background,
-    var(--nx-color-blue-600)
-  );
-  --color-information-foreground: var(
-    --nx-color-information-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-information-background-hover: var(
-    --nx-color-information-background-hover,
-    var(--nx-color-blue-700)
-  );
-  --color-information-background-active: var(
-    --nx-color-information-background-active,
-    var(--nx-color-blue-800)
-  );
-  --color-information-disabled: var(
-    --nx-color-information-disabled,
-    var(--nx-color-blue-300)
-  );
-  --color-information-subtle: var(
-    --nx-color-information-subtle,
-    var(--nx-color-blue-50)
-  );
-  --color-information-subtle-foreground: var(
-    --nx-color-information-subtle-foreground,
-    var(--nx-color-blue-600)
-  );
-  --color-information-subtle-hover: var(
-    --nx-color-information-subtle-hover,
-    var(--nx-color-blue-100)
-  );
-  --color-information-subtle-active: var(
-    --nx-color-information-subtle-active,
-    var(--nx-color-blue-200)
-  );
-  --color-warning-background: var(
-    --nx-color-warning-background,
-    var(--nx-color-orange-600)
-  );
-  --color-warning-foreground: var(
-    --nx-color-warning-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-warning-background-hover: var(
-    --nx-color-warning-background-hover,
-    var(--nx-color-orange-700)
-  );
-  --color-warning-background-active: var(
-    --nx-color-warning-background-active,
-    var(--nx-color-orange-800)
-  );
-  --color-warning-disabled: var(
-    --nx-color-warning-disabled,
-    var(--nx-color-orange-300)
-  );
-  --color-warning-subtle: var(
-    --nx-color-warning-subtle,
-    var(--nx-color-orange-50)
-  );
-  --color-warning-subtle-foreground: var(
-    --nx-color-warning-subtle-foreground,
-    var(--nx-color-orange-600)
-  );
-  --color-warning-subtle-hover: var(
-    --nx-color-warning-subtle-hover,
-    var(--nx-color-orange-100)
-  );
-  --color-warning-subtle-active: var(
-    --nx-color-warning-subtle-active,
-    var(--nx-color-orange-200)
-  );
-  --color-primary-background: var(
-    --nx-color-primary-background,
-    var(--nx-color-black-base)
-  );
-  --color-primary-background-active: var(
-    --nx-color-primary-background-active,
-    var(--nx-color-neutral-950)
-  );
-  --color-primary-foreground: var(
-    --nx-color-primary-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-primary-background-hover: var(
-    --nx-color-primary-background-hover,
-    var(--nx-color-neutral-900)
-  );
-  --color-primary-disabled: var(
-    --nx-color-primary-disabled,
-    var(--nx-color-neutral-300)
-  );
-  --color-primary-subtle: var(
-    --nx-color-primary-subtle,
-    var(--nx-color-neutral-50)
-  );
-  --color-primary-subtle-foreground: var(
-    --nx-color-primary-subtle-foreground,
-    var(--nx-color-black-base)
-  );
-  --color-primary-subtle-hover: var(
-    --nx-color-primary-subtle-hover,
-    var(--nx-color-neutral-100)
-  );
-  --color-primary-subtle-active: var(
-    --nx-color-primary-subtle-active,
-    var(--nx-color-neutral-200)
-  );
-  --color-secondary-background: var(
-    --nx-color-secondary-background,
-    var(--nx-color-neutral-100)
-  );
-  --color-secondary-foreground: var(
-    --nx-color-secondary-foreground,
-    var(--nx-color-neutral-900)
-  );
-  --color-secondary-background-hover: var(
-    --nx-color-secondary-background-hover,
-    var(--nx-color-neutral-200)
-  );
-  --color-secondary-background-active: var(
-    --nx-color-secondary-background-active,
-    var(--nx-color-neutral-300)
-  );
-  --color-secondary-disabled: var(
-    --nx-color-secondary-disabled,
-    var(--nx-color-neutral-50)
-  );
-  --color-secondary-subtle: var(
-    --nx-color-secondary-subtle,
-    var(--nx-color-neutral-100)
-  );
-  --color-secondary-subtle-foreground: var(
-    --nx-color-secondary-subtle-foreground,
-    var(--nx-color-neutral-600)
-  );
-  --color-secondary-subtle-hover: var(
-    --nx-color-secondary-subtle-hover,
-    var(--nx-color-neutral-200)
-  );
-  --color-secondary-subtle-active: var(
-    --nx-color-secondary-subtle-active,
-    var(--nx-color-neutral-300)
-  );
-  --color-border-primary: var(
-    --nx-color-border-primary,
-    var(--nx-color-neutral-200)
-  );
-  --color-border-primary-active: var(
-    --nx-color-border-primary-active,
-    var(--nx-color-neutral-400)
-  );
-  --color-chart-categorical-1: var(
-    --nx-color-chart-categorical-1,
-    var(--nx-color-teal-600)
-  );
-  --color-chart-categorical-2: var(
-    --nx-color-chart-categorical-2,
-    var(--nx-color-lime-700)
-  );
-  --color-chart-categorical-3: var(
-    --nx-color-chart-categorical-3,
-    var(--nx-color-orange-600)
-  );
-  --color-chart-categorical-4: var(
-    --nx-color-chart-categorical-4,
-    var(--nx-color-rose-600)
-  );
-  --color-chart-categorical-5: var(
-    --nx-color-chart-categorical-5,
-    var(--nx-color-indigo-600)
-  );
-  --color-focus-default: var(
-    --nx-color-focus-default,
-    var(--nx-focus-color-default)
-  );
-  --color-focus-error: var(--nx-color-focus-error, var(--nx-focus-color-error));
 }
 
 /* ===== DARK MODE ===== */


### PR DESCRIPTION
## Summary

- Restore semantic color token generation to the pre-runtime-bridge shape under plain `@theme`.
- Remove the generated `@theme inline` runtime color fallback aliases from the Tailwind and docs theme outputs.
- Update generator tests to assert the prefixed static theme-variable compile path again.

## GitHub Issue

Not linked.

## Test Plan

- [x] `./node_modules/.bin/vitest run --project=unit packages/core/scripts/__tests__/generate-tailwind-package.test.js`
- [x] `./node_modules/.bin/vitest run --project=unit packages/core/scripts/__tests__/generate-modular.test.js`
- [x] `git diff --check`
- [x] `corepack pnpm lint-staged`