### PR TITLE
feat(react): add combobox component

### DIFF
--- a/packages/react/src/components/combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/combobox/Combobox.stories.tsx
@@ -24,8 +24,9 @@ type ComboboxItemData = {
   group?: string;
 };
 
-// cmdk lowercases the value passed to onSelect, so keep option values lowercase
-// and compare against them directly.
+// cmdk filters on each item's `value` + `keywords`, not its rendered children,
+// so pass the label as a keyword to make it searchable. `onSelect` receives the
+// trimmed `value` (case preserved) — compare against `option.value` directly.
 const frameworks: ComboboxItemData[] = [
   { value: 'next', label: 'Next.js' },
   { value: 'sveltekit', label: 'SvelteKit' },
@@ -121,6 +122,7 @@ function ComboboxExample({
                 <ComboboxItem
                   key={option.value}
                   value={option.value}
+                  keywords={[option.label]}
                   disabled={option.disabled}
                   selected={value === option.value}
                   onSelect={handleSelect}
@@ -185,6 +187,7 @@ export const Controlled: Story = {
                   <ComboboxItem
                     key={framework.value}
                     value={framework.value}
+                    keywords={[framework.label]}
                     selected={value === framework.value}
                     onSelect={handleSelect}
                   >
@@ -276,7 +279,7 @@ export const InvalidField: Story = {
         Choose the framework used by this project.
       </FieldDescription>
       <FieldError id="framework-invalid-error">
-        Framework is required.
+        Select a supported framework.
       </FieldError>
     </Field>
   ),

--- a/packages/react/src/components/combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/combobox/Combobox.stories.tsx
@@ -3,19 +3,30 @@ import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
-import { Button } from '../button';
+import { cn } from '../../lib/utils';
 import { Field, FieldDescription, FieldError, FieldLabel } from '../field';
 
 import {
   Combobox,
   ComboboxContent,
   ComboboxEmpty,
+  ComboboxGroup,
   ComboboxInput,
+  ComboboxItem,
   ComboboxList,
-  type ComboboxOption,
+  ComboboxTrigger,
 } from './combobox';
 
-const frameworks: ComboboxOption[] = [
+type ComboboxItemData = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+  group?: string;
+};
+
+// cmdk lowercases the value passed to onSelect, so keep option values lowercase
+// and compare against them directly.
+const frameworks: ComboboxItemData[] = [
   { value: 'next', label: 'Next.js' },
   { value: 'sveltekit', label: 'SvelteKit' },
   { value: 'nuxt', label: 'Nuxt.js' },
@@ -23,50 +34,105 @@ const frameworks: ComboboxOption[] = [
   { value: 'astro', label: 'Astro' },
 ];
 
-const groupedFrameworks: ComboboxOption[] = [
+const groupedFrameworks: ComboboxItemData[] = [
   { value: 'next', label: 'Next.js', group: 'React' },
   { value: 'remix', label: 'Remix', group: 'React' },
   { value: 'sveltekit', label: 'SvelteKit', group: 'Svelte' },
   { value: 'nuxt', label: 'Nuxt.js', group: 'Vue' },
-  { value: 'astro', label: 'Astro', group: 'Meta frameworks' },
+  { value: 'astro', label: 'Astro', group: 'Other' },
 ];
 
-function FrameworkCombobox({
-  inputClassName = 'nx:w-64',
-  items = frameworks,
-  placeholder = 'Select a framework',
-  ...props
-}: Omit<React.ComponentProps<typeof Combobox>, 'items'> & {
-  inputClassName?: string;
-  items?: ComboboxOption[];
-  placeholder?: string;
-}) {
-  return (
-    <Combobox items={items} {...props}>
-      <ComboboxInput
-        aria-label="Framework"
-        className={inputClassName}
-        placeholder={placeholder}
-        showClear
-      />
-      <ComboboxContent>
-        <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
-        <ComboboxList />
-      </ComboboxContent>
-    </Combobox>
-  );
+const longFrameworks: ComboboxItemData[] = [
+  { value: 'next', label: 'Next.js — the React framework for the web' },
+  {
+    value: 'sveltekit',
+    label: 'SvelteKit — the fastest way to build Svelte apps',
+  },
+  {
+    value: 'astro',
+    label: 'Astro — the web framework for content-driven sites',
+  },
+];
+
+function toGroups(items: ComboboxItemData[]) {
+  if (!items.some((item) => item.group))
+    return [{ heading: undefined, options: items }];
+
+  const groups = new Map<string, ComboboxItemData[]>();
+
+  for (const item of items) {
+    const heading = item.group ?? 'Other';
+    groups.set(heading, [...(groups.get(heading) ?? []), item]);
+  }
+
+  return [...groups.entries()].map(([heading, options]) => ({
+    heading,
+    options,
+  }));
 }
 
-function ControlledComboboxExample() {
-  const [value, setValue] = React.useState('astro');
+function ComboboxExample({
+  defaultValue = '',
+  emptyText = 'No framework found.',
+  items = frameworks,
+  placeholder = 'Select framework',
+  searchPlaceholder = 'Search framework...',
+  triggerClassName = 'nx:w-64',
+  ...triggerProps
+}: {
+  defaultValue?: string;
+  emptyText?: string;
+  items?: ComboboxItemData[];
+  placeholder?: string;
+  searchPlaceholder?: string;
+  triggerClassName?: string;
+} & Omit<
+  React.ComponentProps<typeof ComboboxTrigger>,
+  'children' | 'className'
+>) {
+  const [open, setOpen] = React.useState(false);
+  const [value, setValue] = React.useState(defaultValue);
+  const selectedLabel = items.find((item) => item.value === value)?.label;
+
+  const handleSelect = (next: string) => {
+    setValue(next === value ? '' : next);
+    setOpen(false);
+  };
 
   return (
-    <div className="nx:flex nx:flex-col nx:gap-3">
-      <FrameworkCombobox value={value} onValueChange={setValue} />
-      <output className="nx:typography-body-small nx:text-muted-foreground">
-        Selected: {value || 'none'}
-      </output>
-    </div>
+    <Combobox open={open} onOpenChange={setOpen}>
+      <ComboboxTrigger className={triggerClassName} {...triggerProps}>
+        <span
+          className={cn(
+            'nx:min-w-0 nx:flex-1 nx:truncate nx:text-left',
+            selectedLabel ? undefined : 'nx:text-muted-foreground'
+          )}
+        >
+          {selectedLabel ?? placeholder}
+        </span>
+      </ComboboxTrigger>
+      <ComboboxContent label="Framework">
+        <ComboboxInput placeholder={searchPlaceholder} />
+        <ComboboxList>
+          <ComboboxEmpty>{emptyText}</ComboboxEmpty>
+          {toGroups(items).map(({ heading, options }) => (
+            <ComboboxGroup key={heading ?? '_root'} heading={heading}>
+              {options.map((option) => (
+                <ComboboxItem
+                  key={option.value}
+                  value={option.value}
+                  disabled={option.disabled}
+                  selected={value === option.value}
+                  onSelect={handleSelect}
+                >
+                  {option.label}
+                </ComboboxItem>
+              ))}
+            </ComboboxGroup>
+          ))}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
   );
 }
 
@@ -82,105 +148,86 @@ export default meta;
 type Story = StoryObj<typeof Combobox>;
 
 export const Default: Story = {
-  render: () => <FrameworkCombobox />,
+  render: () => <ComboboxExample />,
 };
 
-export const WithDefaultValue: Story = {
-  render: () => <FrameworkCombobox defaultValue="next" />,
+export const WithSelection: Story = {
+  render: () => <ComboboxExample defaultValue="next" />,
 };
 
-export const ReopenShowsFullList: Story = {
-  render: () => <FrameworkCombobox defaultValue="next" />,
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const input = canvas.getByRole('combobox', { name: 'Framework' });
-
-    await expect(input).toHaveValue('Next.js');
-    await userEvent.click(input);
-
-    const listbox = await within(document.body).findByRole('listbox');
-
-    await expect(
-      within(listbox).getByRole('option', { name: 'Next.js' })
-    ).toBeInTheDocument();
-    await expect(
-      within(listbox).getByRole('option', { name: 'SvelteKit' })
-    ).toBeInTheDocument();
-    await expect(
-      within(listbox).getByRole('option', { name: 'Astro' })
-    ).toBeInTheDocument();
-
-    await userEvent.keyboard('{Escape}');
-    await waitFor(() => {
-      expect(document.body.querySelector('[role="listbox"]')).toBeNull();
-    });
-
-    await userEvent.click(input);
-    const reopenedListbox = await within(document.body).findByRole('listbox');
-
-    await expect(
-      within(reopenedListbox).getByRole('option', { name: 'Next.js' })
-    ).toBeInTheDocument();
-
-    await userEvent.keyboard('{Escape}');
-  },
-};
-
+// Raw composition holding open + value state at the call site — the canonical
+// controlled usage, and the composition example the pattern is built around.
 export const Controlled: Story = {
-  render: () => <ControlledComboboxExample />,
+  render: function ControlledStory() {
+    const [open, setOpen] = React.useState(false);
+    const [value, setValue] = React.useState('astro');
+    const selectedLabel = frameworks.find((f) => f.value === value)?.label;
+
+    const handleSelect = (next: string) => {
+      setValue(next === value ? '' : next);
+      setOpen(false);
+    };
+
+    return (
+      <div className="nx:flex nx:flex-col nx:gap-3">
+        <Combobox open={open} onOpenChange={setOpen}>
+          <ComboboxTrigger className="nx:w-64">
+            <span className="nx:min-w-0 nx:flex-1 nx:truncate nx:text-left">
+              {selectedLabel ?? 'Select framework'}
+            </span>
+          </ComboboxTrigger>
+          <ComboboxContent label="Framework">
+            <ComboboxInput placeholder="Search framework..." />
+            <ComboboxList>
+              <ComboboxEmpty>No framework found.</ComboboxEmpty>
+              <ComboboxGroup>
+                {frameworks.map((framework) => (
+                  <ComboboxItem
+                    key={framework.value}
+                    value={framework.value}
+                    selected={value === framework.value}
+                    onSelect={handleSelect}
+                  >
+                    {framework.label}
+                  </ComboboxItem>
+                ))}
+              </ComboboxGroup>
+            </ComboboxList>
+          </ComboboxContent>
+        </Combobox>
+        <output className="nx:typography-body-small nx:text-muted-foreground">
+          Selected: {value || 'none'}
+        </output>
+      </div>
+    );
+  },
 };
 
 export const Sizes: Story = {
   render: () => (
     <div className="nx:flex nx:w-64 nx:flex-col nx:gap-3">
-      <FrameworkCombobox placeholder="Default" inputClassName="" />
-      <Combobox items={frameworks}>
-        <ComboboxInput
-          aria-label="Small framework"
-          size="sm"
-          placeholder="Sm"
-        />
-        <ComboboxContent>
-          <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
-          <ComboboxList />
-        </ComboboxContent>
-      </Combobox>
-      <Combobox items={frameworks}>
-        <ComboboxInput
-          aria-label="Large framework"
-          size="lg"
-          placeholder="Lg"
-        />
-        <ComboboxContent>
-          <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
-          <ComboboxList />
-        </ComboboxContent>
-      </Combobox>
+      <ComboboxExample
+        size="sm"
+        placeholder="Small"
+        triggerClassName="nx:w-full"
+      />
+      <ComboboxExample placeholder="Default" triggerClassName="nx:w-full" />
+      <ComboboxExample
+        size="lg"
+        placeholder="Large"
+        triggerClassName="nx:w-full"
+      />
     </div>
   ),
 };
 
 export const Grouped: Story = {
-  render: () => <FrameworkCombobox items={groupedFrameworks} />,
-};
-
-export const Disabled: Story = {
-  render: () => <FrameworkCombobox disabled defaultValue="next" />,
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const input = canvas.getByRole('combobox', { name: 'Framework' });
-
-    await expect(input).toBeDisabled();
-    await userEvent.click(input);
-    await waitFor(() => {
-      expect(document.body.querySelector('[role="listbox"]')).toBeNull();
-    });
-  },
+  render: () => <ComboboxExample items={groupedFrameworks} />,
 };
 
 export const WithDisabledOption: Story = {
   render: () => (
-    <FrameworkCombobox
+    <ComboboxExample
       items={[
         { value: 'next', label: 'Next.js' },
         { value: 'sveltekit', label: 'SvelteKit', disabled: true },
@@ -190,176 +237,185 @@ export const WithDisabledOption: Story = {
   ),
 };
 
-export const InvalidRequiredField: Story = {
+export const LongLabelsNarrowField: Story = {
+  render: () => (
+    <ComboboxExample
+      items={longFrameworks}
+      triggerClassName="nx:w-56"
+      defaultValue="sveltekit"
+    />
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => <ComboboxExample disabled defaultValue="next" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Next.js' });
+
+    await expect(trigger).toBeDisabled();
+    // The disabled trigger sets pointer-events: none; bypass the guard to prove
+    // the click is a no-op and the popover stays closed.
+    await userEvent.click(trigger, { pointerEventsCheck: 0 });
+    await waitFor(() => {
+      expect(document.body.querySelector('[role="listbox"]')).toBeNull();
+    });
+  },
+};
+
+export const InvalidField: Story = {
   render: () => (
     <Field data-invalid>
-      <FieldLabel htmlFor="framework-required">Framework</FieldLabel>
-      <Combobox items={frameworks} required invalid>
-        <ComboboxInput
-          id="framework-required"
-          aria-describedby="framework-required-description framework-required-error"
-          aria-label="Framework"
-          className="nx:w-64"
-          placeholder="Select a framework"
-        />
-        <ComboboxContent>
-          <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
-          <ComboboxList />
-        </ComboboxContent>
-      </Combobox>
-      <FieldDescription id="framework-required-description">
+      <FieldLabel htmlFor="framework-invalid">Framework</FieldLabel>
+      <ComboboxExample
+        id="framework-invalid"
+        aria-invalid
+        aria-describedby="framework-invalid-description framework-invalid-error"
+      />
+      <FieldDescription id="framework-invalid-description">
         Choose the framework used by this project.
       </FieldDescription>
-      <FieldError id="framework-required-error">
+      <FieldError id="framework-invalid-error">
         Framework is required.
       </FieldError>
     </Field>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const input = canvas.getByRole('combobox', { name: 'Framework' });
+    const trigger = canvas.getByRole('button');
 
-    await expect(input).toBeRequired();
-    await expect(input).toHaveAttribute('aria-invalid', 'true');
-    await expect(input).toHaveAttribute('aria-required', 'true');
-  },
-};
-
-export const KeyboardInteraction: Story = {
-  render: () => <FrameworkCombobox />,
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const input = canvas.getByRole('combobox', { name: 'Framework' });
-
-    await userEvent.click(input);
-    await userEvent.keyboard('rem');
-
-    const listbox = await within(document.body).findByRole('listbox');
-
-    await expect(
-      within(listbox).getByRole('option', { name: 'Remix' })
-    ).toBeInTheDocument();
-    await userEvent.keyboard('{ArrowDown}{Enter}');
-
-    await waitFor(() => {
-      expect(input).toHaveValue('Remix');
-    });
+    await expect(trigger).toHaveAttribute('aria-invalid', 'true');
   },
 };
 
 export const ClickInteraction: Story = {
-  render: () => <FrameworkCombobox />,
+  render: () => <ComboboxExample />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const input = canvas.getByRole('combobox', { name: 'Framework' });
-    const trigger = canvas.getByRole('button', { name: 'Open options' });
+    const trigger = canvas.getByRole('button', { name: 'Select framework' });
 
     await userEvent.click(trigger);
     const listbox = await within(document.body).findByRole('listbox');
-
     await userEvent.click(
       within(listbox).getByRole('option', { name: 'Astro' })
     );
 
-    await expect(input).toHaveValue('Astro');
-  },
-};
-
-export const ClearButton: Story = {
-  render: () => <FrameworkCombobox defaultValue="next" />,
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const input = canvas.getByRole('combobox', { name: 'Framework' });
-    const clearButton = canvas.getByRole('button', { name: 'Clear selection' });
-
-    await expect(input).toHaveValue('Next.js');
-    await userEvent.click(clearButton);
     await waitFor(() => {
-      expect(input).toHaveValue('');
+      expect(canvas.getByRole('button', { name: 'Astro' })).toBeInTheDocument();
     });
   },
 };
 
-export const FormReset: Story = {
-  render: () => (
-    <form className="nx:flex nx:flex-col nx:items-start nx:gap-3">
-      <FrameworkCombobox name="framework" defaultValue="next" />
-      <Button type="reset" variant="outline">
-        Reset
-      </Button>
-    </form>
-  ),
+export const KeyboardInteraction: Story = {
+  render: () => <ComboboxExample />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const input = canvas.getByRole('combobox', { name: 'Framework' });
-    const hiddenInput = canvasElement.querySelector('input[type="hidden"]');
+    const trigger = canvas.getByRole('button', { name: 'Select framework' });
 
-    await userEvent.click(input);
+    await userEvent.click(trigger);
+    const input = await within(document.body).findByRole('combobox', {
+      name: 'Framework',
+    });
+
+    await userEvent.type(input, 'rem');
+    const listbox = within(document.body).getByRole('listbox');
+    await expect(
+      within(listbox).getByRole('option', { name: 'Remix' })
+    ).toBeInTheDocument();
+
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => {
+      expect(canvas.getByRole('button', { name: 'Remix' })).toBeInTheDocument();
+    });
+  },
+};
+
+export const ClearOnReselect: Story = {
+  render: () => <ComboboxExample defaultValue="next" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Next.js' });
+
+    await userEvent.click(trigger);
     const listbox = await within(document.body).findByRole('listbox');
     await userEvent.click(
-      within(listbox).getByRole('option', { name: 'Astro' })
+      within(listbox).getByRole('option', { name: 'Next.js' })
     );
 
-    await expect(input).toHaveValue('Astro');
-    await expect(hiddenInput).toHaveValue('astro');
-
-    await userEvent.click(canvas.getByRole('button', { name: 'Reset' }));
-
     await waitFor(() => {
-      expect(input).toHaveValue('Next.js');
-      expect(hiddenInput).toHaveValue('next');
+      expect(
+        canvas.getByRole('button', { name: 'Select framework' })
+      ).toBeInTheDocument();
     });
+  },
+};
+
+export const EmptyResults: Story = {
+  render: () => <ComboboxExample />,
+  parameters: {
+    a11y: {
+      // aria-required-children flags the transient absence of option children
+      // while the query matches nothing, which is expected here. All other a11y
+      // rules stay enabled. Mirrors the Command Empty story.
+      config: { rules: [{ id: 'aria-required-children', enabled: false }] },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Select framework' });
+
+    await userEvent.click(trigger);
+    const input = await within(document.body).findByRole('combobox', {
+      name: 'Framework',
+    });
+
+    await userEvent.type(input, 'zzz');
+    await expect(
+      await within(document.body).findByText('No framework found.')
+    ).toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
   },
 };
 
 export const WithDataAttributes: Story = {
-  render: () => <FrameworkCombobox />,
+  render: () => <ComboboxExample />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const input = canvas.getByRole('combobox', { name: 'Framework' });
-    const trigger = canvas.getByRole('button', { name: 'Open options' });
-    const field = canvasElement.querySelector('[data-slot="combobox-field"]');
+    const trigger = canvas.getByRole('button', { name: 'Select framework' });
 
-    await expect(field).toHaveAttribute('data-size', 'default');
-    await expect(field).toHaveAttribute('data-variant', 'default');
-    await expect(field).toHaveClass('nx:border-default');
-    await expect(field).toHaveClass('nx:border-border-default');
     await expect(trigger).toHaveAttribute('data-slot', 'combobox-trigger');
-    await expect(input).toHaveAttribute('data-slot', 'combobox-input');
+
+    await userEvent.click(trigger);
+    const listbox = await within(document.body).findByRole('listbox');
+    await expect(listbox).toHaveAttribute('data-slot', 'combobox-list');
+    await expect(
+      within(listbox).getByRole('option', { name: 'Next.js' })
+    ).toHaveAttribute('data-slot', 'combobox-item');
+
+    await userEvent.keyboard('{Escape}');
   },
 };
 
 export const AllVariants: Story = {
   render: () => (
     <div className="nx:grid nx:w-[520px] nx:grid-cols-2 nx:gap-4">
-      <FrameworkCombobox placeholder="Default empty" inputClassName="" />
-      <FrameworkCombobox
+      <ComboboxExample placeholder="Empty" triggerClassName="nx:w-full" />
+      <ComboboxExample
         defaultValue="next"
-        placeholder="Default filled"
-        inputClassName=""
+        placeholder="Filled"
+        triggerClassName="nx:w-full"
       />
-      <Combobox items={frameworks}>
-        <ComboboxInput
-          variant="borderless"
-          aria-label="Borderless empty"
-          placeholder="Borderless empty"
-        />
-        <ComboboxContent>
-          <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
-          <ComboboxList />
-        </ComboboxContent>
-      </Combobox>
-      <Combobox items={frameworks} defaultValue="astro">
-        <ComboboxInput
-          variant="borderless"
-          aria-label="Borderless filled"
-          placeholder="Borderless filled"
-        />
-        <ComboboxContent>
-          <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
-          <ComboboxList />
-        </ComboboxContent>
-      </Combobox>
+      <ComboboxExample
+        disabled
+        defaultValue="astro"
+        triggerClassName="nx:w-full"
+      />
+      <ComboboxExample
+        aria-invalid
+        placeholder="Invalid"
+        triggerClassName="nx:w-full"
+      />
     </div>
   ),
 };

--- a/packages/react/src/components/combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/combobox/Combobox.stories.tsx
@@ -33,16 +33,16 @@ const groupedFrameworks: ComboboxOption[] = [
 
 function FrameworkCombobox({
   inputClassName = 'nx:w-64',
-  options = frameworks,
+  items = frameworks,
   placeholder = 'Select a framework',
   ...props
-}: Omit<React.ComponentProps<typeof Combobox>, 'options'> & {
+}: Omit<React.ComponentProps<typeof Combobox>, 'items'> & {
   inputClassName?: string;
-  options?: ComboboxOption[];
+  items?: ComboboxOption[];
   placeholder?: string;
 }) {
   return (
-    <Combobox options={options} {...props}>
+    <Combobox items={items} {...props}>
       <ComboboxInput
         aria-label="Framework"
         className={inputClassName}
@@ -122,7 +122,7 @@ export const Sizes: Story = {
   render: () => (
     <div className="nx:flex nx:w-64 nx:flex-col nx:gap-3">
       <FrameworkCombobox placeholder="Default" inputClassName="" />
-      <Combobox options={frameworks}>
+      <Combobox items={frameworks}>
         <ComboboxInput
           aria-label="Small framework"
           size="sm"
@@ -133,7 +133,7 @@ export const Sizes: Story = {
           <ComboboxList />
         </ComboboxContent>
       </Combobox>
-      <Combobox options={frameworks}>
+      <Combobox items={frameworks}>
         <ComboboxInput
           aria-label="Large framework"
           size="lg"
@@ -149,7 +149,7 @@ export const Sizes: Story = {
 };
 
 export const Grouped: Story = {
-  render: () => <FrameworkCombobox options={groupedFrameworks} />,
+  render: () => <FrameworkCombobox items={groupedFrameworks} />,
 };
 
 export const Disabled: Story = {
@@ -169,7 +169,7 @@ export const Disabled: Story = {
 export const WithDisabledOption: Story = {
   render: () => (
     <FrameworkCombobox
-      options={[
+      items={[
         { value: 'next', label: 'Next.js' },
         { value: 'sveltekit', label: 'SvelteKit', disabled: true },
         { value: 'astro', label: 'Astro' },
@@ -182,7 +182,7 @@ export const InvalidRequiredField: Story = {
   render: () => (
     <Field data-invalid>
       <FieldLabel htmlFor="framework-required">Framework</FieldLabel>
-      <Combobox options={frameworks} required invalid>
+      <Combobox items={frameworks} required invalid>
         <ComboboxInput
           id="framework-required"
           aria-describedby="framework-required-description framework-required-error"
@@ -321,7 +321,7 @@ export const AllVariants: Story = {
         placeholder="Default filled"
         inputClassName=""
       />
-      <Combobox options={frameworks}>
+      <Combobox items={frameworks}>
         <ComboboxInput
           variant="borderless"
           aria-label="Borderless empty"
@@ -332,7 +332,7 @@ export const AllVariants: Story = {
           <ComboboxList />
         </ComboboxContent>
       </Combobox>
-      <Combobox options={frameworks} defaultValue="astro">
+      <Combobox items={frameworks} defaultValue="astro">
         <ComboboxInput
           variant="borderless"
           aria-label="Borderless filled"

--- a/packages/react/src/components/combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/combobox/Combobox.stories.tsx
@@ -1,0 +1,348 @@
+import * as React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { Button } from '../button';
+import { Field, FieldDescription, FieldError, FieldLabel } from '../field';
+
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxList,
+  type ComboboxOption,
+} from './combobox';
+
+const frameworks: ComboboxOption[] = [
+  { value: 'next', label: 'Next.js' },
+  { value: 'sveltekit', label: 'SvelteKit' },
+  { value: 'nuxt', label: 'Nuxt.js' },
+  { value: 'remix', label: 'Remix' },
+  { value: 'astro', label: 'Astro' },
+];
+
+const groupedFrameworks: ComboboxOption[] = [
+  { value: 'next', label: 'Next.js', group: 'React' },
+  { value: 'remix', label: 'Remix', group: 'React' },
+  { value: 'sveltekit', label: 'SvelteKit', group: 'Svelte' },
+  { value: 'nuxt', label: 'Nuxt.js', group: 'Vue' },
+  { value: 'astro', label: 'Astro', group: 'Meta frameworks' },
+];
+
+function FrameworkCombobox({
+  inputClassName = 'nx:w-64',
+  options = frameworks,
+  placeholder = 'Select a framework',
+  ...props
+}: Omit<React.ComponentProps<typeof Combobox>, 'options'> & {
+  inputClassName?: string;
+  options?: ComboboxOption[];
+  placeholder?: string;
+}) {
+  return (
+    <Combobox options={options} {...props}>
+      <ComboboxInput
+        aria-label="Framework"
+        className={inputClassName}
+        placeholder={placeholder}
+        showClear
+      />
+      <ComboboxContent>
+        <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
+        <ComboboxList />
+      </ComboboxContent>
+    </Combobox>
+  );
+}
+
+function ControlledComboboxExample() {
+  const [value, setValue] = React.useState('astro');
+
+  return (
+    <div className="nx:flex nx:flex-col nx:gap-3">
+      <FrameworkCombobox value={value} onValueChange={setValue} />
+      <output className="nx:typography-body-small nx:text-muted-foreground">
+        Selected: {value || 'none'}
+      </output>
+    </div>
+  );
+}
+
+const meta: Meta<typeof Combobox> = {
+  title: 'Components/Combobox',
+  component: Combobox,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Combobox>;
+
+export const Default: Story = {
+  render: () => <FrameworkCombobox />,
+};
+
+export const WithDefaultValue: Story = {
+  render: () => <FrameworkCombobox defaultValue="next" />,
+};
+
+export const ReopenShowsFullList: Story = {
+  render: () => <FrameworkCombobox defaultValue="next" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox', { name: 'Framework' });
+
+    await expect(input).toHaveValue('Next.js');
+    await userEvent.click(input);
+
+    const listbox = await within(document.body).findByRole('listbox');
+
+    await expect(
+      within(listbox).getByRole('option', { name: 'Next.js' })
+    ).toBeInTheDocument();
+    await expect(
+      within(listbox).getByRole('option', { name: 'SvelteKit' })
+    ).toBeInTheDocument();
+    await expect(
+      within(listbox).getByRole('option', { name: 'Astro' })
+    ).toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
+  },
+};
+
+export const Controlled: Story = {
+  render: () => <ControlledComboboxExample />,
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-64 nx:flex-col nx:gap-3">
+      <FrameworkCombobox placeholder="Default" inputClassName="" />
+      <Combobox options={frameworks}>
+        <ComboboxInput
+          aria-label="Small framework"
+          size="sm"
+          placeholder="Sm"
+        />
+        <ComboboxContent>
+          <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
+          <ComboboxList />
+        </ComboboxContent>
+      </Combobox>
+      <Combobox options={frameworks}>
+        <ComboboxInput
+          aria-label="Large framework"
+          size="lg"
+          placeholder="Lg"
+        />
+        <ComboboxContent>
+          <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
+          <ComboboxList />
+        </ComboboxContent>
+      </Combobox>
+    </div>
+  ),
+};
+
+export const Grouped: Story = {
+  render: () => <FrameworkCombobox options={groupedFrameworks} />,
+};
+
+export const Disabled: Story = {
+  render: () => <FrameworkCombobox disabled defaultValue="next" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox', { name: 'Framework' });
+
+    await expect(input).toBeDisabled();
+    await userEvent.click(input);
+    await waitFor(() => {
+      expect(document.body.querySelector('[role="listbox"]')).toBeNull();
+    });
+  },
+};
+
+export const WithDisabledOption: Story = {
+  render: () => (
+    <FrameworkCombobox
+      options={[
+        { value: 'next', label: 'Next.js' },
+        { value: 'sveltekit', label: 'SvelteKit', disabled: true },
+        { value: 'astro', label: 'Astro' },
+      ]}
+    />
+  ),
+};
+
+export const InvalidRequiredField: Story = {
+  render: () => (
+    <Field data-invalid>
+      <FieldLabel htmlFor="framework-required">Framework</FieldLabel>
+      <Combobox options={frameworks} required invalid>
+        <ComboboxInput
+          id="framework-required"
+          aria-describedby="framework-required-description framework-required-error"
+          aria-label="Framework"
+          className="nx:w-64"
+          placeholder="Select a framework"
+        />
+        <ComboboxContent>
+          <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
+          <ComboboxList />
+        </ComboboxContent>
+      </Combobox>
+      <FieldDescription id="framework-required-description">
+        Choose the framework used by this project.
+      </FieldDescription>
+      <FieldError id="framework-required-error">
+        Framework is required.
+      </FieldError>
+    </Field>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox', { name: 'Framework' });
+
+    await expect(input).toBeRequired();
+    await expect(input).toHaveAttribute('aria-invalid', 'true');
+    await expect(input).toHaveAttribute('aria-required', 'true');
+  },
+};
+
+export const KeyboardInteraction: Story = {
+  render: () => <FrameworkCombobox />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox', { name: 'Framework' });
+
+    await userEvent.click(input);
+    await userEvent.keyboard('rem');
+
+    const listbox = await within(document.body).findByRole('listbox');
+
+    await expect(
+      within(listbox).getByRole('option', { name: 'Remix' })
+    ).toBeInTheDocument();
+    await userEvent.keyboard('{ArrowDown}{Enter}');
+
+    await waitFor(() => {
+      expect(input).toHaveValue('Remix');
+    });
+  },
+};
+
+export const ClickInteraction: Story = {
+  render: () => <FrameworkCombobox />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox', { name: 'Framework' });
+
+    await userEvent.click(input);
+    const listbox = await within(document.body).findByRole('listbox');
+
+    await userEvent.click(
+      within(listbox).getByRole('option', { name: 'Astro' })
+    );
+
+    await expect(input).toHaveValue('Astro');
+  },
+};
+
+export const ClearButton: Story = {
+  render: () => <FrameworkCombobox defaultValue="next" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox', { name: 'Framework' });
+    const clearButton = canvas.getByRole('button', { name: 'Clear selection' });
+
+    await expect(input).toHaveValue('Next.js');
+    await userEvent.click(clearButton);
+    await waitFor(() => {
+      expect(input).toHaveValue('');
+    });
+  },
+};
+
+export const FormReset: Story = {
+  render: () => (
+    <form className="nx:flex nx:flex-col nx:items-start nx:gap-3">
+      <FrameworkCombobox name="framework" defaultValue="next" />
+      <Button type="reset" variant="outline">
+        Reset
+      </Button>
+    </form>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox', { name: 'Framework' });
+    const hiddenInput = canvasElement.querySelector('input[type="hidden"]');
+
+    await userEvent.click(input);
+    const listbox = await within(document.body).findByRole('listbox');
+    await userEvent.click(
+      within(listbox).getByRole('option', { name: 'Astro' })
+    );
+
+    await expect(input).toHaveValue('Astro');
+    await expect(hiddenInput).toHaveValue('astro');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Reset' }));
+
+    await waitFor(() => {
+      expect(input).toHaveValue('Next.js');
+      expect(hiddenInput).toHaveValue('next');
+    });
+  },
+};
+
+export const WithDataAttributes: Story = {
+  render: () => <FrameworkCombobox />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('combobox', { name: 'Framework' });
+    const field = canvasElement.querySelector('[data-slot="combobox-field"]');
+
+    await expect(field).toHaveAttribute('data-size', 'default');
+    await expect(field).toHaveAttribute('data-variant', 'default');
+    await expect(input).toHaveAttribute('data-slot', 'combobox-input');
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:grid nx:w-[520px] nx:grid-cols-2 nx:gap-4">
+      <FrameworkCombobox placeholder="Default empty" inputClassName="" />
+      <FrameworkCombobox
+        defaultValue="next"
+        placeholder="Default filled"
+        inputClassName=""
+      />
+      <Combobox options={frameworks}>
+        <ComboboxInput
+          variant="borderless"
+          aria-label="Borderless empty"
+          placeholder="Borderless empty"
+        />
+        <ComboboxContent>
+          <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
+          <ComboboxList />
+        </ComboboxContent>
+      </Combobox>
+      <Combobox options={frameworks} defaultValue="astro">
+        <ComboboxInput
+          variant="borderless"
+          aria-label="Borderless filled"
+          placeholder="Borderless filled"
+        />
+        <ComboboxContent>
+          <ComboboxEmpty>No frameworks found.</ComboboxEmpty>
+          <ComboboxList />
+        </ComboboxContent>
+      </Combobox>
+    </div>
+  ),
+};

--- a/packages/react/src/components/combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/combobox/Combobox.stories.tsx
@@ -111,6 +111,18 @@ export const ReopenShowsFullList: Story = {
     ).toBeInTheDocument();
 
     await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(document.body.querySelector('[role="listbox"]')).toBeNull();
+    });
+
+    await userEvent.click(input);
+    const reopenedListbox = await within(document.body).findByRole('listbox');
+
+    await expect(
+      within(reopenedListbox).getByRole('option', { name: 'Next.js' })
+    ).toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
   },
 };
 
@@ -240,8 +252,9 @@ export const ClickInteraction: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByRole('combobox', { name: 'Framework' });
+    const trigger = canvas.getByRole('button', { name: 'Open options' });
 
-    await userEvent.click(input);
+    await userEvent.click(trigger);
     const listbox = await within(document.body).findByRole('listbox');
 
     await userEvent.click(
@@ -304,10 +317,14 @@ export const WithDataAttributes: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByRole('combobox', { name: 'Framework' });
+    const trigger = canvas.getByRole('button', { name: 'Open options' });
     const field = canvasElement.querySelector('[data-slot="combobox-field"]');
 
     await expect(field).toHaveAttribute('data-size', 'default');
     await expect(field).toHaveAttribute('data-variant', 'default');
+    await expect(field).toHaveClass('nx:border-default');
+    await expect(field).toHaveClass('nx:border-border-default');
+    await expect(trigger).toHaveAttribute('data-slot', 'combobox-trigger');
     await expect(input).toHaveAttribute('data-slot', 'combobox-input');
   },
 };

--- a/packages/react/src/components/combobox/combobox.tsx
+++ b/packages/react/src/components/combobox/combobox.tsx
@@ -1,0 +1,903 @@
+import * as React from 'react';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { IconCheck, IconChevronDown, IconX } from '../../lib/icons';
+import { cn } from '../../lib/utils';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  type PopoverContentProps,
+} from '../popover';
+
+interface ComboboxOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+  group?: string;
+  keywords?: string[];
+}
+
+interface ComboboxContextValue {
+  activeValue: string;
+  disabled: boolean;
+  inputValue: string;
+  invalid: boolean;
+  listId: string;
+  open: boolean;
+  options: ComboboxOption[];
+  readOnly: boolean;
+  required: boolean;
+  selectedLabel: string;
+  selectedValue: string;
+  setActiveValue: (value: string) => void;
+  setInputElement: (input: HTMLInputElement | null) => void;
+  setInputValue: (value: string) => void;
+  setOpenFromField: () => void;
+  setOpenState: (open: boolean) => void;
+  setSelectedValue: (value: string) => void;
+  stepActiveValue: (direction: 1 | -1) => void;
+  visibleOptions: ComboboxOption[];
+}
+
+const ComboboxContext = React.createContext<ComboboxContextValue | null>(null);
+
+function useComboboxContext(componentName: string) {
+  const context = React.useContext(ComboboxContext);
+
+  if (!context)
+    throw new Error(`${componentName} must be used inside Combobox.`);
+
+  return context;
+}
+
+function useControllableStringState({
+  value,
+  defaultValue = '',
+  onValueChange,
+}: {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+}) {
+  const [uncontrolledValue, setUncontrolledValue] =
+    React.useState(defaultValue);
+  const isControlled = value !== undefined;
+  const currentValue = isControlled ? value : uncontrolledValue;
+
+  const setCurrentValue = React.useCallback(
+    (nextValue: string) => {
+      if (!isControlled) setUncontrolledValue(nextValue);
+      onValueChange?.(nextValue);
+    },
+    [isControlled, onValueChange]
+  );
+
+  return [currentValue, setCurrentValue, setUncontrolledValue] as const;
+}
+
+function useControllableBooleanState({
+  value,
+  defaultValue = false,
+  onValueChange,
+}: {
+  value?: boolean;
+  defaultValue?: boolean;
+  onValueChange?: (value: boolean) => void;
+}) {
+  const [uncontrolledValue, setUncontrolledValue] =
+    React.useState(defaultValue);
+  const isControlled = value !== undefined;
+  const currentValue = isControlled ? value : uncontrolledValue;
+
+  const setCurrentValue = React.useCallback(
+    (nextValue: boolean) => {
+      if (!isControlled) setUncontrolledValue(nextValue);
+      onValueChange?.(nextValue);
+    },
+    [isControlled, onValueChange]
+  );
+
+  return [currentValue, setCurrentValue] as const;
+}
+
+function getOptionSearchText(option: ComboboxOption) {
+  return [option.label, option.value, ...(option.keywords ?? [])]
+    .join(' ')
+    .toLowerCase();
+}
+
+function filterOptions(options: ComboboxOption[], filterValue: string) {
+  const query = filterValue.trim().toLowerCase();
+
+  if (!query) return options;
+
+  return options.filter((option) =>
+    getOptionSearchText(option).includes(query)
+  );
+}
+
+function getFirstEnabledValue(options: ComboboxOption[]) {
+  return options.find((option) => !option.disabled)?.value ?? '';
+}
+
+function getLastEnabledValue(options: ComboboxOption[]) {
+  return [...options].reverse().find((option) => !option.disabled)?.value ?? '';
+}
+
+function getSteppedValue(
+  options: ComboboxOption[],
+  currentValue: string,
+  direction: 1 | -1
+) {
+  const enabledOptions = options.filter((option) => !option.disabled);
+
+  if (enabledOptions.length === 0) return '';
+
+  const currentIndex = enabledOptions.findIndex(
+    (option) => option.value === currentValue
+  );
+  const fallbackIndex = direction === 1 ? 0 : enabledOptions.length - 1;
+
+  if (currentIndex === -1) return enabledOptions[fallbackIndex]?.value ?? '';
+
+  const nextIndex =
+    (currentIndex + direction + enabledOptions.length) % enabledOptions.length;
+
+  return enabledOptions[nextIndex]?.value ?? '';
+}
+
+function getOptionId(listId: string, value: string) {
+  return `${listId}-option-${value.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+}
+
+const comboboxFieldVariants = cva(
+  [
+    'nx:group/combobox nx:relative nx:flex nx:box-border nx:w-full nx:min-w-0 nx:items-center nx:rounded-md nx:border-0 nx:transition-colors nx:outline-none',
+    'nx:has-[[data-slot=combobox-input]:focus-visible]:outline-2 nx:has-[[data-slot=combobox-input]:focus-visible]:outline-focus-default nx:has-[[data-slot=combobox-input]:focus-visible]:outline-offset-(--focus-offset)',
+    'nx:data-[invalid=true]:border-border-error nx:has-[[data-slot=combobox-input][aria-invalid=true]:focus-visible]:outline-focus-error',
+    'nx:data-[disabled=true]:cursor-not-allowed nx:data-[disabled=true]:bg-disabled nx:data-[disabled=true]:text-disabled-foreground',
+  ],
+  {
+    variants: {
+      size: {
+        sm: 'nx:h-8 nx:px-2.5 nx:typography-body-small',
+        default: 'nx:h-10 nx:px-3 nx:typography-body-default',
+        lg: 'nx:h-12 nx:px-3.5 nx:typography-body-default',
+      },
+      variant: {
+        default:
+          'nx:border-border-default nx:bg-background nx:not-data-[disabled=true]:hover:bg-background-hover nx:data-[disabled=true]:border-border-disabled',
+        borderless:
+          'nx:border-transparent nx:bg-control-background nx:not-data-[disabled=true]:hover:bg-control-background-hover',
+      },
+    },
+    defaultVariants: {
+      size: 'default',
+      variant: 'default',
+    },
+  }
+);
+
+interface ComboboxProps extends Omit<
+  React.ComponentProps<'div'>,
+  'defaultValue' | 'onChange'
+> {
+  /**
+   * Options rendered by `ComboboxList` when its children are a render function.
+   */
+  options: ComboboxOption[];
+  /**
+   * Controlled selected option value.
+   */
+  value?: string;
+  /**
+   * Initial selected option value for uncontrolled usage.
+   * @default ''
+   */
+  defaultValue?: string;
+  /**
+   * Called when the selected option value changes.
+   */
+  onValueChange?: (value: string) => void;
+  /**
+   * Controlled popover state.
+   */
+  open?: boolean;
+  /**
+   * Initial popover state for uncontrolled usage.
+   * @default false
+   */
+  defaultOpen?: boolean;
+  /**
+   * Called when the popover opens or closes.
+   */
+  onOpenChange?: (open: boolean) => void;
+  /**
+   * Native form field name. The submitted value is the selected option value.
+   */
+  name?: string;
+  /**
+   * Disables the combobox and omits its form value.
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * Prevents editing and selection while keeping the value readable.
+   * @default false
+   */
+  readOnly?: boolean;
+  /**
+   * Marks the combobox as required for forms and assistive technology.
+   * @default false
+   */
+  required?: boolean;
+  /**
+   * Marks the combobox invalid.
+   * @default false
+   */
+  invalid?: boolean;
+}
+
+function Combobox({
+  children,
+  className,
+  defaultOpen,
+  defaultValue,
+  disabled = false,
+  invalid = false,
+  name,
+  onOpenChange,
+  onValueChange,
+  open: openProp,
+  options,
+  readOnly = false,
+  required = false,
+  value: valueProp,
+  ...props
+}: ComboboxProps) {
+  const reactListId = React.useId();
+  const listId = `${reactListId}-listbox`;
+  const [selectedValue, setSelectedValue, setUncontrolledSelectedValue] =
+    useControllableStringState({
+      value: valueProp,
+      defaultValue,
+      onValueChange,
+    });
+  const [open, setOpen] = useControllableBooleanState({
+    value: openProp,
+    defaultValue: defaultOpen,
+    onValueChange: onOpenChange,
+  });
+  const [inputValue, setInputValue] = React.useState('');
+  const [filterValue, setFilterValue] = React.useState('');
+  const [activeValue, setActiveValue] = React.useState('');
+  const [inputElement, setInputElement] =
+    React.useState<HTMLInputElement | null>(null);
+  const hiddenInputRef = React.useRef<HTMLInputElement>(null);
+
+  const selectedOption = React.useMemo(
+    () => options.find((option) => option.value === selectedValue),
+    [options, selectedValue]
+  );
+  const selectedLabel = selectedOption?.label ?? '';
+  const visibleOptions = React.useMemo(
+    () => filterOptions(options, filterValue),
+    [filterValue, options]
+  );
+
+  const setOpenState = React.useCallback(
+    (nextOpen: boolean) => {
+      if ((disabled || readOnly) && nextOpen) return;
+
+      setOpen(nextOpen);
+
+      if (nextOpen) {
+        setInputValue(selectedLabel);
+        setFilterValue('');
+        setActiveValue(selectedValue || getFirstEnabledValue(options));
+      } else {
+        setInputValue('');
+        setFilterValue('');
+        setActiveValue('');
+      }
+    },
+    [disabled, options, readOnly, selectedLabel, selectedValue, setOpen]
+  );
+
+  const setOpenFromField = React.useCallback(() => {
+    setOpenState(true);
+  }, [setOpenState]);
+
+  const handleInputValueChange = React.useCallback(
+    (nextValue: string) => {
+      if (disabled || readOnly) return;
+
+      const nextVisibleOptions = filterOptions(options, nextValue);
+
+      setInputValue(nextValue);
+      setFilterValue(nextValue);
+      setActiveValue(getFirstEnabledValue(nextVisibleOptions));
+      setOpen(true);
+
+      if (selectedValue && nextValue !== selectedLabel) {
+        setSelectedValue('');
+      }
+    },
+    [
+      disabled,
+      options,
+      readOnly,
+      selectedLabel,
+      selectedValue,
+      setOpen,
+      setSelectedValue,
+    ]
+  );
+
+  const handleSelectedValueChange = React.useCallback(
+    (nextValue: string) => {
+      if (!nextValue) {
+        setSelectedValue('');
+        setInputValue('');
+        setFilterValue('');
+        setActiveValue(getFirstEnabledValue(options));
+        return;
+      }
+
+      const option = options.find((item) => item.value === nextValue);
+
+      if (!option || option.disabled || disabled || readOnly) return;
+
+      setSelectedValue(nextValue);
+      setInputValue(option.label);
+      setFilterValue('');
+      setActiveValue(nextValue);
+      setOpen(false);
+    },
+    [disabled, options, readOnly, setOpen, setSelectedValue]
+  );
+
+  const stepActiveValue = React.useCallback(
+    (direction: 1 | -1) => {
+      setActiveValue((currentValue) =>
+        getSteppedValue(visibleOptions, currentValue, direction)
+      );
+    },
+    [visibleOptions]
+  );
+
+  React.useEffect(() => {
+    if (!inputElement) return;
+
+    const validityMessage =
+      required && !disabled && !selectedValue ? 'Please select an option.' : '';
+
+    inputElement.setCustomValidity(validityMessage);
+  }, [disabled, inputElement, required, selectedValue]);
+
+  React.useEffect(() => {
+    const form = hiddenInputRef.current?.form;
+
+    if (!form) return;
+
+    const handleReset = () => {
+      window.setTimeout(() => {
+        if (valueProp === undefined)
+          setUncontrolledSelectedValue(defaultValue ?? '');
+
+        setInputValue('');
+        setFilterValue('');
+        setActiveValue('');
+        setOpen(false);
+      });
+    };
+
+    form.addEventListener('reset', handleReset);
+
+    return () => form.removeEventListener('reset', handleReset);
+  }, [defaultValue, setOpen, setUncontrolledSelectedValue, valueProp]);
+
+  const contextValue = React.useMemo<ComboboxContextValue>(
+    () => ({
+      activeValue,
+      disabled,
+      inputValue,
+      invalid,
+      listId,
+      open,
+      options,
+      readOnly,
+      required,
+      selectedLabel,
+      selectedValue,
+      setActiveValue,
+      setInputElement,
+      setInputValue: handleInputValueChange,
+      setOpenFromField,
+      setOpenState,
+      setSelectedValue: handleSelectedValueChange,
+      stepActiveValue,
+      visibleOptions,
+    }),
+    [
+      activeValue,
+      disabled,
+      handleInputValueChange,
+      handleSelectedValueChange,
+      inputValue,
+      invalid,
+      listId,
+      open,
+      options,
+      readOnly,
+      required,
+      selectedLabel,
+      selectedValue,
+      setOpenFromField,
+      setOpenState,
+      stepActiveValue,
+      visibleOptions,
+    ]
+  );
+
+  return (
+    <ComboboxContext.Provider value={contextValue}>
+      <div
+        data-slot="combobox"
+        className={cn('nx:contents', className)}
+        {...props}
+      >
+        <Popover open={open} onOpenChange={setOpenState}>
+          {children}
+        </Popover>
+        {name ? (
+          <input
+            ref={hiddenInputRef}
+            type="hidden"
+            name={name}
+            value={selectedValue}
+            disabled={disabled}
+            readOnly
+          />
+        ) : null}
+      </div>
+    </ComboboxContext.Provider>
+  );
+}
+
+interface ComboboxInputProps
+  extends
+    Omit<
+      React.ComponentProps<'input'>,
+      'disabled' | 'readOnly' | 'required' | 'size' | 'value'
+    >,
+    VariantProps<typeof comboboxFieldVariants> {
+  /**
+   * Shows an in-field clear button when a value is selected.
+   * @default false
+   */
+  showClear?: boolean;
+}
+
+function ComboboxInput({
+  className,
+  onChange,
+  onClick,
+  onFocus,
+  onKeyDown,
+  showClear = false,
+  size,
+  variant,
+  ...props
+}: ComboboxInputProps) {
+  const context = useComboboxContext('ComboboxInput');
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const skipNextFocusOpenRef = React.useRef(false);
+  const displayValue = context.open
+    ? context.inputValue
+    : context.selectedLabel;
+  const showClearButton =
+    showClear && Boolean(context.selectedValue) && !context.disabled;
+  const activeOptionId =
+    context.open && context.activeValue
+      ? getOptionId(context.listId, context.activeValue)
+      : undefined;
+
+  const handleInputRef = React.useCallback(
+    (node: HTMLInputElement | null) => {
+      inputRef.current = node;
+      context.setInputElement(node);
+    },
+    [context]
+  );
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    context.setInputValue(event.target.value);
+    onChange?.(event);
+  };
+
+  const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
+    if (skipNextFocusOpenRef.current) {
+      skipNextFocusOpenRef.current = false;
+      onFocus?.(event);
+      return;
+    }
+
+    context.setOpenFromField();
+    onFocus?.(event);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      context.setOpenState(false);
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      if (!context.open) context.setOpenFromField();
+      context.stepActiveValue(1);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (!context.open) context.setOpenFromField();
+      context.stepActiveValue(-1);
+    } else if (event.key === 'Home' && context.open) {
+      event.preventDefault();
+      context.setActiveValue(getFirstEnabledValue(context.visibleOptions));
+    } else if (event.key === 'End' && context.open) {
+      event.preventDefault();
+      context.setActiveValue(getLastEnabledValue(context.visibleOptions));
+    } else if (event.key === 'Enter' && context.open) {
+      event.preventDefault();
+      context.setSelectedValue(context.activeValue);
+    }
+
+    onKeyDown?.(event);
+  };
+
+  const handleClear = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    skipNextFocusOpenRef.current = true;
+    context.setSelectedValue('');
+    context.setInputValue('');
+    inputRef.current?.focus();
+  };
+
+  const stopClearClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  return (
+    <PopoverAnchor asChild>
+      <div
+        data-slot="combobox-field"
+        data-size={size ?? 'default'}
+        data-variant={variant ?? 'default'}
+        data-disabled={context.disabled || undefined}
+        data-invalid={context.invalid || undefined}
+        className={cn(comboboxFieldVariants({ size, variant }), className)}
+      >
+        <input
+          ref={handleInputRef}
+          data-slot="combobox-input"
+          value={displayValue}
+          onChange={handleChange}
+          onClick={onClick}
+          onFocus={handleFocus}
+          onKeyDown={handleKeyDown}
+          disabled={context.disabled}
+          readOnly={context.readOnly}
+          required={context.required}
+          aria-activedescendant={activeOptionId}
+          aria-autocomplete="list"
+          aria-controls={context.open ? context.listId : undefined}
+          aria-expanded={context.open}
+          aria-invalid={context.invalid || undefined}
+          aria-required={context.required || undefined}
+          role="combobox"
+          className={cn(
+            'nx:min-w-0 nx:flex-1 nx:bg-transparent nx:py-0 nx:text-foreground nx:outline-none',
+            'nx:placeholder:text-muted-foreground',
+            'nx:disabled:cursor-not-allowed nx:disabled:text-disabled-foreground nx:disabled:placeholder:text-disabled-foreground'
+          )}
+          {...props}
+        />
+        {showClearButton ? (
+          <button
+            type="button"
+            data-slot="combobox-clear"
+            aria-label="Clear selection"
+            className="nx:-mr-1 nx:flex nx:size-6 nx:items-center nx:justify-center nx:rounded-sm nx:text-muted-foreground nx:hover:bg-background-hover nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
+            onClick={stopClearClick}
+            onMouseDown={handleClear}
+          >
+            <IconX aria-hidden="true" className="nx:size-4" />
+          </button>
+        ) : null}
+        <IconChevronDown
+          aria-hidden="true"
+          data-slot="combobox-chevron"
+          className="nx:size-4 nx:shrink-0 nx:text-muted-foreground nx:group-data-[disabled=true]/combobox:text-disabled-foreground"
+        />
+      </div>
+    </PopoverAnchor>
+  );
+}
+
+interface ComboboxContentProps extends PopoverContentProps {}
+
+function ComboboxContent({
+  align = 'start',
+  className,
+  sideOffset = 6,
+  ...props
+}: ComboboxContentProps) {
+  return (
+    <PopoverContent
+      data-slot="combobox-content"
+      align={align}
+      role="presentation"
+      sideOffset={sideOffset}
+      className={cn(
+        'nx:w-(--radix-popper-anchor-width) nx:min-w-48 nx:p-0',
+        className
+      )}
+      onOpenAutoFocus={(event) => event.preventDefault()}
+      {...props}
+    />
+  );
+}
+
+interface ComboboxListProps extends React.ComponentProps<'div'> {}
+
+function renderComboboxOption(option: ComboboxOption) {
+  return (
+    <ComboboxItem
+      key={option.value}
+      value={option.value}
+      disabled={option.disabled}
+    >
+      {option.label}
+    </ComboboxItem>
+  );
+}
+
+function ComboboxList({
+  'aria-label': ariaLabel = 'Combobox options',
+  children,
+  className,
+  ...props
+}: ComboboxListProps) {
+  const context = useComboboxContext('ComboboxList');
+  const hasGroups = context.visibleOptions.some((option) => option.group);
+
+  if (children)
+    return (
+      <div
+        id={context.listId}
+        role="listbox"
+        aria-label={ariaLabel}
+        data-slot="combobox-list"
+        className={cn(
+          'nx:max-h-72 nx:overflow-y-auto nx:overflow-x-hidden nx:p-1',
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+
+  if (!hasGroups)
+    return (
+      <div
+        id={context.listId}
+        role="listbox"
+        aria-label={ariaLabel}
+        data-slot="combobox-list"
+        className={cn(
+          'nx:max-h-72 nx:overflow-y-auto nx:overflow-x-hidden nx:p-1',
+          className
+        )}
+        {...props}
+      >
+        {context.visibleOptions.map(renderComboboxOption)}
+      </div>
+    );
+
+  const groupedOptions = new Map<string, ComboboxOption[]>();
+
+  for (const option of context.visibleOptions) {
+    const group = option.group ?? 'Options';
+    const groupOptions = groupedOptions.get(group) ?? [];
+
+    groupOptions.push(option);
+    groupedOptions.set(group, groupOptions);
+  }
+
+  return (
+    <div
+      id={context.listId}
+      role="listbox"
+      aria-label={ariaLabel}
+      data-slot="combobox-list"
+      className={cn(
+        'nx:max-h-72 nx:overflow-y-auto nx:overflow-x-hidden nx:p-1',
+        className
+      )}
+      {...props}
+    >
+      {[...groupedOptions.entries()].map(([group, options]) => (
+        <ComboboxGroup key={group} heading={group}>
+          {options.map(renderComboboxOption)}
+        </ComboboxGroup>
+      ))}
+    </div>
+  );
+}
+
+interface ComboboxEmptyProps extends React.ComponentProps<'div'> {}
+
+function ComboboxEmpty({ className, ...props }: ComboboxEmptyProps) {
+  const context = useComboboxContext('ComboboxEmpty');
+
+  if (context.visibleOptions.length > 0) return null;
+
+  return (
+    <div
+      data-slot="combobox-empty"
+      className={cn(
+        'nx:py-6 nx:text-center nx:typography-body-default nx:text-muted-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+interface ComboboxGroupProps extends React.ComponentProps<'div'> {
+  heading?: string;
+}
+
+function ComboboxGroup({
+  children,
+  className,
+  heading,
+  ...props
+}: ComboboxGroupProps) {
+  return (
+    <div
+      role="group"
+      aria-label={heading}
+      data-slot="combobox-group"
+      className={cn('nx:p-1', className)}
+      {...props}
+    >
+      {heading ? (
+        <div
+          data-slot="combobox-group-heading"
+          className="nx:px-2 nx:py-1.5 nx:typography-label-small nx:text-muted-foreground"
+        >
+          {heading}
+        </div>
+      ) : null}
+      {children}
+    </div>
+  );
+}
+
+interface ComboboxSeparatorProps extends React.ComponentProps<'div'> {}
+
+function ComboboxSeparator({ className, ...props }: ComboboxSeparatorProps) {
+  return (
+    <div
+      role="presentation"
+      data-slot="combobox-separator"
+      className={cn(
+        'nx:-mx-1 nx:my-1 nx:h-px nx:bg-border-default-alpha',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+interface ComboboxItemProps extends Omit<
+  React.ComponentProps<'div'>,
+  'onSelect'
+> {
+  value: string;
+  disabled?: boolean;
+  onSelect?: (value: string) => void;
+}
+
+function ComboboxItem({
+  children,
+  className,
+  disabled = false,
+  onMouseDown,
+  onMouseMove,
+  onSelect,
+  value,
+  ...props
+}: ComboboxItemProps) {
+  const context = useComboboxContext('ComboboxItem');
+  const selected = context.selectedValue === value;
+  const active = context.activeValue === value;
+
+  const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+
+    if (!disabled) {
+      context.setSelectedValue(value);
+      onSelect?.(value);
+    }
+
+    onMouseDown?.(event);
+  };
+
+  const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!disabled) context.setActiveValue(value);
+    onMouseMove?.(event);
+  };
+
+  return (
+    <div
+      id={getOptionId(context.listId, value)}
+      role="option"
+      aria-disabled={disabled || undefined}
+      aria-selected={selected}
+      tabIndex={-1}
+      data-active={active || undefined}
+      data-disabled={disabled || undefined}
+      data-selected={selected || undefined}
+      data-slot="combobox-item"
+      className={cn(
+        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:rounded-sm nx:typography-body-default nx:outline-none',
+        'nx:gap-3 nx:px-3 nx:py-2.5',
+        'nx:data-[active=true]:bg-popover-hover nx:data-[active=true]:text-popover-foreground',
+        'nx:data-[disabled=true]:pointer-events-none nx:data-[disabled=true]:text-disabled-foreground',
+        'nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+        className
+      )}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      {...props}
+    >
+      <span data-slot="combobox-item-label" className="nx:min-w-0 nx:flex-1">
+        {children}
+      </span>
+      <IconCheck
+        aria-hidden="true"
+        data-slot="combobox-item-indicator"
+        className={cn(
+          'nx:ml-auto nx:size-4 nx:transition-opacity',
+          selected ? 'nx:opacity-100' : 'nx:opacity-0'
+        )}
+      />
+    </div>
+  );
+}
+
+export {
+  Combobox,
+  ComboboxContent,
+  type ComboboxContentProps,
+  ComboboxEmpty,
+  type ComboboxEmptyProps,
+  comboboxFieldVariants,
+  ComboboxGroup,
+  type ComboboxGroupProps,
+  ComboboxInput,
+  type ComboboxInputProps,
+  ComboboxItem,
+  type ComboboxItemProps,
+  ComboboxList,
+  type ComboboxListProps,
+  type ComboboxOption,
+  type ComboboxProps,
+  ComboboxSeparator,
+  type ComboboxSeparatorProps,
+};

--- a/packages/react/src/components/combobox/combobox.tsx
+++ b/packages/react/src/components/combobox/combobox.tsx
@@ -154,7 +154,7 @@ function getOptionId(listId: string, value: string) {
 
 const comboboxFieldVariants = cva(
   [
-    'nx:group/combobox nx:relative nx:flex nx:box-border nx:w-full nx:min-w-0 nx:items-center nx:rounded-md nx:border-0 nx:transition-colors nx:outline-none',
+    'nx:group/combobox nx:relative nx:flex nx:box-border nx:w-full nx:min-w-0 nx:items-center nx:rounded-md nx:border-default nx:transition-colors nx:outline-none',
     'nx:has-[[data-slot=combobox-input]:focus-visible]:outline-2 nx:has-[[data-slot=combobox-input]:focus-visible]:outline-focus-default nx:has-[[data-slot=combobox-input]:focus-visible]:outline-offset-(--focus-offset)',
     'nx:data-[invalid=true]:border-border-error nx:has-[[data-slot=combobox-input][aria-invalid=true]:focus-visible]:outline-focus-error',
     'nx:data-[disabled=true]:cursor-not-allowed nx:data-[disabled=true]:bg-disabled nx:data-[disabled=true]:text-disabled-foreground',
@@ -499,7 +499,10 @@ function ComboboxInput({
     ? context.inputValue
     : context.selectedLabel;
   const showClearButton =
-    showClear && Boolean(context.selectedValue) && !context.disabled;
+    showClear &&
+    Boolean(context.selectedValue) &&
+    !context.disabled &&
+    !context.readOnly;
   const activeOptionId =
     context.open && context.activeValue
       ? getOptionId(context.listId, context.activeValue)
@@ -516,6 +519,11 @@ function ComboboxInput({
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     context.setInputValue(event.target.value);
     onChange?.(event);
+  };
+
+  const handleInputClick = (event: React.MouseEvent<HTMLInputElement>) => {
+    context.setOpenFromField();
+    onClick?.(event);
   };
 
   const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
@@ -569,6 +577,20 @@ function ComboboxInput({
     event.stopPropagation();
   };
 
+  const handleTriggerMouseDown = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    inputRef.current?.focus();
+    context.setOpenFromField();
+  };
+
+  const stopTriggerClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
   return (
     <PopoverAnchor asChild>
       <div
@@ -584,7 +606,7 @@ function ComboboxInput({
           data-slot="combobox-input"
           value={displayValue}
           onChange={handleChange}
-          onClick={onClick}
+          onClick={handleInputClick}
           onFocus={handleFocus}
           onKeyDown={handleKeyDown}
           disabled={context.disabled}
@@ -616,11 +638,21 @@ function ComboboxInput({
             <IconX aria-hidden="true" className="nx:size-4" />
           </button>
         ) : null}
-        <IconChevronDown
-          aria-hidden="true"
-          data-slot="combobox-chevron"
-          className="nx:size-4 nx:shrink-0 nx:text-muted-foreground nx:group-data-[disabled=true]/combobox:text-disabled-foreground"
-        />
+        <button
+          type="button"
+          data-slot="combobox-trigger"
+          aria-label="Open options"
+          disabled={context.disabled || context.readOnly}
+          className="nx:-mr-1 nx:flex nx:size-6 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-sm nx:text-muted-foreground nx:hover:bg-background-hover nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:cursor-not-allowed nx:disabled:text-disabled-foreground"
+          onClick={stopTriggerClick}
+          onMouseDown={handleTriggerMouseDown}
+        >
+          <IconChevronDown
+            aria-hidden="true"
+            data-slot="combobox-chevron"
+            className="nx:size-4"
+          />
+        </button>
       </div>
     </PopoverAnchor>
   );

--- a/packages/react/src/components/combobox/combobox.tsx
+++ b/packages/react/src/components/combobox/combobox.tsx
@@ -24,9 +24,9 @@ interface ComboboxContextValue {
   disabled: boolean;
   inputValue: string;
   invalid: boolean;
+  items: ComboboxOption[];
   listId: string;
   open: boolean;
-  options: ComboboxOption[];
   readOnly: boolean;
   required: boolean;
   selectedLabel: string;
@@ -185,9 +185,9 @@ interface ComboboxProps extends Omit<
   'defaultValue' | 'onChange'
 > {
   /**
-   * Options rendered by `ComboboxList` when its children are a render function.
+   * Items rendered by `ComboboxList` when its children are omitted.
    */
-  options: ComboboxOption[];
+  items: ComboboxOption[];
   /**
    * Controlled selected option value.
    */
@@ -247,11 +247,11 @@ function Combobox({
   defaultValue,
   disabled = false,
   invalid = false,
+  items,
   name,
   onOpenChange,
   onValueChange,
   open: openProp,
-  options,
   readOnly = false,
   required = false,
   value: valueProp,
@@ -278,13 +278,13 @@ function Combobox({
   const hiddenInputRef = React.useRef<HTMLInputElement>(null);
 
   const selectedOption = React.useMemo(
-    () => options.find((option) => option.value === selectedValue),
-    [options, selectedValue]
+    () => items.find((option) => option.value === selectedValue),
+    [items, selectedValue]
   );
   const selectedLabel = selectedOption?.label ?? '';
   const visibleOptions = React.useMemo(
-    () => filterOptions(options, filterValue),
-    [filterValue, options]
+    () => filterOptions(items, filterValue),
+    [filterValue, items]
   );
 
   const setOpenState = React.useCallback(
@@ -296,14 +296,14 @@ function Combobox({
       if (nextOpen) {
         setInputValue(selectedLabel);
         setFilterValue('');
-        setActiveValue(selectedValue || getFirstEnabledValue(options));
+        setActiveValue(selectedValue || getFirstEnabledValue(items));
       } else {
         setInputValue('');
         setFilterValue('');
         setActiveValue('');
       }
     },
-    [disabled, options, readOnly, selectedLabel, selectedValue, setOpen]
+    [disabled, items, readOnly, selectedLabel, selectedValue, setOpen]
   );
 
   const setOpenFromField = React.useCallback(() => {
@@ -314,7 +314,7 @@ function Combobox({
     (nextValue: string) => {
       if (disabled || readOnly) return;
 
-      const nextVisibleOptions = filterOptions(options, nextValue);
+      const nextVisibleOptions = filterOptions(items, nextValue);
 
       setInputValue(nextValue);
       setFilterValue(nextValue);
@@ -327,7 +327,7 @@ function Combobox({
     },
     [
       disabled,
-      options,
+      items,
       readOnly,
       selectedLabel,
       selectedValue,
@@ -342,11 +342,11 @@ function Combobox({
         setSelectedValue('');
         setInputValue('');
         setFilterValue('');
-        setActiveValue(getFirstEnabledValue(options));
+        setActiveValue(getFirstEnabledValue(items));
         return;
       }
 
-      const option = options.find((item) => item.value === nextValue);
+      const option = items.find((item) => item.value === nextValue);
 
       if (!option || option.disabled || disabled || readOnly) return;
 
@@ -356,7 +356,7 @@ function Combobox({
       setActiveValue(nextValue);
       setOpen(false);
     },
-    [disabled, options, readOnly, setOpen, setSelectedValue]
+    [disabled, items, readOnly, setOpen, setSelectedValue]
   );
 
   const stepActiveValue = React.useCallback(
@@ -405,9 +405,9 @@ function Combobox({
       disabled,
       inputValue,
       invalid,
+      items,
       listId,
       open,
-      options,
       readOnly,
       required,
       selectedLabel,
@@ -428,9 +428,9 @@ function Combobox({
       handleSelectedValueChange,
       inputValue,
       invalid,
+      items,
       listId,
       open,
-      options,
       readOnly,
       required,
       selectedLabel,

--- a/packages/react/src/components/combobox/combobox.tsx
+++ b/packages/react/src/components/combobox/combobox.tsx
@@ -1,915 +1,317 @@
 import * as React from 'react';
 
-import { cva, type VariantProps } from 'class-variance-authority';
-
-import { IconCheck, IconChevronDown, IconX } from '../../lib/icons';
+import { IconCheck, IconSelector } from '../../lib/icons';
 import { cn } from '../../lib/utils';
+import { Button, type ButtonProps } from '../button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '../command';
 import {
   Popover,
-  PopoverAnchor,
   PopoverContent,
   type PopoverContentProps,
+  PopoverTrigger,
 } from '../popover';
 
-interface ComboboxOption {
-  value: string;
-  label: string;
-  disabled?: boolean;
-  group?: string;
-  keywords?: string[];
+/**
+ * ComboboxProps
+ *
+ * Props for the Combobox root. Inherits the Popover root props (`open`,
+ * `onOpenChange`, `defaultOpen`, `modal`, …).
+ */
+interface ComboboxProps extends React.ComponentProps<typeof Popover> {}
+
+/**
+ * Combobox
+ *
+ * A searchable single-select field: a Popover trigger paired with the cmdk-powered
+ * Command list. cmdk owns filtering, keyboard navigation, active-descendant
+ * tracking, and ARIA — the combobox only composes the pieces. Hold the selected
+ * `value` and the popover `open` state at the call site.
+ *
+ * @example
+ * ```tsx
+ * const [open, setOpen] = React.useState(false);
+ * const [value, setValue] = React.useState('');
+ *
+ * <Combobox open={open} onOpenChange={setOpen}>
+ *   <ComboboxTrigger>
+ *     {frameworks.find((f) => f.value === value)?.label ?? 'Select framework'}
+ *   </ComboboxTrigger>
+ *   <ComboboxContent>
+ *     <ComboboxInput placeholder="Search framework..." />
+ *     <ComboboxList>
+ *       <ComboboxEmpty>No framework found.</ComboboxEmpty>
+ *       {frameworks.map((framework) => (
+ *         <ComboboxItem
+ *           key={framework.value}
+ *           value={framework.value}
+ *           selected={value === framework.value}
+ *           onSelect={(next) => {
+ *             setValue(next === value ? '' : next);
+ *             setOpen(false);
+ *           }}
+ *         >
+ *           {framework.label}
+ *         </ComboboxItem>
+ *       ))}
+ *     </ComboboxList>
+ *   </ComboboxContent>
+ * </Combobox>
+ * ```
+ */
+function Combobox(props: ComboboxProps) {
+  return <Popover {...props} />;
 }
 
-interface ComboboxContextValue {
-  activeValue: string;
-  disabled: boolean;
-  inputValue: string;
-  invalid: boolean;
-  items: ComboboxOption[];
-  listId: string;
-  open: boolean;
-  readOnly: boolean;
-  required: boolean;
-  selectedLabel: string;
-  selectedValue: string;
-  setActiveValue: (value: string) => void;
-  setInputElement: (input: HTMLInputElement | null) => void;
-  setInputValue: (value: string) => void;
-  setOpenFromField: () => void;
-  setOpenState: (open: boolean) => void;
-  setSelectedValue: (value: string) => void;
-  stepActiveValue: (direction: 1 | -1) => void;
-  visibleOptions: ComboboxOption[];
-}
+/**
+ * ComboboxTriggerProps
+ *
+ * Props for the ComboboxTrigger. Inherits Button props, so `size`, `disabled`,
+ * and `aria-invalid` flow through to the underlying control.
+ */
+interface ComboboxTriggerProps extends ButtonProps {}
 
-const ComboboxContext = React.createContext<ComboboxContextValue | null>(null);
-
-function useComboboxContext(componentName: string) {
-  const context = React.useContext(ComboboxContext);
-
-  if (!context)
-    throw new Error(`${componentName} must be used inside Combobox.`);
-
-  return context;
-}
-
-function useControllableStringState({
-  value,
-  defaultValue = '',
-  onValueChange,
-}: {
-  value?: string;
-  defaultValue?: string;
-  onValueChange?: (value: string) => void;
-}) {
-  const [uncontrolledValue, setUncontrolledValue] =
-    React.useState(defaultValue);
-  const isControlled = value !== undefined;
-  const currentValue = isControlled ? value : uncontrolledValue;
-
-  const setCurrentValue = React.useCallback(
-    (nextValue: string) => {
-      if (!isControlled) setUncontrolledValue(nextValue);
-      onValueChange?.(nextValue);
-    },
-    [isControlled, onValueChange]
-  );
-
-  return [currentValue, setCurrentValue, setUncontrolledValue] as const;
-}
-
-function useControllableBooleanState({
-  value,
-  defaultValue = false,
-  onValueChange,
-}: {
-  value?: boolean;
-  defaultValue?: boolean;
-  onValueChange?: (value: boolean) => void;
-}) {
-  const [uncontrolledValue, setUncontrolledValue] =
-    React.useState(defaultValue);
-  const isControlled = value !== undefined;
-  const currentValue = isControlled ? value : uncontrolledValue;
-
-  const setCurrentValue = React.useCallback(
-    (nextValue: boolean) => {
-      if (!isControlled) setUncontrolledValue(nextValue);
-      onValueChange?.(nextValue);
-    },
-    [isControlled, onValueChange]
-  );
-
-  return [currentValue, setCurrentValue] as const;
-}
-
-function getOptionSearchText(option: ComboboxOption) {
-  return [option.label, option.value, ...(option.keywords ?? [])]
-    .join(' ')
-    .toLowerCase();
-}
-
-function filterOptions(options: ComboboxOption[], filterValue: string) {
-  const query = filterValue.trim().toLowerCase();
-
-  if (!query) return options;
-
-  return options.filter((option) =>
-    getOptionSearchText(option).includes(query)
-  );
-}
-
-function getFirstEnabledValue(options: ComboboxOption[]) {
-  return options.find((option) => !option.disabled)?.value ?? '';
-}
-
-function getLastEnabledValue(options: ComboboxOption[]) {
-  return [...options].reverse().find((option) => !option.disabled)?.value ?? '';
-}
-
-function getSteppedValue(
-  options: ComboboxOption[],
-  currentValue: string,
-  direction: 1 | -1
-) {
-  const enabledOptions = options.filter((option) => !option.disabled);
-
-  if (enabledOptions.length === 0) return '';
-
-  const currentIndex = enabledOptions.findIndex(
-    (option) => option.value === currentValue
-  );
-  const fallbackIndex = direction === 1 ? 0 : enabledOptions.length - 1;
-
-  if (currentIndex === -1) return enabledOptions[fallbackIndex]?.value ?? '';
-
-  const nextIndex =
-    (currentIndex + direction + enabledOptions.length) % enabledOptions.length;
-
-  return enabledOptions[nextIndex]?.value ?? '';
-}
-
-function getOptionId(listId: string, value: string) {
-  return `${listId}-option-${value.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
-}
-
-const comboboxFieldVariants = cva(
-  [
-    'nx:group/combobox nx:relative nx:flex nx:box-border nx:w-full nx:min-w-0 nx:items-center nx:rounded-md nx:border-default nx:transition-colors nx:outline-none',
-    'nx:has-[[data-slot=combobox-input]:focus-visible]:outline-2 nx:has-[[data-slot=combobox-input]:focus-visible]:outline-focus-default nx:has-[[data-slot=combobox-input]:focus-visible]:outline-offset-(--focus-offset)',
-    'nx:data-[invalid=true]:border-border-error nx:has-[[data-slot=combobox-input][aria-invalid=true]:focus-visible]:outline-focus-error',
-    'nx:data-[disabled=true]:cursor-not-allowed nx:data-[disabled=true]:bg-disabled nx:data-[disabled=true]:text-disabled-foreground',
-  ],
-  {
-    variants: {
-      size: {
-        sm: 'nx:h-8 nx:px-2.5 nx:typography-body-small',
-        default: 'nx:h-10 nx:px-3 nx:typography-body-default',
-        lg: 'nx:h-12 nx:px-3.5 nx:typography-body-default',
-      },
-      variant: {
-        default:
-          'nx:border-border-default nx:bg-background nx:not-data-[disabled=true]:hover:bg-background-hover nx:data-[disabled=true]:border-border-disabled',
-        borderless:
-          'nx:border-transparent nx:bg-control-background nx:not-data-[disabled=true]:hover:bg-control-background-hover',
-      },
-    },
-    defaultVariants: {
-      size: 'default',
-      variant: 'default',
-    },
-  }
-);
-
-interface ComboboxProps extends Omit<
-  React.ComponentProps<'div'>,
-  'defaultValue' | 'onChange'
-> {
-  /**
-   * Items rendered by `ComboboxList` when its children are omitted.
-   */
-  items: ComboboxOption[];
-  /**
-   * Controlled selected option value.
-   */
-  value?: string;
-  /**
-   * Initial selected option value for uncontrolled usage.
-   * @default ''
-   */
-  defaultValue?: string;
-  /**
-   * Called when the selected option value changes.
-   */
-  onValueChange?: (value: string) => void;
-  /**
-   * Controlled popover state.
-   */
-  open?: boolean;
-  /**
-   * Initial popover state for uncontrolled usage.
-   * @default false
-   */
-  defaultOpen?: boolean;
-  /**
-   * Called when the popover opens or closes.
-   */
-  onOpenChange?: (open: boolean) => void;
-  /**
-   * Native form field name. The submitted value is the selected option value.
-   */
-  name?: string;
-  /**
-   * Disables the combobox and omits its form value.
-   * @default false
-   */
-  disabled?: boolean;
-  /**
-   * Prevents editing and selection while keeping the value readable.
-   * @default false
-   */
-  readOnly?: boolean;
-  /**
-   * Marks the combobox as required for forms and assistive technology.
-   * @default false
-   */
-  required?: boolean;
-  /**
-   * Marks the combobox invalid.
-   * @default false
-   */
-  invalid?: boolean;
-}
-
-function Combobox({
+/**
+ * ComboboxTrigger
+ *
+ * The button that opens the popover, showing the current selection. Renders an
+ * outline Button by default with a trailing selector affordance. Radix supplies
+ * `aria-expanded` and focus return; the real combobox semantics live on the
+ * ComboboxInput inside the popover.
+ */
+function ComboboxTrigger({
   children,
   className,
-  defaultOpen,
-  defaultValue,
-  disabled = false,
-  invalid = false,
-  items,
-  name,
-  onOpenChange,
-  onValueChange,
-  open: openProp,
-  readOnly = false,
-  required = false,
-  value: valueProp,
+  variant = 'outline',
   ...props
-}: ComboboxProps) {
-  const reactListId = React.useId();
-  const listId = `${reactListId}-listbox`;
-  const [selectedValue, setSelectedValue, setUncontrolledSelectedValue] =
-    useControllableStringState({
-      value: valueProp,
-      defaultValue,
-      onValueChange,
-    });
-  const [open, setOpen] = useControllableBooleanState({
-    value: openProp,
-    defaultValue: defaultOpen,
-    onValueChange: onOpenChange,
-  });
-  const [inputValue, setInputValue] = React.useState('');
-  const [filterValue, setFilterValue] = React.useState('');
-  const [activeValue, setActiveValue] = React.useState('');
-  const [inputElement, setInputElement] =
-    React.useState<HTMLInputElement | null>(null);
-  const hiddenInputRef = React.useRef<HTMLInputElement>(null);
-
-  const selectedOption = React.useMemo(
-    () => items.find((option) => option.value === selectedValue),
-    [items, selectedValue]
-  );
-  const selectedLabel = selectedOption?.label ?? '';
-  const visibleOptions = React.useMemo(
-    () => filterOptions(items, filterValue),
-    [filterValue, items]
-  );
-
-  const setOpenState = React.useCallback(
-    (nextOpen: boolean) => {
-      if ((disabled || readOnly) && nextOpen) return;
-
-      setOpen(nextOpen);
-
-      if (nextOpen) {
-        setInputValue(selectedLabel);
-        setFilterValue('');
-        setActiveValue(selectedValue || getFirstEnabledValue(items));
-      } else {
-        setInputValue('');
-        setFilterValue('');
-        setActiveValue('');
-      }
-    },
-    [disabled, items, readOnly, selectedLabel, selectedValue, setOpen]
-  );
-
-  const setOpenFromField = React.useCallback(() => {
-    setOpenState(true);
-  }, [setOpenState]);
-
-  const handleInputValueChange = React.useCallback(
-    (nextValue: string) => {
-      if (disabled || readOnly) return;
-
-      const nextVisibleOptions = filterOptions(items, nextValue);
-
-      setInputValue(nextValue);
-      setFilterValue(nextValue);
-      setActiveValue(getFirstEnabledValue(nextVisibleOptions));
-      setOpen(true);
-
-      if (selectedValue && nextValue !== selectedLabel) {
-        setSelectedValue('');
-      }
-    },
-    [
-      disabled,
-      items,
-      readOnly,
-      selectedLabel,
-      selectedValue,
-      setOpen,
-      setSelectedValue,
-    ]
-  );
-
-  const handleSelectedValueChange = React.useCallback(
-    (nextValue: string) => {
-      if (!nextValue) {
-        setSelectedValue('');
-        setInputValue('');
-        setFilterValue('');
-        setActiveValue(getFirstEnabledValue(items));
-        return;
-      }
-
-      const option = items.find((item) => item.value === nextValue);
-
-      if (!option || option.disabled || disabled || readOnly) return;
-
-      setSelectedValue(nextValue);
-      setInputValue(option.label);
-      setFilterValue('');
-      setActiveValue(nextValue);
-      setOpen(false);
-    },
-    [disabled, items, readOnly, setOpen, setSelectedValue]
-  );
-
-  const stepActiveValue = React.useCallback(
-    (direction: 1 | -1) => {
-      setActiveValue((currentValue) =>
-        getSteppedValue(visibleOptions, currentValue, direction)
-      );
-    },
-    [visibleOptions]
-  );
-
-  React.useEffect(() => {
-    if (!inputElement) return;
-
-    const validityMessage =
-      required && !disabled && !selectedValue ? 'Please select an option.' : '';
-
-    inputElement.setCustomValidity(validityMessage);
-  }, [disabled, inputElement, required, selectedValue]);
-
-  React.useEffect(() => {
-    const form = hiddenInputRef.current?.form;
-
-    if (!form) return;
-
-    const handleReset = () => {
-      window.setTimeout(() => {
-        if (valueProp === undefined)
-          setUncontrolledSelectedValue(defaultValue ?? '');
-
-        setInputValue('');
-        setFilterValue('');
-        setActiveValue('');
-        setOpen(false);
-      });
-    };
-
-    form.addEventListener('reset', handleReset);
-
-    return () => form.removeEventListener('reset', handleReset);
-  }, [defaultValue, setOpen, setUncontrolledSelectedValue, valueProp]);
-
-  const contextValue = React.useMemo<ComboboxContextValue>(
-    () => ({
-      activeValue,
-      disabled,
-      inputValue,
-      invalid,
-      items,
-      listId,
-      open,
-      readOnly,
-      required,
-      selectedLabel,
-      selectedValue,
-      setActiveValue,
-      setInputElement,
-      setInputValue: handleInputValueChange,
-      setOpenFromField,
-      setOpenState,
-      setSelectedValue: handleSelectedValueChange,
-      stepActiveValue,
-      visibleOptions,
-    }),
-    [
-      activeValue,
-      disabled,
-      handleInputValueChange,
-      handleSelectedValueChange,
-      inputValue,
-      invalid,
-      items,
-      listId,
-      open,
-      readOnly,
-      required,
-      selectedLabel,
-      selectedValue,
-      setOpenFromField,
-      setOpenState,
-      stepActiveValue,
-      visibleOptions,
-    ]
-  );
-
+}: ComboboxTriggerProps) {
   return (
-    <ComboboxContext.Provider value={contextValue}>
-      <div
-        data-slot="combobox"
-        className={cn('nx:contents', className)}
+    <PopoverTrigger asChild>
+      <Button
+        data-slot="combobox-trigger"
+        variant={variant}
+        className={cn(
+          'nx:w-full nx:justify-between',
+          'nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error',
+          className
+        )}
         {...props}
       >
-        <Popover open={open} onOpenChange={setOpenState}>
-          {children}
-        </Popover>
-        {name ? (
-          <input
-            ref={hiddenInputRef}
-            type="hidden"
-            name={name}
-            value={selectedValue}
-            disabled={disabled}
-            readOnly
-          />
-        ) : null}
-      </div>
-    </ComboboxContext.Provider>
-  );
-}
-
-interface ComboboxInputProps
-  extends
-    Omit<
-      React.ComponentProps<'input'>,
-      'disabled' | 'readOnly' | 'required' | 'size' | 'value'
-    >,
-    VariantProps<typeof comboboxFieldVariants> {
-  /**
-   * Shows an in-field clear button when a value is selected.
-   * @default false
-   */
-  showClear?: boolean;
-}
-
-function ComboboxInput({
-  className,
-  onChange,
-  onClick,
-  onFocus,
-  onKeyDown,
-  showClear = false,
-  size,
-  variant,
-  ...props
-}: ComboboxInputProps) {
-  const context = useComboboxContext('ComboboxInput');
-  const inputRef = React.useRef<HTMLInputElement | null>(null);
-  const skipNextFocusOpenRef = React.useRef(false);
-  const displayValue = context.open
-    ? context.inputValue
-    : context.selectedLabel;
-  const showClearButton =
-    showClear &&
-    Boolean(context.selectedValue) &&
-    !context.disabled &&
-    !context.readOnly;
-  const activeOptionId =
-    context.open && context.activeValue
-      ? getOptionId(context.listId, context.activeValue)
-      : undefined;
-
-  const handleInputRef = React.useCallback(
-    (node: HTMLInputElement | null) => {
-      inputRef.current = node;
-      context.setInputElement(node);
-    },
-    [context]
-  );
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    context.setInputValue(event.target.value);
-    onChange?.(event);
-  };
-
-  const handleInputClick = (event: React.MouseEvent<HTMLInputElement>) => {
-    context.setOpenFromField();
-    onClick?.(event);
-  };
-
-  const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
-    if (skipNextFocusOpenRef.current) {
-      skipNextFocusOpenRef.current = false;
-      onFocus?.(event);
-      return;
-    }
-
-    context.setOpenFromField();
-    onFocus?.(event);
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      context.setOpenState(false);
-    } else if (event.key === 'ArrowDown') {
-      event.preventDefault();
-      if (!context.open) context.setOpenFromField();
-      context.stepActiveValue(1);
-    } else if (event.key === 'ArrowUp') {
-      event.preventDefault();
-      if (!context.open) context.setOpenFromField();
-      context.stepActiveValue(-1);
-    } else if (event.key === 'Home' && context.open) {
-      event.preventDefault();
-      context.setActiveValue(getFirstEnabledValue(context.visibleOptions));
-    } else if (event.key === 'End' && context.open) {
-      event.preventDefault();
-      context.setActiveValue(getLastEnabledValue(context.visibleOptions));
-    } else if (event.key === 'Enter' && context.open) {
-      event.preventDefault();
-      context.setSelectedValue(context.activeValue);
-    }
-
-    onKeyDown?.(event);
-  };
-
-  const handleClear = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-    skipNextFocusOpenRef.current = true;
-    context.setSelectedValue('');
-    context.setInputValue('');
-    inputRef.current?.focus();
-  };
-
-  const stopClearClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-  };
-
-  const handleTriggerMouseDown = (
-    event: React.MouseEvent<HTMLButtonElement>
-  ) => {
-    event.preventDefault();
-    event.stopPropagation();
-    inputRef.current?.focus();
-    context.setOpenFromField();
-  };
-
-  const stopTriggerClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-  };
-
-  return (
-    <PopoverAnchor asChild>
-      <div
-        data-slot="combobox-field"
-        data-size={size ?? 'default'}
-        data-variant={variant ?? 'default'}
-        data-disabled={context.disabled || undefined}
-        data-invalid={context.invalid || undefined}
-        className={cn(comboboxFieldVariants({ size, variant }), className)}
-      >
-        <input
-          ref={handleInputRef}
-          data-slot="combobox-input"
-          value={displayValue}
-          onChange={handleChange}
-          onClick={handleInputClick}
-          onFocus={handleFocus}
-          onKeyDown={handleKeyDown}
-          disabled={context.disabled}
-          readOnly={context.readOnly}
-          required={context.required}
-          aria-activedescendant={activeOptionId}
-          aria-autocomplete="list"
-          aria-controls={context.open ? context.listId : undefined}
-          aria-expanded={context.open}
-          aria-invalid={context.invalid || undefined}
-          aria-required={context.required || undefined}
-          role="combobox"
-          className={cn(
-            'nx:min-w-0 nx:flex-1 nx:bg-transparent nx:py-0 nx:text-foreground nx:outline-none',
-            'nx:placeholder:text-muted-foreground',
-            'nx:disabled:cursor-not-allowed nx:disabled:text-disabled-foreground nx:disabled:placeholder:text-disabled-foreground'
-          )}
-          {...props}
+        {children}
+        <IconSelector
+          aria-hidden="true"
+          data-slot="combobox-trigger-icon"
+          className="nx:shrink-0 nx:text-muted-foreground"
         />
-        {showClearButton ? (
-          <button
-            type="button"
-            data-slot="combobox-clear"
-            aria-label="Clear selection"
-            className="nx:-mr-1 nx:flex nx:size-6 nx:items-center nx:justify-center nx:rounded-sm nx:text-muted-foreground nx:hover:bg-background-hover nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
-            onClick={stopClearClick}
-            onMouseDown={handleClear}
-          >
-            <IconX aria-hidden="true" className="nx:size-4" />
-          </button>
-        ) : null}
-        <button
-          type="button"
-          data-slot="combobox-trigger"
-          aria-label="Open options"
-          disabled={context.disabled || context.readOnly}
-          className="nx:-mr-1 nx:flex nx:size-6 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-sm nx:text-muted-foreground nx:hover:bg-background-hover nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:cursor-not-allowed nx:disabled:text-disabled-foreground"
-          onClick={stopTriggerClick}
-          onMouseDown={handleTriggerMouseDown}
-        >
-          <IconChevronDown
-            aria-hidden="true"
-            data-slot="combobox-chevron"
-            className="nx:size-4"
-          />
-        </button>
-      </div>
-    </PopoverAnchor>
+      </Button>
+    </PopoverTrigger>
   );
 }
 
-interface ComboboxContentProps extends PopoverContentProps {}
+/**
+ * ComboboxContentProps
+ *
+ * Props for the ComboboxContent. Inherits PopoverContent props.
+ */
+interface ComboboxContentProps extends PopoverContentProps {
+  /**
+   * Accessible name for the search field and its popup. cmdk applies it to the
+   * combobox input (via `aria-labelledby`), and it names the popover dialog. Set
+   * it to the field's purpose, e.g. the associated label text.
+   * @default 'Options'
+   */
+  label?: string;
+}
 
+/**
+ * ComboboxContent
+ *
+ * The floating panel: a PopoverContent that hosts the Command. Matches the
+ * trigger width by default and drops the popover's inner padding so the Command's
+ * input bar and list own the spacing.
+ */
 function ComboboxContent({
   align = 'start',
+  children,
   className,
-  sideOffset = 6,
+  label = 'Options',
+  sideOffset = 4,
   ...props
 }: ComboboxContentProps) {
   return (
     <PopoverContent
       data-slot="combobox-content"
+      aria-label={label}
       align={align}
-      role="presentation"
       sideOffset={sideOffset}
       className={cn(
-        'nx:w-(--radix-popper-anchor-width) nx:min-w-48 nx:p-0',
+        'nx:w-(--radix-popover-trigger-width) nx:min-w-48 nx:p-0',
         className
       )}
-      onOpenAutoFocus={(event) => event.preventDefault()}
       {...props}
-    />
-  );
-}
-
-interface ComboboxListProps extends React.ComponentProps<'div'> {}
-
-function renderComboboxOption(option: ComboboxOption) {
-  return (
-    <ComboboxItem
-      key={option.value}
-      value={option.value}
-      disabled={option.disabled}
     >
-      {option.label}
-    </ComboboxItem>
-  );
-}
-
-function ComboboxList({
-  'aria-label': ariaLabel = 'Combobox options',
-  children,
-  className,
-  ...props
-}: ComboboxListProps) {
-  const context = useComboboxContext('ComboboxList');
-  const hasGroups = context.visibleOptions.some((option) => option.group);
-
-  if (children)
-    return (
-      <div
-        id={context.listId}
-        role="listbox"
-        aria-label={ariaLabel}
-        data-slot="combobox-list"
-        className={cn(
-          'nx:max-h-72 nx:overflow-y-auto nx:overflow-x-hidden nx:p-1',
-          className
-        )}
-        {...props}
-      >
+      {/* PopoverContent already paints the translucent popover surface — keep the
+          Command transparent so it shows through instead of a solid fill. */}
+      <Command label={label} className="nx:bg-transparent">
         {children}
-      </div>
-    );
-
-  if (!hasGroups)
-    return (
-      <div
-        id={context.listId}
-        role="listbox"
-        aria-label={ariaLabel}
-        data-slot="combobox-list"
-        className={cn(
-          'nx:max-h-72 nx:overflow-y-auto nx:overflow-x-hidden nx:p-1',
-          className
-        )}
-        {...props}
-      >
-        {context.visibleOptions.map(renderComboboxOption)}
-      </div>
-    );
-
-  const groupedOptions = new Map<string, ComboboxOption[]>();
-
-  for (const option of context.visibleOptions) {
-    const group = option.group ?? 'Options';
-    const groupOptions = groupedOptions.get(group) ?? [];
-
-    groupOptions.push(option);
-    groupedOptions.set(group, groupOptions);
-  }
-
-  return (
-    <div
-      id={context.listId}
-      role="listbox"
-      aria-label={ariaLabel}
-      data-slot="combobox-list"
-      className={cn(
-        'nx:max-h-72 nx:overflow-y-auto nx:overflow-x-hidden nx:p-1',
-        className
-      )}
-      {...props}
-    >
-      {[...groupedOptions.entries()].map(([group, options]) => (
-        <ComboboxGroup key={group} heading={group}>
-          {options.map(renderComboboxOption)}
-        </ComboboxGroup>
-      ))}
-    </div>
+      </Command>
+    </PopoverContent>
   );
 }
 
-interface ComboboxEmptyProps extends React.ComponentProps<'div'> {}
+/**
+ * ComboboxInputProps
+ *
+ * Props for the ComboboxInput.
+ */
+interface ComboboxInputProps extends React.ComponentProps<
+  typeof CommandInput
+> {}
 
-function ComboboxEmpty({ className, ...props }: ComboboxEmptyProps) {
-  const context = useComboboxContext('ComboboxEmpty');
-
-  if (context.visibleOptions.length > 0) return null;
-
+/**
+ * ComboboxInput
+ *
+ * The search field. cmdk wires it as the actual `role="combobox"` control that
+ * owns `aria-activedescendant`, `aria-controls`, and `aria-expanded`.
+ */
+function ComboboxInput({ className, ...props }: ComboboxInputProps) {
   return (
-    <div
+    <CommandInput data-slot="combobox-input" className={className} {...props} />
+  );
+}
+
+/**
+ * ComboboxListProps
+ *
+ * Props for the ComboboxList.
+ */
+interface ComboboxListProps extends React.ComponentProps<typeof CommandList> {}
+
+/**
+ * ComboboxList
+ *
+ * The scrollable `role="listbox"` container for options, empty state, and groups.
+ */
+function ComboboxList({ className, ...props }: ComboboxListProps) {
+  return (
+    <CommandList data-slot="combobox-list" className={className} {...props} />
+  );
+}
+
+/**
+ * ComboboxEmptyProps
+ *
+ * Props for the ComboboxEmpty.
+ */
+interface ComboboxEmptyProps extends React.ComponentProps<
+  typeof CommandEmpty
+> {}
+
+/**
+ * ComboboxEmpty
+ *
+ * Rendered by cmdk when the query matches no options.
+ */
+function ComboboxEmpty({ className, ...props }: ComboboxEmptyProps) {
+  return (
+    <CommandEmpty
       data-slot="combobox-empty"
-      className={cn(
-        'nx:py-6 nx:text-center nx:typography-body-default nx:text-muted-foreground',
-        className
-      )}
+      className={cn('nx:text-muted-foreground', className)}
       {...props}
     />
   );
 }
 
-interface ComboboxGroupProps extends React.ComponentProps<'div'> {
-  heading?: string;
-}
+/**
+ * ComboboxGroupProps
+ *
+ * Props for the ComboboxGroup.
+ */
+interface ComboboxGroupProps extends React.ComponentProps<
+  typeof CommandGroup
+> {}
 
-function ComboboxGroup({
-  children,
-  className,
-  heading,
-  ...props
-}: ComboboxGroupProps) {
+/**
+ * ComboboxGroup
+ *
+ * Groups related options under an optional `heading`.
+ */
+function ComboboxGroup({ className, ...props }: ComboboxGroupProps) {
   return (
-    <div
-      role="group"
-      aria-label={heading}
-      data-slot="combobox-group"
-      className={cn('nx:p-1', className)}
-      {...props}
-    >
-      {heading ? (
-        <div
-          data-slot="combobox-group-heading"
-          className="nx:px-2 nx:py-1.5 nx:typography-label-small nx:text-muted-foreground"
-        >
-          {heading}
-        </div>
-      ) : null}
-      {children}
-    </div>
+    <CommandGroup data-slot="combobox-group" className={className} {...props} />
   );
 }
 
-interface ComboboxSeparatorProps extends React.ComponentProps<'div'> {}
+/**
+ * ComboboxSeparatorProps
+ *
+ * Props for the ComboboxSeparator.
+ */
+interface ComboboxSeparatorProps extends React.ComponentProps<
+  typeof CommandSeparator
+> {}
 
+/**
+ * ComboboxSeparator
+ *
+ * A decorative divider between groups or options.
+ */
 function ComboboxSeparator({ className, ...props }: ComboboxSeparatorProps) {
   return (
-    <div
-      role="presentation"
+    <CommandSeparator
       data-slot="combobox-separator"
-      className={cn(
-        'nx:-mx-1 nx:my-1 nx:h-px nx:bg-border-default-alpha',
-        className
-      )}
+      className={className}
       {...props}
     />
   );
 }
 
-interface ComboboxItemProps extends Omit<
-  React.ComponentProps<'div'>,
-  'onSelect'
-> {
-  value: string;
-  disabled?: boolean;
-  onSelect?: (value: string) => void;
+/**
+ * ComboboxItemProps
+ *
+ * Props for the ComboboxItem.
+ */
+interface ComboboxItemProps extends React.ComponentProps<typeof CommandItem> {
+  /**
+   * Marks this option as the current selection, showing the check indicator.
+   * cmdk lowercases the value passed to `onSelect`, so compare against
+   * lowercase `value`s at the call site.
+   * @default false
+   */
+  selected?: boolean;
 }
 
+/**
+ * ComboboxItem
+ *
+ * A selectable option. cmdk marks the pointer/keyboard-active item with
+ * `data-selected`; `selected` marks the chosen value with a trailing check.
+ */
 function ComboboxItem({
   children,
   className,
-  disabled = false,
-  onMouseDown,
-  onMouseMove,
-  onSelect,
-  value,
+  selected = false,
   ...props
 }: ComboboxItemProps) {
-  const context = useComboboxContext('ComboboxItem');
-  const selected = context.selectedValue === value;
-  const active = context.activeValue === value;
-
-  const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
-    event.preventDefault();
-
-    if (!disabled) {
-      context.setSelectedValue(value);
-      onSelect?.(value);
-    }
-
-    onMouseDown?.(event);
-  };
-
-  const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (!disabled) context.setActiveValue(value);
-    onMouseMove?.(event);
-  };
-
   return (
-    <div
-      id={getOptionId(context.listId, value)}
-      role="option"
-      aria-disabled={disabled || undefined}
-      aria-selected={selected}
-      tabIndex={-1}
-      data-active={active || undefined}
-      data-disabled={disabled || undefined}
-      data-selected={selected || undefined}
-      data-slot="combobox-item"
-      className={cn(
-        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:rounded-sm nx:typography-body-default nx:outline-none',
-        'nx:gap-3 nx:px-3 nx:py-2.5',
-        'nx:data-[active=true]:bg-popover-hover nx:data-[active=true]:text-popover-foreground',
-        'nx:data-[disabled=true]:pointer-events-none nx:data-[disabled=true]:text-disabled-foreground',
-        'nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
-        className
-      )}
-      onMouseDown={handleMouseDown}
-      onMouseMove={handleMouseMove}
-      {...props}
-    >
-      <span data-slot="combobox-item-label" className="nx:min-w-0 nx:flex-1">
-        {children}
-      </span>
+    <CommandItem data-slot="combobox-item" className={className} {...props}>
+      {children}
       <IconCheck
         aria-hidden="true"
         data-slot="combobox-item-indicator"
         className={cn(
-          'nx:ml-auto nx:size-4 nx:transition-opacity',
+          'nx:ml-auto nx:transition-opacity',
           selected ? 'nx:opacity-100' : 'nx:opacity-0'
         )}
       />
-    </div>
+    </CommandItem>
   );
 }
 
@@ -919,7 +321,6 @@ export {
   type ComboboxContentProps,
   ComboboxEmpty,
   type ComboboxEmptyProps,
-  comboboxFieldVariants,
   ComboboxGroup,
   type ComboboxGroupProps,
   ComboboxInput,
@@ -928,8 +329,9 @@ export {
   type ComboboxItemProps,
   ComboboxList,
   type ComboboxListProps,
-  type ComboboxOption,
   type ComboboxProps,
   ComboboxSeparator,
   type ComboboxSeparatorProps,
+  ComboboxTrigger,
+  type ComboboxTriggerProps,
 };

--- a/packages/react/src/components/combobox/combobox.tsx
+++ b/packages/react/src/components/combobox/combobox.tsx
@@ -32,8 +32,9 @@ interface ComboboxProps extends React.ComponentProps<typeof Popover> {}
  *
  * A searchable single-select field: a Popover trigger paired with the cmdk-powered
  * Command list. cmdk owns filtering, keyboard navigation, active-descendant
- * tracking, and ARIA — the combobox only composes the pieces. Hold the selected
- * `value` and the popover `open` state at the call site.
+ * tracking, and ARIA — the combobox only composes the pieces. The selected
+ * `value` and the popover `open` state are controlled at the call site; the
+ * root owns no internal value, matching the composition (shadcn) model.
  *
  * @example
  * ```tsx
@@ -52,6 +53,7 @@ interface ComboboxProps extends React.ComponentProps<typeof Popover> {}
  *         <ComboboxItem
  *           key={framework.value}
  *           value={framework.value}
+ *           keywords={[framework.label]}
  *           selected={value === framework.value}
  *           onSelect={(next) => {
  *             setValue(next === value ? '' : next);
@@ -157,9 +159,7 @@ function ComboboxContent({
       )}
       {...props}
     >
-      {/* PopoverContent already paints the translucent popover surface — keep the
-          Command transparent so it shows through instead of a solid fill. */}
-      <Command label={label} className="nx:bg-transparent">
+      <Command data-slot="combobox" label={label} className="nx:bg-transparent">
         {children}
       </Command>
     </PopoverContent>
@@ -281,8 +281,6 @@ function ComboboxSeparator({ className, ...props }: ComboboxSeparatorProps) {
 interface ComboboxItemProps extends React.ComponentProps<typeof CommandItem> {
   /**
    * Marks this option as the current selection, showing the check indicator.
-   * cmdk lowercases the value passed to `onSelect`, so compare against
-   * lowercase `value`s at the call site.
    * @default false
    */
   selected?: boolean;
@@ -293,6 +291,11 @@ interface ComboboxItemProps extends React.ComponentProps<typeof CommandItem> {
  *
  * A selectable option. cmdk marks the pointer/keyboard-active item with
  * `data-selected`; `selected` marks the chosen value with a trailing check.
+ *
+ * cmdk filters on each item's `value` + `keywords`, never its rendered children
+ * — pass the visible label as a `keyword` so typing it matches. `onSelect`
+ * receives the trimmed `value` (case preserved); compare it against the
+ * option's `value` directly at the call site.
  */
 function ComboboxItem({
   children,

--- a/packages/react/src/components/combobox/index.ts
+++ b/packages/react/src/components/combobox/index.ts
@@ -1,0 +1,1 @@
+export * from './combobox';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -24,6 +24,7 @@ export * from './components/chart';
 export * from './components/checkbox';
 export * from './components/choice-row';
 export * from './components/collapsible';
+export * from './components/combobox';
 export * from './components/command';
 export * from './components/context-menu';
 export * from './components/date-picker';

--- a/packages/react/src/lib/icons.ts
+++ b/packages/react/src/lib/icons.ts
@@ -25,6 +25,7 @@ export {
   IconChevronUp,
   IconDots,
   IconLayoutSidebar,
+  IconSelector,
 } from '@tabler/icons-react';
 
 // Actions


### PR DESCRIPTION
## Summary

- Adds a clean Combobox component with a shadcn-style items API, field sizing, invalid and disabled states, grouped items, and a controlled value held at the call site.
- Exposes the reference anatomy: Combobox, ComboboxTrigger, ComboboxInput, ComboboxContent, ComboboxEmpty, ComboboxList, ComboboxGroup, ComboboxSeparator, and ComboboxItem.
- Positions a Radix Popover over the cmdk-powered Command list — cmdk owns filtering, keyboard navigation, active-descendant tracking, and ARIA; the selected value and open state are controlled at the call site (the composition/shadcn model).
- Adds focused Storybook coverage for default, controlled, sizes, grouped, disabled, invalid, keyboard, click, clear, reset, and data attributes.

## GitHub Issue

Part of #620. This split PR intentionally does not auto-close the shared Combobox + MultiSelect tracker.

## Test Plan

- [x] corepack pnpm --filter @nexus_ds/core build
- [x] corepack pnpm --filter @nexus_ds/react typecheck
- [x] corepack pnpm lint
- [x] corepack pnpm format:check
- [x] corepack pnpm test:storybook packages/react/src/components/combobox/Combobox.stories.tsx
