### PR TITLE
feat(core): expose full shipped appearance modes

### DIFF
--- a/.changeset/full-appearance-modes.md
+++ b/.changeset/full-appearance-modes.md
@@ -1,0 +1,5 @@
+---
+'@nexus_ds/core': minor
+---
+
+Expose the full shipped density, corner, and elevation modes through the public appearance model unions, option tables, and sanitizers.

--- a/packages/core/src/lib/appearance-model.test.ts
+++ b/packages/core/src/lib/appearance-model.test.ts
@@ -70,9 +70,11 @@ describe('appearance model', () => {
 
   it('maps friendly layout labels to token axes', () => {
     expect(DENSITY_OPTIONS).toEqual([
+      { value: 'tight', label: 'Tight' },
       { value: 'compact', label: 'Compact' },
       { value: 'default', label: 'Default' },
       { value: 'comfortable', label: 'Comfortable' },
+      { value: 'relaxed', label: 'Relaxed' },
       { value: 'spacious', label: 'Spacious' },
     ]);
     expect(CORNER_OPTIONS).toEqual([
@@ -80,9 +82,12 @@ describe('appearance model', () => {
       { value: 'subtle', label: 'Subtle' },
       { value: 'smooth', label: 'Smooth' },
       { value: 'round', label: 'Round' },
+      { value: 'extra-round', label: 'Extra Round' },
     ]);
     expect(ELEVATION_OPTIONS).toEqual([
+      { value: 'flat', label: 'Flat' },
       { value: 'quiet', label: 'Quiet' },
+      { value: 'soft', label: 'Soft' },
       { value: 'standard', label: 'Standard' },
       { value: 'strong', label: 'Strong' },
     ]);
@@ -108,9 +113,9 @@ describe('sanitizeNexusAppearance', () => {
       surfaceTone: 'slate' as const,
       lightContrast: 42,
       darkContrast: 42,
-      density: 'spacious' as const,
-      corners: 'round' as const,
-      elevation: 'strong' as const,
+      density: 'tight' as const,
+      corners: 'extra-round' as const,
+      elevation: 'flat' as const,
       stroke: 'fine' as const,
       prefs: {
         ...DEFAULT_NEXUS_APPEARANCE.prefs,
@@ -122,6 +127,26 @@ describe('sanitizeNexusAppearance', () => {
     };
 
     expect(sanitizeNexusAppearance(valid)).toEqual(valid);
+  });
+
+  it('accepts every shipped layout mode', () => {
+    for (const option of DENSITY_OPTIONS) {
+      expect(sanitizeNexusAppearance({ density: option.value }).density).toBe(
+        option.value
+      );
+    }
+
+    for (const option of CORNER_OPTIONS) {
+      expect(sanitizeNexusAppearance({ corners: option.value }).corners).toBe(
+        option.value
+      );
+    }
+
+    for (const option of ELEVATION_OPTIONS) {
+      expect(
+        sanitizeNexusAppearance({ elevation: option.value }).elevation
+      ).toBe(option.value);
+    }
   });
 
   it('rejects prototype-chain keys as tones', () => {
@@ -158,6 +183,18 @@ describe('sanitizeNexusAppearance', () => {
         density: 'wat',
       }).density
     ).toBe('default');
+    expect(
+      sanitizeNexusAppearance({
+        ...DEFAULT_NEXUS_APPEARANCE,
+        corners: 'pill',
+      }).corners
+    ).toBe('square');
+    expect(
+      sanitizeNexusAppearance({
+        ...DEFAULT_NEXUS_APPEARANCE,
+        elevation: 'dramatic',
+      }).elevation
+    ).toBe('quiet');
   });
 
   it('normalizes a persisted density codename to its friendly value', () => {

--- a/packages/core/src/lib/appearance-model.ts
+++ b/packages/core/src/lib/appearance-model.ts
@@ -5,9 +5,20 @@ import { isColor } from './perceptual-ramp';
 type ModeSeeds = Pick<ThemeSeeds, 'background' | 'foreground'>;
 
 export type NexusAppearanceMode = 'light' | 'dark' | 'system';
-export type NexusDensity = 'compact' | 'default' | 'comfortable' | 'spacious';
-export type NexusCorners = 'square' | 'subtle' | 'smooth' | 'round';
-export type NexusElevation = 'quiet' | 'standard' | 'strong';
+export type NexusDensity =
+  | 'tight'
+  | 'compact'
+  | 'default'
+  | 'comfortable'
+  | 'relaxed'
+  | 'spacious';
+export type NexusCorners =
+  | 'square'
+  | 'subtle'
+  | 'smooth'
+  | 'round'
+  | 'extra-round';
+export type NexusElevation = 'flat' | 'quiet' | 'soft' | 'standard' | 'strong';
 export type NexusStroke = 'fine' | 'normal' | 'strong';
 
 export interface NexusAppearancePrefs {
@@ -74,9 +85,11 @@ export const BASE_TONE_SEEDS: Record<
 };
 
 export const DENSITY_OPTIONS = [
+  { value: 'tight', label: 'Tight' },
   { value: 'compact', label: 'Compact' },
   { value: 'default', label: 'Default' },
   { value: 'comfortable', label: 'Comfortable' },
+  { value: 'relaxed', label: 'Relaxed' },
   { value: 'spacious', label: 'Spacious' },
 ] as const satisfies readonly { value: NexusDensity; label: string }[];
 
@@ -85,10 +98,13 @@ export const CORNER_OPTIONS = [
   { value: 'subtle', label: 'Subtle' },
   { value: 'smooth', label: 'Smooth' },
   { value: 'round', label: 'Round' },
+  { value: 'extra-round', label: 'Extra Round' },
 ] as const satisfies readonly { value: NexusCorners; label: string }[];
 
 export const ELEVATION_OPTIONS = [
+  { value: 'flat', label: 'Flat' },
   { value: 'quiet', label: 'Quiet' },
+  { value: 'soft', label: 'Soft' },
   { value: 'standard', label: 'Standard' },
   { value: 'strong', label: 'Strong' },
 ] as const satisfies readonly { value: NexusElevation; label: string }[];

--- a/packages/react/src/components/appearance/appearance-settings/AppearanceSettings.stories.tsx
+++ b/packages/react/src/components/appearance/appearance-settings/AppearanceSettings.stories.tsx
@@ -1,6 +1,11 @@
-import { DEFAULT_NEXUS_APPEARANCE } from '@nexus_ds/core';
+import {
+  CORNER_OPTIONS,
+  DEFAULT_NEXUS_APPEARANCE,
+  DENSITY_OPTIONS,
+  ELEVATION_OPTIONS,
+} from '@nexus_ds/core';
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { NexusAppearanceProvider } from '../provider';
 
@@ -27,6 +32,51 @@ export default meta;
 type Story = StoryObj<typeof NexusAppearanceSettings>;
 
 export const Default: Story = {};
+
+async function expectSelectOptions(
+  canvasElement: HTMLElement,
+  name: string,
+  labels: readonly string[]
+) {
+  const canvas = within(canvasElement);
+  const trigger = canvas.getByRole('combobox', { name });
+
+  try {
+    await userEvent.click(trigger);
+
+    const listbox = await within(document.body).findByRole('listbox');
+    for (const label of labels) {
+      await expect(
+        within(listbox).getByRole('option', { name: label })
+      ).toBeInTheDocument();
+    }
+  } finally {
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => {
+      expect(document.querySelector('[role="listbox"]')).toBeNull();
+    });
+  }
+}
+
+export const LayoutModeOptions: Story = {
+  play: async ({ canvasElement }) => {
+    await expectSelectOptions(
+      canvasElement,
+      'Density',
+      DENSITY_OPTIONS.map((option) => option.label)
+    );
+    await expectSelectOptions(
+      canvasElement,
+      'Corners',
+      CORNER_OPTIONS.map((option) => option.label)
+    );
+    await expectSelectOptions(
+      canvasElement,
+      'Elevation',
+      ELEVATION_OPTIONS.map((option) => option.label)
+    );
+  },
+};
 
 export const ContrastIsolation: Story = {
   play: async ({ canvasElement }) => {


### PR DESCRIPTION
## Summary

- Phase 4 / PR B0 only: expand the public appearance mode surface before docs migration.
- Adds the full shipped density, corner, and elevation values to the core unions, option tables, and sanitizer-backed accepted values.
- Verifies React appearance settings expose those core option tables through the layout-mode selects.
- No docs migration, docs CI, deletion work, semantic JSON removal, parity-test removal, legacy path removal, or generator behavior change is included.
- Unlocks B-ci, B-docs, and B-del in order after this precursor PR lands.

## GitHub Issue

N/A - Phase 4 / PR B0 precursor.

## Test Plan

- [x] `CI=true corepack pnpm test:unit`
- [x] `CI=true corepack pnpm test:storybook`
- [x] `CI=true corepack pnpm format:check`
- [x] `CI=true corepack pnpm lint`
