### PR TITLE
feat(menu): align checkbox and radio indicators

### DIFF
--- a/packages/react/src/components/context-menu/ContextMenu.stories.tsx
+++ b/packages/react/src/components/context-menu/ContextMenu.stories.tsx
@@ -147,6 +147,116 @@ export const WithRadioItems: Story = {
   },
 };
 
+export const IndicatorCrossFade: Story = {
+  render: (_args) => (
+    <ContextMenu>
+      <ContextMenuTrigger className={triggerClass}>
+        Indicator Motion
+      </ContextMenuTrigger>
+      <ContextMenuContent className="nx:w-56">
+        <ContextMenuCheckboxItem checked>Status Bar</ContextMenuCheckboxItem>
+        <ContextMenuCheckboxItem checked={false}>
+          Activity Bar
+        </ContextMenuCheckboxItem>
+        <ContextMenuCheckboxItem checked="indeterminate">
+          Bookmarks Bar
+        </ContextMenuCheckboxItem>
+        <ContextMenuSeparator />
+        <ContextMenuRadioGroup value="bottom">
+          <ContextMenuRadioItem value="top">Top</ContextMenuRadioItem>
+          <ContextMenuRadioItem value="bottom">Bottom</ContextMenuRadioItem>
+        </ContextMenuRadioGroup>
+      </ContextMenuContent>
+    </ContextMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByText('Indicator Motion');
+
+    try {
+      await fireEvent.contextMenu(trigger, { clientX: 20, clientY: 20 });
+
+      const menu = await within(document.body).findByRole('menu');
+      const checkedItem = within(menu).getByRole('menuitemcheckbox', {
+        name: 'Status Bar',
+      });
+      const uncheckedItem = within(menu).getByRole('menuitemcheckbox', {
+        name: 'Activity Bar',
+      });
+      const indeterminateItem = within(menu).getByRole('menuitemcheckbox', {
+        name: 'Bookmarks Bar',
+      });
+      const selectedRadio = within(menu).getByRole('menuitemradio', {
+        name: 'Bottom',
+      });
+      const unselectedRadio = within(menu).getByRole('menuitemradio', {
+        name: 'Top',
+      });
+
+      const checkedIndicator = checkedItem.querySelector(
+        '[data-slot="context-menu-checkbox-indicator"]'
+      );
+      const checkedIcon = checkedItem.querySelector(
+        '[data-slot="context-menu-checkbox-indicator-icon"]'
+      );
+      const uncheckedIcon = uncheckedItem.querySelector(
+        '[data-slot="context-menu-checkbox-indicator-icon"]'
+      );
+      const indeterminateIcon = indeterminateItem.querySelector(
+        '[data-slot="context-menu-checkbox-indicator-icon"]'
+      );
+      const selectedIndicator = selectedRadio.querySelector(
+        '[data-slot="context-menu-radio-indicator"]'
+      );
+      const selectedDot = selectedRadio.querySelector(
+        '[data-slot="context-menu-radio-indicator-icon"]'
+      );
+      const unselectedDot = unselectedRadio.querySelector(
+        '[data-slot="context-menu-radio-indicator-icon"]'
+      );
+
+      await expect(checkedIndicator).toBeInTheDocument();
+      await expect(checkedIcon).toBeInTheDocument();
+      await expect(uncheckedIcon).toBeInTheDocument();
+      await expect(indeterminateIcon).toBeInTheDocument();
+      await expect(selectedIndicator).toBeInTheDocument();
+      await expect(selectedDot).toBeInTheDocument();
+      await expect(unselectedDot).toBeInTheDocument();
+      await expect(checkedItem).toHaveAttribute('data-state', 'checked');
+      await expect(uncheckedItem).toHaveAttribute('data-state', 'unchecked');
+      await expect(indeterminateItem).toHaveAttribute(
+        'data-state',
+        'indeterminate'
+      );
+      await expect(checkedItem).toHaveClass('nx:group');
+      await expect(selectedRadio).toHaveClass('nx:group');
+      await expect(checkedIcon).toHaveAttribute('aria-hidden', 'true');
+      await expect(selectedDot).toHaveAttribute('aria-hidden', 'true');
+      await expect(checkedIcon).toHaveClass('nx:transition-[opacity,scale]');
+      await expect(uncheckedIcon).toHaveClass('nx:scale-50');
+      await expect(uncheckedIcon).toHaveClass('nx:opacity-0');
+      await expect(checkedIcon).toHaveClass(
+        'nx:group-data-[state=checked]:opacity-100'
+      );
+      await expect(indeterminateIcon).toHaveClass(
+        'nx:group-data-[state=indeterminate]:opacity-100'
+      );
+      await expect(checkedIcon).toHaveClass('nx:motion-reduce:transition-none');
+      await expect(unselectedDot).toHaveClass('nx:scale-50');
+      await expect(unselectedDot).toHaveClass('nx:opacity-0');
+      await expect(selectedDot).toHaveClass(
+        'nx:group-data-[state=checked]:opacity-100'
+      );
+    } finally {
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(document.querySelector('[role="menu"]')).toBeNull();
+        expect(document.querySelector('[data-aria-hidden="true"]')).toBeNull();
+      });
+    }
+  },
+};
+
 export const WithSubMenu: Story = {
   render: (_args) => (
     <ContextMenu>

--- a/packages/react/src/components/context-menu/context-menu.tsx
+++ b/packages/react/src/components/context-menu/context-menu.tsx
@@ -4,6 +4,7 @@ import * as ContextMenuPrimitive from '@radix-ui/react-context-menu';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { IconCheck, IconChevronRight, IconCircleFilled } from '../../lib/icons';
+import { selectionIndicatorMotionClassName } from '../../lib/motion';
 import { cn } from '../../lib/utils';
 import {
   staggeredItemClassName,
@@ -286,7 +287,7 @@ function ContextMenuCheckboxItem({
     <ContextMenuPrimitive.CheckboxItem
       data-slot="context-menu-checkbox-item"
       className={cn(
-        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
+        'nx:group nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
         'nx:rounded-sm nx:py-1.5 nx:pl-8 nx:pr-2 nx:typography-body-default nx:outline-none',
         'nx:transition-colors',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
@@ -297,9 +298,21 @@ function ContextMenuCheckboxItem({
       checked={checked}
       {...props}
     >
-      <span className="nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
-        <ContextMenuPrimitive.ItemIndicator>
-          <IconCheck className="nx:size-4" />
+      <span className="nx:pointer-events-none nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
+        <ContextMenuPrimitive.ItemIndicator
+          forceMount
+          data-slot="context-menu-checkbox-indicator"
+        >
+          <IconCheck
+            data-slot="context-menu-checkbox-indicator-icon"
+            aria-hidden="true"
+            className={cn(
+              'nx:size-4',
+              selectionIndicatorMotionClassName,
+              'nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100',
+              'nx:group-data-[state=indeterminate]:scale-100 nx:group-data-[state=indeterminate]:opacity-100'
+            )}
+          />
         </ContextMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -338,7 +351,7 @@ function ContextMenuRadioItem({
     <ContextMenuPrimitive.RadioItem
       data-slot="context-menu-radio-item"
       className={cn(
-        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
+        'nx:group nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
         'nx:rounded-sm nx:py-1.5 nx:pl-8 nx:pr-2 nx:typography-body-default nx:outline-none',
         'nx:transition-colors',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
@@ -348,9 +361,20 @@ function ContextMenuRadioItem({
       )}
       {...props}
     >
-      <span className="nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
-        <ContextMenuPrimitive.ItemIndicator>
-          <IconCircleFilled className="nx:size-2" />
+      <span className="nx:pointer-events-none nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
+        <ContextMenuPrimitive.ItemIndicator
+          forceMount
+          data-slot="context-menu-radio-indicator"
+        >
+          <IconCircleFilled
+            data-slot="context-menu-radio-indicator-icon"
+            aria-hidden="true"
+            className={cn(
+              'nx:size-2',
+              selectionIndicatorMotionClassName,
+              'nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100'
+            )}
+          />
         </ContextMenuPrimitive.ItemIndicator>
       </span>
       {children}

--- a/packages/react/src/components/menubar/Menubar.stories.tsx
+++ b/packages/react/src/components/menubar/Menubar.stories.tsx
@@ -131,6 +131,116 @@ export const WithRadioItems: Story = {
   },
 };
 
+export const IndicatorCrossFade: Story = {
+  render: (_args) => (
+    <Menubar>
+      <MenubarMenu>
+        <MenubarTrigger>View</MenubarTrigger>
+        <MenubarContent>
+          <MenubarCheckboxItem checked>Status Bar</MenubarCheckboxItem>
+          <MenubarCheckboxItem checked={false}>
+            Activity Bar
+          </MenubarCheckboxItem>
+          <MenubarCheckboxItem checked="indeterminate">
+            Bookmarks Bar
+          </MenubarCheckboxItem>
+          <MenubarSeparator />
+          <MenubarRadioGroup value="bottom">
+            <MenubarRadioItem value="top">Top</MenubarRadioItem>
+            <MenubarRadioItem value="bottom">Bottom</MenubarRadioItem>
+          </MenubarRadioGroup>
+        </MenubarContent>
+      </MenubarMenu>
+    </Menubar>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('menuitem', { name: 'View' });
+
+    try {
+      await userEvent.click(trigger);
+
+      const menu = await within(document.body).findByRole('menu');
+      const checkedItem = within(menu).getByRole('menuitemcheckbox', {
+        name: 'Status Bar',
+      });
+      const uncheckedItem = within(menu).getByRole('menuitemcheckbox', {
+        name: 'Activity Bar',
+      });
+      const indeterminateItem = within(menu).getByRole('menuitemcheckbox', {
+        name: 'Bookmarks Bar',
+      });
+      const selectedRadio = within(menu).getByRole('menuitemradio', {
+        name: 'Bottom',
+      });
+      const unselectedRadio = within(menu).getByRole('menuitemradio', {
+        name: 'Top',
+      });
+
+      const checkedIndicator = checkedItem.querySelector(
+        '[data-slot="menubar-checkbox-indicator"]'
+      );
+      const checkedIcon = checkedItem.querySelector(
+        '[data-slot="menubar-checkbox-indicator-icon"]'
+      );
+      const uncheckedIcon = uncheckedItem.querySelector(
+        '[data-slot="menubar-checkbox-indicator-icon"]'
+      );
+      const indeterminateIcon = indeterminateItem.querySelector(
+        '[data-slot="menubar-checkbox-indicator-icon"]'
+      );
+      const selectedIndicator = selectedRadio.querySelector(
+        '[data-slot="menubar-radio-indicator"]'
+      );
+      const selectedDot = selectedRadio.querySelector(
+        '[data-slot="menubar-radio-indicator-icon"]'
+      );
+      const unselectedDot = unselectedRadio.querySelector(
+        '[data-slot="menubar-radio-indicator-icon"]'
+      );
+
+      await expect(checkedIndicator).toBeInTheDocument();
+      await expect(checkedIcon).toBeInTheDocument();
+      await expect(uncheckedIcon).toBeInTheDocument();
+      await expect(indeterminateIcon).toBeInTheDocument();
+      await expect(selectedIndicator).toBeInTheDocument();
+      await expect(selectedDot).toBeInTheDocument();
+      await expect(unselectedDot).toBeInTheDocument();
+      await expect(checkedItem).toHaveAttribute('data-state', 'checked');
+      await expect(uncheckedItem).toHaveAttribute('data-state', 'unchecked');
+      await expect(indeterminateItem).toHaveAttribute(
+        'data-state',
+        'indeterminate'
+      );
+      await expect(checkedItem).toHaveClass('nx:group');
+      await expect(selectedRadio).toHaveClass('nx:group');
+      await expect(checkedIcon).toHaveAttribute('aria-hidden', 'true');
+      await expect(selectedDot).toHaveAttribute('aria-hidden', 'true');
+      await expect(checkedIcon).toHaveClass('nx:transition-[opacity,scale]');
+      await expect(uncheckedIcon).toHaveClass('nx:scale-50');
+      await expect(uncheckedIcon).toHaveClass('nx:opacity-0');
+      await expect(checkedIcon).toHaveClass(
+        'nx:group-data-[state=checked]:opacity-100'
+      );
+      await expect(indeterminateIcon).toHaveClass(
+        'nx:group-data-[state=indeterminate]:opacity-100'
+      );
+      await expect(checkedIcon).toHaveClass('nx:motion-reduce:transition-none');
+      await expect(unselectedDot).toHaveClass('nx:scale-50');
+      await expect(unselectedDot).toHaveClass('nx:opacity-0');
+      await expect(selectedDot).toHaveClass(
+        'nx:group-data-[state=checked]:opacity-100'
+      );
+    } finally {
+      await userEvent.keyboard('{Escape}');
+      await waitFor(() => {
+        expect(document.querySelector('[role="menu"]')).toBeNull();
+        expect(document.querySelector('[data-aria-hidden="true"]')).toBeNull();
+      });
+    }
+  },
+};
+
 export const WithSubMenu: Story = {
   render: (_args) => (
     <Menubar>

--- a/packages/react/src/components/menubar/menubar.tsx
+++ b/packages/react/src/components/menubar/menubar.tsx
@@ -4,6 +4,7 @@ import * as MenubarPrimitive from '@radix-ui/react-menubar';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { IconCheck, IconChevronRight, IconCircleFilled } from '../../lib/icons';
+import { selectionIndicatorMotionClassName } from '../../lib/motion';
 import { cn } from '../../lib/utils';
 import {
   staggeredItemClassName,
@@ -342,7 +343,7 @@ function MenubarCheckboxItem({
     <MenubarPrimitive.CheckboxItem
       data-slot="menubar-checkbox-item"
       className={cn(
-        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
+        'nx:group nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
         'nx:rounded-sm nx:py-1.5 nx:pl-8 nx:pr-2 nx:typography-body-default nx:outline-none',
         'nx:transition-colors',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
@@ -353,9 +354,21 @@ function MenubarCheckboxItem({
       checked={checked}
       {...props}
     >
-      <span className="nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
-        <MenubarPrimitive.ItemIndicator>
-          <IconCheck className="nx:size-4" />
+      <span className="nx:pointer-events-none nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
+        <MenubarPrimitive.ItemIndicator
+          forceMount
+          data-slot="menubar-checkbox-indicator"
+        >
+          <IconCheck
+            data-slot="menubar-checkbox-indicator-icon"
+            aria-hidden="true"
+            className={cn(
+              'nx:size-4',
+              selectionIndicatorMotionClassName,
+              'nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100',
+              'nx:group-data-[state=indeterminate]:scale-100 nx:group-data-[state=indeterminate]:opacity-100'
+            )}
+          />
         </MenubarPrimitive.ItemIndicator>
       </span>
       {children}
@@ -394,7 +407,7 @@ function MenubarRadioItem({
     <MenubarPrimitive.RadioItem
       data-slot="menubar-radio-item"
       className={cn(
-        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
+        'nx:group nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center',
         'nx:rounded-sm nx:py-1.5 nx:pl-8 nx:pr-2 nx:typography-body-default nx:outline-none',
         'nx:transition-colors',
         'nx:focus:bg-popover-hover nx:focus:text-popover-foreground',
@@ -404,9 +417,20 @@ function MenubarRadioItem({
       )}
       {...props}
     >
-      <span className="nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
-        <MenubarPrimitive.ItemIndicator>
-          <IconCircleFilled className="nx:size-2" />
+      <span className="nx:pointer-events-none nx:absolute nx:left-2 nx:flex nx:size-3.5 nx:items-center nx:justify-center">
+        <MenubarPrimitive.ItemIndicator
+          forceMount
+          data-slot="menubar-radio-indicator"
+        >
+          <IconCircleFilled
+            data-slot="menubar-radio-indicator-icon"
+            aria-hidden="true"
+            className={cn(
+              'nx:size-2',
+              selectionIndicatorMotionClassName,
+              'nx:group-data-[state=checked]:scale-100 nx:group-data-[state=checked]:opacity-100'
+            )}
+          />
         </MenubarPrimitive.ItemIndicator>
       </span>
       {children}


### PR DESCRIPTION
## Summary

- Align ContextMenu checkbox/radio indicator markup with the DropdownMenu marker pattern.
- Align Menubar checkbox/radio indicator markup with the same forced-mounted marker slots and motion classes.
- Add Storybook coverage for checked, unchecked, indeterminate, selected, and unselected marker visibility hooks.

## GitHub Issue

Closes #619

## Test Plan

- [x] `corepack pnpm test:storybook -- packages/react/src/components/context-menu/ContextMenu.stories.tsx packages/react/src/components/menubar/Menubar.stories.tsx packages/react/src/components/dropdown-menu/DropdownMenu.stories.tsx`
- [x] `CI=true PATH=/Users/temp/.nvm/versions/node/v24.12.0/bin:$PATH corepack pnpm typecheck`
- [x] `CI=true PATH=/Users/temp/.nvm/versions/node/v24.12.0/bin:$PATH corepack pnpm lint`
- [x] `git diff --check`
