### PR TITLE
fix(storybook): restore story wrapper background

### DIFF
--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -225,7 +225,7 @@ const AppearanceDecorator: Decorator = (Story, context) => {
       onStateChange={handleStateChange}
     >
       <div
-        className={`nx:flex nx:items-center nx:justify-center nx:text-foreground ${isDocs ? 'nx:py-12' : 'nx:min-h-svh'}`}
+        className={`nx:flex nx:items-center nx:justify-center nx:bg-background nx:text-foreground ${isDocs ? 'nx:py-12' : 'nx:min-h-svh'}`}
       >
         <Story />
       </div>
@@ -263,11 +263,11 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
-    // Disable Storybook's built-in background selector. The imported consumer
-    // CSS still owns the iframe body background for theme parity; the per-story
-    // wrapper stays transparent so components do not get an extra surface.
+    // Disable Storybook's built-in background selector
+    // Theme switching is handled by the decorator which applies
+    // nx:bg-background class that uses CSS variables
     backgrounds: { disable: true },
-    // Use fullscreen layout so our theme wrapper owns alignment and min-height
+    // Use fullscreen layout so our theme wrapper fills the entire canvas
     layout: 'fullscreen',
     viewport: {
       options: {


### PR DESCRIPTION
## Summary

- Restore the Storybook appearance decorator's `nx:bg-background` wrapper class.
- Revert the preview comments to describe the wrapper-owned background again.

## GitHub Issue

N/A

## Test Plan

- [x] `git diff --check`
- [x] `node -e "const fs=require('fs'); const p='packages/react/.storybook/preview.tsx'; const s=fs.readFileSync(p,'utf8'); if(!s.includes('nx:bg-background nx:text-foreground')) process.exit(1); if(!s.includes('nx:bg-background class that uses CSS variables')) process.exit(2); console.log('Storybook wrapper background restored');"`
- [x] `corepack pnpm --filter @nexus_ds/react build`
- [ ] `corepack pnpm --filter @nexus_ds/react typecheck` (blocked locally by existing Storybook type resolution errors such as `Cannot find module '@storybook/react'` across story files)
