### PR TITLE
feat(core): bake engine floor into generated CSS

### DIFF
--- a/.changeset/tailwind-engine-floor.md
+++ b/.changeset/tailwind-engine-floor.md
@@ -1,5 +1,4 @@
 ---
-'@nexus_ds/core': minor
 '@nexus_ds/tailwind': minor
 ---
 

--- a/.changeset/tailwind-engine-floor.md
+++ b/.changeset/tailwind-engine-floor.md
@@ -1,0 +1,6 @@
+---
+'@nexus_ds/core': minor
+'@nexus_ds/tailwind': minor
+---
+
+Bake the token engine floor into generated Tailwind CSS semantic color fallbacks. Runtime `--nx-color-*` overrides still win, while the committed fallback literals now come from the reviewed engine matrix instead of semantic color JSON.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,9 @@ jobs:
       - name: Check canonical step set freshness
         run: pnpm --filter @nexus_ds/eslint-plugin refresh:canonical-set --check
 
+      - name: Build @nexus_ds/core
+        run: pnpm --filter @nexus_ds/core build
+
       - name: Regenerate token outputs (tailwind + modular)
         id: regen
         run: |
@@ -381,8 +384,6 @@ jobs:
           set -euo pipefail
           DIRTY=$(git status --porcelain -- \
             packages/tailwind \
-            apps/console/public/themes \
-            apps/console/src/styles \
             apps/docs/public/themes)
           if [ -n "$DIRTY" ]; then
             echo "::error::Token output is stale. Affected paths:"

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -1,8 +1,8 @@
+import * as engine from '@nexus_ds/core';
 import fs from 'fs';
 import { createRequire } from 'module';
 import os from 'os';
 import path from 'path';
-import * as engine from '@nexus_ds/core';
 import * as prettier from 'prettier';
 import { compile } from 'tailwindcss';
 import { fileURLToPath } from 'url';

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import { createRequire } from 'module';
 import os from 'os';
 import path from 'path';
+import * as engine from '@nexus_ds/core';
 import * as prettier from 'prettier';
 import { compile } from 'tailwindcss';
 import { fileURLToPath } from 'url';
@@ -31,6 +32,9 @@ const SPACING_MODES = [
 const RADIUS_MODES = ['extra-round', 'round', 'smooth', 'square', 'subtle'];
 const SHADOW_MODES = ['flat', 'quiet', 'soft', 'standard', 'strong'];
 const BORDERWIDTH_MODES = ['fine', 'normal', 'strong'];
+const DEFAULT_ENGINE_THEME = engine.deriveTheme(
+  engine.createNexusThemeContract(engine.DEFAULT_NEXUS_APPEARANCE)
+);
 
 function readSpacingModeJson(mode) {
   return JSON.parse(
@@ -48,6 +52,59 @@ function makeTmpDir() {
 
 function read(distDir, fileName) {
   return fs.readFileSync(path.join(distDir, fileName), 'utf8');
+}
+
+function generatorOptions(distDir) {
+  return { distDir, engine };
+}
+
+function engineColor(name, mode = 'light') {
+  const value = DEFAULT_ENGINE_THEME[mode][`--nx-color-${name}`];
+  if (!value) {
+    throw new Error(`Missing engine color ${mode}.${name}`);
+  }
+  return value;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function colorFallbackPattern(name, mode = 'light') {
+  return new RegExp(
+    `${escapeRegExp(`--color-${name}:`)}\\s*var\\(\\s*${escapeRegExp(
+      `--nx-color-${name}`
+    )},\\s*${escapeRegExp(engineColor(name, mode))}\\s*\\);`
+  );
+}
+
+function colorPropertyFallbackPattern(property, name, mode = 'light') {
+  return new RegExp(
+    `${escapeRegExp(`${property}:`)}\\s*var\\(\\s*${escapeRegExp(
+      `--nx-color-${name}`
+    )},\\s*${escapeRegExp(engineColor(name, mode))}\\s*\\);`
+  );
+}
+
+function colorDeclarationPattern(name, mode = 'light') {
+  return new RegExp(
+    `${escapeRegExp(`--nx-color-${name}:`)}\\s*${escapeRegExp(
+      engineColor(name, mode)
+    )};`
+  );
+}
+
+function extractCompiledClassBlock(css, className) {
+  const cssSelector = `.${className.replace(/:/g, '\\:')}`;
+  const pattern = new RegExp(
+    `${escapeRegExp(cssSelector)}\\s*\\{([\\s\\S]*?)\\}`,
+    'm'
+  );
+  const match = css.match(pattern);
+  if (!match) {
+    throw new Error(`Compiled class "${className}" not found in CSS`);
+  }
+  return match[1];
 }
 
 function extractBlock(css, openSelector) {
@@ -119,6 +176,15 @@ function compactCss(value) {
   return value.replace(/\s+/g, ' ').trim();
 }
 
+function normalizeCssValue(value) {
+  return compactCss(value)
+    .replace(/(-?\d+\.\d+)/g, (number) => String(Number(number)))
+    .replace(/var\(\s+/g, 'var(')
+    .replace(/oklch\(\s+/g, 'oklch(')
+    .replace(/,\s*/g, ', ')
+    .replace(/\s+\)/g, ')');
+}
+
 async function compileGeneratedTailwind(distDir, candidates) {
   const source = [
     `@import './nexus.css';`,
@@ -162,7 +228,7 @@ describe('border alias utility generators', () => {
 
   it('emits color aliases only for approved semantic border names', () => {
     const result = generateBorderColorAliasUtilitiesCSS([
-      { cssName: 'color-border-default' },
+      { cssName: 'color-border-default', value: engineColor('border-default') },
       { cssName: 'color-border-radius-sm' },
       { cssName: 'color-nav-border' },
     ]);
@@ -192,7 +258,7 @@ describe('generateTailwindPackage', () => {
 
     try {
       distDir = makeTmpDir();
-      await generateTailwindPackage(DEFAULT_CONFIG, { distDir });
+      await generateTailwindPackage(DEFAULT_CONFIG, generatorOptions(distDir));
     } finally {
       console.warn = originalWarn;
     }
@@ -232,12 +298,8 @@ describe('generateTailwindPackage', () => {
   // catches duplicate emission via the dimension scan (the --breakpoint-* trap).
   it('promotes focus colours to --color-* and emits --focus-offset plus focus ring CSS', () => {
     const themeBlock = compactCss(extractBlock(nexusCSS, '@theme inline'));
-    expect(themeBlock).toMatch(
-      /--color-focus-default: var\(\s*--nx-color-focus-default,\s*var\(--color-primary-subtle-foreground\)\s*\);/
-    );
-    expect(themeBlock).toMatch(
-      /--color-focus-error: var\(\s*--nx-color-focus-error,\s*var\(--nx-focus-color-error\)\s*\);/
-    );
+    expect(themeBlock).toMatch(colorFallbackPattern('focus-default'));
+    expect(themeBlock).toMatch(colorFallbackPattern('focus-error'));
     expect(nexusCSS.match(/--focus-offset:/g)).toHaveLength(1);
     expect(themeBlock).not.toMatch(/--focus-offset/);
     expect(nexusCSS).toMatch(/:root\s*\{[^}]*--focus-offset: 2px;[^}]*\}/);
@@ -358,13 +420,36 @@ describe('generateTailwindPackage', () => {
     }
   });
 
+  it('emits the engine floor at every semantic color emission site', () => {
+    const themeDeclarations = cssDeclarations(
+      extractBlock(nexusCSS, '@theme inline')
+    );
+    const rootDeclarations = cssDeclarations(extractBlock(nexusCSS, ':root'));
+    const darkDeclarations = cssDeclarations(extractBlock(nexusCSS, '.dark'));
+
+    for (const { name } of engine.SEMANTIC_TOKEN_REGISTRY) {
+      const lightFallback = normalizeCssValue(
+        `var(--nx-color-${name}, ${engineColor(name)})`
+      );
+      expect(
+        normalizeCssValue(themeDeclarations[`--color-${name}`]),
+        `@theme inline ${name}`
+      ).toBe(lightFallback);
+      expect(
+        normalizeCssValue(rootDeclarations[`--color-${name}`]),
+        `:root ${name}`
+      ).toBe(lightFallback);
+      expect(
+        normalizeCssValue(darkDeclarations[`--nx-color-${name}`]),
+        `.dark ${name}`
+      ).toBe(normalizeCssValue(engineColor(name, 'dark')));
+    }
+  });
+
   it('aliases semantic colors at :root for non-utility CSS consumers', () => {
-    expect(nexusCSS).toMatch(
-      /:root\s*\{[\s\S]*--color-background:\s*var\(--nx-color-background,\s*var\(--nx-color-white-base\)\);[\s\S]*\}/
-    );
-    expect(nexusCSS).toMatch(
-      /:root\s*\{[\s\S]*--color-focus-default:\s*var\(\s*--nx-color-focus-default,\s*var\(--color-primary-subtle-foreground\)\s*\);[\s\S]*\}/
-    );
+    const rootBlock = compactCss(extractBlock(nexusCSS, ':root'));
+    expect(rootBlock).toMatch(colorFallbackPattern('background'));
+    expect(rootBlock).toMatch(colorFallbackPattern('focus-default'));
   });
 
   it('emits the off-grid Model 2 surface primitives as concrete variables', () => {
@@ -389,10 +474,10 @@ describe('generateTailwindPackage', () => {
     );
 
     expect(css).toMatch(
-      /background-color:\s*var\(--nx-color-background,\s*var\(--nx-color-white-base\)\);/
+      colorPropertyFallbackPattern('background-color', 'background')
     );
     expect(css).toMatch(
-      /outline-color:\s*var\(\s*--nx-color-focus-default,\s*var\(--color-primary-subtle-foreground\)\s*\);/
+      colorPropertyFallbackPattern('outline-color', 'focus-default')
     );
   });
 
@@ -444,19 +529,15 @@ describe('generateTailwindPackage', () => {
 
   it('emits chart.categorical tokens in @theme (light) and .dark (dark override)', () => {
     const themeBlock = compactCss(extractBlock(nexusCSS, '@theme inline'));
-    expect(themeBlock).toMatch(
-      /--color-chart-categorical-1: var\(\s*--nx-color-chart-categorical-1,\s*var\(--nx-color-teal-600\)\s*\);/
-    );
-    expect(themeBlock).toMatch(
-      /--color-chart-categorical-5: var\(\s*--nx-color-chart-categorical-5,\s*var\(--nx-color-indigo-600\)\s*\);/
-    );
+    expect(themeBlock).toMatch(colorFallbackPattern('chart-categorical-1'));
+    expect(themeBlock).toMatch(colorFallbackPattern('chart-categorical-5'));
 
-    const darkBlock = extractBlock(nexusCSS, '.dark');
+    const darkBlock = compactCss(extractBlock(nexusCSS, '.dark'));
     expect(darkBlock).toMatch(
-      /--nx-color-chart-categorical-1: var\(--nx-color-teal-200\);/
+      colorDeclarationPattern('chart-categorical-1', 'dark')
     );
     expect(darkBlock).toMatch(
-      /--nx-color-chart-categorical-5: var\(--nx-color-indigo-200\);/
+      colorDeclarationPattern('chart-categorical-5', 'dark')
     );
   });
 
@@ -1062,22 +1143,24 @@ describe('generateTailwindPackage', () => {
       borderColorAliasesCSS,
       '@utility border-color-default'
     );
-    expect(defaultBlock).toMatch(
-      /border-color:\s*var\(--color-border-default\);/
+    expect(compactCss(defaultBlock)).toMatch(
+      colorPropertyFallbackPattern('border-color', 'border-default')
     );
 
     const errorBlock = extractBlock(
       borderColorAliasesCSS,
       '@utility border-color-error'
     );
-    expect(errorBlock).toMatch(/border-color:\s*var\(--color-border-error\);/);
+    expect(compactCss(errorBlock)).toMatch(
+      colorPropertyFallbackPattern('border-color', 'border-error')
+    );
 
     const informationActiveBlock = extractBlock(
       borderColorAliasesCSS,
       '@utility border-color-information-active'
     );
-    expect(informationActiveBlock).toMatch(
-      /border-color:\s*var\(--color-border-information-active\);/
+    expect(compactCss(informationActiveBlock)).toMatch(
+      colorPropertyFallbackPattern('border-color', 'border-information-active')
     );
   });
 
@@ -1102,8 +1185,32 @@ describe('generateTailwindPackage', () => {
     expect(css).toMatch(
       /border-inline-width:\s*var\(--nx-borderwidth-thick\);/
     );
-    expect(css).toMatch(/border-color:\s*var\(--color-border-default\);/);
-    expect(css).toMatch(/border-color:\s*var\(--color-border-error\);/);
+    expect(css).toMatch(
+      colorPropertyFallbackPattern('border-color', 'border-default')
+    );
+    expect(css).toMatch(
+      colorPropertyFallbackPattern('border-color', 'border-error')
+    );
+  });
+
+  it('emits no dangling --color-* references in compiled border color utilities', async () => {
+    const css = await compileGeneratedTailwind(distDir, [
+      'nx:border-color-default',
+      'nx:border-color-error',
+    ]);
+
+    expect(
+      extractCompiledClassBlock(css, 'nx:border-color-default')
+    ).not.toMatch(/var\(\s*--color-/);
+    expect(extractCompiledClassBlock(css, 'nx:border-color-error')).not.toMatch(
+      /var\(\s*--color-/
+    );
+    expect(extractCompiledClassBlock(css, 'nx:border-color-default')).toMatch(
+      colorPropertyFallbackPattern('border-color', 'border-default')
+    );
+    expect(extractCompiledClassBlock(css, 'nx:border-color-error')).toMatch(
+      colorPropertyFallbackPattern('border-color', 'border-error')
+    );
   });
 
   it('spacing-utilities.css declares all 4 role utilities with correct property bindings', () => {
@@ -1227,8 +1334,8 @@ describe('generateTailwindPackage', () => {
     // spacing-touched files.
     const dirA = makeTmpDir();
     const dirB = makeTmpDir();
-    await generateTailwindPackage(DEFAULT_CONFIG, { distDir: dirA });
-    await generateTailwindPackage(DEFAULT_CONFIG, { distDir: dirB });
+    await generateTailwindPackage(DEFAULT_CONFIG, generatorOptions(dirA));
+    await generateTailwindPackage(DEFAULT_CONFIG, generatorOptions(dirB));
 
     for (const file of [
       'variables.css',
@@ -1247,10 +1354,10 @@ describe('generateTailwindPackage', () => {
     await expect(
       generateTailwindPackage(
         { ...DEFAULT_CONFIG, base: 'nonexistent' },
-        { distDir: dir }
+        generatorOptions(dir)
       )
     ).rejects.toThrow(
-      'getSemanticFiles: themed type "base" has no mode "nonexistent"'
+      'generateTailwindPackage: config.base "nonexistent" must be one of: stone, neutral, zinc, slate, gray.'
     );
   });
 
@@ -1260,7 +1367,7 @@ describe('generateTailwindPackage', () => {
     const dir = makeTmpDir();
     await generateTailwindPackage(
       { ...DEFAULT_CONFIG, spacingDefault: 'relaxed' },
-      { distDir: dir }
+      generatorOptions(dir)
     );
     const css = read(dir, 'nexus.css');
 

--- a/packages/core/scripts/generate-tailwind-package.js
+++ b/packages/core/scripts/generate-tailwind-package.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 import {
   CANONICAL_SPACING_DEFAULT_MODE,
@@ -10,7 +10,6 @@ import {
   collectMotionTokens,
   collectRadiusModes,
   collectRadiusTokens,
-  collectSemanticColorTokensVarRef,
   collectSemanticDimensionTokens,
   collectShadowModes,
   collectShadowTokens,
@@ -53,6 +52,11 @@ const TOKENS_DIR = path.join(__dirname, '../tokens');
 const DEFAULT_DIST_DIR = path.join(__dirname, '../dist/tailwind');
 const PRIMITIVES_DIR = path.join(TOKENS_DIR, 'primitives');
 const SEMANTIC_DIR = path.join(TOKENS_DIR, 'semantic');
+const RUNTIME_DIST_ENTRY = path.join(__dirname, '../dist/runtime/index.js');
+
+async function loadDistRuntimeEngine() {
+  return import(pathToFileURL(RUNTIME_DIST_ENTRY).href);
+}
 
 /**
  * Get primitive file paths based on discovered structure and config.
@@ -131,54 +135,80 @@ function assertPrimitiveFilesExist(primitiveFiles) {
   }
 }
 
-/**
- * Get semantic file names based on discovered structure and config
- */
-function getSemanticFiles(discovered, config) {
-  const result = {
-    themed: [],
-    standalone: [],
+function getSemanticSupportFiles(discovered) {
+  return {
+    standalone: discovered.standalone,
   };
+}
 
-  for (const [type, modes] of Object.entries(discovered.themed)) {
-    const configKey = type;
-    let selectedMode = config[configKey];
-
-    if (!selectedMode) {
-      const modeKeys = Object.keys(modes);
-      if (modeKeys.length > 1) {
-        throw new Error(
-          `getSemanticFiles: themed type "${type}" has ${modeKeys.length} modes [${modeKeys.join(', ')}] but no config["${configKey}"] selector. Add '${configKey}': '<mode>' to DEFAULT_CONFIG.`
-        );
-      }
-      selectedMode = modeKeys[0];
-    }
-
-    const selectedFiles = modes[selectedMode];
-    if (!selectedFiles) {
-      throw new Error(
-        `getSemanticFiles: themed type "${type}" has no mode "${selectedMode}". Available modes: ${Object.keys(
-          modes
-        ).join(', ')}.`
-      );
-    }
-
-    if (!selectedFiles.light || !selectedFiles.dark) {
-      throw new Error(
-        `getSemanticFiles: themed type "${type}" mode "${selectedMode}" must provide both light and dark files.`
-      );
-    }
-
-    result.themed.push({
-      type,
-      mode: selectedMode,
-      light: selectedFiles.light,
-      dark: selectedFiles.dark,
-    });
+function assertTokenEngine(engine) {
+  if (
+    !engine ||
+    typeof engine.deriveTheme !== 'function' ||
+    typeof engine.createNexusThemeContract !== 'function' ||
+    !engine.DEFAULT_NEXUS_APPEARANCE ||
+    !Array.isArray(engine.BASE_TONE_OPTIONS) ||
+    !Array.isArray(engine.SEMANTIC_TOKEN_REGISTRY)
+  ) {
+    throw new Error(
+      'generateTailwindPackage: token engine must provide deriveTheme, createNexusThemeContract, DEFAULT_NEXUS_APPEARANCE, BASE_TONE_OPTIONS, and SEMANTIC_TOKEN_REGISTRY.'
+    );
   }
 
-  result.standalone = discovered.standalone;
-  return result;
+  return engine;
+}
+
+function validateBaseTone(config, engine) {
+  const baseTone = config.base ?? DEFAULT_CONFIG.base;
+  const allowedTones = engine.BASE_TONE_OPTIONS.map((option) => option.value);
+
+  if (!allowedTones.includes(baseTone)) {
+    throw new Error(
+      `generateTailwindPackage: config.base "${baseTone}" must be one of: ${allowedTones.join(', ')}.`
+    );
+  }
+
+  return baseTone;
+}
+
+function semanticTokensFromEngineMap(tokenMap, registry) {
+  return registry.map(({ name }) => {
+    const runtimeName = `--nx-color-${name}`;
+    const value = tokenMap[runtimeName];
+
+    if (typeof value !== 'string') {
+      throw new Error(
+        `generateTailwindPackage: token engine did not emit ${runtimeName}.`
+      );
+    }
+
+    return {
+      cssName: `color-${name}`,
+      value,
+    };
+  });
+}
+
+function deriveEngineSemanticTokens(config, engine) {
+  const baseTone = validateBaseTone(config, engine);
+  const theme = engine.deriveTheme(
+    engine.createNexusThemeContract({
+      ...engine.DEFAULT_NEXUS_APPEARANCE,
+      surfaceTone: baseTone,
+    })
+  );
+
+  return {
+    baseTone,
+    lightSemanticTokens: semanticTokensFromEngineMap(
+      theme.light,
+      engine.SEMANTIC_TOKEN_REGISTRY
+    ),
+    darkSemanticTokens: semanticTokensFromEngineMap(
+      theme.dark,
+      engine.SEMANTIC_TOKEN_REGISTRY
+    ),
+  };
 }
 
 /**
@@ -399,36 +429,11 @@ function generateVariablesCSS(primitiveTokens, divergentDark, usedModes) {
  * canonical default baseline because @theme drives Tailwind's utility codegen
  * (build-time); the cascade flip happens at runtime via the per-mode blocks.
  */
-function collectLightSemanticTokens(semanticFiles, primitiveMap) {
-  const lightSemanticTokens = [];
-
-  for (const themed of semanticFiles.themed) {
-    lightSemanticTokens.push(
-      ...collectSemanticColorTokensVarRef(
-        SEMANTIC_DIR,
-        themed.light,
-        primitiveMap
-      )
-    );
-  }
-
-  for (const standaloneFile of semanticFiles.standalone) {
-    lightSemanticTokens.push(
-      ...collectSemanticColorTokensVarRef(
-        SEMANTIC_DIR,
-        standaloneFile,
-        primitiveMap
-      )
-    );
-  }
-
-  return lightSemanticTokens;
-}
-
 function generateNexusCSS(
   semanticFiles,
   primitiveMap,
   lightSemanticTokens,
+  darkSemanticTokens,
   usedModes,
   spacingModes,
   spacingDefault,
@@ -448,24 +453,13 @@ function generateNexusCSS(
     );
   }
 
-  // Light + dark semantic color accumulators. Dimension tokens (e.g.
-  // focus.offset) are collected separately into `dimensionTokens` so they emit
-  // at :root, not @theme (see generateRootDimensionsCSS / #506).
-  const darkSemanticTokens = [];
+  // Semantic colors are engine-owned in the Tailwind bundle. Dimension tokens
+  // (e.g. focus.offset) still come from semantic JSON and emit at :root, not
+  // @theme (see generateRootDimensionsCSS / #506).
   const dimensionTokens = [];
 
-  for (const themed of semanticFiles.themed) {
-    const darkTokens = collectSemanticColorTokensVarRef(
-      SEMANTIC_DIR,
-      themed.dark,
-      primitiveMap
-    );
-    darkSemanticTokens.push(...darkTokens);
-  }
-
-  // Process standalone semantic files (like focus.json). Color leaves promote to
-  // --color-focus-* utilities in @theme; dimension leaves (focus.offset) go to
-  // dimensionTokens for the :root block, not @theme (see generateRootDimensionsCSS).
+  // Process standalone semantic files for non-color dimensions. Color leaves are
+  // ignored here because the engine registry now owns the Tailwind color surface.
   for (const standaloneFile of semanticFiles.standalone) {
     if (!FILES_WITH_DEDICATED_DIMENSION_COLLECTORS.has(standaloneFile)) {
       dimensionTokens.push(
@@ -578,8 +572,11 @@ function generateNexusCSS(
  */
 export async function generateTailwindPackage(
   config,
-  { distDir = DEFAULT_DIST_DIR } = {}
+  { distDir = DEFAULT_DIST_DIR, engine } = {}
 ) {
+  const tokenEngine = assertTokenEngine(
+    engine ?? (await loadDistRuntimeEngine())
+  );
   ensureDir(distDir);
 
   const writeDistFile = (fileName, content) => {
@@ -590,7 +587,9 @@ export async function generateTailwindPackage(
 
   const discoveredPrimitives = discoverPrimitives(PRIMITIVES_DIR);
   const discoveredSemantics = discoverSemantics(SEMANTIC_DIR);
-  const semanticFiles = getSemanticFiles(discoveredSemantics, config);
+  const semanticFiles = getSemanticSupportFiles(discoveredSemantics);
+  const { baseTone, lightSemanticTokens, darkSemanticTokens } =
+    deriveEngineSemanticTokens(config, tokenEngine);
 
   const {
     tokens: primitiveTokens,
@@ -606,20 +605,13 @@ export async function generateTailwindPackage(
       console.log(`   ${category}: ${mode}`);
     }
   }
-  for (const themed of semanticFiles.themed) {
-    console.log(`   ${themed.type}: ${themed.mode}`);
-  }
+  console.log(`   base: ${baseTone}`);
   console.log('');
 
   const divergentDark = filterDivergentDark(
     primitiveTokens,
     darkPrimitiveTokens
   );
-  const lightSemanticTokens = collectLightSemanticTokens(
-    semanticFiles,
-    primitiveMap
-  );
-
   const variablesCSS = generateVariablesCSS(
     primitiveTokens,
     divergentDark,
@@ -642,8 +634,10 @@ export async function generateTailwindPackage(
     log.success(`Generated ${borderWidth.count} border width utilities`);
   }
 
-  const borderColorAliases =
-    generateBorderColorAliasUtilitiesCSS(lightSemanticTokens);
+  const borderColorAliases = generateBorderColorAliasUtilitiesCSS(
+    lightSemanticTokens,
+    { runtimeFallback: true }
+  );
   if (borderColorAliases.css) {
     writeDistFile('border-color-aliases.css', borderColorAliases.css);
     log.success(
@@ -687,6 +681,7 @@ export async function generateTailwindPackage(
     semanticFiles,
     primitiveMap,
     lightSemanticTokens,
+    darkSemanticTokens,
     usedModes,
     spacingModes,
     spacingDefault,
@@ -696,7 +691,6 @@ export async function generateTailwindPackage(
 
   await formatDistCssFiles(distDir);
 
-  const themeCount = semanticFiles.themed.length;
   console.log('');
   console.log(`📊 Summary:`);
   console.log(
@@ -705,7 +699,7 @@ export async function generateTailwindPackage(
   if (divergentDark.length > 0) {
     console.log(`   Dark overrides: ${divergentDark.length} tokens`);
   }
-  console.log(`   Semantic themes: ${themeCount} (light + dark)`);
+  console.log(`   Engine semantic colors: ${lightSemanticTokens.length}`);
   console.log(`   Typography utilities: ${typography.count}`);
   console.log(`   Border width utilities: ${borderWidth.count}`);
   console.log(`   Output: ${distDir}`);
@@ -713,6 +707,7 @@ export async function generateTailwindPackage(
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   console.log('🎨 Generating @nexus_ds/tailwind package from DTCG tokens...');
+  const engine = await loadDistRuntimeEngine();
   const cliConfig = parseArgs(undefined, {
     allowedKeys: [
       'base',
@@ -726,7 +721,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
       'spacingDefault',
     ],
   });
-  await generateTailwindPackage(cliConfig);
+  await generateTailwindPackage(cliConfig, { engine });
   console.log('');
   console.log('✨ @nexus_ds/tailwind package generation complete!');
 }

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -874,12 +874,6 @@ export function generateBorderColorAliasUtilitiesCSS(
   let css = `/* Border Color Alias Utilities */\n\n`;
 
   for (const { token, name } of borderColorTokens) {
-    if (runtimeFallback && typeof token.value !== 'string') {
-      throw new Error(
-        `generateBorderColorAliasUtilitiesCSS: ${token.cssName} is missing an engine fallback value.`
-      );
-    }
-
     css += `@utility border-color-${name} {\n`;
     const value = runtimeFallback
       ? `var(--nx-${token.cssName}, ${token.value})`

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -817,7 +817,7 @@ export function generateBorderWidthUtilitiesCSS(tokens) {
   return { css, count: tokens.length * BORDER_WIDTH_UTILITIES_PER_TOKEN };
 }
 
-const BORDER_COLOR_ALIAS_NAMES = new Set([
+const BORDER_COLOR_ALIAS_NAMES = [
   'default',
   'default-alpha',
   'active',
@@ -832,7 +832,9 @@ const BORDER_COLOR_ALIAS_NAMES = new Set([
   'information-active',
   'primary',
   'primary-active',
-]);
+];
+
+const BORDER_COLOR_ALIAS_NAME_SET = new Set(BORDER_COLOR_ALIAS_NAMES);
 
 function getBorderColorAliasName(cssName) {
   const prefix = 'color-border-';
@@ -841,7 +843,7 @@ function getBorderColorAliasName(cssName) {
   }
 
   const name = cssName.slice(prefix.length);
-  return BORDER_COLOR_ALIAS_NAMES.has(name) ? name : null;
+  return BORDER_COLOR_ALIAS_NAME_SET.has(name) ? name : null;
 }
 
 /**
@@ -852,10 +854,18 @@ function getBorderColorAliasName(cssName) {
  * @param {object[]} tokens - Array of semantic color tokens with cssName property (e.g., "color-border-default")
  * @returns {{ css: string, count: number }} Generated CSS and utility count
  */
-export function generateBorderColorAliasUtilitiesCSS(tokens) {
+export function generateBorderColorAliasUtilitiesCSS(
+  tokens,
+  { runtimeFallback = false } = {}
+) {
   const borderColorTokens = (tokens ?? [])
     .map((token) => ({ token, name: getBorderColorAliasName(token.cssName) }))
-    .filter(({ name }) => name !== null);
+    .filter(({ name }) => name !== null)
+    .sort(
+      (a, b) =>
+        BORDER_COLOR_ALIAS_NAMES.indexOf(a.name) -
+        BORDER_COLOR_ALIAS_NAMES.indexOf(b.name)
+    );
 
   if (borderColorTokens.length === 0) {
     return { css: '', count: 0 };
@@ -864,8 +874,17 @@ export function generateBorderColorAliasUtilitiesCSS(tokens) {
   let css = `/* Border Color Alias Utilities */\n\n`;
 
   for (const { token, name } of borderColorTokens) {
+    if (runtimeFallback && typeof token.value !== 'string') {
+      throw new Error(
+        `generateBorderColorAliasUtilitiesCSS: ${token.cssName} is missing an engine fallback value.`
+      );
+    }
+
     css += `@utility border-color-${name} {\n`;
-    css += `  border-color: var(--${token.cssName});\n`;
+    const value = runtimeFallback
+      ? `var(--nx-${token.cssName}, ${token.value})`
+      : `var(--${token.cssName})`;
+    css += `  border-color: ${value};\n`;
     css += `}\n\n`;
   }
 

--- a/packages/tailwind/border-color-aliases.css
+++ b/packages/tailwind/border-color-aliases.css
@@ -1,57 +1,69 @@
 /* Border Color Alias Utilities */
 
 @utility border-color-default {
-  border-color: var(--color-border-default);
+  border-color: var(--nx-color-border-default, oklch(0.1448 0 0 / 0.0941));
 }
 
 @utility border-color-default-alpha {
-  border-color: var(--color-border-default-alpha);
+  border-color: var(
+    --nx-color-border-default-alpha,
+    oklch(0.13 0.006 70 / 0.0941)
+  );
 }
 
 @utility border-color-active {
-  border-color: var(--color-border-active);
+  border-color: var(--nx-color-border-active, oklch(0.6601 0.0118 70));
 }
 
 @utility border-color-disabled {
-  border-color: var(--color-border-disabled);
+  border-color: var(--nx-color-border-disabled, oklch(0.1448 0 0 / 0.0941));
 }
 
 @utility border-color-warning {
-  border-color: var(--color-border-warning);
+  border-color: var(--nx-color-border-warning, oklch(0.91 0.0819 70.697));
 }
 
 @utility border-color-warning-active {
-  border-color: var(--color-border-warning-active);
+  border-color: var(
+    --nx-color-border-warning-active,
+    oklch(0.78 0.1803 55.934)
+  );
 }
 
 @utility border-color-success {
-  border-color: var(--color-border-success);
+  border-color: var(--nx-color-border-success, oklch(0.925 0.1596 139.892));
 }
 
 @utility border-color-success-active {
-  border-color: var(--color-border-success-active);
+  border-color: var(
+    --nx-color-border-success-active,
+    oklch(0.79 0.2864 140.349)
+  );
 }
 
 @utility border-color-error {
-  border-color: var(--color-border-error);
+  border-color: var(--nx-color-border-error, oklch(0.885 0.0747 27.394));
 }
 
 @utility border-color-error-active {
-  border-color: var(--color-border-error-active);
+  border-color: var(--nx-color-border-error-active, oklch(0.704 0.2267 27.842));
 }
 
 @utility border-color-information {
-  border-color: var(--color-border-information);
+  border-color: var(--nx-color-border-information, oklch(0.882 0.0612 253.613));
 }
 
 @utility border-color-information-active {
-  border-color: var(--color-border-information-active);
+  border-color: var(
+    --nx-color-border-information-active,
+    oklch(0.707 0.1599 255.225)
+  );
 }
 
 @utility border-color-primary {
-  border-color: var(--color-border-primary);
+  border-color: var(--nx-color-border-primary, oklch(0.87 0 0));
 }
 
 @utility border-color-primary-active {
-  border-color: var(--color-border-primary-active);
+  border-color: var(--nx-color-border-primary-active, oklch(0.66 0 0));
 }

--- a/packages/tailwind/nexus.css
+++ b/packages/tailwind/nexus.css
@@ -142,900 +142,836 @@
 
 @theme inline {
   /* Semantic tokens */
-  --color-background: var(--nx-color-background, var(--nx-color-white-base));
-  --color-foreground: var(--nx-color-foreground, var(--nx-color-black-a900));
+  --color-background: var(--nx-color-background, oklch(1 0 0));
   --color-background-hover: var(
     --nx-color-background-hover,
-    var(--nx-color-stone-50)
-  );
-  --color-background-hover-alpha: var(
-    --nx-color-background-hover-alpha,
-    var(--nx-color-stone-a100)
+    oklch(0.9849 0.0082 70)
   );
   --color-background-active: var(
     --nx-color-background-active,
-    var(--nx-color-stone-150)
+    oklch(0.9227 0.0089 70)
   );
-  --color-muted: var(--nx-color-muted, var(--nx-color-stone-75));
-  --color-muted-foreground: var(
-    --nx-color-muted-foreground,
-    var(--nx-color-black-a600)
-  );
-  --color-muted-foreground-subtle: var(
-    --nx-color-muted-foreground-subtle,
-    var(--nx-color-black-a500)
-  );
-  --color-disabled: var(--nx-color-disabled, var(--nx-color-stone-100));
-  --color-disabled-foreground: var(
-    --nx-color-disabled-foreground,
-    var(--nx-color-stone-400)
-  );
-  --color-container: var(--nx-color-container, var(--nx-color-white-base));
-  --color-container-foreground: var(
-    --nx-color-container-foreground,
-    var(--nx-color-stone-950)
-  );
+  --color-muted: var(--nx-color-muted, oklch(0.9698 0.0083 70));
+  --color-container: var(--nx-color-container, oklch(1 0 0));
   --color-container-hover: var(
     --nx-color-container-hover,
-    var(--nx-color-stone-75)
+    oklch(0.9698 0.0083 70)
   );
   --color-container-active: var(
     --nx-color-container-active,
-    var(--nx-color-stone-100)
+    oklch(0.9451 0.0086 70)
   );
-  --color-popover: var(--nx-color-popover, var(--nx-color-white-base));
-  --color-popover-foreground: var(
-    --nx-color-popover-foreground,
-    var(--nx-color-stone-950)
-  );
-  --color-popover-hover: var(
-    --nx-color-popover-hover,
-    var(--nx-color-stone-100)
-  );
+  --color-popover: var(--nx-color-popover, oklch(1 0 0));
+  --color-popover-hover: var(--nx-color-popover-hover, oklch(0.9451 0.0086 70));
   --color-popover-active: var(
     --nx-color-popover-active,
-    var(--nx-color-stone-100)
-  );
-  --color-popover-alpha: var(
-    --nx-color-popover-alpha,
-    var(--nx-color-white-a700)
-  );
-  --color-popover-backdrop: var(
-    --nx-color-popover-backdrop,
-    var(--nx-color-stone-a900)
+    oklch(0.9451 0.0086 70)
   );
   --color-control-background: var(
     --nx-color-control-background,
-    var(--nx-color-stone-150)
+    oklch(0.9227 0.0089 70)
   );
   --color-control-background-hover: var(
     --nx-color-control-background-hover,
-    var(--nx-color-stone-200)
+    oklch(0.8701 0.0095 70)
   );
-  --color-control-thumb: var(
-    --nx-color-control-thumb,
-    var(--nx-color-white-base)
-  );
+  --color-control-thumb: var(--nx-color-control-thumb, oklch(1 0 0));
   --color-nav-background: var(
     --nx-color-nav-background,
-    var(--nx-color-stone-75)
-  );
-  --color-nav-foreground: var(
-    --nx-color-nav-foreground,
-    var(--nx-color-stone-900)
-  );
-  --color-nav-muted-foreground: var(
-    --nx-color-nav-muted-foreground,
-    var(--nx-color-stone-600)
+    oklch(0.9698 0.0083 70)
   );
   --color-nav-item-hover: var(
     --nx-color-nav-item-hover,
-    var(--nx-color-stone-150)
+    oklch(0.9227 0.0089 70)
   );
   --color-nav-item-active: var(
     --nx-color-nav-item-active,
-    var(--nx-color-stone-150)
+    oklch(0.9227 0.0089 70)
   );
-  --color-nav-border: var(--nx-color-nav-border, var(--nx-color-stone-150));
-  --color-overlay: var(--nx-color-overlay, var(--nx-color-stone-a700));
+  --color-nav-border: var(--nx-color-nav-border, oklch(0.9227 0.0089 70));
+  --color-disabled: var(--nx-color-disabled, oklch(0.9451 0.0086 70));
+  --color-border-active: var(--nx-color-border-active, oklch(0.6601 0.0118 70));
+  --color-foreground: var(--nx-color-foreground, oklch(0.1448 0 0 / 0.9098));
+  --color-container-foreground: var(
+    --nx-color-container-foreground,
+    oklch(0.2161 0.0061 56.043)
+  );
+  --color-popover-foreground: var(
+    --nx-color-popover-foreground,
+    oklch(0.2161 0.0061 56.043)
+  );
+  --color-nav-foreground: var(
+    --nx-color-nav-foreground,
+    oklch(0.2161 0.0061 56.043)
+  );
+  --color-muted-foreground: var(
+    --nx-color-muted-foreground,
+    oklch(0.1448 0 0 / 0.6275)
+  );
+  --color-nav-muted-foreground: var(
+    --nx-color-nav-muted-foreground,
+    oklch(0.5176 0.0061 56.043)
+  );
+  --color-muted-foreground-subtle: var(
+    --nx-color-muted-foreground-subtle,
+    oklch(0.1448 0 0 / 0.502)
+  );
+  --color-disabled-foreground: var(
+    --nx-color-disabled-foreground,
+    oklch(0.5806 0.0061 56.043)
+  );
   --color-border-default: var(
     --nx-color-border-default,
-    var(--nx-color-black-a200)
-  );
-  --color-border-hairline: var(
-    --nx-color-border-hairline,
-    var(--nx-color-black-a200)
-  );
-  --color-border-default-alpha: var(
-    --nx-color-border-default-alpha,
-    var(--nx-color-stone-a200)
-  );
-  --color-border-active: var(
-    --nx-color-border-active,
-    var(--nx-color-stone-400)
+    oklch(0.1448 0 0 / 0.0941)
   );
   --color-border-disabled: var(
     --nx-color-border-disabled,
-    var(--nx-color-black-a200)
+    oklch(0.1448 0 0 / 0.0941)
   );
-  --color-border-warning: var(
-    --nx-color-border-warning,
-    var(--nx-color-orange-200)
-  );
-  --color-border-warning-active: var(
-    --nx-color-border-warning-active,
-    var(--nx-color-orange-400)
-  );
-  --color-border-success: var(
-    --nx-color-border-success,
-    var(--nx-color-green-200)
-  );
-  --color-border-success-active: var(
-    --nx-color-border-success-active,
-    var(--nx-color-green-400)
-  );
-  --color-border-error: var(--nx-color-border-error, var(--nx-color-red-200));
-  --color-border-error-active: var(
-    --nx-color-border-error-active,
-    var(--nx-color-red-400)
-  );
-  --color-border-information: var(
-    --nx-color-border-information,
-    var(--nx-color-blue-200)
-  );
-  --color-border-information-active: var(
-    --nx-color-border-information-active,
-    var(--nx-color-blue-400)
-  );
-  --color-error-background: var(
-    --nx-color-error-background,
-    var(--nx-color-red-600)
-  );
-  --color-error-foreground: var(
-    --nx-color-error-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-error-background-hover: var(
-    --nx-color-error-background-hover,
-    var(--nx-color-red-700)
-  );
-  --color-error-background-active: var(
-    --nx-color-error-background-active,
-    var(--nx-color-red-800)
-  );
-  --color-error-disabled: var(
-    --nx-color-error-disabled,
-    var(--nx-color-red-300)
-  );
-  --color-error-subtle: var(--nx-color-error-subtle, var(--nx-color-red-50));
-  --color-error-subtle-foreground: var(
-    --nx-color-error-subtle-foreground,
-    var(--nx-color-red-600)
-  );
-  --color-error-subtle-hover: var(
-    --nx-color-error-subtle-hover,
-    var(--nx-color-red-100)
-  );
-  --color-error-subtle-active: var(
-    --nx-color-error-subtle-active,
-    var(--nx-color-red-200)
-  );
-  --color-success-background: var(
-    --nx-color-success-background,
-    var(--nx-color-green-600)
-  );
-  --color-success-foreground: var(
-    --nx-color-success-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-success-background-hover: var(
-    --nx-color-success-background-hover,
-    var(--nx-color-green-700)
-  );
-  --color-success-background-active: var(
-    --nx-color-success-background-active,
-    var(--nx-color-green-800)
-  );
-  --color-success-disabled: var(
-    --nx-color-success-disabled,
-    var(--nx-color-green-300)
-  );
-  --color-success-subtle: var(
-    --nx-color-success-subtle,
-    var(--nx-color-green-50)
-  );
-  --color-success-subtle-foreground: var(
-    --nx-color-success-subtle-foreground,
-    var(--nx-color-green-700)
-  );
-  --color-success-subtle-hover: var(
-    --nx-color-success-subtle-hover,
-    var(--nx-color-green-100)
-  );
-  --color-success-subtle-active: var(
-    --nx-color-success-subtle-active,
-    var(--nx-color-green-200)
-  );
-  --color-information-background: var(
-    --nx-color-information-background,
-    var(--nx-color-blue-600)
-  );
-  --color-information-foreground: var(
-    --nx-color-information-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-information-background-hover: var(
-    --nx-color-information-background-hover,
-    var(--nx-color-blue-700)
-  );
-  --color-information-background-active: var(
-    --nx-color-information-background-active,
-    var(--nx-color-blue-800)
-  );
-  --color-information-disabled: var(
-    --nx-color-information-disabled,
-    var(--nx-color-blue-300)
-  );
-  --color-information-subtle: var(
-    --nx-color-information-subtle,
-    var(--nx-color-blue-50)
-  );
-  --color-information-subtle-foreground: var(
-    --nx-color-information-subtle-foreground,
-    var(--nx-color-blue-600)
-  );
-  --color-information-subtle-hover: var(
-    --nx-color-information-subtle-hover,
-    var(--nx-color-blue-100)
-  );
-  --color-information-subtle-active: var(
-    --nx-color-information-subtle-active,
-    var(--nx-color-blue-200)
-  );
-  --color-warning-background: var(
-    --nx-color-warning-background,
-    var(--nx-color-orange-600)
-  );
-  --color-warning-foreground: var(
-    --nx-color-warning-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-warning-background-hover: var(
-    --nx-color-warning-background-hover,
-    var(--nx-color-orange-700)
-  );
-  --color-warning-background-active: var(
-    --nx-color-warning-background-active,
-    var(--nx-color-orange-800)
-  );
-  --color-warning-disabled: var(
-    --nx-color-warning-disabled,
-    var(--nx-color-orange-300)
-  );
-  --color-warning-subtle: var(
-    --nx-color-warning-subtle,
-    var(--nx-color-orange-50)
-  );
-  --color-warning-subtle-foreground: var(
-    --nx-color-warning-subtle-foreground,
-    var(--nx-color-orange-600)
-  );
-  --color-warning-subtle-hover: var(
-    --nx-color-warning-subtle-hover,
-    var(--nx-color-orange-100)
-  );
-  --color-warning-subtle-active: var(
-    --nx-color-warning-subtle-active,
-    var(--nx-color-orange-200)
-  );
-  --color-chart-categorical-1: var(
-    --nx-color-chart-categorical-1,
-    var(--nx-color-teal-600)
-  );
-  --color-chart-categorical-2: var(
-    --nx-color-chart-categorical-2,
-    var(--nx-color-lime-700)
-  );
-  --color-chart-categorical-3: var(
-    --nx-color-chart-categorical-3,
-    var(--nx-color-orange-600)
-  );
-  --color-chart-categorical-4: var(
-    --nx-color-chart-categorical-4,
-    var(--nx-color-rose-600)
-  );
-  --color-chart-categorical-5: var(
-    --nx-color-chart-categorical-5,
-    var(--nx-color-indigo-600)
+  --color-border-hairline: var(
+    --nx-color-border-hairline,
+    oklch(0.1448 0 0 / 0.0941)
   );
   --color-primary-background: var(
     --nx-color-primary-background,
-    var(--nx-color-black-base)
-  );
-  --color-primary-background-active: var(
-    --nx-color-primary-background-active,
-    var(--nx-color-neutral-950)
-  );
-  --color-primary-foreground: var(
-    --nx-color-primary-foreground,
-    var(--nx-color-white-base)
+    oklch(0.1448 0 0)
   );
   --color-primary-background-hover: var(
     --nx-color-primary-background-hover,
-    var(--nx-color-neutral-900)
+    oklch(0.207 0 0)
   );
-  --color-primary-disabled: var(
-    --nx-color-primary-disabled,
-    var(--nx-color-neutral-300)
+  --color-primary-background-active: var(
+    --nx-color-primary-background-active,
+    oklch(0.118 0 0)
   );
-  --color-primary-subtle: var(
-    --nx-color-primary-subtle,
-    var(--nx-color-neutral-50)
-  );
+  --color-primary-foreground: var(--nx-color-primary-foreground, oklch(1 0 0));
+  --color-primary-disabled: var(--nx-color-primary-disabled, oklch(0.765 0 0));
+  --color-primary-subtle: var(--nx-color-primary-subtle, oklch(0.985 0 0));
   --color-primary-subtle-foreground: var(
     --nx-color-primary-subtle-foreground,
-    var(--nx-color-black-base)
+    oklch(0.1448 0 0)
   );
   --color-primary-subtle-hover: var(
     --nx-color-primary-subtle-hover,
-    var(--nx-color-neutral-100)
+    oklch(0.945 0 0)
   );
   --color-primary-subtle-active: var(
     --nx-color-primary-subtle-active,
-    var(--nx-color-neutral-200)
+    oklch(0.87 0 0)
+  );
+  --color-border-primary: var(--nx-color-border-primary, oklch(0.87 0 0));
+  --color-border-primary-active: var(
+    --nx-color-border-primary-active,
+    oklch(0.66 0 0)
   );
   --color-secondary-background: var(
     --nx-color-secondary-background,
-    var(--nx-color-neutral-100)
-  );
-  --color-secondary-foreground: var(
-    --nx-color-secondary-foreground,
-    var(--nx-color-neutral-900)
+    oklch(0.945 0 0)
   );
   --color-secondary-background-hover: var(
     --nx-color-secondary-background-hover,
-    var(--nx-color-neutral-200)
+    oklch(0.87 0 0)
   );
   --color-secondary-background-active: var(
     --nx-color-secondary-background-active,
-    var(--nx-color-neutral-300)
+    oklch(0.765 0 0)
+  );
+  --color-secondary-foreground: var(
+    --nx-color-secondary-foreground,
+    oklch(0.207 0 0)
   );
   --color-secondary-disabled: var(
     --nx-color-secondary-disabled,
-    var(--nx-color-neutral-50)
+    oklch(0.985 0 0)
   );
-  --color-secondary-subtle: var(
-    --nx-color-secondary-subtle,
-    var(--nx-color-neutral-100)
-  );
+  --color-secondary-subtle: var(--nx-color-secondary-subtle, oklch(0.945 0 0));
   --color-secondary-subtle-foreground: var(
     --nx-color-secondary-subtle-foreground,
-    var(--nx-color-neutral-600)
+    oklch(0.46 0 0)
   );
   --color-secondary-subtle-hover: var(
     --nx-color-secondary-subtle-hover,
-    var(--nx-color-neutral-200)
+    oklch(0.87 0 0)
   );
   --color-secondary-subtle-active: var(
     --nx-color-secondary-subtle-active,
-    var(--nx-color-neutral-300)
+    oklch(0.765 0 0)
   );
-  --color-border-primary: var(
-    --nx-color-border-primary,
-    var(--nx-color-neutral-200)
+  --color-success-background: var(
+    --nx-color-success-background,
+    oklch(0.62 0.2233 140.055)
   );
-  --color-border-primary-active: var(
-    --nx-color-border-primary-active,
-    var(--nx-color-neutral-400)
+  --color-success-background-hover: var(
+    --nx-color-success-background-hover,
+    oklch(0.52 0.1871 140.022)
   );
-  --color-focus-default: var(
-    --nx-color-focus-default,
-    var(--color-primary-subtle-foreground)
+  --color-success-background-active: var(
+    --nx-color-success-background-active,
+    oklch(0.43 0.1534 139.623)
   );
-  --color-focus-error: var(--nx-color-focus-error, var(--nx-focus-color-error));
+  --color-success-foreground: var(--nx-color-success-foreground, oklch(1 0 0));
+  --color-success-disabled: var(
+    --nx-color-success-disabled,
+    oklch(0.87 0.3119 139.843)
+  );
+  --color-success-subtle: var(
+    --nx-color-success-subtle,
+    oklch(0.982 0.035 137.785)
+  );
+  --color-success-subtle-foreground: var(
+    --nx-color-success-subtle-foreground,
+    oklch(0.52 0.1871 140.022)
+  );
+  --color-success-subtle-hover: var(
+    --nx-color-success-subtle-hover,
+    oklch(0.96 0.0789 139.835)
+  );
+  --color-success-subtle-active: var(
+    --nx-color-success-subtle-active,
+    oklch(0.925 0.1596 139.892)
+  );
+  --color-border-success: var(
+    --nx-color-border-success,
+    oklch(0.925 0.1596 139.892)
+  );
+  --color-border-success-active: var(
+    --nx-color-border-success-active,
+    oklch(0.79 0.2864 140.349)
+  );
+  --color-warning-background: var(
+    --nx-color-warning-background,
+    oklch(0.62 0.2044 41.116)
+  );
+  --color-warning-background-hover: var(
+    --nx-color-warning-background-hover,
+    oklch(0.52 0.1809 38.402)
+  );
+  --color-warning-background-active: var(
+    --nx-color-warning-background-active,
+    oklch(0.43 0.153 37.304)
+  );
+  --color-warning-foreground: var(--nx-color-warning-foreground, oklch(1 0 0));
+  --color-warning-disabled: var(
+    --nx-color-warning-disabled,
+    oklch(0.84 0.142 66.29)
+  );
+  --color-warning-subtle: var(
+    --nx-color-warning-subtle,
+    oklch(0.98 0.0185 73.684)
+  );
+  --color-warning-subtle-foreground: var(
+    --nx-color-warning-subtle-foreground,
+    oklch(0.62 0.2044 41.116)
+  );
+  --color-warning-subtle-hover: var(
+    --nx-color-warning-subtle-hover,
+    oklch(0.955 0.0435 75.164)
+  );
+  --color-warning-subtle-active: var(
+    --nx-color-warning-subtle-active,
+    oklch(0.91 0.0819 70.697)
+  );
+  --color-border-warning: var(
+    --nx-color-border-warning,
+    oklch(0.91 0.0819 70.697)
+  );
+  --color-border-warning-active: var(
+    --nx-color-border-warning-active,
+    oklch(0.78 0.1803 55.934)
+  );
+  --color-error-background: var(
+    --nx-color-error-background,
+    oklch(0.577 0.2523 27.926)
+  );
+  --color-error-background-hover: var(
+    --nx-color-error-background-hover,
+    oklch(0.505 0.2209 27.946)
+  );
+  --color-error-background-active: var(
+    --nx-color-error-background-active,
+    oklch(0.42 0.1838 28.144)
+  );
+  --color-error-foreground: var(--nx-color-error-foreground, oklch(1 0 0));
+  --color-error-disabled: var(
+    --nx-color-error-disabled,
+    oklch(0.808 0.1333 28.058)
+  );
+  --color-error-subtle: var(
+    --nx-color-error-subtle,
+    oklch(0.971 0.0176 28.865)
+  );
+  --color-error-subtle-foreground: var(
+    --nx-color-error-subtle-foreground,
+    oklch(0.577 0.2523 27.926)
+  );
+  --color-error-subtle-hover: var(
+    --nx-color-error-subtle-hover,
+    oklch(0.936 0.0399 27.342)
+  );
+  --color-error-subtle-active: var(
+    --nx-color-error-subtle-active,
+    oklch(0.885 0.0747 27.394)
+  );
+  --color-border-error: var(
+    --nx-color-border-error,
+    oklch(0.885 0.0747 27.394)
+  );
+  --color-border-error-active: var(
+    --nx-color-border-error-active,
+    oklch(0.704 0.2267 27.842)
+  );
+  --color-information-background: var(
+    --nx-color-information-background,
+    oklch(0.546 0.2205 255.276)
+  );
+  --color-information-background-hover: var(
+    --nx-color-information-background-hover,
+    oklch(0.488 0.197 255.267)
+  );
+  --color-information-background-active: var(
+    --nx-color-information-background-active,
+    oklch(0.41 0.1633 254.871)
+  );
+  --color-information-foreground: var(
+    --nx-color-information-foreground,
+    oklch(1 0 0)
+  );
+  --color-information-disabled: var(
+    --nx-color-information-disabled,
+    oklch(0.809 0.1012 254.248)
+  );
+  --color-information-subtle: var(
+    --nx-color-information-subtle,
+    oklch(0.97 0.0152 252.81)
+  );
+  --color-information-subtle-foreground: var(
+    --nx-color-information-subtle-foreground,
+    oklch(0.546 0.2205 255.276)
+  );
+  --color-information-subtle-hover: var(
+    --nx-color-information-subtle-hover,
+    oklch(0.932 0.0342 257.472)
+  );
+  --color-information-subtle-active: var(
+    --nx-color-information-subtle-active,
+    oklch(0.882 0.0612 253.613)
+  );
+  --color-border-information: var(
+    --nx-color-border-information,
+    oklch(0.882 0.0612 253.613)
+  );
+  --color-border-information-active: var(
+    --nx-color-border-information-active,
+    oklch(0.707 0.1599 255.225)
+  );
+  --color-chart-categorical-1: var(
+    --nx-color-chart-categorical-1,
+    oklch(0.52 0.1168 186.391)
+  );
+  --color-chart-categorical-2: var(
+    --nx-color-chart-categorical-2,
+    oklch(0.61 0.1871 131.589)
+  );
+  --color-chart-categorical-3: var(
+    --nx-color-chart-categorical-3,
+    oklch(0.62 0.2044 41.116)
+  );
+  --color-chart-categorical-4: var(
+    --nx-color-chart-categorical-4,
+    oklch(0.58 0.2489 17.585)
+  );
+  --color-chart-categorical-5: var(
+    --nx-color-chart-categorical-5,
+    oklch(0.49 0.2912 276.966)
+  );
+  --color-focus-default: var(--nx-color-focus-default, oklch(0.1448 0 0));
+  --color-focus-error: var(--nx-color-focus-error, oklch(0.577 0.2523 27.926));
+  --color-background-hover-alpha: var(
+    --nx-color-background-hover-alpha,
+    oklch(0.13 0.006 70 / 0.0627)
+  );
+  --color-border-default-alpha: var(
+    --nx-color-border-default-alpha,
+    oklch(0.13 0.006 70 / 0.0941)
+  );
+  --color-overlay: var(--nx-color-overlay, oklch(0.13 0.006 70 / 0.7529));
+  --color-popover-alpha: var(--nx-color-popover-alpha, oklch(1 0 0 / 0.7529));
+  --color-popover-backdrop: var(
+    --nx-color-popover-backdrop,
+    oklch(0.13 0.006 70 / 0.9098)
+  );
 }
 
 /* ===== RUNTIME COLOR ALIASES ===== */
 :root {
-  --color-background: var(--nx-color-background, var(--nx-color-white-base));
-  --color-foreground: var(--nx-color-foreground, var(--nx-color-black-a900));
+  --color-background: var(--nx-color-background, oklch(1 0 0));
   --color-background-hover: var(
     --nx-color-background-hover,
-    var(--nx-color-stone-50)
-  );
-  --color-background-hover-alpha: var(
-    --nx-color-background-hover-alpha,
-    var(--nx-color-stone-a100)
+    oklch(0.9849 0.0082 70)
   );
   --color-background-active: var(
     --nx-color-background-active,
-    var(--nx-color-stone-150)
+    oklch(0.9227 0.0089 70)
   );
-  --color-muted: var(--nx-color-muted, var(--nx-color-stone-75));
-  --color-muted-foreground: var(
-    --nx-color-muted-foreground,
-    var(--nx-color-black-a600)
-  );
-  --color-muted-foreground-subtle: var(
-    --nx-color-muted-foreground-subtle,
-    var(--nx-color-black-a500)
-  );
-  --color-disabled: var(--nx-color-disabled, var(--nx-color-stone-100));
-  --color-disabled-foreground: var(
-    --nx-color-disabled-foreground,
-    var(--nx-color-stone-400)
-  );
-  --color-container: var(--nx-color-container, var(--nx-color-white-base));
-  --color-container-foreground: var(
-    --nx-color-container-foreground,
-    var(--nx-color-stone-950)
-  );
+  --color-muted: var(--nx-color-muted, oklch(0.9698 0.0083 70));
+  --color-container: var(--nx-color-container, oklch(1 0 0));
   --color-container-hover: var(
     --nx-color-container-hover,
-    var(--nx-color-stone-75)
+    oklch(0.9698 0.0083 70)
   );
   --color-container-active: var(
     --nx-color-container-active,
-    var(--nx-color-stone-100)
+    oklch(0.9451 0.0086 70)
   );
-  --color-popover: var(--nx-color-popover, var(--nx-color-white-base));
-  --color-popover-foreground: var(
-    --nx-color-popover-foreground,
-    var(--nx-color-stone-950)
-  );
-  --color-popover-hover: var(
-    --nx-color-popover-hover,
-    var(--nx-color-stone-100)
-  );
+  --color-popover: var(--nx-color-popover, oklch(1 0 0));
+  --color-popover-hover: var(--nx-color-popover-hover, oklch(0.9451 0.0086 70));
   --color-popover-active: var(
     --nx-color-popover-active,
-    var(--nx-color-stone-100)
-  );
-  --color-popover-alpha: var(
-    --nx-color-popover-alpha,
-    var(--nx-color-white-a700)
-  );
-  --color-popover-backdrop: var(
-    --nx-color-popover-backdrop,
-    var(--nx-color-stone-a900)
+    oklch(0.9451 0.0086 70)
   );
   --color-control-background: var(
     --nx-color-control-background,
-    var(--nx-color-stone-150)
+    oklch(0.9227 0.0089 70)
   );
   --color-control-background-hover: var(
     --nx-color-control-background-hover,
-    var(--nx-color-stone-200)
+    oklch(0.8701 0.0095 70)
   );
-  --color-control-thumb: var(
-    --nx-color-control-thumb,
-    var(--nx-color-white-base)
-  );
+  --color-control-thumb: var(--nx-color-control-thumb, oklch(1 0 0));
   --color-nav-background: var(
     --nx-color-nav-background,
-    var(--nx-color-stone-75)
-  );
-  --color-nav-foreground: var(
-    --nx-color-nav-foreground,
-    var(--nx-color-stone-900)
-  );
-  --color-nav-muted-foreground: var(
-    --nx-color-nav-muted-foreground,
-    var(--nx-color-stone-600)
+    oklch(0.9698 0.0083 70)
   );
   --color-nav-item-hover: var(
     --nx-color-nav-item-hover,
-    var(--nx-color-stone-150)
+    oklch(0.9227 0.0089 70)
   );
   --color-nav-item-active: var(
     --nx-color-nav-item-active,
-    var(--nx-color-stone-150)
+    oklch(0.9227 0.0089 70)
   );
-  --color-nav-border: var(--nx-color-nav-border, var(--nx-color-stone-150));
-  --color-overlay: var(--nx-color-overlay, var(--nx-color-stone-a700));
+  --color-nav-border: var(--nx-color-nav-border, oklch(0.9227 0.0089 70));
+  --color-disabled: var(--nx-color-disabled, oklch(0.9451 0.0086 70));
+  --color-border-active: var(--nx-color-border-active, oklch(0.6601 0.0118 70));
+  --color-foreground: var(--nx-color-foreground, oklch(0.1448 0 0 / 0.9098));
+  --color-container-foreground: var(
+    --nx-color-container-foreground,
+    oklch(0.2161 0.0061 56.043)
+  );
+  --color-popover-foreground: var(
+    --nx-color-popover-foreground,
+    oklch(0.2161 0.0061 56.043)
+  );
+  --color-nav-foreground: var(
+    --nx-color-nav-foreground,
+    oklch(0.2161 0.0061 56.043)
+  );
+  --color-muted-foreground: var(
+    --nx-color-muted-foreground,
+    oklch(0.1448 0 0 / 0.6275)
+  );
+  --color-nav-muted-foreground: var(
+    --nx-color-nav-muted-foreground,
+    oklch(0.5176 0.0061 56.043)
+  );
+  --color-muted-foreground-subtle: var(
+    --nx-color-muted-foreground-subtle,
+    oklch(0.1448 0 0 / 0.502)
+  );
+  --color-disabled-foreground: var(
+    --nx-color-disabled-foreground,
+    oklch(0.5806 0.0061 56.043)
+  );
   --color-border-default: var(
     --nx-color-border-default,
-    var(--nx-color-black-a200)
-  );
-  --color-border-hairline: var(
-    --nx-color-border-hairline,
-    var(--nx-color-black-a200)
-  );
-  --color-border-default-alpha: var(
-    --nx-color-border-default-alpha,
-    var(--nx-color-stone-a200)
-  );
-  --color-border-active: var(
-    --nx-color-border-active,
-    var(--nx-color-stone-400)
+    oklch(0.1448 0 0 / 0.0941)
   );
   --color-border-disabled: var(
     --nx-color-border-disabled,
-    var(--nx-color-black-a200)
+    oklch(0.1448 0 0 / 0.0941)
   );
-  --color-border-warning: var(
-    --nx-color-border-warning,
-    var(--nx-color-orange-200)
-  );
-  --color-border-warning-active: var(
-    --nx-color-border-warning-active,
-    var(--nx-color-orange-400)
-  );
-  --color-border-success: var(
-    --nx-color-border-success,
-    var(--nx-color-green-200)
-  );
-  --color-border-success-active: var(
-    --nx-color-border-success-active,
-    var(--nx-color-green-400)
-  );
-  --color-border-error: var(--nx-color-border-error, var(--nx-color-red-200));
-  --color-border-error-active: var(
-    --nx-color-border-error-active,
-    var(--nx-color-red-400)
-  );
-  --color-border-information: var(
-    --nx-color-border-information,
-    var(--nx-color-blue-200)
-  );
-  --color-border-information-active: var(
-    --nx-color-border-information-active,
-    var(--nx-color-blue-400)
-  );
-  --color-error-background: var(
-    --nx-color-error-background,
-    var(--nx-color-red-600)
-  );
-  --color-error-foreground: var(
-    --nx-color-error-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-error-background-hover: var(
-    --nx-color-error-background-hover,
-    var(--nx-color-red-700)
-  );
-  --color-error-background-active: var(
-    --nx-color-error-background-active,
-    var(--nx-color-red-800)
-  );
-  --color-error-disabled: var(
-    --nx-color-error-disabled,
-    var(--nx-color-red-300)
-  );
-  --color-error-subtle: var(--nx-color-error-subtle, var(--nx-color-red-50));
-  --color-error-subtle-foreground: var(
-    --nx-color-error-subtle-foreground,
-    var(--nx-color-red-600)
-  );
-  --color-error-subtle-hover: var(
-    --nx-color-error-subtle-hover,
-    var(--nx-color-red-100)
-  );
-  --color-error-subtle-active: var(
-    --nx-color-error-subtle-active,
-    var(--nx-color-red-200)
-  );
-  --color-success-background: var(
-    --nx-color-success-background,
-    var(--nx-color-green-600)
-  );
-  --color-success-foreground: var(
-    --nx-color-success-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-success-background-hover: var(
-    --nx-color-success-background-hover,
-    var(--nx-color-green-700)
-  );
-  --color-success-background-active: var(
-    --nx-color-success-background-active,
-    var(--nx-color-green-800)
-  );
-  --color-success-disabled: var(
-    --nx-color-success-disabled,
-    var(--nx-color-green-300)
-  );
-  --color-success-subtle: var(
-    --nx-color-success-subtle,
-    var(--nx-color-green-50)
-  );
-  --color-success-subtle-foreground: var(
-    --nx-color-success-subtle-foreground,
-    var(--nx-color-green-700)
-  );
-  --color-success-subtle-hover: var(
-    --nx-color-success-subtle-hover,
-    var(--nx-color-green-100)
-  );
-  --color-success-subtle-active: var(
-    --nx-color-success-subtle-active,
-    var(--nx-color-green-200)
-  );
-  --color-information-background: var(
-    --nx-color-information-background,
-    var(--nx-color-blue-600)
-  );
-  --color-information-foreground: var(
-    --nx-color-information-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-information-background-hover: var(
-    --nx-color-information-background-hover,
-    var(--nx-color-blue-700)
-  );
-  --color-information-background-active: var(
-    --nx-color-information-background-active,
-    var(--nx-color-blue-800)
-  );
-  --color-information-disabled: var(
-    --nx-color-information-disabled,
-    var(--nx-color-blue-300)
-  );
-  --color-information-subtle: var(
-    --nx-color-information-subtle,
-    var(--nx-color-blue-50)
-  );
-  --color-information-subtle-foreground: var(
-    --nx-color-information-subtle-foreground,
-    var(--nx-color-blue-600)
-  );
-  --color-information-subtle-hover: var(
-    --nx-color-information-subtle-hover,
-    var(--nx-color-blue-100)
-  );
-  --color-information-subtle-active: var(
-    --nx-color-information-subtle-active,
-    var(--nx-color-blue-200)
-  );
-  --color-warning-background: var(
-    --nx-color-warning-background,
-    var(--nx-color-orange-600)
-  );
-  --color-warning-foreground: var(
-    --nx-color-warning-foreground,
-    var(--nx-color-white-base)
-  );
-  --color-warning-background-hover: var(
-    --nx-color-warning-background-hover,
-    var(--nx-color-orange-700)
-  );
-  --color-warning-background-active: var(
-    --nx-color-warning-background-active,
-    var(--nx-color-orange-800)
-  );
-  --color-warning-disabled: var(
-    --nx-color-warning-disabled,
-    var(--nx-color-orange-300)
-  );
-  --color-warning-subtle: var(
-    --nx-color-warning-subtle,
-    var(--nx-color-orange-50)
-  );
-  --color-warning-subtle-foreground: var(
-    --nx-color-warning-subtle-foreground,
-    var(--nx-color-orange-600)
-  );
-  --color-warning-subtle-hover: var(
-    --nx-color-warning-subtle-hover,
-    var(--nx-color-orange-100)
-  );
-  --color-warning-subtle-active: var(
-    --nx-color-warning-subtle-active,
-    var(--nx-color-orange-200)
-  );
-  --color-chart-categorical-1: var(
-    --nx-color-chart-categorical-1,
-    var(--nx-color-teal-600)
-  );
-  --color-chart-categorical-2: var(
-    --nx-color-chart-categorical-2,
-    var(--nx-color-lime-700)
-  );
-  --color-chart-categorical-3: var(
-    --nx-color-chart-categorical-3,
-    var(--nx-color-orange-600)
-  );
-  --color-chart-categorical-4: var(
-    --nx-color-chart-categorical-4,
-    var(--nx-color-rose-600)
-  );
-  --color-chart-categorical-5: var(
-    --nx-color-chart-categorical-5,
-    var(--nx-color-indigo-600)
+  --color-border-hairline: var(
+    --nx-color-border-hairline,
+    oklch(0.1448 0 0 / 0.0941)
   );
   --color-primary-background: var(
     --nx-color-primary-background,
-    var(--nx-color-black-base)
-  );
-  --color-primary-background-active: var(
-    --nx-color-primary-background-active,
-    var(--nx-color-neutral-950)
-  );
-  --color-primary-foreground: var(
-    --nx-color-primary-foreground,
-    var(--nx-color-white-base)
+    oklch(0.1448 0 0)
   );
   --color-primary-background-hover: var(
     --nx-color-primary-background-hover,
-    var(--nx-color-neutral-900)
+    oklch(0.207 0 0)
   );
-  --color-primary-disabled: var(
-    --nx-color-primary-disabled,
-    var(--nx-color-neutral-300)
+  --color-primary-background-active: var(
+    --nx-color-primary-background-active,
+    oklch(0.118 0 0)
   );
-  --color-primary-subtle: var(
-    --nx-color-primary-subtle,
-    var(--nx-color-neutral-50)
-  );
+  --color-primary-foreground: var(--nx-color-primary-foreground, oklch(1 0 0));
+  --color-primary-disabled: var(--nx-color-primary-disabled, oklch(0.765 0 0));
+  --color-primary-subtle: var(--nx-color-primary-subtle, oklch(0.985 0 0));
   --color-primary-subtle-foreground: var(
     --nx-color-primary-subtle-foreground,
-    var(--nx-color-black-base)
+    oklch(0.1448 0 0)
   );
   --color-primary-subtle-hover: var(
     --nx-color-primary-subtle-hover,
-    var(--nx-color-neutral-100)
+    oklch(0.945 0 0)
   );
   --color-primary-subtle-active: var(
     --nx-color-primary-subtle-active,
-    var(--nx-color-neutral-200)
+    oklch(0.87 0 0)
+  );
+  --color-border-primary: var(--nx-color-border-primary, oklch(0.87 0 0));
+  --color-border-primary-active: var(
+    --nx-color-border-primary-active,
+    oklch(0.66 0 0)
   );
   --color-secondary-background: var(
     --nx-color-secondary-background,
-    var(--nx-color-neutral-100)
-  );
-  --color-secondary-foreground: var(
-    --nx-color-secondary-foreground,
-    var(--nx-color-neutral-900)
+    oklch(0.945 0 0)
   );
   --color-secondary-background-hover: var(
     --nx-color-secondary-background-hover,
-    var(--nx-color-neutral-200)
+    oklch(0.87 0 0)
   );
   --color-secondary-background-active: var(
     --nx-color-secondary-background-active,
-    var(--nx-color-neutral-300)
+    oklch(0.765 0 0)
+  );
+  --color-secondary-foreground: var(
+    --nx-color-secondary-foreground,
+    oklch(0.207 0 0)
   );
   --color-secondary-disabled: var(
     --nx-color-secondary-disabled,
-    var(--nx-color-neutral-50)
+    oklch(0.985 0 0)
   );
-  --color-secondary-subtle: var(
-    --nx-color-secondary-subtle,
-    var(--nx-color-neutral-100)
-  );
+  --color-secondary-subtle: var(--nx-color-secondary-subtle, oklch(0.945 0 0));
   --color-secondary-subtle-foreground: var(
     --nx-color-secondary-subtle-foreground,
-    var(--nx-color-neutral-600)
+    oklch(0.46 0 0)
   );
   --color-secondary-subtle-hover: var(
     --nx-color-secondary-subtle-hover,
-    var(--nx-color-neutral-200)
+    oklch(0.87 0 0)
   );
   --color-secondary-subtle-active: var(
     --nx-color-secondary-subtle-active,
-    var(--nx-color-neutral-300)
+    oklch(0.765 0 0)
   );
-  --color-border-primary: var(
-    --nx-color-border-primary,
-    var(--nx-color-neutral-200)
+  --color-success-background: var(
+    --nx-color-success-background,
+    oklch(0.62 0.2233 140.055)
   );
-  --color-border-primary-active: var(
-    --nx-color-border-primary-active,
-    var(--nx-color-neutral-400)
+  --color-success-background-hover: var(
+    --nx-color-success-background-hover,
+    oklch(0.52 0.1871 140.022)
   );
-  --color-focus-default: var(
-    --nx-color-focus-default,
-    var(--color-primary-subtle-foreground)
+  --color-success-background-active: var(
+    --nx-color-success-background-active,
+    oklch(0.43 0.1534 139.623)
   );
-  --color-focus-error: var(--nx-color-focus-error, var(--nx-focus-color-error));
+  --color-success-foreground: var(--nx-color-success-foreground, oklch(1 0 0));
+  --color-success-disabled: var(
+    --nx-color-success-disabled,
+    oklch(0.87 0.3119 139.843)
+  );
+  --color-success-subtle: var(
+    --nx-color-success-subtle,
+    oklch(0.982 0.035 137.785)
+  );
+  --color-success-subtle-foreground: var(
+    --nx-color-success-subtle-foreground,
+    oklch(0.52 0.1871 140.022)
+  );
+  --color-success-subtle-hover: var(
+    --nx-color-success-subtle-hover,
+    oklch(0.96 0.0789 139.835)
+  );
+  --color-success-subtle-active: var(
+    --nx-color-success-subtle-active,
+    oklch(0.925 0.1596 139.892)
+  );
+  --color-border-success: var(
+    --nx-color-border-success,
+    oklch(0.925 0.1596 139.892)
+  );
+  --color-border-success-active: var(
+    --nx-color-border-success-active,
+    oklch(0.79 0.2864 140.349)
+  );
+  --color-warning-background: var(
+    --nx-color-warning-background,
+    oklch(0.62 0.2044 41.116)
+  );
+  --color-warning-background-hover: var(
+    --nx-color-warning-background-hover,
+    oklch(0.52 0.1809 38.402)
+  );
+  --color-warning-background-active: var(
+    --nx-color-warning-background-active,
+    oklch(0.43 0.153 37.304)
+  );
+  --color-warning-foreground: var(--nx-color-warning-foreground, oklch(1 0 0));
+  --color-warning-disabled: var(
+    --nx-color-warning-disabled,
+    oklch(0.84 0.142 66.29)
+  );
+  --color-warning-subtle: var(
+    --nx-color-warning-subtle,
+    oklch(0.98 0.0185 73.684)
+  );
+  --color-warning-subtle-foreground: var(
+    --nx-color-warning-subtle-foreground,
+    oklch(0.62 0.2044 41.116)
+  );
+  --color-warning-subtle-hover: var(
+    --nx-color-warning-subtle-hover,
+    oklch(0.955 0.0435 75.164)
+  );
+  --color-warning-subtle-active: var(
+    --nx-color-warning-subtle-active,
+    oklch(0.91 0.0819 70.697)
+  );
+  --color-border-warning: var(
+    --nx-color-border-warning,
+    oklch(0.91 0.0819 70.697)
+  );
+  --color-border-warning-active: var(
+    --nx-color-border-warning-active,
+    oklch(0.78 0.1803 55.934)
+  );
+  --color-error-background: var(
+    --nx-color-error-background,
+    oklch(0.577 0.2523 27.926)
+  );
+  --color-error-background-hover: var(
+    --nx-color-error-background-hover,
+    oklch(0.505 0.2209 27.946)
+  );
+  --color-error-background-active: var(
+    --nx-color-error-background-active,
+    oklch(0.42 0.1838 28.144)
+  );
+  --color-error-foreground: var(--nx-color-error-foreground, oklch(1 0 0));
+  --color-error-disabled: var(
+    --nx-color-error-disabled,
+    oklch(0.808 0.1333 28.058)
+  );
+  --color-error-subtle: var(
+    --nx-color-error-subtle,
+    oklch(0.971 0.0176 28.865)
+  );
+  --color-error-subtle-foreground: var(
+    --nx-color-error-subtle-foreground,
+    oklch(0.577 0.2523 27.926)
+  );
+  --color-error-subtle-hover: var(
+    --nx-color-error-subtle-hover,
+    oklch(0.936 0.0399 27.342)
+  );
+  --color-error-subtle-active: var(
+    --nx-color-error-subtle-active,
+    oklch(0.885 0.0747 27.394)
+  );
+  --color-border-error: var(
+    --nx-color-border-error,
+    oklch(0.885 0.0747 27.394)
+  );
+  --color-border-error-active: var(
+    --nx-color-border-error-active,
+    oklch(0.704 0.2267 27.842)
+  );
+  --color-information-background: var(
+    --nx-color-information-background,
+    oklch(0.546 0.2205 255.276)
+  );
+  --color-information-background-hover: var(
+    --nx-color-information-background-hover,
+    oklch(0.488 0.197 255.267)
+  );
+  --color-information-background-active: var(
+    --nx-color-information-background-active,
+    oklch(0.41 0.1633 254.871)
+  );
+  --color-information-foreground: var(
+    --nx-color-information-foreground,
+    oklch(1 0 0)
+  );
+  --color-information-disabled: var(
+    --nx-color-information-disabled,
+    oklch(0.809 0.1012 254.248)
+  );
+  --color-information-subtle: var(
+    --nx-color-information-subtle,
+    oklch(0.97 0.0152 252.81)
+  );
+  --color-information-subtle-foreground: var(
+    --nx-color-information-subtle-foreground,
+    oklch(0.546 0.2205 255.276)
+  );
+  --color-information-subtle-hover: var(
+    --nx-color-information-subtle-hover,
+    oklch(0.932 0.0342 257.472)
+  );
+  --color-information-subtle-active: var(
+    --nx-color-information-subtle-active,
+    oklch(0.882 0.0612 253.613)
+  );
+  --color-border-information: var(
+    --nx-color-border-information,
+    oklch(0.882 0.0612 253.613)
+  );
+  --color-border-information-active: var(
+    --nx-color-border-information-active,
+    oklch(0.707 0.1599 255.225)
+  );
+  --color-chart-categorical-1: var(
+    --nx-color-chart-categorical-1,
+    oklch(0.52 0.1168 186.391)
+  );
+  --color-chart-categorical-2: var(
+    --nx-color-chart-categorical-2,
+    oklch(0.61 0.1871 131.589)
+  );
+  --color-chart-categorical-3: var(
+    --nx-color-chart-categorical-3,
+    oklch(0.62 0.2044 41.116)
+  );
+  --color-chart-categorical-4: var(
+    --nx-color-chart-categorical-4,
+    oklch(0.58 0.2489 17.585)
+  );
+  --color-chart-categorical-5: var(
+    --nx-color-chart-categorical-5,
+    oklch(0.49 0.2912 276.966)
+  );
+  --color-focus-default: var(--nx-color-focus-default, oklch(0.1448 0 0));
+  --color-focus-error: var(--nx-color-focus-error, oklch(0.577 0.2523 27.926));
+  --color-background-hover-alpha: var(
+    --nx-color-background-hover-alpha,
+    oklch(0.13 0.006 70 / 0.0627)
+  );
+  --color-border-default-alpha: var(
+    --nx-color-border-default-alpha,
+    oklch(0.13 0.006 70 / 0.0941)
+  );
+  --color-overlay: var(--nx-color-overlay, oklch(0.13 0.006 70 / 0.7529));
+  --color-popover-alpha: var(--nx-color-popover-alpha, oklch(1 0 0 / 0.7529));
+  --color-popover-backdrop: var(
+    --nx-color-popover-backdrop,
+    oklch(0.13 0.006 70 / 0.9098)
+  );
 }
 
 /* ===== DARK MODE ===== */
 .dark {
-  --nx-color-background: var(--nx-color-stone-950);
-  --nx-color-foreground: var(--nx-color-white-a900);
-  --nx-color-background-hover: var(--nx-color-stone-900);
-  --nx-color-background-hover-alpha: var(--nx-color-stone-a100);
-  --nx-color-background-active: var(--nx-color-stone-900);
-  --nx-color-muted: var(--nx-color-stone-900);
-  --nx-color-muted-foreground: var(--nx-color-white-a600);
-  --nx-color-muted-foreground-subtle: var(--nx-color-white-a600);
-  --nx-color-disabled: var(--nx-color-stone-900);
-  --nx-color-disabled-foreground: var(--nx-color-stone-300);
-  --nx-color-container: var(--nx-color-stone-900);
-  --nx-color-container-foreground: var(--nx-color-white-base);
-  --nx-color-container-hover: var(--nx-color-stone-800);
-  --nx-color-container-active: var(--nx-color-stone-900);
-  --nx-color-popover: var(--nx-color-stone-800);
-  --nx-color-popover-foreground: var(--nx-color-white-base);
-  --nx-color-popover-hover: var(--nx-color-stone-700);
-  --nx-color-popover-active: var(--nx-color-stone-800);
-  --nx-color-popover-alpha: var(--nx-color-stone-a700);
-  --nx-color-popover-backdrop: var(--nx-color-stone-a900);
-  --nx-color-control-background: var(--nx-color-stone-800);
-  --nx-color-control-background-hover: var(--nx-color-stone-700);
-  --nx-color-control-thumb: var(--nx-color-white-base);
-  --nx-color-nav-background: var(--nx-color-stone-900);
-  --nx-color-nav-foreground: var(--nx-color-stone-50);
-  --nx-color-nav-muted-foreground: var(--nx-color-stone-300);
-  --nx-color-nav-item-hover: var(--nx-color-stone-800);
-  --nx-color-nav-item-active: var(--nx-color-stone-800);
-  --nx-color-nav-border: var(--nx-color-stone-800);
-  --nx-color-overlay: var(--nx-color-stone-a800);
-  --nx-color-border-default: var(--nx-color-white-a300);
-  --nx-color-border-hairline: var(--nx-color-white-a200);
-  --nx-color-border-default-alpha: var(--nx-color-stone-a300);
-  --nx-color-border-active: var(--nx-color-stone-400);
-  --nx-color-border-disabled: var(--nx-color-white-a300);
-  --nx-color-border-warning: var(--nx-color-orange-700);
-  --nx-color-border-warning-active: var(--nx-color-orange-500);
-  --nx-color-border-success: var(--nx-color-green-700);
-  --nx-color-border-success-active: var(--nx-color-green-500);
-  --nx-color-border-error: var(--nx-color-red-700);
-  --nx-color-border-error-active: var(--nx-color-red-500);
-  --nx-color-border-information: var(--nx-color-blue-700);
-  --nx-color-border-information-active: var(--nx-color-blue-500);
-  --nx-color-error-background: var(--nx-color-red-600);
-  --nx-color-error-foreground: var(--nx-color-white-base);
-  --nx-color-error-background-hover: var(--nx-color-red-700);
-  --nx-color-error-background-active: var(--nx-color-red-800);
-  --nx-color-error-disabled: var(--nx-color-red-900);
-  --nx-color-error-subtle: var(--nx-color-red-950);
-  --nx-color-error-subtle-foreground: var(--nx-color-red-200);
-  --nx-color-error-subtle-hover: var(--nx-color-red-900);
-  --nx-color-error-subtle-active: var(--nx-color-red-800);
-  --nx-color-success-background: var(--nx-color-green-600);
-  --nx-color-success-foreground: var(--nx-color-white-base);
-  --nx-color-success-background-hover: var(--nx-color-green-700);
-  --nx-color-success-background-active: var(--nx-color-green-800);
-  --nx-color-success-disabled: var(--nx-color-green-900);
-  --nx-color-success-subtle: var(--nx-color-green-950);
-  --nx-color-success-subtle-foreground: var(--nx-color-green-300);
-  --nx-color-success-subtle-hover: var(--nx-color-green-900);
-  --nx-color-success-subtle-active: var(--nx-color-green-800);
-  --nx-color-information-background: var(--nx-color-blue-600);
-  --nx-color-information-foreground: var(--nx-color-white-base);
-  --nx-color-information-background-hover: var(--nx-color-blue-700);
-  --nx-color-information-background-active: var(--nx-color-blue-800);
-  --nx-color-information-disabled: var(--nx-color-blue-900);
-  --nx-color-information-subtle: var(--nx-color-blue-950);
-  --nx-color-information-subtle-foreground: var(--nx-color-blue-300);
-  --nx-color-information-subtle-hover: var(--nx-color-blue-900);
-  --nx-color-information-subtle-active: var(--nx-color-blue-800);
-  --nx-color-warning-background: var(--nx-color-orange-600);
-  --nx-color-warning-foreground: var(--nx-color-white-base);
-  --nx-color-warning-background-hover: var(--nx-color-orange-700);
-  --nx-color-warning-background-active: var(--nx-color-orange-800);
-  --nx-color-warning-disabled: var(--nx-color-orange-900);
-  --nx-color-warning-subtle: var(--nx-color-orange-950);
-  --nx-color-warning-subtle-foreground: var(--nx-color-orange-200);
-  --nx-color-warning-subtle-hover: var(--nx-color-orange-900);
-  --nx-color-warning-subtle-active: var(--nx-color-orange-800);
-  --nx-color-chart-categorical-1: var(--nx-color-teal-200);
-  --nx-color-chart-categorical-2: var(--nx-color-lime-200);
-  --nx-color-chart-categorical-3: var(--nx-color-orange-200);
-  --nx-color-chart-categorical-4: var(--nx-color-rose-200);
-  --nx-color-chart-categorical-5: var(--nx-color-indigo-200);
-  --nx-color-primary-background: var(--nx-color-white-base);
-  --nx-color-primary-background-active: var(--nx-color-neutral-200);
-  --nx-color-primary-foreground: var(--nx-color-black-base);
-  --nx-color-primary-background-hover: var(--nx-color-neutral-100);
-  --nx-color-primary-disabled: var(--nx-color-neutral-800);
-  --nx-color-primary-subtle: var(--nx-color-neutral-950);
-  --nx-color-primary-subtle-foreground: var(--nx-color-white-base);
-  --nx-color-primary-subtle-hover: var(--nx-color-neutral-900);
-  --nx-color-primary-subtle-active: var(--nx-color-neutral-800);
-  --nx-color-secondary-background: var(--nx-color-neutral-900);
-  --nx-color-secondary-foreground: var(--nx-color-neutral-100);
-  --nx-color-secondary-background-hover: var(--nx-color-neutral-700);
-  --nx-color-secondary-background-active: var(--nx-color-neutral-600);
-  --nx-color-secondary-disabled: var(--nx-color-neutral-950);
-  --nx-color-secondary-subtle: var(--nx-color-neutral-800);
-  --nx-color-secondary-subtle-foreground: var(--nx-color-neutral-200);
-  --nx-color-secondary-subtle-hover: var(--nx-color-neutral-700);
-  --nx-color-secondary-subtle-active: var(--nx-color-neutral-600);
-  --nx-color-border-primary: var(--nx-color-neutral-700);
-  --nx-color-border-primary-active: var(--nx-color-neutral-500);
+  --nx-color-background: oklch(0.2161 0.006 70);
+  --nx-color-background-hover: oklch(0.2481 0.006 70);
+  --nx-color-background-active: oklch(0.2481 0.006 70);
+  --nx-color-muted: oklch(0.2481 0.006 70);
+  --nx-color-container: oklch(0.2481 0.006 70);
+  --nx-color-container-hover: oklch(0.2801 0.006 70);
+  --nx-color-container-active: oklch(0.2481 0.006 70);
+  --nx-color-popover: oklch(0.2801 0.006 70);
+  --nx-color-popover-hover: oklch(0.3121 0.006 70);
+  --nx-color-popover-active: oklch(0.2801 0.006 70);
+  --nx-color-control-background: oklch(0.2801 0.006 70);
+  --nx-color-control-background-hover: oklch(0.3121 0.006 70);
+  --nx-color-control-thumb: oklch(1 0 0);
+  --nx-color-nav-background: oklch(0.2481 0.006 70);
+  --nx-color-nav-item-hover: oklch(0.2801 0.006 70);
+  --nx-color-nav-item-active: oklch(0.2801 0.006 70);
+  --nx-color-nav-border: oklch(0.2801 0.006 70);
+  --nx-color-disabled: oklch(0.2481 0.006 70);
+  --nx-color-border-active: oklch(0.4097 0.006 70);
+  --nx-color-foreground: oklch(1 0 0 / 0.9098);
+  --nx-color-container-foreground: oklch(0.9848 0.0013 106.424);
+  --nx-color-popover-foreground: oklch(0.9848 0.0013 106.424);
+  --nx-color-nav-foreground: oklch(0.9848 0.0013 106.424);
+  --nx-color-muted-foreground: oklch(1 0 0 / 0.6275);
+  --nx-color-nav-muted-foreground: oklch(0.8375 0.0013 106.424);
+  --nx-color-muted-foreground-subtle: oklch(1 0 0 / 0.6275);
+  --nx-color-disabled-foreground: oklch(0.6901 0.0013 106.424);
+  --nx-color-border-default: oklch(1 0 0 / 0.12);
+  --nx-color-border-disabled: oklch(1 0 0 / 0.12);
+  --nx-color-border-hairline: oklch(1 0 0 / 0.0941);
+  --nx-color-primary-background: oklch(1 0 0);
+  --nx-color-primary-background-hover: oklch(0.945 0 0);
+  --nx-color-primary-background-active: oklch(0.87 0 0);
+  --nx-color-primary-foreground: oklch(0.1448 0 0);
+  --nx-color-primary-disabled: oklch(0.118 0 0);
+  --nx-color-primary-subtle: oklch(0.118 0 0);
+  --nx-color-primary-subtle-foreground: oklch(1 0 0);
+  --nx-color-primary-subtle-hover: oklch(0.207 0 0);
+  --nx-color-primary-subtle-active: oklch(0.297 0 0);
+  --nx-color-border-primary: oklch(0.385 0 0);
+  --nx-color-border-primary-active: oklch(0.553 0 0);
+  --nx-color-secondary-background: oklch(0.207 0 0);
+  --nx-color-secondary-background-hover: oklch(0.385 0 0);
+  --nx-color-secondary-background-active: oklch(0.46 0 0);
+  --nx-color-secondary-foreground: oklch(0.945 0 0);
+  --nx-color-secondary-disabled: oklch(0.118 0 0);
+  --nx-color-secondary-subtle: oklch(0.297 0 0);
+  --nx-color-secondary-subtle-foreground: oklch(0.87 0 0);
+  --nx-color-secondary-subtle-hover: oklch(0.385 0 0);
+  --nx-color-secondary-subtle-active: oklch(0.46 0 0);
+  --nx-color-success-background: oklch(0.62 0.2233 140.055);
+  --nx-color-success-background-hover: oklch(0.52 0.1871 140.022);
+  --nx-color-success-background-active: oklch(0.43 0.1534 139.623);
+  --nx-color-success-foreground: oklch(1 0 0);
+  --nx-color-success-disabled: oklch(0.25 0.0887 139.4);
+  --nx-color-success-subtle: oklch(0.25 0.0887 139.4);
+  --nx-color-success-subtle-foreground: oklch(0.87 0.3119 139.843);
+  --nx-color-success-subtle-hover: oklch(0.34 0.1216 139.757);
+  --nx-color-success-subtle-active: oklch(0.43 0.1534 139.623);
+  --nx-color-border-success: oklch(0.52 0.1871 140.022);
+  --nx-color-border-success-active: oklch(0.72 0.2591 140.014);
+  --nx-color-warning-background: oklch(0.62 0.2044 41.116);
+  --nx-color-warning-background-hover: oklch(0.52 0.1809 38.402);
+  --nx-color-warning-background-active: oklch(0.43 0.153 37.304);
+  --nx-color-warning-foreground: oklch(1 0 0);
+  --nx-color-warning-disabled: oklch(0.25 0.091 36.259);
+  --nx-color-warning-subtle: oklch(0.25 0.091 36.259);
+  --nx-color-warning-subtle-foreground: oklch(0.84 0.142 66.29);
+  --nx-color-warning-subtle-hover: oklch(0.34 0.1188 38.172);
+  --nx-color-warning-subtle-active: oklch(0.43 0.153 37.304);
+  --nx-color-border-warning: oklch(0.52 0.1809 38.402);
+  --nx-color-border-warning-active: oklch(0.71 0.2099 47.604);
+  --nx-color-error-background: oklch(0.577 0.2523 27.926);
+  --nx-color-error-background-hover: oklch(0.505 0.2209 27.946);
+  --nx-color-error-background-active: oklch(0.42 0.1838 28.144);
+  --nx-color-error-foreground: oklch(1 0 0);
+  --nx-color-error-disabled: oklch(0.25 0.1094 28.309);
+  --nx-color-error-subtle: oklch(0.25 0.1094 28.309);
+  --nx-color-error-subtle-foreground: oklch(0.808 0.1333 28.058);
+  --nx-color-error-subtle-hover: oklch(0.34 0.1487 28.057);
+  --nx-color-error-subtle-active: oklch(0.42 0.1838 28.144);
+  --nx-color-border-error: oklch(0.505 0.2209 27.946);
+  --nx-color-border-error-active: oklch(0.637 0.2786 27.978);
+  --nx-color-information-background: oklch(0.546 0.2205 255.276);
+  --nx-color-information-background-hover: oklch(0.488 0.197 255.267);
+  --nx-color-information-background-active: oklch(0.41 0.1633 254.871);
+  --nx-color-information-foreground: oklch(1 0 0);
+  --nx-color-information-disabled: oklch(0.25 0.1042 256.214);
+  --nx-color-information-subtle: oklch(0.25 0.1042 256.214);
+  --nx-color-information-subtle-foreground: oklch(0.809 0.1012 254.248);
+  --nx-color-information-subtle-hover: oklch(0.33 0.1316 254.902);
+  --nx-color-information-subtle-active: oklch(0.41 0.1633 254.871);
+  --nx-color-border-information: oklch(0.488 0.197 255.267);
+  --nx-color-border-information-active: oklch(0.623 0.2112 255.145);
+  --nx-color-chart-categorical-1: oklch(0.9 0.1682 180.426);
+  --nx-color-chart-categorical-2: oklch(0.93 0.2278 124.321);
+  --nx-color-chart-categorical-3: oklch(0.91 0.0819 70.697);
+  --nx-color-chart-categorical-4: oklch(0.885 0.0771 10.001);
+  --nx-color-chart-categorical-5: oklch(0.865 0.069 274.039);
+  --nx-color-focus-default: oklch(1 0 0);
+  --nx-color-focus-error: oklch(0.808 0.1333 28.058);
+  --nx-color-background-hover-alpha: oklch(0.13 0.006 70 / 0.04);
+  --nx-color-border-default-alpha: oklch(0.13 0.006 70 / 0.12);
+  --nx-color-overlay: oklch(0.13 0.006 70 / 0.8471);
+  --nx-color-popover-alpha: oklch(0.13 0.006 70 / 0.7529);
+  --nx-color-popover-backdrop: oklch(0.13 0.006 70 / 0.9098);
 }
 
 /* ===== RUNTIME DIMENSION TOKENS ===== */

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,7 @@
       "outputs": ["dist/modular/**"]
     },
     "build:tailwind": {
+      "dependsOn": ["build"],
       "inputs": ["scripts/**", "tokens/**", "src/lib/perceptual-grid.json"],
       "outputs": ["dist/tailwind/**"]
     },


### PR DESCRIPTION
## Summary

- Cut over the Tailwind/static CSS generator semantic color fallbacks to the reviewed token engine floor.
- Keep semantic JSON, old JSON-vs-engine parity, modular/docs/static legacy paths, and deletion work intact for Phase 4.
- Thread `config.base` through `surfaceTone` validation so `--base` continues to select the intended engine floor.
- Emit border color aliases through the runtime `--nx-color-*` chain so compiled utilities no longer depend on dangling `--color-*` references.
- Regenerate Tailwind CSS; fallback-form churn from primitive `var(...)` references to resolved `oklch(...)` literals is expected. The engine matrix snapshot was regenerated and remained unchanged.

## GitHub Issue

N/A - Phase 3 / PR A from `docs/superpowers/plans/2026-07-09-single-source-token-engine.md`.

## Test Plan

- [x] `corepack pnpm --filter @nexus_ds/core build`
- [x] `corepack pnpm tokens:tailwind`
- [x] `node packages/core/scripts/generate-engine-snapshot.mjs` with no fixture diff
- [x] `corepack pnpm exec vitest run --project=unit packages/core/scripts/__tests__/generate-modular.test.js packages/core/scripts/__tests__/generate-tailwind-package.test.js`
- [x] `corepack pnpm test:unit`
- [x] `git diff --check`
- [ ] Remaining broad checks (`typecheck`, `typecheck:dist`, `format:check`, `lint`, `export:verify`, `audit:contrast`, `audit:colorblind`, `test:storybook`, `build-storybook`) were blocked locally after Turbo invoked a different pnpm wrapper, disturbed `node_modules`, and the hook/install repair hit `ENOSPC` while linking dependencies. CI should rerun these from a clean install.
