### PR TITLE
feat(react): add multi-select component

### DIFF
--- a/packages/react/src/components/multi-select/MultiSelect.stories.tsx
+++ b/packages/react/src/components/multi-select/MultiSelect.stories.tsx
@@ -84,40 +84,6 @@ export const Controlled: Story = {
   },
 };
 
-export const SingleSelect: Story = {
-  render: () => (
-    <MultiSelect single>
-      <MultiSelectTrigger aria-label="Framework" className="nx:w-80">
-        <MultiSelectValue placeholder="Select a framework" />
-      </MultiSelectTrigger>
-      <MultiSelectContent
-        searchPlaceholder="Search frameworks…"
-        emptyMessage="No frameworks found."
-      >
-        {FRAMEWORKS.map((option) => (
-          <MultiSelectItem key={option.value} value={option.value}>
-            {option.label}
-          </MultiSelectItem>
-        ))}
-      </MultiSelectContent>
-    </MultiSelect>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const body = within(document.body);
-    const trigger = canvas.getByRole('button', { name: 'Framework' });
-
-    await userEvent.click(trigger);
-    await userEvent.click(await body.findByRole('option', { name: 'Vue' }));
-
-    // Single mode collapses to a plain label and closes the popover.
-    await expect(within(trigger).getByText('Vue')).toBeInTheDocument();
-    await waitFor(() =>
-      expect(body.queryByPlaceholderText('Search frameworks…')).toBeNull()
-    );
-  },
-};
-
 export const Grouped: Story = {
   render: () => (
     <MultiSelect defaultValues={['react']}>
@@ -341,6 +307,23 @@ export const ChipRemoval: Story = {
   },
 };
 
+export const ChipKeyboardRemoval: Story = {
+  render: () => <Frameworks defaultValues={['react', 'vue']} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Frameworks' });
+
+    // Backspace on the focused field removes the last selected value without
+    // reopening the list — the keyboard equivalent of clicking a chip's X.
+    trigger.focus();
+    await expect(trigger).toHaveFocus();
+    await userEvent.keyboard('{Backspace}');
+
+    await waitFor(() => expect(within(trigger).queryByText('Vue')).toBeNull());
+    await expect(within(trigger).getByText('React')).toBeInTheDocument();
+  },
+};
+
 export const SearchEmpty: Story = {
   render: () => <Frameworks />,
   parameters: {
@@ -420,21 +403,11 @@ export const AllVariants: Story = {
         placeholder="Overflow"
         triggerClassName=""
       />
-      <MultiSelect single>
-        <MultiSelectTrigger aria-label="Single" className="">
-          <MultiSelectValue placeholder="Single" />
-        </MultiSelectTrigger>
-        <MultiSelectContent
-          searchPlaceholder="Search frameworks…"
-          emptyMessage="No frameworks found."
-        >
-          {FRAMEWORKS.map((option) => (
-            <MultiSelectItem key={option.value} value={option.value}>
-              {option.label}
-            </MultiSelectItem>
-          ))}
-        </MultiSelectContent>
-      </MultiSelect>
+      <Frameworks
+        defaultValues={['react', 'svelte']}
+        placeholder="Grouped"
+        triggerClassName=""
+      />
     </div>
   ),
 };

--- a/packages/react/src/components/multi-select/MultiSelect.stories.tsx
+++ b/packages/react/src/components/multi-select/MultiSelect.stories.tsx
@@ -14,6 +14,7 @@ import {
   type MultiSelectOption,
   MultiSelectSearch,
   MultiSelectTrigger,
+  MultiSelectValue,
 } from './multi-select';
 
 const technologies: MultiSelectOption[] = [
@@ -50,8 +51,9 @@ function TechnologyMultiSelect({
       <MultiSelectTrigger
         aria-label="Technologies"
         className={triggerClassName}
-        placeholder={placeholder}
-      />
+      >
+        <MultiSelectValue placeholder={placeholder} />
+      </MultiSelectTrigger>
       <MultiSelectContent>
         <MultiSelectSearch aria-label="Search technologies" />
         <MultiSelectEmpty>No technologies found.</MultiSelectEmpty>
@@ -102,11 +104,9 @@ export const Sizes: Story = {
     <div className="nx:flex nx:w-80 nx:flex-col nx:gap-3">
       <TechnologyMultiSelect placeholder="Default" triggerClassName="" />
       <MultiSelect options={technologies}>
-        <MultiSelectTrigger
-          aria-label="Small technologies"
-          size="sm"
-          placeholder="Small"
-        />
+        <MultiSelectTrigger aria-label="Small technologies" size="sm">
+          <MultiSelectValue placeholder="Small" />
+        </MultiSelectTrigger>
         <MultiSelectContent>
           <MultiSelectSearch aria-label="Search small technologies" />
           <MultiSelectEmpty>No technologies found.</MultiSelectEmpty>
@@ -114,11 +114,9 @@ export const Sizes: Story = {
         </MultiSelectContent>
       </MultiSelect>
       <MultiSelect options={technologies}>
-        <MultiSelectTrigger
-          aria-label="Large technologies"
-          size="lg"
-          placeholder="Large"
-        />
+        <MultiSelectTrigger aria-label="Large technologies" size="lg">
+          <MultiSelectValue placeholder="Large" />
+        </MultiSelectTrigger>
         <MultiSelectContent>
           <MultiSelectSearch aria-label="Search large technologies" />
           <MultiSelectEmpty>No technologies found.</MultiSelectEmpty>
@@ -306,10 +304,14 @@ export const WithDataAttributes: Story = {
     const field = canvasElement.querySelector(
       '[data-slot="multi-select-field"]'
     );
+    const value = canvasElement.querySelector(
+      '[data-slot="multi-select-value"]'
+    );
 
     await expect(field).toHaveAttribute('data-size', 'default');
     await expect(field).toHaveAttribute('data-variant', 'default');
     await expect(trigger).toHaveAttribute('data-slot', 'multi-select-trigger');
+    await expect(value).toHaveAttribute('data-slot', 'multi-select-value');
   },
 };
 
@@ -323,11 +325,9 @@ export const AllVariants: Story = {
         triggerClassName=""
       />
       <MultiSelect options={technologies}>
-        <MultiSelectTrigger
-          aria-label="Borderless empty"
-          variant="borderless"
-          placeholder="Borderless empty"
-        />
+        <MultiSelectTrigger aria-label="Borderless empty" variant="borderless">
+          <MultiSelectValue placeholder="Borderless empty" />
+        </MultiSelectTrigger>
         <MultiSelectContent>
           <MultiSelectSearch aria-label="Search borderless empty" />
           <MultiSelectEmpty>No technologies found.</MultiSelectEmpty>
@@ -335,11 +335,9 @@ export const AllVariants: Story = {
         </MultiSelectContent>
       </MultiSelect>
       <MultiSelect options={technologies} defaultValue={['astro']}>
-        <MultiSelectTrigger
-          aria-label="Borderless filled"
-          variant="borderless"
-          placeholder="Borderless filled"
-        />
+        <MultiSelectTrigger aria-label="Borderless filled" variant="borderless">
+          <MultiSelectValue placeholder="Borderless filled" />
+        </MultiSelectTrigger>
         <MultiSelectContent>
           <MultiSelectSearch aria-label="Search borderless filled" />
           <MultiSelectEmpty>No technologies found.</MultiSelectEmpty>

--- a/packages/react/src/components/multi-select/MultiSelect.stories.tsx
+++ b/packages/react/src/components/multi-select/MultiSelect.stories.tsx
@@ -310,7 +310,11 @@ export const WithDataAttributes: Story = {
 
     await expect(field).toHaveAttribute('data-size', 'default');
     await expect(field).toHaveAttribute('data-variant', 'default');
+    await expect(field).toHaveClass('nx:border-default');
+    await expect(field).toHaveClass('nx:border-border-default');
     await expect(trigger).toHaveAttribute('data-slot', 'multi-select-trigger');
+    await expect(trigger).toHaveClass('nx:absolute');
+    await expect(trigger).toHaveClass('nx:inset-0');
     await expect(value).toHaveAttribute('data-slot', 'multi-select-value');
   },
 };

--- a/packages/react/src/components/multi-select/MultiSelect.stories.tsx
+++ b/packages/react/src/components/multi-select/MultiSelect.stories.tsx
@@ -1,0 +1,351 @@
+import * as React from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { Button } from '../button';
+import { Field, FieldDescription, FieldError, FieldLabel } from '../field';
+
+import {
+  MultiSelect,
+  MultiSelectContent,
+  MultiSelectEmpty,
+  MultiSelectList,
+  type MultiSelectOption,
+  MultiSelectSearch,
+  MultiSelectTrigger,
+} from './multi-select';
+
+const technologies: MultiSelectOption[] = [
+  { value: 'react', label: 'React' },
+  { value: 'next', label: 'Next.js', keywords: ['framework'] },
+  { value: 'sveltekit', label: 'SvelteKit' },
+  { value: 'nuxt', label: 'Nuxt.js' },
+  { value: 'remix', label: 'Remix' },
+  { value: 'astro', label: 'Astro' },
+  { value: 'tailwind', label: 'Tailwind CSS' },
+];
+
+const groupedTechnologies: MultiSelectOption[] = [
+  { value: 'react', label: 'React', group: 'Libraries' },
+  { value: 'tailwind', label: 'Tailwind CSS', group: 'Libraries' },
+  { value: 'next', label: 'Next.js', group: 'Frameworks' },
+  { value: 'remix', label: 'Remix', group: 'Frameworks' },
+  { value: 'sveltekit', label: 'SvelteKit', group: 'Frameworks' },
+  { value: 'nuxt', label: 'Nuxt.js', group: 'Frameworks' },
+];
+
+function TechnologyMultiSelect({
+  options = technologies,
+  placeholder = 'Select technologies',
+  triggerClassName = 'nx:w-80',
+  ...props
+}: Omit<React.ComponentProps<typeof MultiSelect>, 'options'> & {
+  options?: MultiSelectOption[];
+  placeholder?: string;
+  triggerClassName?: string;
+}) {
+  return (
+    <MultiSelect options={options} {...props}>
+      <MultiSelectTrigger
+        aria-label="Technologies"
+        className={triggerClassName}
+        placeholder={placeholder}
+      />
+      <MultiSelectContent>
+        <MultiSelectSearch aria-label="Search technologies" />
+        <MultiSelectEmpty>No technologies found.</MultiSelectEmpty>
+        <MultiSelectList />
+      </MultiSelectContent>
+    </MultiSelect>
+  );
+}
+
+function ControlledMultiSelectExample() {
+  const [value, setValue] = React.useState(['react', 'tailwind']);
+
+  return (
+    <div className="nx:flex nx:flex-col nx:gap-3">
+      <TechnologyMultiSelect value={value} onValueChange={setValue} />
+      <output className="nx:typography-body-small nx:text-muted-foreground">
+        Selected: {value.join(', ') || 'none'}
+      </output>
+    </div>
+  );
+}
+
+const meta: Meta<typeof MultiSelect> = {
+  title: 'Components/MultiSelect',
+  component: MultiSelect,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MultiSelect>;
+
+export const Default: Story = {
+  render: () => <TechnologyMultiSelect />,
+};
+
+export const WithDefaultValue: Story = {
+  render: () => <TechnologyMultiSelect defaultValue={['react', 'next']} />,
+};
+
+export const Controlled: Story = {
+  render: () => <ControlledMultiSelectExample />,
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="nx:flex nx:w-80 nx:flex-col nx:gap-3">
+      <TechnologyMultiSelect placeholder="Default" triggerClassName="" />
+      <MultiSelect options={technologies}>
+        <MultiSelectTrigger
+          aria-label="Small technologies"
+          size="sm"
+          placeholder="Small"
+        />
+        <MultiSelectContent>
+          <MultiSelectSearch aria-label="Search small technologies" />
+          <MultiSelectEmpty>No technologies found.</MultiSelectEmpty>
+          <MultiSelectList />
+        </MultiSelectContent>
+      </MultiSelect>
+      <MultiSelect options={technologies}>
+        <MultiSelectTrigger
+          aria-label="Large technologies"
+          size="lg"
+          placeholder="Large"
+        />
+        <MultiSelectContent>
+          <MultiSelectSearch aria-label="Search large technologies" />
+          <MultiSelectEmpty>No technologies found.</MultiSelectEmpty>
+          <MultiSelectList />
+        </MultiSelectContent>
+      </MultiSelect>
+    </div>
+  ),
+};
+
+export const Grouped: Story = {
+  render: () => <TechnologyMultiSelect options={groupedTechnologies} />,
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <TechnologyMultiSelect
+      disabled
+      name="technologies"
+      defaultValue={['next']}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Technologies' });
+    const hiddenInput = canvasElement.querySelector('input[type="hidden"]');
+
+    await expect(trigger).toBeDisabled();
+    await expect(hiddenInput).toBeDisabled();
+    await userEvent.click(trigger);
+    await waitFor(() => {
+      expect(document.body.querySelector('[role="listbox"]')).toBeNull();
+    });
+  },
+};
+
+export const WithDisabledOption: Story = {
+  render: () => (
+    <TechnologyMultiSelect
+      options={[
+        { value: 'react', label: 'React' },
+        { value: 'next', label: 'Next.js', disabled: true },
+        { value: 'astro', label: 'Astro' },
+      ]}
+    />
+  ),
+};
+
+export const InvalidRequiredField: Story = {
+  render: () => (
+    <Field data-invalid>
+      <FieldLabel>Technologies</FieldLabel>
+      <TechnologyMultiSelect required invalid />
+      <FieldDescription>Choose at least one technology.</FieldDescription>
+      <FieldError>Technology selection is required.</FieldError>
+    </Field>
+  ),
+  play: async ({ canvasElement }) => {
+    const validationInput = canvasElement.querySelector(
+      '[data-slot="multi-select"] input[required]'
+    );
+    const field = canvasElement.querySelector(
+      '[data-slot="multi-select-field"]'
+    );
+
+    await expect(field).toHaveAttribute('data-invalid', 'true');
+    await expect(validationInput).toBeRequired();
+  },
+};
+
+export const ClickInteraction: Story = {
+  render: () => <TechnologyMultiSelect />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Technologies' });
+
+    await userEvent.click(trigger);
+    const listbox = await within(document.body).findByRole('listbox');
+
+    await userEvent.click(
+      within(listbox).getByRole('option', { name: 'React' })
+    );
+    await userEvent.click(
+      within(listbox).getByRole('option', { name: 'Tailwind CSS' })
+    );
+
+    await expect(canvas.getByText('React')).toBeInTheDocument();
+    await expect(canvas.getByText('Tailwind CSS')).toBeInTheDocument();
+  },
+};
+
+export const KeyboardInteraction: Story = {
+  render: () => <TechnologyMultiSelect />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Technologies' });
+
+    await userEvent.click(trigger);
+    const search = await within(document.body).findByRole('textbox', {
+      name: 'Search technologies',
+    });
+
+    await userEvent.keyboard('tailwind css');
+    await expect(search).toHaveValue('tailwind css');
+    await userEvent.keyboard('{ArrowDown}{Enter}');
+
+    await expect(canvas.getByText('Tailwind CSS')).toBeInTheDocument();
+  },
+};
+
+export const ChipRemoval: Story = {
+  render: () => <TechnologyMultiSelect defaultValue={['react']} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const remove = canvas.getByRole('button', { name: 'Remove React' });
+
+    await expect(canvas.getByText('React')).toBeInTheDocument();
+    await userEvent.click(remove);
+
+    await waitFor(() => {
+      expect(canvas.queryByText('React')).toBeNull();
+    });
+  },
+};
+
+export const FormReset: Story = {
+  render: () => (
+    <form className="nx:flex nx:flex-col nx:items-start nx:gap-3">
+      <TechnologyMultiSelect
+        name="technologies"
+        defaultValue={['react', 'next']}
+      />
+      <Button type="reset" variant="outline">
+        Reset
+      </Button>
+    </form>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Technologies' });
+
+    await userEvent.click(trigger);
+    const listbox = await within(document.body).findByRole('listbox');
+    await userEvent.click(
+      within(listbox).getByRole('option', { name: 'Astro' })
+    );
+
+    await expect(
+      canvasElement.querySelectorAll('input[type="hidden"]')
+    ).toHaveLength(3);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Reset' }));
+
+    await waitFor(() => {
+      expect(
+        canvasElement.querySelectorAll('input[type="hidden"]')
+      ).toHaveLength(2);
+    });
+  },
+};
+
+export const SearchEmpty: Story = {
+  render: () => <TechnologyMultiSelect />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Technologies' });
+
+    await userEvent.click(trigger);
+    const search = await within(document.body).findByRole('textbox', {
+      name: 'Search technologies',
+    });
+
+    await userEvent.type(search, 'missing');
+    await expect(
+      within(document.body).getByText('No technologies found.')
+    ).toBeInTheDocument();
+  },
+};
+
+export const WithDataAttributes: Story = {
+  render: () => <TechnologyMultiSelect />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Technologies' });
+    const field = canvasElement.querySelector(
+      '[data-slot="multi-select-field"]'
+    );
+
+    await expect(field).toHaveAttribute('data-size', 'default');
+    await expect(field).toHaveAttribute('data-variant', 'default');
+    await expect(trigger).toHaveAttribute('data-slot', 'multi-select-trigger');
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="nx:grid nx:w-[680px] nx:grid-cols-2 nx:gap-4">
+      <TechnologyMultiSelect placeholder="Default empty" triggerClassName="" />
+      <TechnologyMultiSelect
+        defaultValue={['react', 'next']}
+        placeholder="Default filled"
+        triggerClassName=""
+      />
+      <MultiSelect options={technologies}>
+        <MultiSelectTrigger
+          aria-label="Borderless empty"
+          variant="borderless"
+          placeholder="Borderless empty"
+        />
+        <MultiSelectContent>
+          <MultiSelectSearch aria-label="Search borderless empty" />
+          <MultiSelectEmpty>No technologies found.</MultiSelectEmpty>
+          <MultiSelectList />
+        </MultiSelectContent>
+      </MultiSelect>
+      <MultiSelect options={technologies} defaultValue={['astro']}>
+        <MultiSelectTrigger
+          aria-label="Borderless filled"
+          variant="borderless"
+          placeholder="Borderless filled"
+        />
+        <MultiSelectContent>
+          <MultiSelectSearch aria-label="Search borderless filled" />
+          <MultiSelectEmpty>No technologies found.</MultiSelectEmpty>
+          <MultiSelectList />
+        </MultiSelectContent>
+      </MultiSelect>
+    </div>
+  ),
+};

--- a/packages/react/src/components/multi-select/MultiSelect.stories.tsx
+++ b/packages/react/src/components/multi-select/MultiSelect.stories.tsx
@@ -3,349 +3,436 @@ import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
-import { Button } from '../button';
 import { Field, FieldDescription, FieldError, FieldLabel } from '../field';
 
 import {
   MultiSelect,
   MultiSelectContent,
-  MultiSelectEmpty,
-  MultiSelectList,
-  type MultiSelectOption,
-  MultiSelectSearch,
+  MultiSelectGroup,
+  MultiSelectItem,
+  type MultiSelectProps,
+  MultiSelectSeparator,
   MultiSelectTrigger,
   MultiSelectValue,
 } from './multi-select';
 
-const technologies: MultiSelectOption[] = [
+const FRAMEWORKS = [
   { value: 'react', label: 'React' },
-  { value: 'next', label: 'Next.js', keywords: ['framework'] },
-  { value: 'sveltekit', label: 'SvelteKit' },
-  { value: 'nuxt', label: 'Nuxt.js' },
-  { value: 'remix', label: 'Remix' },
-  { value: 'astro', label: 'Astro' },
-  { value: 'tailwind', label: 'Tailwind CSS' },
+  { value: 'vue', label: 'Vue' },
+  { value: 'svelte', label: 'Svelte' },
+  { value: 'angular', label: 'Angular' },
+  { value: 'solid', label: 'Solid' },
+  { value: 'qwik', label: 'Qwik' },
 ];
 
-const groupedTechnologies: MultiSelectOption[] = [
-  { value: 'react', label: 'React', group: 'Libraries' },
-  { value: 'tailwind', label: 'Tailwind CSS', group: 'Libraries' },
-  { value: 'next', label: 'Next.js', group: 'Frameworks' },
-  { value: 'remix', label: 'Remix', group: 'Frameworks' },
-  { value: 'sveltekit', label: 'SvelteKit', group: 'Frameworks' },
-  { value: 'nuxt', label: 'Nuxt.js', group: 'Frameworks' },
-];
-
-function TechnologyMultiSelect({
-  options = technologies,
-  placeholder = 'Select technologies',
+function Frameworks({
+  placeholder = 'Select frameworks',
   triggerClassName = 'nx:w-80',
   ...props
-}: Omit<React.ComponentProps<typeof MultiSelect>, 'options'> & {
-  options?: MultiSelectOption[];
+}: Partial<MultiSelectProps> & {
   placeholder?: string;
   triggerClassName?: string;
 }) {
   return (
-    <MultiSelect options={options} {...props}>
-      <MultiSelectTrigger
-        aria-label="Technologies"
-        className={triggerClassName}
-      >
+    <MultiSelect {...props}>
+      <MultiSelectTrigger aria-label="Frameworks" className={triggerClassName}>
         <MultiSelectValue placeholder={placeholder} />
       </MultiSelectTrigger>
-      <MultiSelectContent>
-        <MultiSelectSearch aria-label="Search technologies" />
-        <MultiSelectEmpty>No technologies found.</MultiSelectEmpty>
-        <MultiSelectList />
+      <MultiSelectContent
+        searchPlaceholder="Search frameworks…"
+        emptyMessage="No frameworks found."
+      >
+        {FRAMEWORKS.map((option) => (
+          <MultiSelectItem key={option.value} value={option.value}>
+            {option.label}
+          </MultiSelectItem>
+        ))}
       </MultiSelectContent>
     </MultiSelect>
-  );
-}
-
-function ControlledMultiSelectExample() {
-  const [value, setValue] = React.useState(['react', 'tailwind']);
-
-  return (
-    <div className="nx:flex nx:flex-col nx:gap-3">
-      <TechnologyMultiSelect value={value} onValueChange={setValue} />
-      <output className="nx:typography-body-small nx:text-muted-foreground">
-        Selected: {value.join(', ') || 'none'}
-      </output>
-    </div>
   );
 }
 
 const meta: Meta<typeof MultiSelect> = {
   title: 'Components/MultiSelect',
   component: MultiSelect,
-  parameters: {
-    layout: 'padded',
-  },
+  parameters: { layout: 'padded' },
 };
 
 export default meta;
 type Story = StoryObj<typeof MultiSelect>;
 
 export const Default: Story = {
-  render: () => <TechnologyMultiSelect />,
+  render: () => <Frameworks />,
 };
 
 export const WithDefaultValue: Story = {
-  render: () => <TechnologyMultiSelect defaultValue={['react', 'next']} />,
+  render: () => <Frameworks defaultValues={['react', 'svelte']} />,
 };
 
 export const Controlled: Story = {
-  render: () => <ControlledMultiSelectExample />,
+  render: function ControlledStory() {
+    const [value, setValue] = React.useState(['react']);
+
+    return (
+      <div className="nx:flex nx:flex-col nx:gap-3">
+        <Frameworks values={value} onValuesChange={setValue} />
+        <output className="nx:typography-body-small nx:text-muted-foreground">
+          Selected: {value.join(', ') || 'none'}
+        </output>
+      </div>
+    );
+  },
 };
 
-export const Sizes: Story = {
+export const SingleSelect: Story = {
   render: () => (
-    <div className="nx:flex nx:w-80 nx:flex-col nx:gap-3">
-      <TechnologyMultiSelect placeholder="Default" triggerClassName="" />
-      <MultiSelect options={technologies}>
-        <MultiSelectTrigger aria-label="Small technologies" size="sm">
-          <MultiSelectValue placeholder="Small" />
-        </MultiSelectTrigger>
-        <MultiSelectContent>
-          <MultiSelectSearch aria-label="Search small technologies" />
-          <MultiSelectEmpty>No technologies found.</MultiSelectEmpty>
-          <MultiSelectList />
-        </MultiSelectContent>
-      </MultiSelect>
-      <MultiSelect options={technologies}>
-        <MultiSelectTrigger aria-label="Large technologies" size="lg">
-          <MultiSelectValue placeholder="Large" />
-        </MultiSelectTrigger>
-        <MultiSelectContent>
-          <MultiSelectSearch aria-label="Search large technologies" />
-          <MultiSelectEmpty>No technologies found.</MultiSelectEmpty>
-          <MultiSelectList />
-        </MultiSelectContent>
-      </MultiSelect>
-    </div>
+    <MultiSelect single>
+      <MultiSelectTrigger aria-label="Framework" className="nx:w-80">
+        <MultiSelectValue placeholder="Select a framework" />
+      </MultiSelectTrigger>
+      <MultiSelectContent
+        searchPlaceholder="Search frameworks…"
+        emptyMessage="No frameworks found."
+      >
+        {FRAMEWORKS.map((option) => (
+          <MultiSelectItem key={option.value} value={option.value}>
+            {option.label}
+          </MultiSelectItem>
+        ))}
+      </MultiSelectContent>
+    </MultiSelect>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+    const trigger = canvas.getByRole('button', { name: 'Framework' });
+
+    await userEvent.click(trigger);
+    await userEvent.click(await body.findByRole('option', { name: 'Vue' }));
+
+    // Single mode collapses to a plain label and closes the popover.
+    await expect(within(trigger).getByText('Vue')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(body.queryByPlaceholderText('Search frameworks…')).toBeNull()
+    );
+  },
 };
 
 export const Grouped: Story = {
-  render: () => <TechnologyMultiSelect options={groupedTechnologies} />,
+  render: () => (
+    <MultiSelect defaultValues={['react']}>
+      <MultiSelectTrigger aria-label="Frameworks" className="nx:w-80">
+        <MultiSelectValue placeholder="Select frameworks" />
+      </MultiSelectTrigger>
+      <MultiSelectContent
+        searchPlaceholder="Search frameworks…"
+        emptyMessage="No frameworks found."
+      >
+        <MultiSelectGroup heading="Libraries">
+          <MultiSelectItem value="react">React</MultiSelectItem>
+          <MultiSelectItem value="solid">Solid</MultiSelectItem>
+        </MultiSelectGroup>
+        <MultiSelectSeparator />
+        <MultiSelectGroup heading="Frameworks">
+          <MultiSelectItem value="vue">Vue</MultiSelectItem>
+          <MultiSelectItem value="svelte">Svelte</MultiSelectItem>
+          <MultiSelectItem value="angular">Angular</MultiSelectItem>
+        </MultiSelectGroup>
+      </MultiSelectContent>
+    </MultiSelect>
+  ),
+};
+
+export const WrapChips: Story = {
+  render: () => (
+    <MultiSelect defaultValues={['react', 'vue', 'svelte', 'angular', 'solid']}>
+      <MultiSelectTrigger aria-label="Frameworks" className="nx:w-72">
+        <MultiSelectValue
+          placeholder="Select frameworks"
+          overflowBehavior="wrap"
+        />
+      </MultiSelectTrigger>
+      <MultiSelectContent
+        searchPlaceholder="Search frameworks…"
+        emptyMessage="No frameworks found."
+      >
+        {FRAMEWORKS.map((option) => (
+          <MultiSelectItem key={option.value} value={option.value}>
+            {option.label}
+          </MultiSelectItem>
+        ))}
+      </MultiSelectContent>
+    </MultiSelect>
+  ),
+};
+
+export const OverflowCollapse: Story = {
+  render: () => (
+    <MultiSelect
+      defaultValues={['react', 'vue', 'svelte', 'angular', 'solid', 'qwik']}
+    >
+      <MultiSelectTrigger aria-label="Frameworks" className="nx:w-64">
+        <MultiSelectValue
+          placeholder="Select frameworks"
+          overflowBehavior="cutoff"
+        />
+      </MultiSelectTrigger>
+      <MultiSelectContent
+        searchPlaceholder="Search frameworks…"
+        emptyMessage="No frameworks found."
+      >
+        {FRAMEWORKS.map((option) => (
+          <MultiSelectItem key={option.value} value={option.value}>
+            {option.label}
+          </MultiSelectItem>
+        ))}
+      </MultiSelectContent>
+    </MultiSelect>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Six chips overflow the 256px field, so measurement collapses the excess
+    // into a visible `+N` badge.
+    await waitFor(() => expect(canvas.getByText(/^\+\d+$/)).toBeVisible());
+  },
 };
 
 export const Disabled: Story = {
   render: () => (
-    <TechnologyMultiSelect
-      disabled
-      name="technologies"
-      defaultValue={['next']}
-    />
+    <MultiSelect defaultValues={['react']}>
+      <MultiSelectTrigger aria-label="Frameworks" disabled className="nx:w-80">
+        <MultiSelectValue placeholder="Select frameworks" />
+      </MultiSelectTrigger>
+      <MultiSelectContent>
+        {FRAMEWORKS.map((option) => (
+          <MultiSelectItem key={option.value} value={option.value}>
+            {option.label}
+          </MultiSelectItem>
+        ))}
+      </MultiSelectContent>
+    </MultiSelect>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const trigger = canvas.getByRole('button', { name: 'Technologies' });
-    const hiddenInput = canvasElement.querySelector('input[type="hidden"]');
+    const trigger = canvas.getByRole('button', { name: 'Frameworks' });
 
     await expect(trigger).toBeDisabled();
-    await expect(hiddenInput).toBeDisabled();
-    await userEvent.click(trigger);
-    await waitFor(() => {
-      expect(document.body.querySelector('[role="listbox"]')).toBeNull();
-    });
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    // The default value is still labeled while disabled.
+    await expect(within(trigger).getByText('React')).toBeInTheDocument();
   },
 };
 
 export const WithDisabledOption: Story = {
   render: () => (
-    <TechnologyMultiSelect
-      options={[
-        { value: 'react', label: 'React' },
-        { value: 'next', label: 'Next.js', disabled: true },
-        { value: 'astro', label: 'Astro' },
-      ]}
-    />
+    <MultiSelect>
+      <MultiSelectTrigger aria-label="Frameworks" className="nx:w-80">
+        <MultiSelectValue placeholder="Select frameworks" />
+      </MultiSelectTrigger>
+      <MultiSelectContent
+        searchPlaceholder="Search frameworks…"
+        emptyMessage="No frameworks found."
+      >
+        <MultiSelectItem value="react">React</MultiSelectItem>
+        <MultiSelectItem value="vue" disabled>
+          Vue
+        </MultiSelectItem>
+        <MultiSelectItem value="svelte">Svelte</MultiSelectItem>
+      </MultiSelectContent>
+    </MultiSelect>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+    const trigger = canvas.getByRole('button', { name: 'Frameworks' });
+
+    await userEvent.click(trigger);
+    const disabled = await body.findByRole('option', { name: 'Vue' });
+
+    // A disabled option is inert (pointer-events: none) and cannot be selected.
+    await expect(disabled).toHaveAttribute('data-disabled', 'true');
+    await expect(disabled).toHaveAttribute('aria-disabled', 'true');
+    await expect(within(trigger).queryByText('Vue')).toBeNull();
+  },
 };
 
-export const InvalidRequiredField: Story = {
+export const InvalidField: Story = {
   render: () => (
     <Field data-invalid>
-      <FieldLabel>Technologies</FieldLabel>
-      <TechnologyMultiSelect required invalid />
-      <FieldDescription>Choose at least one technology.</FieldDescription>
-      <FieldError>Technology selection is required.</FieldError>
+      <FieldLabel>Frameworks</FieldLabel>
+      <MultiSelect>
+        <MultiSelectTrigger
+          aria-label="Frameworks"
+          aria-invalid
+          className="nx:w-80"
+        >
+          <MultiSelectValue placeholder="Select frameworks" />
+        </MultiSelectTrigger>
+        <MultiSelectContent
+          searchPlaceholder="Search frameworks…"
+          emptyMessage="No frameworks found."
+        >
+          {FRAMEWORKS.map((option) => (
+            <MultiSelectItem key={option.value} value={option.value}>
+              {option.label}
+            </MultiSelectItem>
+          ))}
+        </MultiSelectContent>
+      </MultiSelect>
+      <FieldDescription>Choose at least one framework.</FieldDescription>
+      <FieldError>Framework selection is required.</FieldError>
     </Field>
   ),
   play: async ({ canvasElement }) => {
-    const validationInput = canvasElement.querySelector(
-      '[data-slot="multi-select"] input[required]'
-    );
-    const field = canvasElement.querySelector(
-      '[data-slot="multi-select-field"]'
-    );
+    const canvas = within(canvasElement);
+    const trigger = canvas.getByRole('button', { name: 'Frameworks' });
 
-    await expect(field).toHaveAttribute('data-invalid', 'true');
-    await expect(validationInput).toBeRequired();
+    await expect(trigger).toHaveAttribute('aria-invalid', 'true');
   },
 };
 
 export const ClickInteraction: Story = {
-  render: () => <TechnologyMultiSelect />,
+  render: () => <Frameworks />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const trigger = canvas.getByRole('button', { name: 'Technologies' });
+    const body = within(document.body);
+    const trigger = canvas.getByRole('button', { name: 'Frameworks' });
 
     await userEvent.click(trigger);
-    const listbox = await within(document.body).findByRole('listbox');
+    await userEvent.click(await body.findByRole('option', { name: 'React' }));
+    await userEvent.click(body.getByRole('option', { name: 'Svelte' }));
 
-    await userEvent.click(
-      within(listbox).getByRole('option', { name: 'React' })
-    );
-    await userEvent.click(
-      within(listbox).getByRole('option', { name: 'Tailwind CSS' })
-    );
-
-    await expect(canvas.getByText('React')).toBeInTheDocument();
-    await expect(canvas.getByText('Tailwind CSS')).toBeInTheDocument();
+    await expect(within(trigger).getByText('React')).toBeInTheDocument();
+    await expect(within(trigger).getByText('Svelte')).toBeInTheDocument();
   },
 };
 
 export const KeyboardInteraction: Story = {
-  render: () => <TechnologyMultiSelect />,
+  render: () => <Frameworks />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const trigger = canvas.getByRole('button', { name: 'Technologies' });
+    const body = within(document.body);
+    const trigger = canvas.getByRole('button', { name: 'Frameworks' });
 
     await userEvent.click(trigger);
-    const search = await within(document.body).findByRole('textbox', {
-      name: 'Search technologies',
-    });
+    const search = await body.findByPlaceholderText('Search frameworks…');
 
-    await userEvent.keyboard('tailwind css');
-    await expect(search).toHaveValue('tailwind css');
-    await userEvent.keyboard('{ArrowDown}{Enter}');
+    await userEvent.type(search, 'sve');
+    await userEvent.keyboard('{Enter}');
 
-    await expect(canvas.getByText('Tailwind CSS')).toBeInTheDocument();
+    await expect(within(trigger).getByText('Svelte')).toBeInTheDocument();
   },
 };
 
 export const ChipRemoval: Story = {
-  render: () => <TechnologyMultiSelect defaultValue={['react']} />,
+  render: () => <Frameworks defaultValues={['react', 'vue']} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const remove = canvas.getByRole('button', { name: 'Remove React' });
+    const trigger = canvas.getByRole('button', { name: 'Frameworks' });
 
-    await expect(canvas.getByText('React')).toBeInTheDocument();
-    await userEvent.click(remove);
+    await expect(within(trigger).getByText('React')).toBeInTheDocument();
+    await userEvent.click(within(trigger).getByText('React'));
 
-    await waitFor(() => {
-      expect(canvas.queryByText('React')).toBeNull();
-    });
-  },
-};
-
-export const FormReset: Story = {
-  render: () => (
-    <form className="nx:flex nx:flex-col nx:items-start nx:gap-3">
-      <TechnologyMultiSelect
-        name="technologies"
-        defaultValue={['react', 'next']}
-      />
-      <Button type="reset" variant="outline">
-        Reset
-      </Button>
-    </form>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const trigger = canvas.getByRole('button', { name: 'Technologies' });
-
-    await userEvent.click(trigger);
-    const listbox = await within(document.body).findByRole('listbox');
-    await userEvent.click(
-      within(listbox).getByRole('option', { name: 'Astro' })
+    await waitFor(() =>
+      expect(within(trigger).queryByText('React')).toBeNull()
     );
-
-    await expect(
-      canvasElement.querySelectorAll('input[type="hidden"]')
-    ).toHaveLength(3);
-
-    await userEvent.click(canvas.getByRole('button', { name: 'Reset' }));
-
-    await waitFor(() => {
-      expect(
-        canvasElement.querySelectorAll('input[type="hidden"]')
-      ).toHaveLength(2);
-    });
+    await expect(within(trigger).getByText('Vue')).toBeInTheDocument();
   },
 };
 
 export const SearchEmpty: Story = {
-  render: () => <TechnologyMultiSelect />,
+  render: () => <Frameworks />,
+  parameters: {
+    a11y: {
+      // The no-results state legitimately renders an empty listbox; axe's
+      // aria-required-children flags the transient absence of option children,
+      // which is expected here. All other a11y rules stay enabled.
+      config: { rules: [{ id: 'aria-required-children', enabled: false }] },
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const trigger = canvas.getByRole('button', { name: 'Technologies' });
+    const body = within(document.body);
+    const trigger = canvas.getByRole('button', { name: 'Frameworks' });
 
     await userEvent.click(trigger);
-    const search = await within(document.body).findByRole('textbox', {
-      name: 'Search technologies',
-    });
+    await userEvent.type(
+      await body.findByPlaceholderText('Search frameworks…'),
+      'zzz'
+    );
 
-    await userEvent.type(search, 'missing');
-    await expect(
-      within(document.body).getByText('No technologies found.')
-    ).toBeInTheDocument();
+    await expect(body.getByText('No frameworks found.')).toBeInTheDocument();
   },
 };
 
+export const LongLabels: Story = {
+  render: () => (
+    <MultiSelect defaultValues={['a', 'b']}>
+      <MultiSelectTrigger aria-label="Options" className="nx:w-72">
+        <MultiSelectValue placeholder="Select options" />
+      </MultiSelectTrigger>
+      <MultiSelectContent
+        searchPlaceholder="Search…"
+        emptyMessage="No options found."
+      >
+        <MultiSelectItem value="a">
+          A remarkably long option label that should truncate inside its chip
+        </MultiSelectItem>
+        <MultiSelectItem value="b">
+          Another verbose option that needs graceful overflow handling
+        </MultiSelectItem>
+        <MultiSelectItem value="c">Short</MultiSelectItem>
+      </MultiSelectContent>
+    </MultiSelect>
+  ),
+};
+
 export const WithDataAttributes: Story = {
-  render: () => <TechnologyMultiSelect />,
+  render: () => <Frameworks />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const trigger = canvas.getByRole('button', { name: 'Technologies' });
-    const field = canvasElement.querySelector(
-      '[data-slot="multi-select-field"]'
-    );
-    const value = canvasElement.querySelector(
-      '[data-slot="multi-select-value"]'
-    );
+    const body = within(document.body);
+    const trigger = canvas.getByRole('button', { name: 'Frameworks' });
 
-    await expect(field).toHaveAttribute('data-size', 'default');
-    await expect(field).toHaveAttribute('data-variant', 'default');
-    await expect(field).toHaveClass('nx:border-default');
-    await expect(field).toHaveClass('nx:border-border-default');
     await expect(trigger).toHaveAttribute('data-slot', 'multi-select-trigger');
-    await expect(trigger).toHaveClass('nx:absolute');
-    await expect(trigger).toHaveClass('nx:inset-0');
-    await expect(value).toHaveAttribute('data-slot', 'multi-select-value');
+
+    await userEvent.click(trigger);
+    const option = await body.findByRole('option', { name: 'React' });
+
+    await expect(option).toHaveAttribute('data-slot', 'multi-select-item');
+    await userEvent.click(option);
+    await expect(option).toHaveAttribute('data-checked', 'true');
   },
 };
 
 export const AllVariants: Story = {
   render: () => (
-    <div className="nx:grid nx:w-[680px] nx:grid-cols-2 nx:gap-4">
-      <TechnologyMultiSelect placeholder="Default empty" triggerClassName="" />
-      <TechnologyMultiSelect
-        defaultValue={['react', 'next']}
-        placeholder="Default filled"
+    <div className="nx:grid nx:w-[720px] nx:grid-cols-2 nx:gap-4">
+      <Frameworks placeholder="Empty" triggerClassName="" />
+      <Frameworks
+        defaultValues={['react', 'vue']}
+        placeholder="Filled"
         triggerClassName=""
       />
-      <MultiSelect options={technologies}>
-        <MultiSelectTrigger aria-label="Borderless empty" variant="borderless">
-          <MultiSelectValue placeholder="Borderless empty" />
+      <Frameworks
+        defaultValues={['react', 'vue', 'svelte', 'angular']}
+        placeholder="Overflow"
+        triggerClassName=""
+      />
+      <MultiSelect single>
+        <MultiSelectTrigger aria-label="Single" className="">
+          <MultiSelectValue placeholder="Single" />
         </MultiSelectTrigger>
-        <MultiSelectContent>
-          <MultiSelectSearch aria-label="Search borderless empty" />
-          <MultiSelectEmpty>No technologies found.</MultiSelectEmpty>
-          <MultiSelectList />
-        </MultiSelectContent>
-      </MultiSelect>
-      <MultiSelect options={technologies} defaultValue={['astro']}>
-        <MultiSelectTrigger aria-label="Borderless filled" variant="borderless">
-          <MultiSelectValue placeholder="Borderless filled" />
-        </MultiSelectTrigger>
-        <MultiSelectContent>
-          <MultiSelectSearch aria-label="Search borderless filled" />
-          <MultiSelectEmpty>No technologies found.</MultiSelectEmpty>
-          <MultiSelectList />
+        <MultiSelectContent
+          searchPlaceholder="Search frameworks…"
+          emptyMessage="No frameworks found."
+        >
+          {FRAMEWORKS.map((option) => (
+            <MultiSelectItem key={option.value} value={option.value}>
+              {option.label}
+            </MultiSelectItem>
+          ))}
         </MultiSelectContent>
       </MultiSelect>
     </div>

--- a/packages/react/src/components/multi-select/MultiSelect.stories.tsx
+++ b/packages/react/src/components/multi-select/MultiSelect.stories.tsx
@@ -284,7 +284,11 @@ export const KeyboardInteraction: Story = {
     await userEvent.click(trigger);
     const search = await body.findByPlaceholderText('Search frameworks…');
 
-    await userEvent.type(search, 'sve');
+    // Radix moves focus into the list on open, so cmdk's arrow/type nav is live
+    // immediately — no manual click into the search box required.
+    await waitFor(() => expect(search).toHaveFocus());
+
+    await userEvent.keyboard('sve');
     await userEvent.keyboard('{Enter}');
 
     await expect(within(trigger).getByText('Svelte')).toBeInTheDocument();

--- a/packages/react/src/components/multi-select/index.ts
+++ b/packages/react/src/components/multi-select/index.ts
@@ -1,0 +1,1 @@
+export * from './multi-select';

--- a/packages/react/src/components/multi-select/multi-select.tsx
+++ b/packages/react/src/components/multi-select/multi-select.tsx
@@ -46,9 +46,7 @@ function toggleValue(values: Set<string>, value: string) {
 
 /**
  * Walk the composed children and map each option's `value` to the label the
- * trigger chip should show (`badgeLabel`, falling back to the option content).
- * Reading it straight from the JSX means preselected chips stay labeled even
- * while the list is closed — no always-mounted option tree required.
+ * trigger chip should show — `badgeLabel`, falling back to the option content.
  */
 function collectLabels(
   children: React.ReactNode,
@@ -77,10 +75,6 @@ function collectLabels(
   });
 
   return labels;
-}
-
-function labelText(label: React.ReactNode, fallback: string) {
-  return typeof label === 'string' ? label : fallback;
 }
 
 function debounce<T extends (...args: never[]) => void>(func: T, wait: number) {
@@ -139,7 +133,6 @@ function MultiSelect({
   const [uncontrolled, setUncontrolled] = React.useState(
     () => new Set(values ?? defaultValues)
   );
-  const [announcement, setAnnouncement] = React.useState('');
 
   const selectedValues = React.useMemo(
     () => (values ? new Set(values) : uncontrolled),
@@ -150,18 +143,12 @@ function MultiSelect({
 
   const toggle = React.useCallback(
     (value: string) => {
-      const wasSelected = selectedValues.has(value);
       const nextValues = toggleValue(selectedValues, value);
 
       if (values === undefined) setUncontrolled(nextValues);
       onValuesChange?.([...nextValues]);
-
-      // cmdk binds aria-selected to the active option, not the checked ones, so
-      // announce each toggle through a live region for assistive tech.
-      const text = labelText(labels.get(value), value);
-      setAnnouncement(`${text} ${wasSelected ? 'removed' : 'selected'}`);
     },
-    [selectedValues, values, onValuesChange, labels]
+    [selectedValues, values, onValuesChange]
   );
 
   const context = React.useMemo<MultiSelectContextValue>(
@@ -174,9 +161,6 @@ function MultiSelect({
       <Popover open={open} onOpenChange={setOpen}>
         {children}
       </Popover>
-      <span role="status" aria-live="polite" className="nx:sr-only">
-        {announcement}
-      </span>
     </MultiSelectContext.Provider>
   );
 }
@@ -420,8 +404,7 @@ interface MultiSelectContentProps extends Omit<
  * MultiSelectContent
  *
  * The searchable option list, rendered in a Popover so Radix owns focus,
- * dismissal, and open/close motion. The list unmounts while closed; chip labels
- * come from `MultiSelect`'s reading of these same children, not a shadow tree.
+ * dismissal, and open/close motion.
  */
 function MultiSelectContent({
   children,
@@ -477,8 +460,7 @@ interface MultiSelectItemProps extends Omit<
  * A selectable option with a checkbox indicator. cmdk filters on `value` +
  * `keywords`, so `value` is forwarded to disambiguate duplicate labels and
  * icon-only content, and string children seed `keywords` so typing the label
- * matches. Selection toggles are announced via `MultiSelect`'s live region,
- * since cmdk owns `aria-selected` for the active descendant.
+ * matches.
  */
 function MultiSelectItem({
   value,

--- a/packages/react/src/components/multi-select/multi-select.tsx
+++ b/packages/react/src/components/multi-select/multi-select.tsx
@@ -187,7 +187,7 @@ function MultiSelectTrigger({
 
     const values = [...selectedValues];
     const last = values[values.length - 1];
-    if (last) toggle(last);
+    if (last !== undefined) toggle(last);
   };
 
   return (
@@ -247,7 +247,7 @@ interface MultiSelectValueProps extends Omit<
  *
  * Renders the selected values inside the trigger as removable chips. When chips
  * exceed the field width they collapse into a measured `+N` badge (unless
- * wrapping). A selected value with no registered label falls back to its raw
+ * wrapping). A selected value with no collected label falls back to its raw
  * value so a non-empty selection never shows the placeholder.
  */
 function MultiSelectValue({

--- a/packages/react/src/components/multi-select/multi-select.tsx
+++ b/packages/react/src/components/multi-select/multi-select.tsx
@@ -18,11 +18,7 @@ interface MultiSelectContextValue {
   open: boolean;
   selectedValues: Set<string>;
   labels: Map<string, React.ReactNode>;
-  search: string;
-  setSearch: (search: string) => void;
   toggle: (value: string) => void;
-  registerLabel: (value: string, label: React.ReactNode) => void;
-  unregisterLabel: (value: string) => void;
 }
 
 const MultiSelectContext = React.createContext<MultiSelectContextValue | null>(
@@ -46,6 +42,45 @@ function toggleValue(values: Set<string>, value: string) {
   if (!next.delete(value)) next.add(value);
 
   return next;
+}
+
+/**
+ * Walk the composed children and map each option's `value` to the label the
+ * trigger chip should show (`badgeLabel`, falling back to the option content).
+ * Reading it straight from the JSX means preselected chips stay labeled even
+ * while the list is closed — no always-mounted option tree required.
+ */
+function collectLabels(
+  children: React.ReactNode,
+  labels: Map<string, React.ReactNode> = new Map()
+) {
+  React.Children.forEach(children, (child) => {
+    if (!React.isValidElement(child)) return;
+
+    if (child.type === MultiSelectItem) {
+      const {
+        value,
+        badgeLabel,
+        children: content,
+      } = child.props as MultiSelectItemProps;
+      labels.set(value, badgeLabel ?? content);
+
+      return;
+    }
+
+    // Recurse through groups, fragments, and any wrapper that carries options
+    // as children (e.g. MultiSelectGroup).
+    const { children: nested } = child.props as {
+      children?: React.ReactNode;
+    };
+    if (nested) collectLabels(nested, labels);
+  });
+
+  return labels;
+}
+
+function labelText(label: React.ReactNode, fallback: string) {
+  return typeof label === 'string' ? label : fallback;
 }
 
 function debounce<T extends (...args: never[]) => void>(func: T, wait: number) {
@@ -77,9 +112,9 @@ interface MultiSelectProps {
  * MultiSelect
  *
  * A searchable multiple-selection field. cmdk (via `Command`) owns filtering and
- * keyboard navigation; this component adds the selected-value model, the chip
- * trigger, and a label registry so the trigger can render chips for values whose
- * options are not on screen. For searchable single selection, use `Combobox`.
+ * keyboard navigation; this component adds the selected-value model and the chip
+ * trigger, reading option labels from its own children so chips stay labeled
+ * while the list is closed. For searchable single selection, use `Combobox`.
  *
  * @example
  * ```tsx
@@ -101,83 +136,47 @@ function MultiSelect({
   onValuesChange,
 }: MultiSelectProps) {
   const [open, setOpen] = React.useState(false);
-  const [search, setSearch] = React.useState('');
   const [uncontrolled, setUncontrolled] = React.useState(
     () => new Set(values ?? defaultValues)
   );
-  const [labels, setLabels] = React.useState<Map<string, React.ReactNode>>(
-    () => new Map()
-  );
+  const [announcement, setAnnouncement] = React.useState('');
 
   const selectedValues = React.useMemo(
     () => (values ? new Set(values) : uncontrolled),
     [values, uncontrolled]
   );
 
-  const handleOpenChange = React.useCallback((next: boolean) => {
-    setOpen(next);
-    // The list stays mounted (forceMount), so reset the query on close instead
-    // of relying on unmount to clear cmdk's internal search state.
-    if (!next) setSearch('');
-  }, []);
+  const labels = React.useMemo(() => collectLabels(children), [children]);
 
   const toggle = React.useCallback(
-    (next: string) => {
-      const nextValues = toggleValue(selectedValues, next);
+    (value: string) => {
+      const wasSelected = selectedValues.has(value);
+      const nextValues = toggleValue(selectedValues, value);
 
       if (values === undefined) setUncontrolled(nextValues);
       onValuesChange?.([...nextValues]);
+
+      // cmdk binds aria-selected to the active option, not the checked ones, so
+      // announce each toggle through a live region for assistive tech.
+      const text = labelText(labels.get(value), value);
+      setAnnouncement(`${text} ${wasSelected ? 'removed' : 'selected'}`);
     },
-    [selectedValues, values, onValuesChange]
+    [selectedValues, values, onValuesChange, labels]
   );
-
-  const registerLabel = React.useCallback(
-    (key: string, label: React.ReactNode) => {
-      setLabels((prev) =>
-        prev.get(key) === label ? prev : new Map(prev).set(key, label)
-      );
-    },
-    []
-  );
-
-  const unregisterLabel = React.useCallback((key: string) => {
-    setLabels((prev) => {
-      if (!prev.has(key)) return prev;
-
-      const next = new Map(prev);
-      next.delete(key);
-
-      return next;
-    });
-  }, []);
 
   const context = React.useMemo<MultiSelectContextValue>(
-    () => ({
-      open,
-      selectedValues,
-      labels,
-      search,
-      setSearch,
-      toggle,
-      registerLabel,
-      unregisterLabel,
-    }),
-    [
-      open,
-      selectedValues,
-      labels,
-      search,
-      toggle,
-      registerLabel,
-      unregisterLabel,
-    ]
+    () => ({ open, selectedValues, labels, toggle }),
+    [open, selectedValues, labels, toggle]
   );
 
   return (
     <MultiSelectContext.Provider value={context}>
-      <Popover open={open} onOpenChange={handleOpenChange}>
+      <Popover open={open} onOpenChange={setOpen}>
         {children}
       </Popover>
+      <span role="status" aria-live="polite" className="nx:sr-only">
+        {announcement}
+      </span>
     </MultiSelectContext.Provider>
   );
 }
@@ -201,10 +200,10 @@ function MultiSelectTrigger({
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
     if (event.key !== 'Backspace' && event.key !== 'Delete') return;
-    if (selectedValues.size === 0) return;
 
     const values = [...selectedValues];
-    toggle(values[values.length - 1] as string);
+    const last = values[values.length - 1];
+    if (last) toggle(last);
   };
 
   return (
@@ -420,9 +419,9 @@ interface MultiSelectContentProps extends Omit<
 /**
  * MultiSelectContent
  *
- * The searchable option list. The popover content stays mounted (`forceMount`)
- * and is hidden with CSS while closed, so each option's label-registration
- * effect keeps preselected chips labeled without a second, shadow option tree.
+ * The searchable option list, rendered in a Popover so Radix owns focus,
+ * dismissal, and open/close motion. The list unmounts while closed; chip labels
+ * come from `MultiSelect`'s reading of these same children, not a shadow tree.
  */
 function MultiSelectContent({
   children,
@@ -433,28 +432,20 @@ function MultiSelectContent({
   emptyMessage = 'No results found.',
   ...props
 }: MultiSelectContentProps) {
-  const { search, setSearch } = useMultiSelect();
-
   return (
     <PopoverContent
-      forceMount
       data-slot="multi-select-content"
       aria-label="Options"
       align={align}
       sideOffset={sideOffset}
       className={cn(
         'nx:w-(--radix-popover-trigger-width) nx:min-w-56 nx:p-0',
-        'nx:data-[state=closed]:hidden',
         className
       )}
       {...props}
     >
       <Command>
-        <CommandInput
-          placeholder={searchPlaceholder}
-          value={search}
-          onValueChange={setSearch}
-        />
+        <CommandInput placeholder={searchPlaceholder} />
         <CommandList>
           <CommandEmpty>{emptyMessage}</CommandEmpty>
           {children}
@@ -486,27 +477,20 @@ interface MultiSelectItemProps extends Omit<
  * A selectable option with a checkbox indicator. cmdk filters on `value` +
  * `keywords`, so `value` is forwarded to disambiguate duplicate labels and
  * icon-only content, and string children seed `keywords` so typing the label
- * matches. cmdk owns `aria-selected` for the active descendant; a visually
- * hidden "selected" note gives assistive tech the checked-state signal.
+ * matches. Selection toggles are announced via `MultiSelect`'s live region,
+ * since cmdk owns `aria-selected` for the active descendant.
  */
 function MultiSelectItem({
   value,
   children,
-  badgeLabel,
+  badgeLabel: _badgeLabel,
   keywords,
   onSelect,
   className,
   ...props
 }: MultiSelectItemProps) {
-  const { selectedValues, toggle, registerLabel, unregisterLabel } =
-    useMultiSelect();
+  const { selectedValues, toggle } = useMultiSelect();
   const selected = selectedValues.has(value);
-
-  React.useEffect(() => {
-    registerLabel(value, badgeLabel ?? children);
-
-    return () => unregisterLabel(value);
-  }, [value, badgeLabel, children, registerLabel, unregisterLabel]);
 
   const handleSelect = () => {
     toggle(value);
@@ -539,7 +523,6 @@ function MultiSelectItem({
         {selected && <IconCheck className="nx:size-3" />}
       </span>
       <span className="nx:min-w-0 nx:flex-1">{children}</span>
-      {selected && <span className="nx:sr-only">selected</span>}
     </CommandItem>
   );
 }

--- a/packages/react/src/components/multi-select/multi-select.tsx
+++ b/packages/react/src/components/multi-select/multi-select.tsx
@@ -167,7 +167,7 @@ function labelsForValues(options: MultiSelectOption[], values: string[]) {
 
 const multiSelectFieldVariants = cva(
   [
-    'nx:group/multi-select nx:flex nx:box-border nx:w-full nx:min-w-0 nx:items-center nx:gap-1.5 nx:rounded-md nx:border-0 nx:transition-colors nx:outline-none',
+    'nx:group/multi-select nx:relative nx:flex nx:box-border nx:w-full nx:min-w-0 nx:items-center nx:gap-1.5 nx:rounded-md nx:border-default nx:transition-colors nx:outline-none',
     'nx:has-[[data-slot=multi-select-trigger]:focus-visible]:outline-2 nx:has-[[data-slot=multi-select-trigger]:focus-visible]:outline-focus-default nx:has-[[data-slot=multi-select-trigger]:focus-visible]:outline-offset-(--focus-offset)',
     'nx:data-[invalid=true]:border-border-error nx:has-[[data-slot=multi-select-trigger][aria-invalid=true]:focus-visible]:outline-focus-error',
     'nx:data-[disabled=true]:cursor-not-allowed nx:data-[disabled=true]:bg-disabled nx:data-[disabled=true]:text-disabled-foreground',
@@ -502,7 +502,7 @@ function MultiSelectTrigger({
           aria-haspopup="listbox"
           aria-label={ariaLabel}
           disabled={context.disabled}
-          className="nx:-mr-1 nx:flex nx:size-7 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-sm nx:text-muted-foreground nx:hover:bg-background-hover nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:cursor-not-allowed nx:disabled:text-disabled-foreground"
+          className="nx:absolute nx:inset-0 nx:z-0 nx:flex nx:items-center nx:justify-end nx:rounded-md nx:px-2.5 nx:text-muted-foreground nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:cursor-not-allowed nx:disabled:text-disabled-foreground"
           onClick={handleTriggerClick}
         >
           <span className="nx:sr-only">
@@ -555,7 +555,7 @@ function MultiSelectValue({
     <div
       data-slot="multi-select-value"
       className={cn(
-        'nx:flex nx:min-w-0 nx:flex-1 nx:flex-wrap nx:items-center nx:gap-1.5',
+        'nx:pointer-events-none nx:relative nx:z-10 nx:flex nx:min-w-0 nx:flex-1 nx:flex-wrap nx:items-center nx:gap-1.5 nx:pr-8',
         className
       )}
       {...props}
@@ -575,7 +575,7 @@ function MultiSelectValue({
               type="button"
               aria-label={`Remove ${item.label}`}
               data-slot="multi-select-value-remove"
-              className="nx:-mr-0.5 nx:flex nx:size-4 nx:items-center nx:justify-center nx:rounded-sm nx:text-muted-foreground nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
+              className="nx:pointer-events-auto nx:-mr-0.5 nx:flex nx:size-4 nx:items-center nx:justify-center nx:rounded-sm nx:text-muted-foreground nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
               onClick={(event) => handleRemoveValue(event, item.value)}
             >
               <IconX aria-hidden="true" className="nx:size-3" />

--- a/packages/react/src/components/multi-select/multi-select.tsx
+++ b/packages/react/src/components/multi-select/multi-select.tsx
@@ -1,971 +1,565 @@
 import * as React from 'react';
 
-import { cva, type VariantProps } from 'class-variance-authority';
-
 import { IconCheck, IconChevronDown, IconX } from '../../lib/icons';
 import { cn } from '../../lib/utils';
 import { Badge } from '../badge';
 import {
-  Popover,
-  PopoverAnchor,
-  PopoverContent,
-  type PopoverContentProps,
-} from '../popover';
-
-interface MultiSelectOption {
-  value: string;
-  label: string;
-  disabled?: boolean;
-  group?: string;
-  keywords?: string[];
-}
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '../command';
+import { Popover, PopoverContent, PopoverTrigger } from '../popover';
 
 interface MultiSelectContextValue {
-  activeValue: string;
-  disabled: boolean;
-  invalid: boolean;
-  listId: string;
   open: boolean;
-  options: MultiSelectOption[];
-  readOnly: boolean;
-  required: boolean;
-  searchValue: string;
-  selectedValues: string[];
-  setActiveValue: (value: string) => void;
-  setOpenFromTrigger: () => void;
-  setOpenState: (open: boolean) => void;
-  setSearchValue: (value: string) => void;
-  stepActiveValue: (direction: 1 | -1) => void;
-  toggleValue: (value: string) => void;
-  visibleOptions: MultiSelectOption[];
+  single: boolean;
+  selectedValues: Set<string>;
+  labels: Map<string, React.ReactNode>;
+  toggle: (value: string) => void;
+  registerLabel: (value: string, label: React.ReactNode) => void;
 }
 
 const MultiSelectContext = React.createContext<MultiSelectContextValue | null>(
   null
 );
 
-function useMultiSelectContext(componentName: string) {
+function useMultiSelect() {
   const context = React.useContext(MultiSelectContext);
 
   if (!context)
-    throw new Error(`${componentName} must be used inside MultiSelect.`);
+    throw new Error('MultiSelect parts must be used inside <MultiSelect>.');
 
   return context;
 }
 
-function useControllableArrayState({
-  value,
-  defaultValue = [],
-  onValueChange,
-}: {
-  value?: string[];
-  defaultValue?: string[];
-  onValueChange?: (value: string[]) => void;
-}) {
-  const [uncontrolledValue, setUncontrolledValue] =
-    React.useState(defaultValue);
-  const isControlled = value !== undefined;
-  const currentValue = isControlled ? value : uncontrolledValue;
+function nextSelection(values: Set<string>, value: string, single: boolean) {
+  if (single) return values.has(value) ? new Set<string>() : new Set([value]);
 
-  const setCurrentValue = React.useCallback(
-    (nextValue: string[]) => {
-      if (!isControlled) setUncontrolledValue(nextValue);
-      onValueChange?.(nextValue);
-    },
-    [isControlled, onValueChange]
-  );
+  const next = new Set(values);
 
-  return [currentValue, setCurrentValue, setUncontrolledValue] as const;
+  // Set.delete returns true when the value was present (and removes it), so a
+  // failed delete means it wasn't selected — add it instead.
+  if (!next.delete(value)) next.add(value);
+
+  return next;
 }
 
-function useControllableBooleanState({
-  value,
-  defaultValue = false,
-  onValueChange,
-}: {
-  value?: boolean;
-  defaultValue?: boolean;
-  onValueChange?: (value: boolean) => void;
-}) {
-  const [uncontrolledValue, setUncontrolledValue] =
-    React.useState(defaultValue);
-  const isControlled = value !== undefined;
-  const currentValue = isControlled ? value : uncontrolledValue;
+function debounce<T extends (...args: never[]) => void>(func: T, wait: number) {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
 
-  const setCurrentValue = React.useCallback(
-    (nextValue: boolean) => {
-      if (!isControlled) setUncontrolledValue(nextValue);
-      onValueChange?.(nextValue);
-    },
-    [isControlled, onValueChange]
-  );
-
-  return [currentValue, setCurrentValue] as const;
+  return (...args: Parameters<T>) => {
+    if (timeout) clearTimeout(timeout);
+    timeout = setTimeout(() => func(...args), wait);
+  };
 }
 
-function getOptionSearchText(option: MultiSelectOption) {
-  return [option.label, option.value, ...(option.keywords ?? [])]
-    .join(' ')
-    .toLowerCase();
-}
-
-function filterOptions(options: MultiSelectOption[], searchValue: string) {
-  const query = searchValue.trim().toLowerCase();
-
-  if (!query) return options;
-
-  return options.filter((option) =>
-    getOptionSearchText(option).includes(query)
-  );
-}
-
-function getFirstEnabledValue(options: MultiSelectOption[]) {
-  return options.find((option) => !option.disabled)?.value ?? '';
-}
-
-function getLastEnabledValue(options: MultiSelectOption[]) {
-  return [...options].reverse().find((option) => !option.disabled)?.value ?? '';
-}
-
-function getSteppedValue(
-  options: MultiSelectOption[],
-  currentValue: string,
-  direction: 1 | -1
-) {
-  const enabledOptions = options.filter((option) => !option.disabled);
-
-  if (enabledOptions.length === 0) return '';
-
-  const currentIndex = enabledOptions.findIndex(
-    (option) => option.value === currentValue
-  );
-  const fallbackIndex = direction === 1 ? 0 : enabledOptions.length - 1;
-
-  if (currentIndex === -1) return enabledOptions[fallbackIndex]?.value ?? '';
-
-  const nextIndex =
-    (currentIndex + direction + enabledOptions.length) % enabledOptions.length;
-
-  return enabledOptions[nextIndex]?.value ?? '';
-}
-
-function getOptionId(listId: string, value: string) {
-  return `${listId}-option-${value.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
-}
-
-function labelsForValues(options: MultiSelectOption[], values: string[]) {
-  const optionByValue = new Map(
-    options.map((option) => [option.value, option])
-  );
-
-  return values.map((value) => ({
-    value,
-    label: optionByValue.get(value)?.label ?? value,
-    disabled: optionByValue.get(value)?.disabled ?? false,
-  }));
-}
-
-const multiSelectFieldVariants = cva(
-  [
-    'nx:group/multi-select nx:relative nx:flex nx:box-border nx:w-full nx:min-w-0 nx:items-center nx:gap-1.5 nx:rounded-md nx:border-default nx:transition-colors nx:outline-none',
-    'nx:has-[[data-slot=multi-select-trigger]:focus-visible]:outline-2 nx:has-[[data-slot=multi-select-trigger]:focus-visible]:outline-focus-default nx:has-[[data-slot=multi-select-trigger]:focus-visible]:outline-offset-(--focus-offset)',
-    'nx:data-[invalid=true]:border-border-error nx:has-[[data-slot=multi-select-trigger][aria-invalid=true]:focus-visible]:outline-focus-error',
-    'nx:data-[disabled=true]:cursor-not-allowed nx:data-[disabled=true]:bg-disabled nx:data-[disabled=true]:text-disabled-foreground',
-  ],
-  {
-    variants: {
-      size: {
-        sm: 'nx:min-h-8 nx:px-2 nx:py-1 nx:typography-body-small',
-        default: 'nx:min-h-10 nx:px-2.5 nx:py-1.5 nx:typography-body-default',
-        lg: 'nx:min-h-12 nx:px-3 nx:py-2 nx:typography-body-default',
-      },
-      variant: {
-        default:
-          'nx:border-border-default nx:bg-background nx:not-data-[disabled=true]:hover:bg-background-hover nx:data-[disabled=true]:border-border-disabled',
-        borderless:
-          'nx:border-transparent nx:bg-control-background nx:not-data-[disabled=true]:hover:bg-control-background-hover',
-      },
-    },
-    defaultVariants: {
-      size: 'default',
-      variant: 'default',
-    },
-  }
-);
-
-interface MultiSelectProps extends Omit<
-  React.ComponentProps<'div'>,
-  'defaultValue' | 'onChange'
-> {
+interface MultiSelectProps {
+  children: React.ReactNode;
   /**
-   * Options available in the multi-select listbox.
+   * Controlled selected values.
    */
-  options: MultiSelectOption[];
+  values?: string[];
   /**
-   * Controlled selected option values.
+   * Initial selected values for uncontrolled usage.
    */
-  value?: string[];
+  defaultValues?: string[];
   /**
-   * Initial selected option values for uncontrolled usage.
-   * @default []
+   * Called with the next selected values whenever selection changes.
    */
-  defaultValue?: string[];
+  onValuesChange?: (values: string[]) => void;
   /**
-   * Called when selected option values change.
-   */
-  onValueChange?: (value: string[]) => void;
-  /**
-   * Controlled popover state.
-   */
-  open?: boolean;
-  /**
-   * Initial popover state for uncontrolled usage.
+   * Collapse to single selection: picking a value replaces the current one and
+   * closes the popover, turning the field into a searchable combobox.
    * @default false
    */
-  defaultOpen?: boolean;
-  /**
-   * Called when the popover opens or closes.
-   */
-  onOpenChange?: (open: boolean) => void;
-  /**
-   * Native form field name. One hidden input is rendered per selected value.
-   */
-  name?: string;
-  /**
-   * Disables the multi-select and omits submitted values.
-   * @default false
-   */
-  disabled?: boolean;
-  /**
-   * Prevents editing while keeping selected values readable.
-   * @default false
-   */
-  readOnly?: boolean;
-  /**
-   * Marks the multi-select as required for forms and assistive technology.
-   * @default false
-   */
-  required?: boolean;
-  /**
-   * Marks the multi-select invalid.
-   * @default false
-   */
-  invalid?: boolean;
+  single?: boolean;
 }
 
+/**
+ * MultiSelect
+ *
+ * A searchable multiple-selection field. cmdk (via `Command`) owns filtering and
+ * keyboard navigation; this component adds the selected-value model, the chip
+ * trigger, and a label registry so the trigger can render chips for values whose
+ * options are not currently mounted.
+ *
+ * @example
+ * ```tsx
+ * <MultiSelect defaultValues={['react']} onValuesChange={setValues}>
+ *   <MultiSelectTrigger aria-label="Frameworks">
+ *     <MultiSelectValue placeholder="Select frameworks" />
+ *   </MultiSelectTrigger>
+ *   <MultiSelectContent>
+ *     <MultiSelectItem value="react">React</MultiSelectItem>
+ *     <MultiSelectItem value="vue">Vue</MultiSelectItem>
+ *   </MultiSelectContent>
+ * </MultiSelect>
+ * ```
+ */
 function MultiSelect({
   children,
-  className,
-  defaultOpen,
-  defaultValue,
-  disabled = false,
-  invalid = false,
-  name,
-  onOpenChange,
-  onValueChange,
-  open: openProp,
-  options,
-  readOnly = false,
-  required = false,
-  value: valueProp,
-  ...props
+  values,
+  defaultValues,
+  onValuesChange,
+  single = false,
 }: MultiSelectProps) {
-  const reactListId = React.useId();
-  const listId = `${reactListId}-listbox`;
-  const [selectedValues, setSelectedValues, setUncontrolledSelectedValues] =
-    useControllableArrayState({
-      value: valueProp,
-      defaultValue,
-      onValueChange,
-    });
-  const [open, setOpen] = useControllableBooleanState({
-    value: openProp,
-    defaultValue: defaultOpen,
-    onValueChange: onOpenChange,
-  });
-  const [searchValue, setSearchValue] = React.useState('');
-  const [activeValue, setActiveValue] = React.useState('');
-  const validationInputRef = React.useRef<HTMLInputElement>(null);
-
-  const visibleOptions = React.useMemo(
-    () => filterOptions(options, searchValue),
-    [options, searchValue]
+  const [open, setOpen] = React.useState(false);
+  const [uncontrolled, setUncontrolled] = React.useState(
+    () => new Set(values ?? defaultValues)
+  );
+  const [labels, setLabels] = React.useState<Map<string, React.ReactNode>>(
+    () => new Map()
   );
 
-  const setOpenState = React.useCallback(
-    (nextOpen: boolean) => {
-      if ((disabled || readOnly) && nextOpen) return;
+  const selectedValues = React.useMemo(
+    () => (values ? new Set(values) : uncontrolled),
+    [values, uncontrolled]
+  );
 
-      setOpen(nextOpen);
+  const toggle = React.useCallback(
+    (next: string) => {
+      const nextValues = nextSelection(selectedValues, next, single);
 
-      if (nextOpen) {
-        setSearchValue('');
-        setActiveValue(getFirstEnabledValue(options));
-      } else {
-        setSearchValue('');
-        setActiveValue('');
-      }
+      if (values === undefined) setUncontrolled(nextValues);
+      onValuesChange?.([...nextValues]);
+      if (single) setOpen(false);
     },
-    [disabled, options, readOnly, setOpen]
+    [selectedValues, single, values, onValuesChange]
   );
 
-  const setOpenFromTrigger = React.useCallback(() => {
-    setOpenState(true);
-  }, [setOpenState]);
-
-  const toggleValue = React.useCallback(
-    (nextValue: string) => {
-      const option = options.find((item) => item.value === nextValue);
-
-      if (!option || option.disabled || disabled || readOnly) return;
-
-      const nextValues = selectedValues.includes(nextValue)
-        ? selectedValues.filter((value) => value !== nextValue)
-        : [...selectedValues, nextValue];
-
-      setSelectedValues(nextValues);
-    },
-    [disabled, options, readOnly, selectedValues, setSelectedValues]
-  );
-
-  const handleSearchValueChange = React.useCallback(
-    (nextValue: string) => {
-      const nextVisibleOptions = filterOptions(options, nextValue);
-
-      setSearchValue(nextValue);
-      setActiveValue(getFirstEnabledValue(nextVisibleOptions));
-    },
-    [options]
-  );
-
-  const stepActiveValue = React.useCallback(
-    (direction: 1 | -1) => {
-      setActiveValue((currentValue) =>
-        getSteppedValue(visibleOptions, currentValue, direction)
+  const registerLabel = React.useCallback(
+    (key: string, label: React.ReactNode) => {
+      setLabels((prev) =>
+        prev.get(key) === label ? prev : new Map(prev).set(key, label)
       );
     },
-    [visibleOptions]
+    []
   );
 
-  React.useEffect(() => {
-    const validationInput = validationInputRef.current;
-
-    if (!validationInput) return;
-
-    const validityMessage =
-      required && !disabled && selectedValues.length === 0
-        ? 'Please select at least one option.'
-        : '';
-
-    validationInput.setCustomValidity(validityMessage);
-  }, [disabled, required, selectedValues.length]);
-
-  React.useEffect(() => {
-    const form = validationInputRef.current?.form;
-
-    if (!form) return;
-
-    const handleReset = () => {
-      window.setTimeout(() => {
-        if (valueProp === undefined)
-          setUncontrolledSelectedValues(defaultValue ?? []);
-
-        setSearchValue('');
-        setActiveValue('');
-        setOpen(false);
-      });
-    };
-
-    form.addEventListener('reset', handleReset);
-
-    return () => form.removeEventListener('reset', handleReset);
-  }, [defaultValue, setOpen, setUncontrolledSelectedValues, valueProp]);
-
-  const contextValue = React.useMemo<MultiSelectContextValue>(
-    () => ({
-      activeValue,
-      disabled,
-      invalid,
-      listId,
-      open,
-      options,
-      readOnly,
-      required,
-      searchValue,
-      selectedValues,
-      setActiveValue,
-      setOpenFromTrigger,
-      setOpenState,
-      setSearchValue: handleSearchValueChange,
-      stepActiveValue,
-      toggleValue,
-      visibleOptions,
-    }),
-    [
-      activeValue,
-      disabled,
-      handleSearchValueChange,
-      invalid,
-      listId,
-      open,
-      options,
-      readOnly,
-      required,
-      searchValue,
-      selectedValues,
-      setOpenFromTrigger,
-      setOpenState,
-      stepActiveValue,
-      toggleValue,
-      visibleOptions,
-    ]
+  const context = React.useMemo<MultiSelectContextValue>(
+    () => ({ open, single, selectedValues, labels, toggle, registerLabel }),
+    [open, single, selectedValues, labels, toggle, registerLabel]
   );
 
   return (
-    <MultiSelectContext.Provider value={contextValue}>
-      <div
-        data-slot="multi-select"
-        className={cn('nx:contents', className)}
-        {...props}
-      >
-        <Popover open={open} onOpenChange={setOpenState}>
-          {children}
-        </Popover>
-        {name
-          ? selectedValues.map((value) => (
-              <input
-                key={value}
-                type="hidden"
-                name={name}
-                value={value}
-                disabled={disabled}
-                readOnly
-              />
-            ))
-          : null}
-        <input
-          ref={validationInputRef}
-          tabIndex={-1}
-          aria-hidden="true"
-          className="nx:sr-only"
-          value={selectedValues.length > 0 ? 'selected' : ''}
-          required={required}
-          disabled={disabled}
-          onChange={() => undefined}
-        />
-      </div>
+    <MultiSelectContext.Provider value={context}>
+      <Popover open={open} onOpenChange={setOpen}>
+        {children}
+      </Popover>
     </MultiSelectContext.Provider>
   );
 }
 
-interface MultiSelectTriggerProps
-  extends
-    Omit<React.ComponentProps<'div'>, 'defaultValue'>,
-    VariantProps<typeof multiSelectFieldVariants> {}
+interface MultiSelectTriggerProps extends React.ComponentProps<'button'> {}
 
+/**
+ * MultiSelectTrigger
+ *
+ * The field surface. Renders the selected value(s) plus a chevron and toggles
+ * the popover. Pass an `aria-label` (or a visible label via `Field`) so the
+ * combobox has an accessible name.
+ */
 function MultiSelectTrigger({
-  'aria-label': ariaLabel = 'Select options',
-  children,
   className,
-  size,
-  variant,
+  children,
   ...props
 }: MultiSelectTriggerProps) {
-  const context = useMultiSelectContext('MultiSelectTrigger');
-
-  const handleTriggerClick = () => {
-    if (context.open) {
-      context.setOpenState(false);
-      return;
-    }
-
-    context.setOpenFromTrigger();
-  };
+  const { open } = useMultiSelect();
 
   return (
-    <PopoverAnchor asChild>
-      <div
-        data-slot="multi-select-field"
-        data-size={size ?? 'default'}
-        data-variant={variant ?? 'default'}
-        data-disabled={context.disabled || undefined}
-        data-invalid={context.invalid || undefined}
-        className={cn(multiSelectFieldVariants({ size, variant }), className)}
+    <PopoverTrigger asChild>
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        data-slot="multi-select-trigger"
+        className={cn(
+          'nx:group/multi-select nx:flex nx:h-auto nx:min-h-10 nx:w-full nx:items-center nx:justify-between nx:gap-2 nx:rounded-md nx:border-default nx:border-border-default nx:bg-background nx:px-3 nx:py-1.5 nx:typography-body-default nx:whitespace-nowrap nx:transition-colors',
+          'nx:enabled:hover:bg-background-hover',
+          'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
+          'nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error',
+          'nx:disabled:cursor-not-allowed nx:disabled:border-border-disabled nx:disabled:bg-disabled nx:disabled:text-disabled-foreground',
+          className
+        )}
         {...props}
       >
-        {children ?? <MultiSelectValue />}
-        <button
-          type="button"
-          data-slot="multi-select-trigger"
-          aria-controls={context.open ? context.listId : undefined}
-          aria-expanded={context.open}
-          aria-haspopup="listbox"
-          aria-label={ariaLabel}
-          disabled={context.disabled}
-          className="nx:absolute nx:inset-0 nx:z-0 nx:flex nx:items-center nx:justify-end nx:rounded-md nx:px-2.5 nx:text-muted-foreground nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:cursor-not-allowed nx:disabled:text-disabled-foreground"
-          onClick={handleTriggerClick}
-        >
-          <span className="nx:sr-only">
-            {context.open ? 'Close options' : 'Open options'}
-          </span>
-          <IconChevronDown aria-hidden="true" className="nx:size-4" />
-        </button>
-      </div>
-    </PopoverAnchor>
+        {children}
+        <IconChevronDown
+          aria-hidden="true"
+          className="nx:size-4 nx:shrink-0 nx:text-muted-foreground nx:group-disabled/multi-select:text-disabled-foreground"
+        />
+      </button>
+    </PopoverTrigger>
   );
 }
 
-interface MultiSelectValueProps extends React.ComponentProps<'div'> {
+interface MultiSelectValueProps extends Omit<
+  React.ComponentProps<'div'>,
+  'children'
+> {
   /**
-   * Placeholder shown when nothing is selected.
+   * Shown when nothing is selected.
    * @default 'Select options'
    */
   placeholder?: React.ReactNode;
   /**
-   * Maximum number of selected value chips to show before collapsing the rest.
-   * @default 3
+   * Render each selected value as a removable chip.
+   * @default true
    */
-  maxVisibleValues?: number;
+  clickToRemove?: boolean;
+  /**
+   * How chips behave when they exceed the field width:
+   * - `wrap` — always wrap onto multiple lines.
+   * - `wrap-when-open` — wrap while the popover is open, collapse to `+N` when closed.
+   * - `cutoff` — always collapse overflow into a `+N` badge.
+   * @default 'wrap-when-open'
+   */
+  overflowBehavior?: 'wrap' | 'wrap-when-open' | 'cutoff';
 }
 
+/**
+ * MultiSelectValue
+ *
+ * Renders selected values inside the trigger — a plain label in `single` mode,
+ * otherwise removable chips. When chips exceed the field width they collapse
+ * into a measured `+N` badge (unless wrapping).
+ */
 function MultiSelectValue({
   className,
-  maxVisibleValues = 3,
   placeholder = 'Select options',
+  clickToRemove = true,
+  overflowBehavior = 'wrap-when-open',
   ...props
 }: MultiSelectValueProps) {
-  const context = useMultiSelectContext('MultiSelectValue');
-  const selectedItems = labelsForValues(
-    context.options,
-    context.selectedValues
-  );
-  const visibleSelectedItems = selectedItems.slice(0, maxVisibleValues);
-  const overflowCount = Math.max(0, selectedItems.length - maxVisibleValues);
+  const { selectedValues, labels, single, open, toggle } = useMultiSelect();
+  const [overflowAmount, setOverflowAmount] = React.useState(0);
+  const valueRef = React.useRef<HTMLDivElement>(null);
+  const overflowRef = React.useRef<HTMLDivElement>(null);
 
-  const handleRemoveValue = (
-    event: React.MouseEvent<HTMLButtonElement>,
-    value: string
-  ) => {
-    event.preventDefault();
+  const shouldWrap =
+    overflowBehavior === 'wrap' ||
+    (overflowBehavior === 'wrap-when-open' && open);
+
+  const checkOverflow = React.useCallback(() => {
+    const container = valueRef.current;
+
+    if (!container) return;
+
+    const overflowBadge = overflowRef.current;
+    const chips = container.querySelectorAll<HTMLElement>(
+      '[data-selected-item]'
+    );
+
+    // Reset to the fully-expanded state, then hide chips from the end until the
+    // row stops overflowing — the count of hidden chips becomes the `+N` badge.
+    if (overflowBadge) overflowBadge.style.display = 'none';
+    chips.forEach((chip) => chip.style.removeProperty('display'));
+
+    let amount = 0;
+
+    for (let i = chips.length - 1; i >= 0; i--) {
+      const chip = chips[i];
+
+      if (!chip) continue;
+      if (container.scrollWidth <= container.clientWidth) break;
+
+      amount = chips.length - i;
+      chip.style.display = 'none';
+      overflowBadge?.style.removeProperty('display');
+    }
+
+    setOverflowAmount(amount);
+  }, []);
+
+  const handleResize = React.useCallback(
+    (node: HTMLDivElement) => {
+      valueRef.current = node;
+
+      const mutationObserver = new MutationObserver(checkOverflow);
+      const resizeObserver = new ResizeObserver(debounce(checkOverflow, 100));
+
+      mutationObserver.observe(node, {
+        childList: true,
+        attributes: true,
+        attributeFilter: ['class', 'style'],
+      });
+      resizeObserver.observe(node);
+
+      return () => {
+        mutationObserver.disconnect();
+        resizeObserver.disconnect();
+        valueRef.current = null;
+      };
+    },
+    [checkOverflow]
+  );
+
+  const selected = [...selectedValues].filter((value) => labels.has(value));
+
+  if (selected.length === 0)
+    return (
+      <span
+        data-slot="multi-select-placeholder"
+        className="nx:truncate nx:text-muted-foreground"
+      >
+        {placeholder}
+      </span>
+    );
+
+  if (single) {
+    const [first] = selected;
+
+    return (
+      <span data-slot="multi-select-value" className="nx:truncate">
+        {first ? labels.get(first) : null}
+      </span>
+    );
+  }
+
+  const removeChip = (event: React.MouseEvent, value: string) => {
     event.stopPropagation();
-    context.toggleValue(value);
+    toggle(value);
   };
 
   return (
     <div
       data-slot="multi-select-value"
+      ref={handleResize}
       className={cn(
-        'nx:pointer-events-none nx:relative nx:z-10 nx:flex nx:min-w-0 nx:flex-1 nx:flex-wrap nx:items-center nx:gap-1.5 nx:pr-8',
+        'nx:flex nx:min-w-0 nx:flex-1 nx:items-center nx:gap-1.5 nx:overflow-hidden',
+        shouldWrap && 'nx:h-full nx:flex-wrap',
         className
       )}
       {...props}
     >
-      {visibleSelectedItems.map((item) => (
+      {selected.map((value) => (
         <Badge
-          key={item.value}
-          data-slot="multi-select-value-chip"
+          key={value}
+          data-slot="multi-select-chip"
+          data-selected-item
           variant="secondary"
           fill="outline"
           isCaps={false}
-          className="nx:max-w-40 nx:pr-1"
+          className={cn(
+            'nx:group/chip nx:max-w-40 nx:gap-1',
+            clickToRemove && 'nx:cursor-pointer'
+          )}
+          onClick={
+            clickToRemove ? (event) => removeChip(event, value) : undefined
+          }
         >
-          <span className="nx:truncate">{item.label}</span>
-          {!context.disabled && !context.readOnly ? (
-            <button
-              type="button"
-              aria-label={`Remove ${item.label}`}
-              data-slot="multi-select-value-remove"
-              className="nx:pointer-events-auto nx:-mr-0.5 nx:flex nx:size-4 nx:items-center nx:justify-center nx:rounded-sm nx:text-muted-foreground nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
-              onClick={(event) => handleRemoveValue(event, item.value)}
-            >
-              <IconX aria-hidden="true" className="nx:size-3" />
-            </button>
-          ) : null}
+          <span className="nx:truncate">{labels.get(value)}</span>
+          {clickToRemove && (
+            <IconX
+              aria-hidden="true"
+              className="nx:size-3 nx:text-muted-foreground nx:transition-colors nx:group-hover/chip:text-error-subtle-foreground"
+            />
+          )}
         </Badge>
       ))}
-      {overflowCount > 0 ? (
-        <Badge
-          data-slot="multi-select-overflow"
-          variant="secondary"
-          fill="light"
-          isCaps={false}
-        >
-          +{overflowCount}
-        </Badge>
-      ) : null}
-      {selectedItems.length === 0 ? (
-        <span
-          data-slot="multi-select-placeholder"
-          className="nx:text-muted-foreground"
-        >
-          {placeholder}
-        </span>
-      ) : null}
+      <Badge
+        ref={overflowRef}
+        data-slot="multi-select-overflow"
+        variant="secondary"
+        fill="light"
+        isCaps={false}
+        style={{
+          display: overflowAmount > 0 && !shouldWrap ? 'block' : 'none',
+        }}
+      >
+        +{overflowAmount}
+      </Badge>
     </div>
   );
 }
 
-interface MultiSelectContentProps extends PopoverContentProps {}
+interface MultiSelectContentProps extends Omit<
+  React.ComponentProps<typeof PopoverContent>,
+  'children'
+> {
+  children: React.ReactNode;
+  /**
+   * Placeholder for the search input.
+   * @default 'Search…'
+   */
+  searchPlaceholder?: string;
+  /**
+   * Shown when the search matches no options.
+   * @default 'No results found.'
+   */
+  emptyMessage?: React.ReactNode;
+}
 
+/**
+ * MultiSelectContent
+ *
+ * The searchable option list. Also renders an always-mounted, hidden copy of the
+ * options so their labels stay registered for the trigger chips while the
+ * popover is closed.
+ */
 function MultiSelectContent({
-  align = 'start',
+  children,
   className,
+  align = 'start',
   sideOffset = 6,
+  searchPlaceholder = 'Search…',
+  emptyMessage = 'No results found.',
   ...props
 }: MultiSelectContentProps) {
   return (
-    <PopoverContent
-      data-slot="multi-select-content"
-      role="presentation"
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        'nx:w-(--radix-popper-anchor-width) nx:min-w-56 nx:p-0',
-        className
-      )}
-      onOpenAutoFocus={(event) => event.preventDefault()}
-      {...props}
-    />
-  );
-}
-
-interface MultiSelectSearchProps extends Omit<
-  React.ComponentProps<'input'>,
-  'disabled' | 'readOnly' | 'value'
-> {}
-
-function MultiSelectSearch({
-  className,
-  onChange,
-  onKeyDown,
-  placeholder = 'Search options',
-  ...props
-}: MultiSelectSearchProps) {
-  const context = useMultiSelectContext('MultiSelectSearch');
-  const inputRef = React.useRef<HTMLInputElement>(null);
-
-  React.useEffect(() => {
-    if (!context.open) return;
-
-    window.setTimeout(() => inputRef.current?.focus());
-  }, [context.open]);
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    context.setSearchValue(event.target.value);
-    onChange?.(event);
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      context.setOpenState(false);
-    } else if (event.key === 'ArrowDown') {
-      event.preventDefault();
-      context.stepActiveValue(1);
-    } else if (event.key === 'ArrowUp') {
-      event.preventDefault();
-      context.stepActiveValue(-1);
-    } else if (event.key === 'Home') {
-      event.preventDefault();
-      context.setActiveValue(getFirstEnabledValue(context.visibleOptions));
-    } else if (event.key === 'End') {
-      event.preventDefault();
-      context.setActiveValue(getLastEnabledValue(context.visibleOptions));
-    } else if (event.key === 'Enter') {
-      event.preventDefault();
-      context.toggleValue(context.activeValue);
-    }
-
-    onKeyDown?.(event);
-  };
-
-  return (
-    <div
-      data-slot="multi-select-search-wrapper"
-      className="nx:flex nx:items-center nx:border-b-default nx:border-border-default nx:px-3 nx:focus-within:border-border-active"
-    >
-      <input
-        ref={inputRef}
-        data-slot="multi-select-search"
-        value={context.searchValue}
-        placeholder={placeholder}
-        disabled={context.disabled}
-        readOnly={context.readOnly}
+    <>
+      {/* Options only mount inside the popover, which unmounts when closed. This
+          hidden copy keeps each MultiSelectItem's label-registration effect
+          alive so preselected chips stay labeled while the popover is closed. */}
+      <div hidden>
+        <Command>
+          <CommandList>{children}</CommandList>
+        </Command>
+      </div>
+      <PopoverContent
+        data-slot="multi-select-content"
+        aria-label="Options"
+        align={align}
+        sideOffset={sideOffset}
         className={cn(
-          'nx:flex nx:w-full nx:bg-transparent nx:py-2 nx:typography-body-default nx:text-foreground nx:outline-none',
-          'nx:placeholder:text-muted-foreground',
-          'nx:disabled:cursor-not-allowed nx:disabled:text-disabled-foreground nx:disabled:placeholder:text-disabled-foreground',
-          className
-        )}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        {...props}
-      />
-    </div>
-  );
-}
-
-interface MultiSelectListProps extends React.ComponentProps<'div'> {}
-
-function renderMultiSelectOption(option: MultiSelectOption) {
-  return (
-    <MultiSelectItem
-      key={option.value}
-      value={option.value}
-      disabled={option.disabled}
-    >
-      {option.label}
-    </MultiSelectItem>
-  );
-}
-
-function MultiSelectList({
-  'aria-label': ariaLabel = 'Multi-select options',
-  children,
-  className,
-  ...props
-}: MultiSelectListProps) {
-  const context = useMultiSelectContext('MultiSelectList');
-  const hasGroups = context.visibleOptions.some((option) => option.group);
-
-  if (children)
-    return (
-      <div
-        id={context.listId}
-        role="listbox"
-        aria-label={ariaLabel}
-        aria-multiselectable="true"
-        data-slot="multi-select-list"
-        className={cn(
-          'nx:max-h-72 nx:overflow-y-auto nx:overflow-x-hidden nx:p-1',
+          'nx:w-(--radix-popover-trigger-width) nx:min-w-56 nx:p-0',
           className
         )}
         {...props}
       >
-        {children}
-      </div>
-    );
-
-  if (!hasGroups)
-    return (
-      <div
-        id={context.listId}
-        role="listbox"
-        aria-label={ariaLabel}
-        aria-multiselectable="true"
-        data-slot="multi-select-list"
-        className={cn(
-          'nx:max-h-72 nx:overflow-y-auto nx:overflow-x-hidden nx:p-1',
-          className
-        )}
-        {...props}
-      >
-        {context.visibleOptions.map(renderMultiSelectOption)}
-      </div>
-    );
-
-  const groupedOptions = new Map<string, MultiSelectOption[]>();
-
-  for (const option of context.visibleOptions) {
-    const group = option.group ?? 'Options';
-    const groupOptions = groupedOptions.get(group) ?? [];
-
-    groupOptions.push(option);
-    groupedOptions.set(group, groupOptions);
-  }
-
-  return (
-    <div
-      id={context.listId}
-      role="listbox"
-      aria-label={ariaLabel}
-      aria-multiselectable="true"
-      data-slot="multi-select-list"
-      className={cn(
-        'nx:max-h-72 nx:overflow-y-auto nx:overflow-x-hidden nx:p-1',
-        className
-      )}
-      {...props}
-    >
-      {[...groupedOptions.entries()].map(([group, options]) => (
-        <MultiSelectGroup key={group} heading={group}>
-          {options.map(renderMultiSelectOption)}
-        </MultiSelectGroup>
-      ))}
-    </div>
-  );
-}
-
-interface MultiSelectEmptyProps extends React.ComponentProps<'div'> {}
-
-function MultiSelectEmpty({ className, ...props }: MultiSelectEmptyProps) {
-  const context = useMultiSelectContext('MultiSelectEmpty');
-
-  if (context.visibleOptions.length > 0) return null;
-
-  return (
-    <div
-      data-slot="multi-select-empty"
-      className={cn(
-        'nx:py-6 nx:text-center nx:typography-body-default nx:text-muted-foreground',
-        className
-      )}
-      {...props}
-    />
-  );
-}
-
-interface MultiSelectGroupProps extends React.ComponentProps<'div'> {
-  heading?: string;
-}
-
-function MultiSelectGroup({
-  children,
-  className,
-  heading,
-  ...props
-}: MultiSelectGroupProps) {
-  return (
-    <div
-      role="group"
-      aria-label={heading}
-      data-slot="multi-select-group"
-      className={cn('nx:p-1', className)}
-      {...props}
-    >
-      {heading ? (
-        <div
-          data-slot="multi-select-group-heading"
-          className="nx:px-2 nx:py-1.5 nx:typography-label-small nx:text-muted-foreground"
-        >
-          {heading}
-        </div>
-      ) : null}
-      {children}
-    </div>
-  );
-}
-
-interface MultiSelectSeparatorProps extends React.ComponentProps<'div'> {}
-
-function MultiSelectSeparator({
-  className,
-  ...props
-}: MultiSelectSeparatorProps) {
-  return (
-    <div
-      role="presentation"
-      data-slot="multi-select-separator"
-      className={cn(
-        'nx:-mx-1 nx:my-1 nx:h-px nx:bg-border-default-alpha',
-        className
-      )}
-      {...props}
-    />
+        <Command>
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>{emptyMessage}</CommandEmpty>
+            {children}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </>
   );
 }
 
 interface MultiSelectItemProps extends Omit<
-  React.ComponentProps<'div'>,
-  'onSelect'
+  React.ComponentProps<typeof CommandItem>,
+  'value' | 'onSelect'
 > {
   value: string;
-  disabled?: boolean;
+  /**
+   * Label for the trigger chip when it differs from the option content (e.g. the
+   * option renders an icon + text but the chip should show text only).
+   */
+  badgeLabel?: React.ReactNode;
+  /**
+   * Called with the value after it is toggled.
+   */
   onSelect?: (value: string) => void;
 }
 
+/**
+ * MultiSelectItem
+ *
+ * A selectable option. Shows a checkbox indicator in multi mode and a trailing
+ * check in `single` mode.
+ */
 function MultiSelectItem({
-  children,
-  className,
-  disabled = false,
-  onMouseDown,
-  onMouseMove,
-  onSelect,
   value,
+  children,
+  badgeLabel,
+  onSelect,
+  className,
   ...props
 }: MultiSelectItemProps) {
-  const context = useMultiSelectContext('MultiSelectItem');
-  const selected = context.selectedValues.includes(value);
-  const active = context.activeValue === value;
+  const { selectedValues, single, toggle, registerLabel } = useMultiSelect();
+  const selected = selectedValues.has(value);
 
-  const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
-    event.preventDefault();
+  React.useEffect(() => {
+    registerLabel(value, badgeLabel ?? children);
+  }, [value, badgeLabel, children, registerLabel]);
 
-    if (!disabled) {
-      context.toggleValue(value);
-      onSelect?.(value);
-    }
-
-    onMouseDown?.(event);
-  };
-
-  const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (!disabled) context.setActiveValue(value);
-    onMouseMove?.(event);
+  const handleSelect = () => {
+    toggle(value);
+    onSelect?.(value);
   };
 
   return (
-    <div
-      id={getOptionId(context.listId, value)}
-      role="option"
-      aria-disabled={disabled || undefined}
-      aria-selected={selected}
-      tabIndex={-1}
-      data-active={active || undefined}
-      data-disabled={disabled || undefined}
-      data-selected={selected || undefined}
+    <CommandItem
       data-slot="multi-select-item"
-      className={cn(
-        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:rounded-sm nx:typography-body-default nx:outline-none',
-        'nx:gap-3 nx:px-3 nx:py-2.5',
-        'nx:data-[active=true]:bg-popover-hover nx:data-[active=true]:text-popover-foreground',
-        'nx:data-[disabled=true]:pointer-events-none nx:data-[disabled=true]:text-disabled-foreground',
-        'nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
-        className
-      )}
-      onMouseDown={handleMouseDown}
-      onMouseMove={handleMouseMove}
+      data-checked={selected || undefined}
+      className={cn('nx:gap-2', className)}
+      onSelect={handleSelect}
       {...props}
     >
-      <span
-        data-slot="multi-select-item-indicator"
-        aria-hidden="true"
-        className={cn(
-          'nx:flex nx:size-4 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-sm nx:border-default nx:border-border-default',
-          selected
-            ? 'nx:bg-primary-background nx:text-primary-foreground'
-            : 'nx:bg-background'
-        )}
-      >
-        {selected ? <IconCheck className="nx:size-3" /> : null}
-      </span>
-      <span
-        data-slot="multi-select-item-label"
-        className="nx:min-w-0 nx:flex-1"
-      >
-        {children}
-      </span>
-    </div>
+      {single ? (
+        <>
+          <span className="nx:min-w-0 nx:flex-1">{children}</span>
+          <IconCheck
+            aria-hidden="true"
+            className={cn(
+              'nx:size-4 nx:shrink-0',
+              selected ? 'nx:opacity-100' : 'nx:opacity-0'
+            )}
+          />
+        </>
+      ) : (
+        <>
+          <span
+            aria-hidden="true"
+            data-slot="multi-select-indicator"
+            className={cn(
+              'nx:flex nx:size-4 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-sm nx:border-default nx:transition-colors',
+              selected
+                ? 'nx:border-transparent nx:bg-primary-background nx:text-primary-foreground'
+                : 'nx:border-border-default nx:bg-background'
+            )}
+          >
+            {selected && <IconCheck className="nx:size-3" />}
+          </span>
+          <span className="nx:min-w-0 nx:flex-1">{children}</span>
+        </>
+      )}
+    </CommandItem>
   );
+}
+
+interface MultiSelectGroupProps extends React.ComponentProps<
+  typeof CommandGroup
+> {}
+
+/**
+ * MultiSelectGroup
+ *
+ * Groups related options under an optional `heading`.
+ */
+function MultiSelectGroup(props: MultiSelectGroupProps) {
+  return <CommandGroup data-slot="multi-select-group" {...props} />;
+}
+
+interface MultiSelectSeparatorProps extends React.ComponentProps<
+  typeof CommandSeparator
+> {}
+
+/**
+ * MultiSelectSeparator
+ *
+ * A visual divider between groups or options.
+ */
+function MultiSelectSeparator(props: MultiSelectSeparatorProps) {
+  return <CommandSeparator data-slot="multi-select-separator" {...props} />;
 }
 
 export {
   MultiSelect,
   MultiSelectContent,
   type MultiSelectContentProps,
-  MultiSelectEmpty,
-  type MultiSelectEmptyProps,
-  multiSelectFieldVariants,
   MultiSelectGroup,
   type MultiSelectGroupProps,
   MultiSelectItem,
   type MultiSelectItemProps,
-  MultiSelectList,
-  type MultiSelectListProps,
-  type MultiSelectOption,
   type MultiSelectProps,
-  MultiSelectSearch,
-  type MultiSelectSearchProps,
   MultiSelectSeparator,
   type MultiSelectSeparatorProps,
   MultiSelectTrigger,

--- a/packages/react/src/components/multi-select/multi-select.tsx
+++ b/packages/react/src/components/multi-select/multi-select.tsx
@@ -461,35 +461,17 @@ function MultiSelect({
 interface MultiSelectTriggerProps
   extends
     Omit<React.ComponentProps<'div'>, 'defaultValue'>,
-    VariantProps<typeof multiSelectFieldVariants> {
-  /**
-   * Placeholder shown when nothing is selected.
-   * @default 'Select options'
-   */
-  placeholder?: string;
-  /**
-   * Maximum number of selected value chips to show before collapsing the rest.
-   * @default 3
-   */
-  maxVisibleValues?: number;
-}
+    VariantProps<typeof multiSelectFieldVariants> {}
 
 function MultiSelectTrigger({
   'aria-label': ariaLabel = 'Select options',
+  children,
   className,
-  maxVisibleValues = 3,
-  placeholder = 'Select options',
   size,
   variant,
   ...props
 }: MultiSelectTriggerProps) {
   const context = useMultiSelectContext('MultiSelectTrigger');
-  const selectedItems = labelsForValues(
-    context.options,
-    context.selectedValues
-  );
-  const visibleSelectedItems = selectedItems.slice(0, maxVisibleValues);
-  const overflowCount = Math.max(0, selectedItems.length - maxVisibleValues);
 
   const handleTriggerClick = () => {
     if (context.open) {
@@ -498,15 +480,6 @@ function MultiSelectTrigger({
     }
 
     context.setOpenFromTrigger();
-  };
-
-  const handleRemoveValue = (
-    event: React.MouseEvent<HTMLButtonElement>,
-    value: string
-  ) => {
-    event.preventDefault();
-    event.stopPropagation();
-    context.toggleValue(value);
   };
 
   return (
@@ -520,52 +493,7 @@ function MultiSelectTrigger({
         className={cn(multiSelectFieldVariants({ size, variant }), className)}
         {...props}
       >
-        <div
-          data-slot="multi-select-values"
-          className="nx:flex nx:min-w-0 nx:flex-1 nx:flex-wrap nx:items-center nx:gap-1.5"
-        >
-          {visibleSelectedItems.map((item) => (
-            <Badge
-              key={item.value}
-              data-slot="multi-select-value"
-              variant="secondary"
-              fill="outline"
-              isCaps={false}
-              className="nx:max-w-40 nx:pr-1"
-            >
-              <span className="nx:truncate">{item.label}</span>
-              {!context.disabled && !context.readOnly ? (
-                <button
-                  type="button"
-                  aria-label={`Remove ${item.label}`}
-                  data-slot="multi-select-value-remove"
-                  className="nx:-mr-0.5 nx:flex nx:size-4 nx:items-center nx:justify-center nx:rounded-sm nx:text-muted-foreground nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
-                  onClick={(event) => handleRemoveValue(event, item.value)}
-                >
-                  <IconX aria-hidden="true" className="nx:size-3" />
-                </button>
-              ) : null}
-            </Badge>
-          ))}
-          {overflowCount > 0 ? (
-            <Badge
-              data-slot="multi-select-overflow"
-              variant="secondary"
-              fill="light"
-              isCaps={false}
-            >
-              +{overflowCount}
-            </Badge>
-          ) : null}
-          {selectedItems.length === 0 ? (
-            <span
-              data-slot="multi-select-placeholder"
-              className="nx:text-muted-foreground"
-            >
-              {placeholder}
-            </span>
-          ) : null}
-        </div>
+        {children ?? <MultiSelectValue />}
         <button
           type="button"
           data-slot="multi-select-trigger"
@@ -584,6 +512,96 @@ function MultiSelectTrigger({
         </button>
       </div>
     </PopoverAnchor>
+  );
+}
+
+interface MultiSelectValueProps extends React.ComponentProps<'div'> {
+  /**
+   * Placeholder shown when nothing is selected.
+   * @default 'Select options'
+   */
+  placeholder?: React.ReactNode;
+  /**
+   * Maximum number of selected value chips to show before collapsing the rest.
+   * @default 3
+   */
+  maxVisibleValues?: number;
+}
+
+function MultiSelectValue({
+  className,
+  maxVisibleValues = 3,
+  placeholder = 'Select options',
+  ...props
+}: MultiSelectValueProps) {
+  const context = useMultiSelectContext('MultiSelectValue');
+  const selectedItems = labelsForValues(
+    context.options,
+    context.selectedValues
+  );
+  const visibleSelectedItems = selectedItems.slice(0, maxVisibleValues);
+  const overflowCount = Math.max(0, selectedItems.length - maxVisibleValues);
+
+  const handleRemoveValue = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    value: string
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    context.toggleValue(value);
+  };
+
+  return (
+    <div
+      data-slot="multi-select-value"
+      className={cn(
+        'nx:flex nx:min-w-0 nx:flex-1 nx:flex-wrap nx:items-center nx:gap-1.5',
+        className
+      )}
+      {...props}
+    >
+      {visibleSelectedItems.map((item) => (
+        <Badge
+          key={item.value}
+          data-slot="multi-select-value-chip"
+          variant="secondary"
+          fill="outline"
+          isCaps={false}
+          className="nx:max-w-40 nx:pr-1"
+        >
+          <span className="nx:truncate">{item.label}</span>
+          {!context.disabled && !context.readOnly ? (
+            <button
+              type="button"
+              aria-label={`Remove ${item.label}`}
+              data-slot="multi-select-value-remove"
+              className="nx:-mr-0.5 nx:flex nx:size-4 nx:items-center nx:justify-center nx:rounded-sm nx:text-muted-foreground nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
+              onClick={(event) => handleRemoveValue(event, item.value)}
+            >
+              <IconX aria-hidden="true" className="nx:size-3" />
+            </button>
+          ) : null}
+        </Badge>
+      ))}
+      {overflowCount > 0 ? (
+        <Badge
+          data-slot="multi-select-overflow"
+          variant="secondary"
+          fill="light"
+          isCaps={false}
+        >
+          +{overflowCount}
+        </Badge>
+      ) : null}
+      {selectedItems.length === 0 ? (
+        <span
+          data-slot="multi-select-placeholder"
+          className="nx:text-muted-foreground"
+        >
+          {placeholder}
+        </span>
+      ) : null}
+    </div>
   );
 }
 
@@ -952,4 +970,6 @@ export {
   type MultiSelectSeparatorProps,
   MultiSelectTrigger,
   type MultiSelectTriggerProps,
+  MultiSelectValue,
+  type MultiSelectValueProps,
 };

--- a/packages/react/src/components/multi-select/multi-select.tsx
+++ b/packages/react/src/components/multi-select/multi-select.tsx
@@ -16,11 +16,13 @@ import { Popover, PopoverContent, PopoverTrigger } from '../popover';
 
 interface MultiSelectContextValue {
   open: boolean;
-  single: boolean;
   selectedValues: Set<string>;
   labels: Map<string, React.ReactNode>;
+  search: string;
+  setSearch: (search: string) => void;
   toggle: (value: string) => void;
   registerLabel: (value: string, label: React.ReactNode) => void;
+  unregisterLabel: (value: string) => void;
 }
 
 const MultiSelectContext = React.createContext<MultiSelectContextValue | null>(
@@ -36,9 +38,7 @@ function useMultiSelect() {
   return context;
 }
 
-function nextSelection(values: Set<string>, value: string, single: boolean) {
-  if (single) return values.has(value) ? new Set<string>() : new Set([value]);
-
+function toggleValue(values: Set<string>, value: string) {
   const next = new Set(values);
 
   // Set.delete returns true when the value was present (and removes it), so a
@@ -71,12 +71,6 @@ interface MultiSelectProps {
    * Called with the next selected values whenever selection changes.
    */
   onValuesChange?: (values: string[]) => void;
-  /**
-   * Collapse to single selection: picking a value replaces the current one and
-   * closes the popover, turning the field into a searchable combobox.
-   * @default false
-   */
-  single?: boolean;
 }
 
 /**
@@ -85,7 +79,7 @@ interface MultiSelectProps {
  * A searchable multiple-selection field. cmdk (via `Command`) owns filtering and
  * keyboard navigation; this component adds the selected-value model, the chip
  * trigger, and a label registry so the trigger can render chips for values whose
- * options are not currently mounted.
+ * options are not on screen. For searchable single selection, use `Combobox`.
  *
  * @example
  * ```tsx
@@ -105,9 +99,9 @@ function MultiSelect({
   values,
   defaultValues,
   onValuesChange,
-  single = false,
 }: MultiSelectProps) {
   const [open, setOpen] = React.useState(false);
+  const [search, setSearch] = React.useState('');
   const [uncontrolled, setUncontrolled] = React.useState(
     () => new Set(values ?? defaultValues)
   );
@@ -120,15 +114,21 @@ function MultiSelect({
     [values, uncontrolled]
   );
 
+  const handleOpenChange = React.useCallback((next: boolean) => {
+    setOpen(next);
+    // The list stays mounted (forceMount), so reset the query on close instead
+    // of relying on unmount to clear cmdk's internal search state.
+    if (!next) setSearch('');
+  }, []);
+
   const toggle = React.useCallback(
     (next: string) => {
-      const nextValues = nextSelection(selectedValues, next, single);
+      const nextValues = toggleValue(selectedValues, next);
 
       if (values === undefined) setUncontrolled(nextValues);
       onValuesChange?.([...nextValues]);
-      if (single) setOpen(false);
     },
-    [selectedValues, single, values, onValuesChange]
+    [selectedValues, values, onValuesChange]
   );
 
   const registerLabel = React.useCallback(
@@ -140,14 +140,42 @@ function MultiSelect({
     []
   );
 
+  const unregisterLabel = React.useCallback((key: string) => {
+    setLabels((prev) => {
+      if (!prev.has(key)) return prev;
+
+      const next = new Map(prev);
+      next.delete(key);
+
+      return next;
+    });
+  }, []);
+
   const context = React.useMemo<MultiSelectContextValue>(
-    () => ({ open, single, selectedValues, labels, toggle, registerLabel }),
-    [open, single, selectedValues, labels, toggle, registerLabel]
+    () => ({
+      open,
+      selectedValues,
+      labels,
+      search,
+      setSearch,
+      toggle,
+      registerLabel,
+      unregisterLabel,
+    }),
+    [
+      open,
+      selectedValues,
+      labels,
+      search,
+      toggle,
+      registerLabel,
+      unregisterLabel,
+    ]
   );
 
   return (
     <MultiSelectContext.Provider value={context}>
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover open={open} onOpenChange={handleOpenChange}>
         {children}
       </Popover>
     </MultiSelectContext.Provider>
@@ -161,14 +189,23 @@ interface MultiSelectTriggerProps extends React.ComponentProps<'button'> {}
  *
  * The field surface. Renders the selected value(s) plus a chevron and toggles
  * the popover. Pass an `aria-label` (or a visible label via `Field`) so the
- * combobox has an accessible name.
+ * combobox has an accessible name. Backspace / Delete removes the last selected
+ * value, so keyboard users can clear chips without reopening the list.
  */
 function MultiSelectTrigger({
   className,
   children,
   ...props
 }: MultiSelectTriggerProps) {
-  const { open } = useMultiSelect();
+  const { open, selectedValues, toggle } = useMultiSelect();
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key !== 'Backspace' && event.key !== 'Delete') return;
+    if (selectedValues.size === 0) return;
+
+    const values = [...selectedValues];
+    toggle(values[values.length - 1] as string);
+  };
 
   return (
     <PopoverTrigger asChild>
@@ -185,6 +222,7 @@ function MultiSelectTrigger({
           'nx:disabled:cursor-not-allowed nx:disabled:border-border-disabled nx:disabled:bg-disabled nx:disabled:text-disabled-foreground',
           className
         )}
+        onKeyDown={handleKeyDown}
         {...props}
       >
         {children}
@@ -224,9 +262,10 @@ interface MultiSelectValueProps extends Omit<
 /**
  * MultiSelectValue
  *
- * Renders selected values inside the trigger — a plain label in `single` mode,
- * otherwise removable chips. When chips exceed the field width they collapse
- * into a measured `+N` badge (unless wrapping).
+ * Renders the selected values inside the trigger as removable chips. When chips
+ * exceed the field width they collapse into a measured `+N` badge (unless
+ * wrapping). A selected value with no registered label falls back to its raw
+ * value so a non-empty selection never shows the placeholder.
  */
 function MultiSelectValue({
   className,
@@ -235,10 +274,9 @@ function MultiSelectValue({
   overflowBehavior = 'wrap-when-open',
   ...props
 }: MultiSelectValueProps) {
-  const { selectedValues, labels, single, open, toggle } = useMultiSelect();
+  const { selectedValues, labels, open, toggle } = useMultiSelect();
   const [overflowAmount, setOverflowAmount] = React.useState(0);
   const valueRef = React.useRef<HTMLDivElement>(null);
-  const overflowRef = React.useRef<HTMLDivElement>(null);
 
   const shouldWrap =
     overflowBehavior === 'wrap' ||
@@ -249,14 +287,13 @@ function MultiSelectValue({
 
     if (!container) return;
 
-    const overflowBadge = overflowRef.current;
     const chips = container.querySelectorAll<HTMLElement>(
       '[data-selected-item]'
     );
 
     // Reset to the fully-expanded state, then hide chips from the end until the
-    // row stops overflowing — the count of hidden chips becomes the `+N` badge.
-    if (overflowBadge) overflowBadge.style.display = 'none';
+    // row stops overflowing — the count of hidden chips becomes the `+N` badge,
+    // whose visibility is driven from that count in render (single source).
     chips.forEach((chip) => chip.style.removeProperty('display'));
 
     let amount = 0;
@@ -269,7 +306,6 @@ function MultiSelectValue({
 
       amount = chips.length - i;
       chip.style.display = 'none';
-      overflowBadge?.style.removeProperty('display');
     }
 
     setOverflowAmount(amount);
@@ -298,9 +334,7 @@ function MultiSelectValue({
     [checkOverflow]
   );
 
-  const selected = [...selectedValues].filter((value) => labels.has(value));
-
-  if (selected.length === 0)
+  if (selectedValues.size === 0)
     return (
       <span
         data-slot="multi-select-placeholder"
@@ -309,16 +343,6 @@ function MultiSelectValue({
         {placeholder}
       </span>
     );
-
-  if (single) {
-    const [first] = selected;
-
-    return (
-      <span data-slot="multi-select-value" className="nx:truncate">
-        {first ? labels.get(first) : null}
-      </span>
-    );
-  }
 
   const removeChip = (event: React.MouseEvent, value: string) => {
     event.stopPropagation();
@@ -336,7 +360,7 @@ function MultiSelectValue({
       )}
       {...props}
     >
-      {selected.map((value) => (
+      {[...selectedValues].map((value) => (
         <Badge
           key={value}
           data-slot="multi-select-chip"
@@ -352,7 +376,7 @@ function MultiSelectValue({
             clickToRemove ? (event) => removeChip(event, value) : undefined
           }
         >
-          <span className="nx:truncate">{labels.get(value)}</span>
+          <span className="nx:truncate">{labels.get(value) ?? value}</span>
           {clickToRemove && (
             <IconX
               aria-hidden="true"
@@ -362,7 +386,6 @@ function MultiSelectValue({
         </Badge>
       ))}
       <Badge
-        ref={overflowRef}
         data-slot="multi-select-overflow"
         variant="secondary"
         fill="light"
@@ -397,9 +420,9 @@ interface MultiSelectContentProps extends Omit<
 /**
  * MultiSelectContent
  *
- * The searchable option list. Also renders an always-mounted, hidden copy of the
- * options so their labels stay registered for the trigger chips while the
- * popover is closed.
+ * The searchable option list. The popover content stays mounted (`forceMount`)
+ * and is hidden with CSS while closed, so each option's label-registration
+ * effect keeps preselected chips labeled without a second, shadow option tree.
  */
 function MultiSelectContent({
   children,
@@ -410,36 +433,34 @@ function MultiSelectContent({
   emptyMessage = 'No results found.',
   ...props
 }: MultiSelectContentProps) {
+  const { search, setSearch } = useMultiSelect();
+
   return (
-    <>
-      {/* Options only mount inside the popover, which unmounts when closed. This
-          hidden copy keeps each MultiSelectItem's label-registration effect
-          alive so preselected chips stay labeled while the popover is closed. */}
-      <div hidden>
-        <Command>
-          <CommandList>{children}</CommandList>
-        </Command>
-      </div>
-      <PopoverContent
-        data-slot="multi-select-content"
-        aria-label="Options"
-        align={align}
-        sideOffset={sideOffset}
-        className={cn(
-          'nx:w-(--radix-popover-trigger-width) nx:min-w-56 nx:p-0',
-          className
-        )}
-        {...props}
-      >
-        <Command>
-          <CommandInput placeholder={searchPlaceholder} />
-          <CommandList>
-            <CommandEmpty>{emptyMessage}</CommandEmpty>
-            {children}
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </>
+    <PopoverContent
+      forceMount
+      data-slot="multi-select-content"
+      aria-label="Options"
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'nx:w-(--radix-popover-trigger-width) nx:min-w-56 nx:p-0',
+        'nx:data-[state=closed]:hidden',
+        className
+      )}
+      {...props}
+    >
+      <Command>
+        <CommandInput
+          placeholder={searchPlaceholder}
+          value={search}
+          onValueChange={setSearch}
+        />
+        <CommandList>
+          <CommandEmpty>{emptyMessage}</CommandEmpty>
+          {children}
+        </CommandList>
+      </Command>
+    </PopoverContent>
   );
 }
 
@@ -462,65 +483,63 @@ interface MultiSelectItemProps extends Omit<
 /**
  * MultiSelectItem
  *
- * A selectable option. Shows a checkbox indicator in multi mode and a trailing
- * check in `single` mode.
+ * A selectable option with a checkbox indicator. cmdk filters on `value` +
+ * `keywords`, so `value` is forwarded to disambiguate duplicate labels and
+ * icon-only content, and string children seed `keywords` so typing the label
+ * matches. cmdk owns `aria-selected` for the active descendant; a visually
+ * hidden "selected" note gives assistive tech the checked-state signal.
  */
 function MultiSelectItem({
   value,
   children,
   badgeLabel,
+  keywords,
   onSelect,
   className,
   ...props
 }: MultiSelectItemProps) {
-  const { selectedValues, single, toggle, registerLabel } = useMultiSelect();
+  const { selectedValues, toggle, registerLabel, unregisterLabel } =
+    useMultiSelect();
   const selected = selectedValues.has(value);
 
   React.useEffect(() => {
     registerLabel(value, badgeLabel ?? children);
-  }, [value, badgeLabel, children, registerLabel]);
+
+    return () => unregisterLabel(value);
+  }, [value, badgeLabel, children, registerLabel, unregisterLabel]);
 
   const handleSelect = () => {
     toggle(value);
     onSelect?.(value);
   };
 
+  const searchKeywords =
+    keywords ?? (typeof children === 'string' ? [children] : undefined);
+
   return (
     <CommandItem
       data-slot="multi-select-item"
       data-checked={selected || undefined}
+      value={value}
+      keywords={searchKeywords}
       className={cn('nx:gap-2', className)}
       onSelect={handleSelect}
       {...props}
     >
-      {single ? (
-        <>
-          <span className="nx:min-w-0 nx:flex-1">{children}</span>
-          <IconCheck
-            aria-hidden="true"
-            className={cn(
-              'nx:size-4 nx:shrink-0',
-              selected ? 'nx:opacity-100' : 'nx:opacity-0'
-            )}
-          />
-        </>
-      ) : (
-        <>
-          <span
-            aria-hidden="true"
-            data-slot="multi-select-indicator"
-            className={cn(
-              'nx:flex nx:size-4 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-sm nx:border-default nx:transition-colors',
-              selected
-                ? 'nx:border-transparent nx:bg-primary-background nx:text-primary-foreground'
-                : 'nx:border-border-default nx:bg-background'
-            )}
-          >
-            {selected && <IconCheck className="nx:size-3" />}
-          </span>
-          <span className="nx:min-w-0 nx:flex-1">{children}</span>
-        </>
-      )}
+      <span
+        aria-hidden="true"
+        data-slot="multi-select-indicator"
+        className={cn(
+          'nx:flex nx:size-4 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-sm nx:border-default nx:transition-colors',
+          selected
+            ? 'nx:border-transparent nx:bg-primary-background nx:text-primary-foreground'
+            : 'nx:border-border-default nx:bg-background'
+        )}
+      >
+        {selected && <IconCheck className="nx:size-3" />}
+      </span>
+      <span className="nx:min-w-0 nx:flex-1">{children}</span>
+      {selected && <span className="nx:sr-only">selected</span>}
     </CommandItem>
   );
 }

--- a/packages/react/src/components/multi-select/multi-select.tsx
+++ b/packages/react/src/components/multi-select/multi-select.tsx
@@ -1,0 +1,955 @@
+import * as React from 'react';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { IconCheck, IconChevronDown, IconX } from '../../lib/icons';
+import { cn } from '../../lib/utils';
+import { Badge } from '../badge';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  type PopoverContentProps,
+} from '../popover';
+
+interface MultiSelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+  group?: string;
+  keywords?: string[];
+}
+
+interface MultiSelectContextValue {
+  activeValue: string;
+  disabled: boolean;
+  invalid: boolean;
+  listId: string;
+  open: boolean;
+  options: MultiSelectOption[];
+  readOnly: boolean;
+  required: boolean;
+  searchValue: string;
+  selectedValues: string[];
+  setActiveValue: (value: string) => void;
+  setOpenFromTrigger: () => void;
+  setOpenState: (open: boolean) => void;
+  setSearchValue: (value: string) => void;
+  stepActiveValue: (direction: 1 | -1) => void;
+  toggleValue: (value: string) => void;
+  visibleOptions: MultiSelectOption[];
+}
+
+const MultiSelectContext = React.createContext<MultiSelectContextValue | null>(
+  null
+);
+
+function useMultiSelectContext(componentName: string) {
+  const context = React.useContext(MultiSelectContext);
+
+  if (!context)
+    throw new Error(`${componentName} must be used inside MultiSelect.`);
+
+  return context;
+}
+
+function useControllableArrayState({
+  value,
+  defaultValue = [],
+  onValueChange,
+}: {
+  value?: string[];
+  defaultValue?: string[];
+  onValueChange?: (value: string[]) => void;
+}) {
+  const [uncontrolledValue, setUncontrolledValue] =
+    React.useState(defaultValue);
+  const isControlled = value !== undefined;
+  const currentValue = isControlled ? value : uncontrolledValue;
+
+  const setCurrentValue = React.useCallback(
+    (nextValue: string[]) => {
+      if (!isControlled) setUncontrolledValue(nextValue);
+      onValueChange?.(nextValue);
+    },
+    [isControlled, onValueChange]
+  );
+
+  return [currentValue, setCurrentValue, setUncontrolledValue] as const;
+}
+
+function useControllableBooleanState({
+  value,
+  defaultValue = false,
+  onValueChange,
+}: {
+  value?: boolean;
+  defaultValue?: boolean;
+  onValueChange?: (value: boolean) => void;
+}) {
+  const [uncontrolledValue, setUncontrolledValue] =
+    React.useState(defaultValue);
+  const isControlled = value !== undefined;
+  const currentValue = isControlled ? value : uncontrolledValue;
+
+  const setCurrentValue = React.useCallback(
+    (nextValue: boolean) => {
+      if (!isControlled) setUncontrolledValue(nextValue);
+      onValueChange?.(nextValue);
+    },
+    [isControlled, onValueChange]
+  );
+
+  return [currentValue, setCurrentValue] as const;
+}
+
+function getOptionSearchText(option: MultiSelectOption) {
+  return [option.label, option.value, ...(option.keywords ?? [])]
+    .join(' ')
+    .toLowerCase();
+}
+
+function filterOptions(options: MultiSelectOption[], searchValue: string) {
+  const query = searchValue.trim().toLowerCase();
+
+  if (!query) return options;
+
+  return options.filter((option) =>
+    getOptionSearchText(option).includes(query)
+  );
+}
+
+function getFirstEnabledValue(options: MultiSelectOption[]) {
+  return options.find((option) => !option.disabled)?.value ?? '';
+}
+
+function getLastEnabledValue(options: MultiSelectOption[]) {
+  return [...options].reverse().find((option) => !option.disabled)?.value ?? '';
+}
+
+function getSteppedValue(
+  options: MultiSelectOption[],
+  currentValue: string,
+  direction: 1 | -1
+) {
+  const enabledOptions = options.filter((option) => !option.disabled);
+
+  if (enabledOptions.length === 0) return '';
+
+  const currentIndex = enabledOptions.findIndex(
+    (option) => option.value === currentValue
+  );
+  const fallbackIndex = direction === 1 ? 0 : enabledOptions.length - 1;
+
+  if (currentIndex === -1) return enabledOptions[fallbackIndex]?.value ?? '';
+
+  const nextIndex =
+    (currentIndex + direction + enabledOptions.length) % enabledOptions.length;
+
+  return enabledOptions[nextIndex]?.value ?? '';
+}
+
+function getOptionId(listId: string, value: string) {
+  return `${listId}-option-${value.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+}
+
+function labelsForValues(options: MultiSelectOption[], values: string[]) {
+  const optionByValue = new Map(
+    options.map((option) => [option.value, option])
+  );
+
+  return values.map((value) => ({
+    value,
+    label: optionByValue.get(value)?.label ?? value,
+    disabled: optionByValue.get(value)?.disabled ?? false,
+  }));
+}
+
+const multiSelectFieldVariants = cva(
+  [
+    'nx:group/multi-select nx:flex nx:box-border nx:w-full nx:min-w-0 nx:items-center nx:gap-1.5 nx:rounded-md nx:border-0 nx:transition-colors nx:outline-none',
+    'nx:has-[[data-slot=multi-select-trigger]:focus-visible]:outline-2 nx:has-[[data-slot=multi-select-trigger]:focus-visible]:outline-focus-default nx:has-[[data-slot=multi-select-trigger]:focus-visible]:outline-offset-(--focus-offset)',
+    'nx:data-[invalid=true]:border-border-error nx:has-[[data-slot=multi-select-trigger][aria-invalid=true]:focus-visible]:outline-focus-error',
+    'nx:data-[disabled=true]:cursor-not-allowed nx:data-[disabled=true]:bg-disabled nx:data-[disabled=true]:text-disabled-foreground',
+  ],
+  {
+    variants: {
+      size: {
+        sm: 'nx:min-h-8 nx:px-2 nx:py-1 nx:typography-body-small',
+        default: 'nx:min-h-10 nx:px-2.5 nx:py-1.5 nx:typography-body-default',
+        lg: 'nx:min-h-12 nx:px-3 nx:py-2 nx:typography-body-default',
+      },
+      variant: {
+        default:
+          'nx:border-border-default nx:bg-background nx:not-data-[disabled=true]:hover:bg-background-hover nx:data-[disabled=true]:border-border-disabled',
+        borderless:
+          'nx:border-transparent nx:bg-control-background nx:not-data-[disabled=true]:hover:bg-control-background-hover',
+      },
+    },
+    defaultVariants: {
+      size: 'default',
+      variant: 'default',
+    },
+  }
+);
+
+interface MultiSelectProps extends Omit<
+  React.ComponentProps<'div'>,
+  'defaultValue' | 'onChange'
+> {
+  /**
+   * Options available in the multi-select listbox.
+   */
+  options: MultiSelectOption[];
+  /**
+   * Controlled selected option values.
+   */
+  value?: string[];
+  /**
+   * Initial selected option values for uncontrolled usage.
+   * @default []
+   */
+  defaultValue?: string[];
+  /**
+   * Called when selected option values change.
+   */
+  onValueChange?: (value: string[]) => void;
+  /**
+   * Controlled popover state.
+   */
+  open?: boolean;
+  /**
+   * Initial popover state for uncontrolled usage.
+   * @default false
+   */
+  defaultOpen?: boolean;
+  /**
+   * Called when the popover opens or closes.
+   */
+  onOpenChange?: (open: boolean) => void;
+  /**
+   * Native form field name. One hidden input is rendered per selected value.
+   */
+  name?: string;
+  /**
+   * Disables the multi-select and omits submitted values.
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * Prevents editing while keeping selected values readable.
+   * @default false
+   */
+  readOnly?: boolean;
+  /**
+   * Marks the multi-select as required for forms and assistive technology.
+   * @default false
+   */
+  required?: boolean;
+  /**
+   * Marks the multi-select invalid.
+   * @default false
+   */
+  invalid?: boolean;
+}
+
+function MultiSelect({
+  children,
+  className,
+  defaultOpen,
+  defaultValue,
+  disabled = false,
+  invalid = false,
+  name,
+  onOpenChange,
+  onValueChange,
+  open: openProp,
+  options,
+  readOnly = false,
+  required = false,
+  value: valueProp,
+  ...props
+}: MultiSelectProps) {
+  const reactListId = React.useId();
+  const listId = `${reactListId}-listbox`;
+  const [selectedValues, setSelectedValues, setUncontrolledSelectedValues] =
+    useControllableArrayState({
+      value: valueProp,
+      defaultValue,
+      onValueChange,
+    });
+  const [open, setOpen] = useControllableBooleanState({
+    value: openProp,
+    defaultValue: defaultOpen,
+    onValueChange: onOpenChange,
+  });
+  const [searchValue, setSearchValue] = React.useState('');
+  const [activeValue, setActiveValue] = React.useState('');
+  const validationInputRef = React.useRef<HTMLInputElement>(null);
+
+  const visibleOptions = React.useMemo(
+    () => filterOptions(options, searchValue),
+    [options, searchValue]
+  );
+
+  const setOpenState = React.useCallback(
+    (nextOpen: boolean) => {
+      if ((disabled || readOnly) && nextOpen) return;
+
+      setOpen(nextOpen);
+
+      if (nextOpen) {
+        setSearchValue('');
+        setActiveValue(getFirstEnabledValue(options));
+      } else {
+        setSearchValue('');
+        setActiveValue('');
+      }
+    },
+    [disabled, options, readOnly, setOpen]
+  );
+
+  const setOpenFromTrigger = React.useCallback(() => {
+    setOpenState(true);
+  }, [setOpenState]);
+
+  const toggleValue = React.useCallback(
+    (nextValue: string) => {
+      const option = options.find((item) => item.value === nextValue);
+
+      if (!option || option.disabled || disabled || readOnly) return;
+
+      const nextValues = selectedValues.includes(nextValue)
+        ? selectedValues.filter((value) => value !== nextValue)
+        : [...selectedValues, nextValue];
+
+      setSelectedValues(nextValues);
+    },
+    [disabled, options, readOnly, selectedValues, setSelectedValues]
+  );
+
+  const handleSearchValueChange = React.useCallback(
+    (nextValue: string) => {
+      const nextVisibleOptions = filterOptions(options, nextValue);
+
+      setSearchValue(nextValue);
+      setActiveValue(getFirstEnabledValue(nextVisibleOptions));
+    },
+    [options]
+  );
+
+  const stepActiveValue = React.useCallback(
+    (direction: 1 | -1) => {
+      setActiveValue((currentValue) =>
+        getSteppedValue(visibleOptions, currentValue, direction)
+      );
+    },
+    [visibleOptions]
+  );
+
+  React.useEffect(() => {
+    const validationInput = validationInputRef.current;
+
+    if (!validationInput) return;
+
+    const validityMessage =
+      required && !disabled && selectedValues.length === 0
+        ? 'Please select at least one option.'
+        : '';
+
+    validationInput.setCustomValidity(validityMessage);
+  }, [disabled, required, selectedValues.length]);
+
+  React.useEffect(() => {
+    const form = validationInputRef.current?.form;
+
+    if (!form) return;
+
+    const handleReset = () => {
+      window.setTimeout(() => {
+        if (valueProp === undefined)
+          setUncontrolledSelectedValues(defaultValue ?? []);
+
+        setSearchValue('');
+        setActiveValue('');
+        setOpen(false);
+      });
+    };
+
+    form.addEventListener('reset', handleReset);
+
+    return () => form.removeEventListener('reset', handleReset);
+  }, [defaultValue, setOpen, setUncontrolledSelectedValues, valueProp]);
+
+  const contextValue = React.useMemo<MultiSelectContextValue>(
+    () => ({
+      activeValue,
+      disabled,
+      invalid,
+      listId,
+      open,
+      options,
+      readOnly,
+      required,
+      searchValue,
+      selectedValues,
+      setActiveValue,
+      setOpenFromTrigger,
+      setOpenState,
+      setSearchValue: handleSearchValueChange,
+      stepActiveValue,
+      toggleValue,
+      visibleOptions,
+    }),
+    [
+      activeValue,
+      disabled,
+      handleSearchValueChange,
+      invalid,
+      listId,
+      open,
+      options,
+      readOnly,
+      required,
+      searchValue,
+      selectedValues,
+      setOpenFromTrigger,
+      setOpenState,
+      stepActiveValue,
+      toggleValue,
+      visibleOptions,
+    ]
+  );
+
+  return (
+    <MultiSelectContext.Provider value={contextValue}>
+      <div
+        data-slot="multi-select"
+        className={cn('nx:contents', className)}
+        {...props}
+      >
+        <Popover open={open} onOpenChange={setOpenState}>
+          {children}
+        </Popover>
+        {name
+          ? selectedValues.map((value) => (
+              <input
+                key={value}
+                type="hidden"
+                name={name}
+                value={value}
+                disabled={disabled}
+                readOnly
+              />
+            ))
+          : null}
+        <input
+          ref={validationInputRef}
+          tabIndex={-1}
+          aria-hidden="true"
+          className="nx:sr-only"
+          value={selectedValues.length > 0 ? 'selected' : ''}
+          required={required}
+          disabled={disabled}
+          onChange={() => undefined}
+        />
+      </div>
+    </MultiSelectContext.Provider>
+  );
+}
+
+interface MultiSelectTriggerProps
+  extends
+    Omit<React.ComponentProps<'div'>, 'defaultValue'>,
+    VariantProps<typeof multiSelectFieldVariants> {
+  /**
+   * Placeholder shown when nothing is selected.
+   * @default 'Select options'
+   */
+  placeholder?: string;
+  /**
+   * Maximum number of selected value chips to show before collapsing the rest.
+   * @default 3
+   */
+  maxVisibleValues?: number;
+}
+
+function MultiSelectTrigger({
+  'aria-label': ariaLabel = 'Select options',
+  className,
+  maxVisibleValues = 3,
+  placeholder = 'Select options',
+  size,
+  variant,
+  ...props
+}: MultiSelectTriggerProps) {
+  const context = useMultiSelectContext('MultiSelectTrigger');
+  const selectedItems = labelsForValues(
+    context.options,
+    context.selectedValues
+  );
+  const visibleSelectedItems = selectedItems.slice(0, maxVisibleValues);
+  const overflowCount = Math.max(0, selectedItems.length - maxVisibleValues);
+
+  const handleTriggerClick = () => {
+    if (context.open) {
+      context.setOpenState(false);
+      return;
+    }
+
+    context.setOpenFromTrigger();
+  };
+
+  const handleRemoveValue = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    value: string
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    context.toggleValue(value);
+  };
+
+  return (
+    <PopoverAnchor asChild>
+      <div
+        data-slot="multi-select-field"
+        data-size={size ?? 'default'}
+        data-variant={variant ?? 'default'}
+        data-disabled={context.disabled || undefined}
+        data-invalid={context.invalid || undefined}
+        className={cn(multiSelectFieldVariants({ size, variant }), className)}
+        {...props}
+      >
+        <div
+          data-slot="multi-select-values"
+          className="nx:flex nx:min-w-0 nx:flex-1 nx:flex-wrap nx:items-center nx:gap-1.5"
+        >
+          {visibleSelectedItems.map((item) => (
+            <Badge
+              key={item.value}
+              data-slot="multi-select-value"
+              variant="secondary"
+              fill="outline"
+              isCaps={false}
+              className="nx:max-w-40 nx:pr-1"
+            >
+              <span className="nx:truncate">{item.label}</span>
+              {!context.disabled && !context.readOnly ? (
+                <button
+                  type="button"
+                  aria-label={`Remove ${item.label}`}
+                  data-slot="multi-select-value-remove"
+                  className="nx:-mr-0.5 nx:flex nx:size-4 nx:items-center nx:justify-center nx:rounded-sm nx:text-muted-foreground nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)"
+                  onClick={(event) => handleRemoveValue(event, item.value)}
+                >
+                  <IconX aria-hidden="true" className="nx:size-3" />
+                </button>
+              ) : null}
+            </Badge>
+          ))}
+          {overflowCount > 0 ? (
+            <Badge
+              data-slot="multi-select-overflow"
+              variant="secondary"
+              fill="light"
+              isCaps={false}
+            >
+              +{overflowCount}
+            </Badge>
+          ) : null}
+          {selectedItems.length === 0 ? (
+            <span
+              data-slot="multi-select-placeholder"
+              className="nx:text-muted-foreground"
+            >
+              {placeholder}
+            </span>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          data-slot="multi-select-trigger"
+          aria-controls={context.open ? context.listId : undefined}
+          aria-expanded={context.open}
+          aria-haspopup="listbox"
+          aria-label={ariaLabel}
+          disabled={context.disabled}
+          className="nx:-mr-1 nx:flex nx:size-7 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-sm nx:text-muted-foreground nx:hover:bg-background-hover nx:hover:text-foreground nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset) nx:disabled:cursor-not-allowed nx:disabled:text-disabled-foreground"
+          onClick={handleTriggerClick}
+        >
+          <span className="nx:sr-only">
+            {context.open ? 'Close options' : 'Open options'}
+          </span>
+          <IconChevronDown aria-hidden="true" className="nx:size-4" />
+        </button>
+      </div>
+    </PopoverAnchor>
+  );
+}
+
+interface MultiSelectContentProps extends PopoverContentProps {}
+
+function MultiSelectContent({
+  align = 'start',
+  className,
+  sideOffset = 6,
+  ...props
+}: MultiSelectContentProps) {
+  return (
+    <PopoverContent
+      data-slot="multi-select-content"
+      role="presentation"
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'nx:w-(--radix-popper-anchor-width) nx:min-w-56 nx:p-0',
+        className
+      )}
+      onOpenAutoFocus={(event) => event.preventDefault()}
+      {...props}
+    />
+  );
+}
+
+interface MultiSelectSearchProps extends Omit<
+  React.ComponentProps<'input'>,
+  'disabled' | 'readOnly' | 'value'
+> {}
+
+function MultiSelectSearch({
+  className,
+  onChange,
+  onKeyDown,
+  placeholder = 'Search options',
+  ...props
+}: MultiSelectSearchProps) {
+  const context = useMultiSelectContext('MultiSelectSearch');
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (!context.open) return;
+
+    window.setTimeout(() => inputRef.current?.focus());
+  }, [context.open]);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    context.setSearchValue(event.target.value);
+    onChange?.(event);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      context.setOpenState(false);
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      context.stepActiveValue(1);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      context.stepActiveValue(-1);
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      context.setActiveValue(getFirstEnabledValue(context.visibleOptions));
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      context.setActiveValue(getLastEnabledValue(context.visibleOptions));
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      context.toggleValue(context.activeValue);
+    }
+
+    onKeyDown?.(event);
+  };
+
+  return (
+    <div
+      data-slot="multi-select-search-wrapper"
+      className="nx:flex nx:items-center nx:border-b-default nx:border-border-default nx:px-3 nx:focus-within:border-border-active"
+    >
+      <input
+        ref={inputRef}
+        data-slot="multi-select-search"
+        value={context.searchValue}
+        placeholder={placeholder}
+        disabled={context.disabled}
+        readOnly={context.readOnly}
+        className={cn(
+          'nx:flex nx:w-full nx:bg-transparent nx:py-2 nx:typography-body-default nx:text-foreground nx:outline-none',
+          'nx:placeholder:text-muted-foreground',
+          'nx:disabled:cursor-not-allowed nx:disabled:text-disabled-foreground nx:disabled:placeholder:text-disabled-foreground',
+          className
+        )}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        {...props}
+      />
+    </div>
+  );
+}
+
+interface MultiSelectListProps extends React.ComponentProps<'div'> {}
+
+function renderMultiSelectOption(option: MultiSelectOption) {
+  return (
+    <MultiSelectItem
+      key={option.value}
+      value={option.value}
+      disabled={option.disabled}
+    >
+      {option.label}
+    </MultiSelectItem>
+  );
+}
+
+function MultiSelectList({
+  'aria-label': ariaLabel = 'Multi-select options',
+  children,
+  className,
+  ...props
+}: MultiSelectListProps) {
+  const context = useMultiSelectContext('MultiSelectList');
+  const hasGroups = context.visibleOptions.some((option) => option.group);
+
+  if (children)
+    return (
+      <div
+        id={context.listId}
+        role="listbox"
+        aria-label={ariaLabel}
+        aria-multiselectable="true"
+        data-slot="multi-select-list"
+        className={cn(
+          'nx:max-h-72 nx:overflow-y-auto nx:overflow-x-hidden nx:p-1',
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+
+  if (!hasGroups)
+    return (
+      <div
+        id={context.listId}
+        role="listbox"
+        aria-label={ariaLabel}
+        aria-multiselectable="true"
+        data-slot="multi-select-list"
+        className={cn(
+          'nx:max-h-72 nx:overflow-y-auto nx:overflow-x-hidden nx:p-1',
+          className
+        )}
+        {...props}
+      >
+        {context.visibleOptions.map(renderMultiSelectOption)}
+      </div>
+    );
+
+  const groupedOptions = new Map<string, MultiSelectOption[]>();
+
+  for (const option of context.visibleOptions) {
+    const group = option.group ?? 'Options';
+    const groupOptions = groupedOptions.get(group) ?? [];
+
+    groupOptions.push(option);
+    groupedOptions.set(group, groupOptions);
+  }
+
+  return (
+    <div
+      id={context.listId}
+      role="listbox"
+      aria-label={ariaLabel}
+      aria-multiselectable="true"
+      data-slot="multi-select-list"
+      className={cn(
+        'nx:max-h-72 nx:overflow-y-auto nx:overflow-x-hidden nx:p-1',
+        className
+      )}
+      {...props}
+    >
+      {[...groupedOptions.entries()].map(([group, options]) => (
+        <MultiSelectGroup key={group} heading={group}>
+          {options.map(renderMultiSelectOption)}
+        </MultiSelectGroup>
+      ))}
+    </div>
+  );
+}
+
+interface MultiSelectEmptyProps extends React.ComponentProps<'div'> {}
+
+function MultiSelectEmpty({ className, ...props }: MultiSelectEmptyProps) {
+  const context = useMultiSelectContext('MultiSelectEmpty');
+
+  if (context.visibleOptions.length > 0) return null;
+
+  return (
+    <div
+      data-slot="multi-select-empty"
+      className={cn(
+        'nx:py-6 nx:text-center nx:typography-body-default nx:text-muted-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+interface MultiSelectGroupProps extends React.ComponentProps<'div'> {
+  heading?: string;
+}
+
+function MultiSelectGroup({
+  children,
+  className,
+  heading,
+  ...props
+}: MultiSelectGroupProps) {
+  return (
+    <div
+      role="group"
+      aria-label={heading}
+      data-slot="multi-select-group"
+      className={cn('nx:p-1', className)}
+      {...props}
+    >
+      {heading ? (
+        <div
+          data-slot="multi-select-group-heading"
+          className="nx:px-2 nx:py-1.5 nx:typography-label-small nx:text-muted-foreground"
+        >
+          {heading}
+        </div>
+      ) : null}
+      {children}
+    </div>
+  );
+}
+
+interface MultiSelectSeparatorProps extends React.ComponentProps<'div'> {}
+
+function MultiSelectSeparator({
+  className,
+  ...props
+}: MultiSelectSeparatorProps) {
+  return (
+    <div
+      role="presentation"
+      data-slot="multi-select-separator"
+      className={cn(
+        'nx:-mx-1 nx:my-1 nx:h-px nx:bg-border-default-alpha',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+interface MultiSelectItemProps extends Omit<
+  React.ComponentProps<'div'>,
+  'onSelect'
+> {
+  value: string;
+  disabled?: boolean;
+  onSelect?: (value: string) => void;
+}
+
+function MultiSelectItem({
+  children,
+  className,
+  disabled = false,
+  onMouseDown,
+  onMouseMove,
+  onSelect,
+  value,
+  ...props
+}: MultiSelectItemProps) {
+  const context = useMultiSelectContext('MultiSelectItem');
+  const selected = context.selectedValues.includes(value);
+  const active = context.activeValue === value;
+
+  const handleMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+
+    if (!disabled) {
+      context.toggleValue(value);
+      onSelect?.(value);
+    }
+
+    onMouseDown?.(event);
+  };
+
+  const handleMouseMove = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!disabled) context.setActiveValue(value);
+    onMouseMove?.(event);
+  };
+
+  return (
+    <div
+      id={getOptionId(context.listId, value)}
+      role="option"
+      aria-disabled={disabled || undefined}
+      aria-selected={selected}
+      tabIndex={-1}
+      data-active={active || undefined}
+      data-disabled={disabled || undefined}
+      data-selected={selected || undefined}
+      data-slot="multi-select-item"
+      className={cn(
+        'nx:relative nx:flex nx:cursor-default nx:select-none nx:items-center nx:rounded-sm nx:typography-body-default nx:outline-none',
+        'nx:gap-3 nx:px-3 nx:py-2.5',
+        'nx:data-[active=true]:bg-popover-hover nx:data-[active=true]:text-popover-foreground',
+        'nx:data-[disabled=true]:pointer-events-none nx:data-[disabled=true]:text-disabled-foreground',
+        'nx:[&_svg]:pointer-events-none nx:[&_svg]:size-4 nx:[&_svg]:shrink-0',
+        className
+      )}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      {...props}
+    >
+      <span
+        data-slot="multi-select-item-indicator"
+        aria-hidden="true"
+        className={cn(
+          'nx:flex nx:size-4 nx:shrink-0 nx:items-center nx:justify-center nx:rounded-sm nx:border-default nx:border-border-default',
+          selected
+            ? 'nx:bg-primary-background nx:text-primary-foreground'
+            : 'nx:bg-background'
+        )}
+      >
+        {selected ? <IconCheck className="nx:size-3" /> : null}
+      </span>
+      <span
+        data-slot="multi-select-item-label"
+        className="nx:min-w-0 nx:flex-1"
+      >
+        {children}
+      </span>
+    </div>
+  );
+}
+
+export {
+  MultiSelect,
+  MultiSelectContent,
+  type MultiSelectContentProps,
+  MultiSelectEmpty,
+  type MultiSelectEmptyProps,
+  multiSelectFieldVariants,
+  MultiSelectGroup,
+  type MultiSelectGroupProps,
+  MultiSelectItem,
+  type MultiSelectItemProps,
+  MultiSelectList,
+  type MultiSelectListProps,
+  type MultiSelectOption,
+  type MultiSelectProps,
+  MultiSelectSearch,
+  type MultiSelectSearchProps,
+  MultiSelectSeparator,
+  type MultiSelectSeparatorProps,
+  MultiSelectTrigger,
+  type MultiSelectTriggerProps,
+};

--- a/packages/react/src/components/popover/popover.tsx
+++ b/packages/react/src/components/popover/popover.tsx
@@ -66,14 +66,16 @@ function PopoverContent({
   className,
   align = 'center',
   sideOffset = 4,
+  forceMount,
   ...props
 }: PopoverContentProps) {
   return (
-    <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Portal forceMount={forceMount}>
       <PopoverPrimitive.Content
         data-slot="popover-content"
         align={align}
         sideOffset={sideOffset}
+        forceMount={forceMount}
         className={cn(
           'nx:z-popover nx:w-72 nx:p-container nx:outline-none',
           popoverSurfaceClassName,

--- a/packages/react/src/components/popover/popover.tsx
+++ b/packages/react/src/components/popover/popover.tsx
@@ -66,16 +66,14 @@ function PopoverContent({
   className,
   align = 'center',
   sideOffset = 4,
-  forceMount,
   ...props
 }: PopoverContentProps) {
   return (
-    <PopoverPrimitive.Portal forceMount={forceMount}>
+    <PopoverPrimitive.Portal>
       <PopoverPrimitive.Content
         data-slot="popover-content"
         align={align}
         sideOffset={sideOffset}
-        forceMount={forceMount}
         className={cn(
           'nx:z-popover nx:w-72 nx:p-container nx:outline-none',
           popoverSurfaceClassName,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -43,6 +43,7 @@ export * from './components/item';
 export * from './components/kbd';
 export * from './components/label';
 export * from './components/menubar';
+export * from './components/multi-select';
 export * from './components/native-select';
 export * from './components/navigation-menu';
 export * from './components/pagination';


### PR DESCRIPTION
## Summary

- Adds a MultiSelect component with chip display/removal, grouped options, a searchable popover, disabled/invalid states, and controlled/uncontrolled selection.
- Aligns the public anatomy with the WDS reference by exposing MultiSelectTrigger plus MultiSelectValue composition.
- Built on Radix Popover + cmdk (consistent with Combobox #632). Radix owns focus, dismissal, and open/close motion; chip labels are read from the composed children so preselected chips stay labeled while the list is closed — no always-mounted shadow option tree.
- Accessibility: multi-select listbox semantics are **not yet solved** and are tracked in #634 — cmdk binds `aria-selected` to the active descendant, not the checked options, so screen readers get no reliable per-option checked-state signal. Arbitrary-chip keyboard removal (beyond Backspace-removes-last) is tracked in the same issue.
- Adds focused Storybook coverage for default, controlled, grouped, disabled, disabled-option, invalid field, search, keyboard (incl. focus-on-open), chip removal (pointer + Backspace), overflow, long labels, and data attributes.

## GitHub Issue

Part of #620. This split PR intentionally does not auto-close the shared Combobox + MultiSelect tracker.

## Test Plan

- [x] corepack pnpm --filter @nexus_ds/react typecheck
- [x] corepack pnpm lint
- [x] corepack pnpm format:check
- [x] corepack pnpm test:storybook packages/react/src/components/multi-select packages/react/src/components/popover packages/react/src/components/combobox
