### PR TITLE
refactor(fields): rename bordered field variant

### DIFF
--- a/apps/console/src/modules/design-system/settings/ProfileTab.tsx
+++ b/apps/console/src/modules/design-system/settings/ProfileTab.tsx
@@ -72,7 +72,7 @@ export function ProfileTab() {
                   <FormItem>
                     <FormLabel>First name</FormLabel>
                     <FormControl>
-                      <Input variant="default" placeholder="Ada" {...field} />
+                      <Input variant="bordered" placeholder="Ada" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -86,7 +86,7 @@ export function ProfileTab() {
                     <FormLabel>Last name</FormLabel>
                     <FormControl>
                       <Input
-                        variant="default"
+                        variant="bordered"
                         placeholder="Lovelace"
                         {...field}
                       />
@@ -106,7 +106,7 @@ export function ProfileTab() {
                   <FormControl>
                     <Input
                       type="email"
-                      variant="default"
+                      variant="bordered"
                       placeholder="you@example.com"
                       {...field}
                     />
@@ -126,7 +126,7 @@ export function ProfileTab() {
                 <FormItem>
                   <FormLabel>Username</FormLabel>
                   <FormControl>
-                    <Input variant="default" placeholder="ada" {...field} />
+                    <Input variant="bordered" placeholder="ada" {...field} />
                   </FormControl>
                   <FormDescription>Your public display name.</FormDescription>
                   <FormMessage />
@@ -142,7 +142,7 @@ export function ProfileTab() {
                   <FormLabel>Bio</FormLabel>
                   <FormControl>
                     <Textarea
-                      variant="default"
+                      variant="bordered"
                       placeholder="Tell us a little about yourself"
                       {...field}
                     />

--- a/apps/console/src/modules/design-system/settings/ProfileTab.tsx
+++ b/apps/console/src/modules/design-system/settings/ProfileTab.tsx
@@ -72,7 +72,7 @@ export function ProfileTab() {
                   <FormItem>
                     <FormLabel>First name</FormLabel>
                     <FormControl>
-                      <Input placeholder="Ada" {...field} />
+                      <Input variant="default" placeholder="Ada" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -85,7 +85,11 @@ export function ProfileTab() {
                   <FormItem>
                     <FormLabel>Last name</FormLabel>
                     <FormControl>
-                      <Input placeholder="Lovelace" {...field} />
+                      <Input
+                        variant="default"
+                        placeholder="Lovelace"
+                        {...field}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -102,6 +106,7 @@ export function ProfileTab() {
                   <FormControl>
                     <Input
                       type="email"
+                      variant="default"
                       placeholder="you@example.com"
                       {...field}
                     />
@@ -121,7 +126,7 @@ export function ProfileTab() {
                 <FormItem>
                   <FormLabel>Username</FormLabel>
                   <FormControl>
-                    <Input placeholder="ada" {...field} />
+                    <Input variant="default" placeholder="ada" {...field} />
                   </FormControl>
                   <FormDescription>Your public display name.</FormDescription>
                   <FormMessage />
@@ -137,6 +142,7 @@ export function ProfileTab() {
                   <FormLabel>Bio</FormLabel>
                   <FormControl>
                     <Textarea
+                      variant="default"
                       placeholder="Tell us a little about yourself"
                       {...field}
                     />

--- a/apps/console/src/modules/design-system/settings/ProfileTab.tsx
+++ b/apps/console/src/modules/design-system/settings/ProfileTab.tsx
@@ -72,7 +72,7 @@ export function ProfileTab() {
                   <FormItem>
                     <FormLabel>First name</FormLabel>
                     <FormControl>
-                      <Input variant="bordered" placeholder="Ada" {...field} />
+                      <Input placeholder="Ada" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -85,11 +85,7 @@ export function ProfileTab() {
                   <FormItem>
                     <FormLabel>Last name</FormLabel>
                     <FormControl>
-                      <Input
-                        variant="bordered"
-                        placeholder="Lovelace"
-                        {...field}
-                      />
+                      <Input placeholder="Lovelace" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -106,7 +102,6 @@ export function ProfileTab() {
                   <FormControl>
                     <Input
                       type="email"
-                      variant="bordered"
                       placeholder="you@example.com"
                       {...field}
                     />
@@ -126,7 +121,7 @@ export function ProfileTab() {
                 <FormItem>
                   <FormLabel>Username</FormLabel>
                   <FormControl>
-                    <Input variant="bordered" placeholder="ada" {...field} />
+                    <Input placeholder="ada" {...field} />
                   </FormControl>
                   <FormDescription>Your public display name.</FormDescription>
                   <FormMessage />
@@ -142,7 +137,6 @@ export function ProfileTab() {
                   <FormLabel>Bio</FormLabel>
                   <FormControl>
                     <Textarea
-                      variant="bordered"
                       placeholder="Tell us a little about yourself"
                       {...field}
                     />

--- a/apps/docs/public/themes/globals.css
+++ b/apps/docs/public/themes/globals.css
@@ -901,12 +901,12 @@
 }
 
 /* ===== FOCUS RING ===== */
-[data-slot='input'][data-variant='default'],
-[data-slot='sidebar-input'][data-variant='default'],
-[data-slot='textarea'][data-variant='default'],
-[data-slot='native-select'][data-variant='default'],
-[data-slot='select-trigger'][data-variant='default'],
-[data-slot='input-group'][data-variant='default'] {
+[data-slot='input'][data-variant='bordered'],
+[data-slot='sidebar-input'][data-variant='bordered'],
+[data-slot='textarea'][data-variant='bordered'],
+[data-slot='native-select'][data-variant='bordered'],
+[data-slot='select-trigger'][data-variant='bordered'],
+[data-slot='input-group'][data-variant='bordered'] {
   border-color: transparent !important;
   border-width: 0;
   box-shadow: inset 0 0 0 1px var(--color-border-default);
@@ -923,12 +923,12 @@
   box-shadow: inset 0 0 0 1px var(--color-border-error);
 }
 
-[data-slot='input'][data-variant='default']:disabled,
-[data-slot='sidebar-input'][data-variant='default']:disabled,
-[data-slot='textarea'][data-variant='default']:disabled,
-[data-slot='native-select'][data-variant='default']:disabled,
-[data-slot='select-trigger'][data-variant='default']:disabled,
-[data-slot='input-group'][data-variant='default'][data-disabled='true'] {
+[data-slot='input'][data-variant='bordered']:disabled,
+[data-slot='sidebar-input'][data-variant='bordered']:disabled,
+[data-slot='textarea'][data-variant='bordered']:disabled,
+[data-slot='native-select'][data-variant='bordered']:disabled,
+[data-slot='select-trigger'][data-variant='bordered']:disabled,
+[data-slot='input-group'][data-variant='bordered'][data-disabled='true'] {
   border-color: transparent !important;
   border-width: 0;
   box-shadow: inset 0 0 0 1px var(--color-border-disabled);
@@ -1057,12 +1057,12 @@
 }
 
 @media (forced-colors: active) {
-  [data-slot='input'][data-variant='default'],
-  [data-slot='sidebar-input'][data-variant='default'],
-  [data-slot='textarea'][data-variant='default'],
-  [data-slot='native-select'][data-variant='default'],
-  [data-slot='select-trigger'][data-variant='default'],
-  [data-slot='input-group'][data-variant='default'],
+  [data-slot='input'][data-variant='bordered'],
+  [data-slot='sidebar-input'][data-variant='bordered'],
+  [data-slot='textarea'][data-variant='bordered'],
+  [data-slot='native-select'][data-variant='bordered'],
+  [data-slot='select-trigger'][data-variant='bordered'],
+  [data-slot='input-group'][data-variant='bordered'],
   [data-slot='input'][aria-invalid='true'],
   [data-slot='sidebar-input'][aria-invalid='true'],
   [data-slot='textarea'][aria-invalid='true'],
@@ -1075,12 +1075,12 @@
     box-shadow: none !important;
   }
 
-  [data-slot='input'][data-variant='default']:disabled,
-  [data-slot='sidebar-input'][data-variant='default']:disabled,
-  [data-slot='textarea'][data-variant='default']:disabled,
-  [data-slot='native-select'][data-variant='default']:disabled,
-  [data-slot='select-trigger'][data-variant='default']:disabled,
-  [data-slot='input-group'][data-variant='default'][data-disabled='true'],
+  [data-slot='input'][data-variant='bordered']:disabled,
+  [data-slot='sidebar-input'][data-variant='bordered']:disabled,
+  [data-slot='textarea'][data-variant='bordered']:disabled,
+  [data-slot='native-select'][data-variant='bordered']:disabled,
+  [data-slot='select-trigger'][data-variant='bordered']:disabled,
+  [data-slot='input-group'][data-variant='bordered'][data-disabled='true'],
   [class~='nx:group/input-otp']:has([data-slot='input-otp']:disabled)
     [data-slot='input-otp-slot'] {
     border-color: GrayText !important;

--- a/packages/core/scripts/__tests__/generate-modular.test.js
+++ b/packages/core/scripts/__tests__/generate-modular.test.js
@@ -115,7 +115,7 @@ describe('generateModular', () => {
     expect(globals).toMatch(
       /\[data-slot='input'\]\[class~='nx:focus-visible:outline-focus-default'\]:focus-visible/
     );
-    expect(globals).toMatch(/\[data-slot='input'\]\[data-variant='default'\]/);
+    expect(globals).toMatch(/\[data-slot='input'\]\[data-variant='bordered'\]/);
     expect(globals).toMatch(
       /box-shadow:\s*inset 0 0 0 1px var\(--color-border-default\);/
     );

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -248,7 +248,9 @@ describe('generateTailwindPackage', () => {
     expect(nexusCSS).toMatch(
       /\[data-slot='input'\]\[class~='nx:focus-visible:outline-focus-default'\]:focus-visible/
     );
-    expect(nexusCSS).toMatch(/\[data-slot='input'\]\[data-variant='default'\]/);
+    expect(nexusCSS).toMatch(
+      /\[data-slot='input'\]\[data-variant='bordered'\]/
+    );
     expect(nexusCSS).toMatch(
       /box-shadow:\s*inset 0 0 0 1px var\(--color-border-default\);/
     );

--- a/packages/core/scripts/__tests__/utils.test.js
+++ b/packages/core/scripts/__tests__/utils.test.js
@@ -242,7 +242,7 @@ describe('utils', () => {
       expect(css).toMatch(
         /\[data-slot='input'\]\[class~='nx:focus-visible:outline-focus-default'\]:focus-visible/
       );
-      expect(css).toMatch(/\[data-slot='input'\]\[data-variant='default'\]/);
+      expect(css).toMatch(/\[data-slot='input'\]\[data-variant='bordered'\]/);
       expect(css).toMatch(
         /box-shadow:\s*inset 0 0 0 1px var\(--color-border-default\);/
       );

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -2055,12 +2055,12 @@ const ERROR_FOCUS_RING_SELECTORS = [
 ];
 
 const FIELD_BOUNDARY_SELECTORS = [
-  "[data-slot='input'][data-variant='default']",
-  "[data-slot='sidebar-input'][data-variant='default']",
-  "[data-slot='textarea'][data-variant='default']",
-  "[data-slot='native-select'][data-variant='default']",
-  "[data-slot='select-trigger'][data-variant='default']",
-  "[data-slot='input-group'][data-variant='default']",
+  "[data-slot='input'][data-variant='bordered']",
+  "[data-slot='sidebar-input'][data-variant='bordered']",
+  "[data-slot='textarea'][data-variant='bordered']",
+  "[data-slot='native-select'][data-variant='bordered']",
+  "[data-slot='select-trigger'][data-variant='bordered']",
+  "[data-slot='input-group'][data-variant='bordered']",
 ];
 
 const FIELD_ERROR_BOUNDARY_SELECTORS = [
@@ -2073,12 +2073,12 @@ const FIELD_ERROR_BOUNDARY_SELECTORS = [
 ];
 
 const FIELD_DISABLED_BOUNDARY_SELECTORS = [
-  "[data-slot='input'][data-variant='default']:disabled",
-  "[data-slot='sidebar-input'][data-variant='default']:disabled",
-  "[data-slot='textarea'][data-variant='default']:disabled",
-  "[data-slot='native-select'][data-variant='default']:disabled",
-  "[data-slot='select-trigger'][data-variant='default']:disabled",
-  "[data-slot='input-group'][data-variant='default'][data-disabled='true']",
+  "[data-slot='input'][data-variant='bordered']:disabled",
+  "[data-slot='sidebar-input'][data-variant='bordered']:disabled",
+  "[data-slot='textarea'][data-variant='bordered']:disabled",
+  "[data-slot='native-select'][data-variant='bordered']:disabled",
+  "[data-slot='select-trigger'][data-variant='bordered']:disabled",
+  "[data-slot='input-group'][data-variant='bordered'][data-disabled='true']",
 ];
 
 const OTP_SLOT_BOUNDARY_SELECTOR = "[data-slot='input-otp-slot']";

--- a/packages/react/src/components/form/Form.stories.tsx
+++ b/packages/react/src/components/form/Form.stories.tsx
@@ -58,7 +58,7 @@ function SignUpForm({
             <FormItem>
               <FormLabel>Username</FormLabel>
               <FormControl>
-                <Input variant="default" placeholder="janedoe" {...field} />
+                <Input variant="bordered" placeholder="janedoe" {...field} />
               </FormControl>
               <FormDescription>Your public display name.</FormDescription>
               <FormMessage />
@@ -74,7 +74,7 @@ function SignUpForm({
               <FormControl>
                 <Input
                   type="email"
-                  variant="default"
+                  variant="bordered"
                   placeholder="jane@example.com"
                   {...field}
                 />
@@ -108,7 +108,7 @@ function UsernameForm({ extraDescriptionId }: { extraDescriptionId?: string }) {
             <FormItem>
               <FormLabel>Username</FormLabel>
               <FormControl aria-describedby={extraDescriptionId}>
-                <Input variant="default" placeholder="janedoe" {...field} />
+                <Input variant="bordered" placeholder="janedoe" {...field} />
               </FormControl>
               <FormDescription>Your public display name.</FormDescription>
               <FormMessage />
@@ -139,7 +139,7 @@ function MessageLessErrorForm() {
             <FormItem>
               <FormLabel>Invite code</FormLabel>
               <FormControl>
-                <Input variant="default" placeholder="NX-123" {...field} />
+                <Input variant="bordered" placeholder="NX-123" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -178,7 +178,7 @@ function AnatomyForm() {
               <FormLabel>Label, control, description</FormLabel>
               <FormControl>
                 <Input
-                  variant="default"
+                  variant="bordered"
                   placeholder="Standard field"
                   {...field}
                 />
@@ -195,7 +195,7 @@ function AnatomyForm() {
               <FormLabel>Label and control</FormLabel>
               <FormControl>
                 <Input
-                  variant="default"
+                  variant="bordered"
                   placeholder="Compact field"
                   {...field}
                 />
@@ -211,7 +211,7 @@ function AnatomyForm() {
             <FormItem>
               <FormLabel>Disabled control</FormLabel>
               <FormControl>
-                <Input disabled variant="default" {...field} />
+                <Input disabled variant="bordered" {...field} />
               </FormControl>
               <FormDescription>The control can be disabled.</FormDescription>
             </FormItem>
@@ -266,7 +266,7 @@ function FieldVsFormErgonomicsExample() {
                   <FormControl>
                     <Input
                       type="email"
-                      variant="default"
+                      variant="bordered"
                       placeholder="jane@example.com"
                       {...field}
                     />
@@ -545,7 +545,7 @@ export const WithDataAttributes: Story = {
     // FormControl wires the control's id + helper description to the FormItem.
     const input = canvas.getByLabelText('Username');
     await expect(input).toHaveAttribute('id', label.getAttribute('for'));
-    await expect(input).toHaveAttribute('data-variant', 'default');
+    await expect(input).toHaveAttribute('data-variant', 'bordered');
     await expect(input).not.toHaveAttribute('data-variant', 'borderless');
     await expect(input).toHaveAttribute(
       'aria-describedby',

--- a/packages/react/src/components/form/Form.stories.tsx
+++ b/packages/react/src/components/form/Form.stories.tsx
@@ -58,7 +58,7 @@ function SignUpForm({
             <FormItem>
               <FormLabel>Username</FormLabel>
               <FormControl>
-                <Input placeholder="janedoe" {...field} />
+                <Input variant="default" placeholder="janedoe" {...field} />
               </FormControl>
               <FormDescription>Your public display name.</FormDescription>
               <FormMessage />
@@ -72,7 +72,12 @@ function SignUpForm({
             <FormItem>
               <FormLabel>Email</FormLabel>
               <FormControl>
-                <Input type="email" placeholder="jane@example.com" {...field} />
+                <Input
+                  type="email"
+                  variant="default"
+                  placeholder="jane@example.com"
+                  {...field}
+                />
               </FormControl>
               <FormDescription>Used for sign-in and receipts.</FormDescription>
               <FormMessage />
@@ -103,7 +108,7 @@ function UsernameForm({ extraDescriptionId }: { extraDescriptionId?: string }) {
             <FormItem>
               <FormLabel>Username</FormLabel>
               <FormControl aria-describedby={extraDescriptionId}>
-                <Input placeholder="janedoe" {...field} />
+                <Input variant="default" placeholder="janedoe" {...field} />
               </FormControl>
               <FormDescription>Your public display name.</FormDescription>
               <FormMessage />
@@ -134,7 +139,7 @@ function MessageLessErrorForm() {
             <FormItem>
               <FormLabel>Invite code</FormLabel>
               <FormControl>
-                <Input placeholder="NX-123" {...field} />
+                <Input variant="default" placeholder="NX-123" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -172,7 +177,11 @@ function AnatomyForm() {
             <FormItem>
               <FormLabel>Label, control, description</FormLabel>
               <FormControl>
-                <Input placeholder="Standard field" {...field} />
+                <Input
+                  variant="default"
+                  placeholder="Standard field"
+                  {...field}
+                />
               </FormControl>
               <FormDescription>Helper text under the control.</FormDescription>
             </FormItem>
@@ -185,7 +194,11 @@ function AnatomyForm() {
             <FormItem>
               <FormLabel>Label and control</FormLabel>
               <FormControl>
-                <Input placeholder="Compact field" {...field} />
+                <Input
+                  variant="default"
+                  placeholder="Compact field"
+                  {...field}
+                />
               </FormControl>
               <FormDescription>Descriptions remain optional.</FormDescription>
             </FormItem>
@@ -198,7 +211,7 @@ function AnatomyForm() {
             <FormItem>
               <FormLabel>Disabled control</FormLabel>
               <FormControl>
-                <Input disabled {...field} />
+                <Input disabled variant="default" {...field} />
               </FormControl>
               <FormDescription>The control can be disabled.</FormDescription>
             </FormItem>
@@ -253,6 +266,7 @@ function FieldVsFormErgonomicsExample() {
                   <FormControl>
                     <Input
                       type="email"
+                      variant="default"
                       placeholder="jane@example.com"
                       {...field}
                     />
@@ -531,11 +545,16 @@ export const WithDataAttributes: Story = {
     // FormControl wires the control's id + helper description to the FormItem.
     const input = canvas.getByLabelText('Username');
     await expect(input).toHaveAttribute('id', label.getAttribute('for'));
+    await expect(input).toHaveAttribute('data-variant', 'default');
+    await expect(input).not.toHaveAttribute('data-variant', 'borderless');
     await expect(input).toHaveAttribute(
       'aria-describedby',
       description.getAttribute('id')
     );
     await expect(input).not.toHaveAttribute('aria-errormessage');
+    await expect(
+      canvasElement.querySelector('[data-variant="borderless"]')
+    ).not.toBeInTheDocument();
 
     await expect(
       canvasElement.querySelector('[data-slot="form-item"]')

--- a/packages/react/src/components/form/Form.stories.tsx
+++ b/packages/react/src/components/form/Form.stories.tsx
@@ -58,7 +58,7 @@ function SignUpForm({
             <FormItem>
               <FormLabel>Username</FormLabel>
               <FormControl>
-                <Input variant="bordered" placeholder="janedoe" {...field} />
+                <Input placeholder="janedoe" {...field} />
               </FormControl>
               <FormDescription>Your public display name.</FormDescription>
               <FormMessage />
@@ -72,12 +72,7 @@ function SignUpForm({
             <FormItem>
               <FormLabel>Email</FormLabel>
               <FormControl>
-                <Input
-                  type="email"
-                  variant="bordered"
-                  placeholder="jane@example.com"
-                  {...field}
-                />
+                <Input type="email" placeholder="jane@example.com" {...field} />
               </FormControl>
               <FormDescription>Used for sign-in and receipts.</FormDescription>
               <FormMessage />
@@ -108,7 +103,7 @@ function UsernameForm({ extraDescriptionId }: { extraDescriptionId?: string }) {
             <FormItem>
               <FormLabel>Username</FormLabel>
               <FormControl aria-describedby={extraDescriptionId}>
-                <Input variant="bordered" placeholder="janedoe" {...field} />
+                <Input placeholder="janedoe" {...field} />
               </FormControl>
               <FormDescription>Your public display name.</FormDescription>
               <FormMessage />
@@ -139,7 +134,7 @@ function MessageLessErrorForm() {
             <FormItem>
               <FormLabel>Invite code</FormLabel>
               <FormControl>
-                <Input variant="bordered" placeholder="NX-123" {...field} />
+                <Input placeholder="NX-123" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -177,11 +172,7 @@ function AnatomyForm() {
             <FormItem>
               <FormLabel>Label, control, description</FormLabel>
               <FormControl>
-                <Input
-                  variant="bordered"
-                  placeholder="Standard field"
-                  {...field}
-                />
+                <Input placeholder="Standard field" {...field} />
               </FormControl>
               <FormDescription>Helper text under the control.</FormDescription>
             </FormItem>
@@ -194,11 +185,7 @@ function AnatomyForm() {
             <FormItem>
               <FormLabel>Label and control</FormLabel>
               <FormControl>
-                <Input
-                  variant="bordered"
-                  placeholder="Compact field"
-                  {...field}
-                />
+                <Input placeholder="Compact field" {...field} />
               </FormControl>
               <FormDescription>Descriptions remain optional.</FormDescription>
             </FormItem>
@@ -211,7 +198,7 @@ function AnatomyForm() {
             <FormItem>
               <FormLabel>Disabled control</FormLabel>
               <FormControl>
-                <Input disabled variant="bordered" {...field} />
+                <Input disabled {...field} />
               </FormControl>
               <FormDescription>The control can be disabled.</FormDescription>
             </FormItem>
@@ -266,7 +253,6 @@ function FieldVsFormErgonomicsExample() {
                   <FormControl>
                     <Input
                       type="email"
-                      variant="bordered"
                       placeholder="jane@example.com"
                       {...field}
                     />
@@ -546,15 +532,11 @@ export const WithDataAttributes: Story = {
     const input = canvas.getByLabelText('Username');
     await expect(input).toHaveAttribute('id', label.getAttribute('for'));
     await expect(input).toHaveAttribute('data-variant', 'bordered');
-    await expect(input).not.toHaveAttribute('data-variant', 'borderless');
     await expect(input).toHaveAttribute(
       'aria-describedby',
       description.getAttribute('id')
     );
     await expect(input).not.toHaveAttribute('aria-errormessage');
-    await expect(
-      canvasElement.querySelector('[data-variant="borderless"]')
-    ).not.toBeInTheDocument();
 
     await expect(
       canvasElement.querySelector('[data-slot="form-item"]')

--- a/packages/react/src/components/input-group/InputGroup.stories.tsx
+++ b/packages/react/src/components/input-group/InputGroup.stories.tsx
@@ -219,7 +219,7 @@ export const WithDataAttributes: Story = {
     const group = canvasElement.querySelector('[data-slot="input-group"]');
     await expect(group).toBeInTheDocument();
     await expect(group).toHaveAttribute('role', 'group');
-    await expect(group).toHaveAttribute('data-variant', 'default');
+    await expect(group).toHaveAttribute('data-variant', 'bordered');
     await expect(
       canvasElement.querySelector('[data-slot="input-group-addon"]')
     ).toBeInTheDocument();

--- a/packages/react/src/components/input-group/input-group.tsx
+++ b/packages/react/src/components/input-group/input-group.tsx
@@ -39,14 +39,14 @@ const inputGroupVariants = cva(
   {
     variants: {
       variant: {
-        default:
+        bordered:
           'nx:border-border-default nx:bg-background nx:not-data-[disabled=true]:hover:bg-background-hover nx:data-[disabled=true]:border-border-disabled',
         borderless:
           'nx:border-transparent nx:bg-control-background nx:not-data-[disabled=true]:hover:bg-control-background-hover',
       },
     },
     defaultVariants: {
-      variant: 'default',
+      variant: 'bordered',
     },
   }
 );
@@ -73,8 +73,9 @@ interface InputGroupProps
  *
  * The visible frame matches a standalone `Input`: an inline group takes the
  * control's `size` height. Stacked (block-aligned) groups stay auto-height.
- * Use `variant="borderless"` to remove the resting field stroke while keeping a
- * tonal control fill for resting affordance.
+ * The `variant="bordered"` treatment is the default; use `variant="borderless"`
+ * to remove the resting field stroke while keeping a tonal control fill for
+ * resting affordance.
  *
  * @example
  * ```tsx
@@ -90,7 +91,7 @@ function InputGroup({ className, variant, ...props }: InputGroupProps) {
   return (
     <div
       data-slot="input-group"
-      data-variant={variant ?? 'default'}
+      data-variant={variant ?? 'bordered'}
       role="group"
       className={cn(inputGroupVariants({ variant, className }))}
       {...props}

--- a/packages/react/src/components/input/Input.stories.tsx
+++ b/packages/react/src/components/input/Input.stories.tsx
@@ -158,7 +158,7 @@ export const BorderlessStates: Story = {
     await expect(readOnly).not.toBeDisabled();
 
     await expect(invalid).toHaveAttribute('aria-invalid', 'true');
-    await expect(invalid).toHaveClass('nx:aria-invalid:border-color-error');
+    await expect(invalid).toHaveClass('nx:aria-invalid:border-border-error');
     await expect(window.getComputedStyle(invalid).borderTopWidth).toBe('0px');
     await expect(window.getComputedStyle(invalid).boxShadow).not.toBe('none');
 

--- a/packages/react/src/components/input/Input.stories.tsx
+++ b/packages/react/src/components/input/Input.stories.tsx
@@ -29,7 +29,7 @@ const meta: Meta<typeof Input> = {
     },
     variant: {
       control: 'select',
-      options: ['default', 'borderless'],
+      options: ['bordered', 'borderless'],
       description: 'The visual treatment of the input',
     },
     type: {
@@ -537,7 +537,7 @@ export const WithDataAttributes: Story = {
 
     await expect(input).toHaveAttribute('data-slot', 'input');
     await expect(input).toHaveAttribute('data-size', 'lg');
-    await expect(input).toHaveAttribute('data-variant', 'default');
+    await expect(input).toHaveAttribute('data-variant', 'bordered');
   },
 };
 
@@ -581,9 +581,9 @@ export const AllVariants: Story = {
         <div className="nx:flex nx:flex-col nx:gap-3">
           <div className="nx:flex nx:items-center nx:gap-4">
             <span className="nx:typography-label-small nx:text-muted-foreground nx:w-20">
-              default
+              bordered
             </span>
-            <Input placeholder="Default input" />
+            <Input placeholder="Bordered input" />
           </div>
           <div className="nx:flex nx:items-center nx:gap-4">
             <span className="nx:typography-label-small nx:text-muted-foreground nx:w-20">

--- a/packages/react/src/components/input/Input.stories.tsx
+++ b/packages/react/src/components/input/Input.stories.tsx
@@ -164,7 +164,9 @@ export const BorderlessStates: Story = {
 
     await expect(disabled).toBeDisabled();
     await expect(disabled).toHaveClass('nx:disabled:bg-disabled');
-    await expect(disabled).not.toHaveClass('nx:disabled:border-color-disabled');
+    await expect(disabled).not.toHaveClass(
+      'nx:disabled:border-border-disabled'
+    );
   },
 };
 
@@ -519,7 +521,7 @@ export const VisualStateTokens: Story = {
       'nx:disabled:placeholder:text-disabled-foreground'
     );
     await expect(disabledEmpty).toHaveClass(
-      'nx:disabled:border-color-disabled'
+      'nx:disabled:border-border-disabled'
     );
     // Disabled uses a token color, not opacity-50 — opacity stays 1.
     await expect(window.getComputedStyle(disabledEmpty).opacity).toBe('1');

--- a/packages/react/src/components/input/input.tsx
+++ b/packages/react/src/components/input/input.tsx
@@ -22,7 +22,7 @@ const inputVariants = cva(
         lg: 'nx:h-12 nx:px-3.5 nx:py-0 nx:typography-body-default',
       },
       variant: {
-        default:
+        bordered:
           'nx:border-color-default nx:bg-background nx:enabled:hover:bg-background-hover nx:disabled:border-color-disabled',
         borderless:
           'nx:border-transparent nx:bg-control-background nx:enabled:hover:bg-control-background-hover',
@@ -30,7 +30,7 @@ const inputVariants = cva(
     },
     defaultVariants: {
       size: 'default',
-      variant: 'default',
+      variant: 'bordered',
     },
   }
 );
@@ -49,9 +49,10 @@ interface InputProps
  * Input
  *
  * A text input field for collecting user data.
- * Supports different sizes and all native input attributes. Use
- * `variant="borderless"` to remove the resting field stroke while keeping a tonal
- * control fill for resting affordance.
+ * Supports different sizes and all native input attributes. The
+ * `variant="bordered"` treatment is the default; use `variant="borderless"` to
+ * remove the resting field stroke while keeping a tonal control fill for
+ * resting affordance.
  *
  * @example
  * ```tsx
@@ -76,7 +77,7 @@ function Input({ className, type, size, variant, ...props }: InputProps) {
       type={type}
       data-slot="input"
       data-size={size ?? 'default'}
-      data-variant={variant ?? 'default'}
+      data-variant={variant ?? 'bordered'}
       className={cn(inputVariants({ size, variant, className }))}
       {...props}
     />

--- a/packages/react/src/components/input/input.tsx
+++ b/packages/react/src/components/input/input.tsx
@@ -23,7 +23,7 @@ const inputVariants = cva(
       },
       variant: {
         bordered:
-          'nx:border-color-default nx:bg-background nx:enabled:hover:bg-background-hover nx:disabled:border-color-disabled',
+          'nx:border-border-default nx:bg-background nx:enabled:hover:bg-background-hover nx:disabled:border-border-disabled',
         borderless:
           'nx:border-transparent nx:bg-control-background nx:enabled:hover:bg-control-background-hover',
       },

--- a/packages/react/src/components/input/input.tsx
+++ b/packages/react/src/components/input/input.tsx
@@ -11,7 +11,7 @@ const inputVariants = cva(
     'nx:file:border-0 nx:file:bg-transparent nx:file:typography-label-default nx:file:text-foreground nx:disabled:file:text-disabled-foreground',
     'nx:placeholder:text-muted-foreground',
     'nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-(--focus-offset)',
-    'nx:aria-invalid:border-color-error nx:aria-invalid:focus-visible:outline-focus-error',
+    'nx:aria-invalid:border-border-error nx:aria-invalid:focus-visible:outline-focus-error',
     'nx:disabled:cursor-not-allowed nx:disabled:bg-disabled nx:disabled:text-disabled-foreground nx:disabled:placeholder:text-disabled-foreground',
   ],
   {

--- a/packages/react/src/components/native-select/NativeSelect.stories.tsx
+++ b/packages/react/src/components/native-select/NativeSelect.stories.tsx
@@ -263,7 +263,7 @@ export const WithDataAttributes: Story = {
     const select = canvasElement.querySelector('[data-slot="native-select"]');
     await expect(select).toBeInTheDocument();
     await expect(select).toHaveAttribute('data-size', 'default');
-    await expect(select).toHaveAttribute('data-variant', 'default');
+    await expect(select).toHaveAttribute('data-variant', 'bordered');
     await expect(
       canvasElement.querySelector('[data-slot="native-select-wrapper"]')
     ).toBeInTheDocument();
@@ -277,12 +277,12 @@ export const WithDataAttributes: Story = {
 // ALL VARIANTS GRID
 // ============================================
 
-// Default, small, invalid, and disabled side by side. Reused by the per-base
+// Bordered, small, invalid, and disabled side by side. Reused by the per-base
 // variant generator.
 export const AllVariants: Story = {
   render: () => (
     <div className="nx:flex nx:flex-col nx:gap-3">
-      <NativeSelect size="default" aria-label="Default" defaultValue="pro">
+      <NativeSelect size="default" aria-label="Bordered" defaultValue="pro">
         <NativeSelectOption value="free">Free</NativeSelectOption>
         <NativeSelectOption value="pro">Pro</NativeSelectOption>
       </NativeSelect>

--- a/packages/react/src/components/native-select/native-select.tsx
+++ b/packages/react/src/components/native-select/native-select.tsx
@@ -20,7 +20,7 @@ const nativeSelectVariants = cva(
         sm: 'nx:px-2.5 nx:py-1.5 nx:pr-9 nx:typography-body-small',
       },
       variant: {
-        default:
+        bordered:
           'nx:border-border-default nx:bg-background nx:enabled:hover:bg-background-hover nx:disabled:border-border-disabled',
         borderless:
           'nx:border-transparent nx:bg-control-background nx:enabled:hover:bg-control-background-hover',
@@ -28,7 +28,7 @@ const nativeSelectVariants = cva(
     },
     defaultVariants: {
       size: 'default',
-      variant: 'default',
+      variant: 'bordered',
     },
   }
 );
@@ -49,8 +49,9 @@ interface NativeSelectProps
  * A styled wrapper over the native `<select>` — on mobile it opens the OS
  * picker (iOS wheel / Android sheet), the preferred dense-form UX there. The
  * open list is OS-rendered. For rich options (icons, descriptions, grouping)
- * on desktop, use `Select`. Use `variant="borderless"` to remove the resting
- * field stroke while keeping a tonal control fill for resting affordance.
+ * on desktop, use `Select`. The `variant="bordered"` treatment is the default;
+ * use `variant="borderless"` to remove the resting field stroke while keeping a
+ * tonal control fill for resting affordance.
  *
  * @example
  * ```tsx
@@ -74,7 +75,7 @@ function NativeSelect({
       <select
         data-slot="native-select"
         data-size={size}
-        data-variant={variant ?? 'default'}
+        data-variant={variant ?? 'bordered'}
         className={cn(nativeSelectVariants({ size, variant, className }))}
         {...props}
       />

--- a/packages/react/src/components/select/Select.stories.tsx
+++ b/packages/react/src/components/select/Select.stories.tsx
@@ -766,7 +766,7 @@ export const WithDataAttributes: Story = {
     // Check trigger data-slot
     const trigger = canvas.getByRole('combobox');
     await expect(trigger).toHaveAttribute('data-slot', 'select-trigger');
-    await expect(trigger).toHaveAttribute('data-variant', 'default');
+    await expect(trigger).toHaveAttribute('data-variant', 'bordered');
     await expect(trigger).toHaveClass('nx:enabled:hover:bg-background-hover');
 
     // Open the select
@@ -807,12 +807,12 @@ export const AllVariants: Story = {
         <div className="nx:flex nx:flex-col nx:gap-4">
           <div className="nx:flex nx:items-center nx:gap-4">
             <span className="nx:typography-label-small nx:text-muted-foreground nx:w-24">
-              Default
+              Bordered
             </span>
             <Select>
               <SelectTrigger
                 className="nx:w-[180px]"
-                aria-label="Default variant select"
+                aria-label="Bordered variant select"
               >
                 <SelectValue placeholder="Select option" />
               </SelectTrigger>

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -64,14 +64,14 @@ const selectTriggerVariants = cva(
   {
     variants: {
       variant: {
-        default:
+        bordered:
           'nx:border-border-default nx:bg-background nx:enabled:hover:bg-background-hover nx:disabled:border-border-disabled',
         borderless:
           'nx:border-transparent nx:bg-control-background nx:enabled:hover:bg-control-background-hover',
       },
     },
     defaultVariants: {
-      variant: 'default',
+      variant: 'bordered',
     },
   }
 );
@@ -89,8 +89,9 @@ interface SelectTriggerProps
 /**
  * SelectTrigger
  *
- * Button that opens the select dropdown. Use `variant="borderless"` to remove
- * the resting field stroke while keeping a tonal control fill for resting affordance.
+ * Button that opens the select dropdown. The `variant="bordered"` treatment is
+ * the default; use `variant="borderless"` to remove the resting field stroke
+ * while keeping a tonal control fill for resting affordance.
  *
  * @example
  * ```tsx
@@ -108,7 +109,7 @@ function SelectTrigger({
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
-      data-variant={variant ?? 'default'}
+      data-variant={variant ?? 'bordered'}
       className={cn(selectTriggerVariants({ variant, className }))}
       {...props}
     >

--- a/packages/react/src/components/textarea/Textarea.stories.tsx
+++ b/packages/react/src/components/textarea/Textarea.stories.tsx
@@ -28,7 +28,7 @@ const meta: Meta<typeof Textarea> = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['default', 'borderless'],
+      options: ['bordered', 'borderless'],
       description: 'The visual treatment of the textarea',
     },
     disabled: {
@@ -379,7 +379,7 @@ export const WithDataAttributes: Story = {
     const textarea = canvas.getByRole('textbox');
 
     await expect(textarea).toHaveAttribute('data-slot', 'textarea');
-    await expect(textarea).toHaveAttribute('data-variant', 'default');
+    await expect(textarea).toHaveAttribute('data-variant', 'bordered');
     await expect(textarea).toHaveClass('nx:enabled:hover:bg-background-hover');
   },
 };
@@ -398,9 +398,9 @@ export const AllVariants: Story = {
         <div className="nx:flex nx:flex-col nx:gap-3">
           <div className="nx:flex nx:items-start nx:gap-4">
             <span className="nx:typography-label-small nx:text-muted-foreground nx:w-20 nx:pt-2">
-              default
+              bordered
             </span>
-            <Textarea placeholder="Default textarea" />
+            <Textarea placeholder="Bordered textarea" />
           </div>
           <div className="nx:flex nx:items-start nx:gap-4">
             <span className="nx:typography-label-small nx:text-muted-foreground nx:w-20 nx:pt-2">

--- a/packages/react/src/components/textarea/textarea.tsx
+++ b/packages/react/src/components/textarea/textarea.tsx
@@ -17,14 +17,14 @@ const textareaVariants = cva(
   {
     variants: {
       variant: {
-        default:
+        bordered:
           'nx:border-border-default nx:bg-background nx:enabled:hover:bg-background-hover nx:disabled:border-border-disabled',
         borderless:
           'nx:border-transparent nx:bg-control-background nx:enabled:hover:bg-control-background-hover',
       },
     },
     defaultVariants: {
-      variant: 'default',
+      variant: 'bordered',
     },
   }
 );
@@ -44,9 +44,10 @@ interface TextareaProps
  *
  * A multi-line text input. Mirrors Input's surface, focus, and `aria-invalid`
  * treatment and accepts all native textarea attributes. Use `rows` (or a
- * `min-height` override via `className`) to set the initial height. Use
- * `variant="borderless"` to remove the resting field stroke while keeping a tonal
- * control fill for resting affordance.
+ * `min-height` override via `className`) to set the initial height. The
+ * `variant="bordered"` treatment is the default; use `variant="borderless"` to
+ * remove the resting field stroke while keeping a tonal control fill for
+ * resting affordance.
  *
  * @example
  * ```tsx
@@ -63,7 +64,7 @@ function Textarea({ className, variant, ...props }: TextareaProps) {
   return (
     <textarea
       data-slot="textarea"
-      data-variant={variant ?? 'default'}
+      data-variant={variant ?? 'bordered'}
       className={cn(textareaVariants({ variant, className }))}
       {...props}
     />

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -1044,12 +1044,12 @@
 }
 
 /* ===== FOCUS RING ===== */
-[data-slot='input'][data-variant='default'],
-[data-slot='sidebar-input'][data-variant='default'],
-[data-slot='textarea'][data-variant='default'],
-[data-slot='native-select'][data-variant='default'],
-[data-slot='select-trigger'][data-variant='default'],
-[data-slot='input-group'][data-variant='default'] {
+[data-slot='input'][data-variant='bordered'],
+[data-slot='sidebar-input'][data-variant='bordered'],
+[data-slot='textarea'][data-variant='bordered'],
+[data-slot='native-select'][data-variant='bordered'],
+[data-slot='select-trigger'][data-variant='bordered'],
+[data-slot='input-group'][data-variant='bordered'] {
   border-color: transparent !important;
   border-width: 0;
   box-shadow: inset 0 0 0 1px var(--color-border-default);
@@ -1066,12 +1066,12 @@
   box-shadow: inset 0 0 0 1px var(--color-border-error);
 }
 
-[data-slot='input'][data-variant='default']:disabled,
-[data-slot='sidebar-input'][data-variant='default']:disabled,
-[data-slot='textarea'][data-variant='default']:disabled,
-[data-slot='native-select'][data-variant='default']:disabled,
-[data-slot='select-trigger'][data-variant='default']:disabled,
-[data-slot='input-group'][data-variant='default'][data-disabled='true'] {
+[data-slot='input'][data-variant='bordered']:disabled,
+[data-slot='sidebar-input'][data-variant='bordered']:disabled,
+[data-slot='textarea'][data-variant='bordered']:disabled,
+[data-slot='native-select'][data-variant='bordered']:disabled,
+[data-slot='select-trigger'][data-variant='bordered']:disabled,
+[data-slot='input-group'][data-variant='bordered'][data-disabled='true'] {
   border-color: transparent !important;
   border-width: 0;
   box-shadow: inset 0 0 0 1px var(--color-border-disabled);
@@ -1200,12 +1200,12 @@
 }
 
 @media (forced-colors: active) {
-  [data-slot='input'][data-variant='default'],
-  [data-slot='sidebar-input'][data-variant='default'],
-  [data-slot='textarea'][data-variant='default'],
-  [data-slot='native-select'][data-variant='default'],
-  [data-slot='select-trigger'][data-variant='default'],
-  [data-slot='input-group'][data-variant='default'],
+  [data-slot='input'][data-variant='bordered'],
+  [data-slot='sidebar-input'][data-variant='bordered'],
+  [data-slot='textarea'][data-variant='bordered'],
+  [data-slot='native-select'][data-variant='bordered'],
+  [data-slot='select-trigger'][data-variant='bordered'],
+  [data-slot='input-group'][data-variant='bordered'],
   [data-slot='input'][aria-invalid='true'],
   [data-slot='sidebar-input'][aria-invalid='true'],
   [data-slot='textarea'][aria-invalid='true'],
@@ -1218,12 +1218,12 @@
     box-shadow: none !important;
   }
 
-  [data-slot='input'][data-variant='default']:disabled,
-  [data-slot='sidebar-input'][data-variant='default']:disabled,
-  [data-slot='textarea'][data-variant='default']:disabled,
-  [data-slot='native-select'][data-variant='default']:disabled,
-  [data-slot='select-trigger'][data-variant='default']:disabled,
-  [data-slot='input-group'][data-variant='default'][data-disabled='true'],
+  [data-slot='input'][data-variant='bordered']:disabled,
+  [data-slot='sidebar-input'][data-variant='bordered']:disabled,
+  [data-slot='textarea'][data-variant='bordered']:disabled,
+  [data-slot='native-select'][data-variant='bordered']:disabled,
+  [data-slot='select-trigger'][data-variant='bordered']:disabled,
+  [data-slot='input-group'][data-variant='bordered'][data-disabled='true'],
   [class~='nx:group/input-otp']:has([data-slot='input-otp']:disabled)
     [data-slot='input-otp-slot'] {
     border-color: GrayText !important;


### PR DESCRIPTION
## Summary

- Replaces the field-family `variant="default"` API with `variant="bordered"` before consumers start depending on the old name.
- Keeps the same visual styling for implicit field controls while changing the rendered `data-variant` hook to `bordered`.
- Updates field stories, Form/Profile examples, generated focus/boundary selectors, and generator tests to use `bordered`.

## GitHub Issue

N/A

## Test Plan

- [x] `npx -y modern-web-guidance@latest search "React form field component variant data attributes bordered borderless focus styling" --skill-version 2026_05_16-c5e7870`
- [x] `npx -y modern-web-guidance@latest retrieve "forms"`
- [x] `corepack pnpm tokens:tailwind`
- [x] `corepack pnpm tokens:modular`
- [x] field-family grep guard for no remaining `variant="default"` / `[data-variant='default']` in field paths or generated field CSS
- [x] `corepack pnpm test:unit -- packages/core/scripts/__tests__/utils.test.js packages/core/scripts/__tests__/generate-modular.test.js packages/core/scripts/__tests__/generate-tailwind-package.test.js`
- [x] `corepack pnpm --filter @nexus_ds/react typecheck`
- [x] `corepack pnpm --filter @nexus_ds/console typecheck`
- [x] `corepack pnpm --filter @nexus_ds/react build`
- [x] `corepack pnpm exec prettier --check` on all changed tracked files
- [x] `corepack pnpm exec eslint` on all changed TS/TSX/JS files
- [x] `corepack pnpm test:storybook -- packages/react/src/components/input/Input.stories.tsx packages/react/src/components/textarea/Textarea.stories.tsx packages/react/src/components/native-select/NativeSelect.stories.tsx packages/react/src/components/select/Select.stories.tsx packages/react/src/components/input-group/InputGroup.stories.tsx packages/react/src/components/form/Form.stories.tsx` (`64` files / `779` tests; runner expanded to full Storybook project)
- [x] `corepack pnpm lint-staged`
