### PR TITLE
ci(docs): require docs build and typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,10 @@ jobs:
       react: ${{ steps.filter.outputs.react }}
       browser: ${{ steps.filter.outputs.browser }}
       browser_source: ${{ steps.filter.outputs.browser_source }}
+      docs: ${{ steps.filter.outputs.docs }}
+      docs_dependencies: ${{ steps.filter.outputs.docs_dependencies }}
       # `packages` is true if `packages/**` changed OR if `apps/**` changed
-      # outside `apps/docs/**`. See the two paths-filter steps below.
+      # outside `apps/docs/**`. Docs changes are handled by the docs job.
       packages: ${{ steps.filter.outputs.packages == 'true' || steps.filter-apps.outputs.apps == 'true' }}
       ci: ${{ steps.filter.outputs.ci }}
     steps:
@@ -44,15 +46,19 @@ jobs:
         id: filter
         with:
           filters: |
-            # `react` intentionally excludes `apps/**` — no app currently
-            # consumes @nexus_ds/react at runtime, so apps/ changes can't break
-            # the react test/build/bundle-size jobs. Revisit if an app starts
-            # importing from @nexus_ds/react.
+            # `react` tracks package-library sources. App consumers such as
+            # docs are covered by app-specific jobs below.
             react:
               - 'packages/react/**'
               - 'packages/tailwind/**'
               - 'packages/core/**'
               - 'packages/test-utils/**'
+            docs:
+              - 'apps/docs/**'
+            docs_dependencies:
+              - 'packages/react/**'
+              - 'packages/tailwind/**'
+              - 'packages/core/**'
             packages:
               - 'packages/**'
             # Mirrors the source roots scanned by `pnpm audit:browser-support`.
@@ -73,8 +79,8 @@ jobs:
       # `predicate-quantifier: every` — required for `!apps/docs/**` to
       # actually negate (under the default `some`, the `apps/**` inclusion
       # wins and the negation is silently a no-op). Combined with `packages`
-      # via the job-level output expression below. Drop `!apps/docs/**` when
-      # @nexus_ds/docs becomes a real package.
+      # via the job-level output expression above; docs changes route to the
+      # dedicated docs job instead.
       - name: Detect non-docs app changes
         uses: dorny/paths-filter@v4
         id: filter-apps
@@ -294,6 +300,46 @@ jobs:
 
       - name: Tailwind and CSS export contract
         run: node scripts/typecheck-tailwind-dist.mjs
+
+  # ============================================
+  # Docs App Jobs
+  # ============================================
+
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    needs: changes
+    if: >-
+      needs.changes.outputs.docs == 'true' ||
+      needs.changes.outputs.docs_dependencies == 'true' ||
+      needs.changes.outputs.ci == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build @nexus_ds/core
+        run: pnpm --filter @nexus_ds/core build
+
+      - name: Build @nexus_ds/react
+        run: pnpm --filter @nexus_ds/react build
+
+      - name: Typecheck docs
+        run: pnpm --filter @nexus_ds/docs typecheck
+
+      - name: Build docs
+        run: pnpm --filter @nexus_ds/docs build
 
   # ============================================
   # React Package Jobs
@@ -547,6 +593,7 @@ jobs:
       - audit-browser-support
       - build
       - typecheck
+      - docs
       - test-unit
       - audit-tokens
       - test-react

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,10 @@ jobs:
       react: ${{ steps.filter.outputs.react }}
       browser: ${{ steps.filter.outputs.browser }}
       browser_source: ${{ steps.filter.outputs.browser_source }}
-      docs: ${{ steps.filter.outputs.docs }}
-      docs_dependencies: ${{ steps.filter.outputs.docs_dependencies }}
-      # `packages` is true if `packages/**` changed OR if `apps/**` changed
-      # outside `apps/docs/**`. Docs changes are handled by the docs job.
-      packages: ${{ steps.filter.outputs.packages == 'true' || steps.filter-apps.outputs.apps == 'true' }}
+      root_config: ${{ steps.filter.outputs.root_config }}
+      # `packages` is true if any package OR any app changed — both are built
+      # and typechecked by the shared turbo `build` / `typecheck` jobs.
+      packages: ${{ steps.filter.outputs.packages }}
       ci: ${{ steps.filter.outputs.ci }}
     steps:
       - name: Checkout
@@ -46,21 +45,18 @@ jobs:
         id: filter
         with:
           filters: |
-            # `react` tracks package-library sources. App consumers such as
-            # docs are covered by app-specific jobs below.
+            # `react` tracks package-library source. App consumers (docs,
+            # console) ride `packages` into the shared build/typecheck jobs.
             react:
               - 'packages/react/**'
               - 'packages/tailwind/**'
               - 'packages/core/**'
               - 'packages/test-utils/**'
-            docs:
-              - 'apps/docs/**'
-            docs_dependencies:
-              - 'packages/react/**'
-              - 'packages/tailwind/**'
-              - 'packages/core/**'
+            # `packages` gates the shared turbo build/typecheck jobs; any
+            # package or app can affect them, so both are matched here.
             packages:
               - 'packages/**'
+              - 'apps/**'
             # Mirrors the source roots scanned by `pnpm audit:browser-support`.
             browser_source:
               - 'apps/**'
@@ -72,24 +68,14 @@ jobs:
               - 'README.md'
               - 'AGENTS.md'
               - 'RTK.md'
+            # Root TS config sits outside every package, so turbo's
+            # `--filter=...[base]` selects no tasks for it; the build and
+            # typecheck jobs detect it here and run unfiltered instead.
+            root_config:
+              - 'tsconfig.base.json'
+              - 'tsconfig.json'
             ci:
               - '.github/workflows/**'
-
-      # Second paths-filter call so the `apps` filter can use
-      # `predicate-quantifier: every` — required for `!apps/docs/**` to
-      # actually negate (under the default `some`, the `apps/**` inclusion
-      # wins and the negation is silently a no-op). Combined with `packages`
-      # via the job-level output expression above; docs changes route to the
-      # dedicated docs job instead.
-      - name: Detect non-docs app changes
-        uses: dorny/paths-filter@v4
-        id: filter-apps
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            apps:
-              - 'apps/**'
-              - '!apps/docs/**'
 
   # format-check and lint run full-tree to mirror local `pnpm lint` /
   # `pnpm format:check`.
@@ -192,7 +178,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true'
+    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -223,7 +209,7 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          if [ "${{ needs.changes.outputs.ci }}" = "true" ]; then
+          if [ "${{ needs.changes.outputs.ci }}" = "true" ] || [ "${{ needs.changes.outputs.root_config }}" = "true" ]; then
             pnpm turbo build
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             pnpm turbo build --filter="...[origin/$BASE_REF]"
@@ -247,7 +233,7 @@ jobs:
     name: TypeScript Check
     runs-on: ubuntu-latest
     needs: [changes, build]
-    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true'
+    if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.root_config == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -284,7 +270,7 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          if [ "${{ needs.changes.outputs.ci }}" = "true" ]; then
+          if [ "${{ needs.changes.outputs.ci }}" = "true" ] || [ "${{ needs.changes.outputs.root_config }}" = "true" ]; then
             pnpm turbo typecheck
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             pnpm turbo typecheck --filter="...[origin/$BASE_REF]"
@@ -300,46 +286,6 @@ jobs:
 
       - name: Tailwind and CSS export contract
         run: node scripts/typecheck-tailwind-dist.mjs
-
-  # ============================================
-  # Docs App Jobs
-  # ============================================
-
-  docs:
-    name: Docs
-    runs-on: ubuntu-latest
-    needs: changes
-    if: >-
-      needs.changes.outputs.docs == 'true' ||
-      needs.changes.outputs.docs_dependencies == 'true' ||
-      needs.changes.outputs.ci == 'true'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build @nexus_ds/core
-        run: pnpm --filter @nexus_ds/core build
-
-      - name: Build @nexus_ds/react
-        run: pnpm --filter @nexus_ds/react build
-
-      - name: Typecheck docs
-        run: pnpm --filter @nexus_ds/docs typecheck
-
-      - name: Build docs
-        run: pnpm --filter @nexus_ds/docs build
 
   # ============================================
   # React Package Jobs
@@ -380,8 +326,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     # Gate on `browser_source` (apps/** + packages/**): the freshness check
-    # and the audit:class-refs / audit:mode-codenames steps scan apps/**
-    # sources — including apps/docs, which the `packages` filter excludes.
+    # and the audit:class-refs / audit:mode-codenames steps scan apps/** and
+    # packages/** sources, including apps/docs.
     if: needs.changes.outputs.browser_source == 'true' || needs.changes.outputs.ci == 'true'
     steps:
       - name: Checkout
@@ -593,7 +539,6 @@ jobs:
       - audit-browser-support
       - build
       - typecheck
-      - docs
       - test-unit
       - audit-tokens
       - test-react

--- a/docs/superpowers/plans/2026-07-09-single-source-token-engine.md
+++ b/docs/superpowers/plans/2026-07-09-single-source-token-engine.md
@@ -371,7 +371,7 @@ The generator stops reading semantic color JSON and bakes the engine floor inste
 **Restructured after Codex review (Finding 5) — split into FOUR PRs, in this order:**
 
 1. **PR B0 — enums** (Task B0). Precursor; no deletions.
-2. **PR B-ci — docs CI job** (Task 5.1, pulled forward). Adds a docs `next build`+typecheck job so the standalone docs PR is actually validated — a docs-only PR otherwise skips build/typecheck (`ci.yml:36,78-86`).
+2. **PR B-ci — docs CI coverage** (Task 5.1) — **SHIPPED #646**. Review rejected the planned dedicated docs job as over-built; shipped the simpler design instead: dropped the `!apps/docs/**` exclusion so `apps/docs` rides the `packages` filter into the shared turbo `build`/`typecheck` jobs (like `apps/console`), plus a `root_config` trigger routing root TS-config changes to the unfiltered run. Docs-only PRs previously skipped build/typecheck.
 3. **PR B-docs — docs migration** (Task 4.6). Docs adopts the provider; link-swap components deleted. `public/themes/*` + `generate-modular.js` still exist but are now unreferenced.
 4. **PR B-del — deletions** (Tasks 4.1–4.5, 4.7); touches `packages/` so the CI filter fires. The "same commit" rule (Task 4.3) applies inside this PR.
 
@@ -478,16 +478,17 @@ The generator stops reading semantic color JSON and bakes the engine floor inste
 
 ## Phase 5 — Post-cutover hardening
 
-### Task 5.1 — Docs build/typecheck CI job
+### Task 5.1 — Docs build/typecheck CI coverage — SHIPPED (PR #646)
 
-> **Scheduled in Phase 4 as PR B-ci** (must land before the docs migration). Listed here for topical grouping.
+> Shipped in Phase 4 as PR B-ci, before the docs migration.
 
-**Files:**
+**Files:** `.github/workflows/ci.yml`
 
-- Modify: `.github/workflows/ci.yml`
+Review (#646) rejected the originally-planned dedicated docs job as over-built and shipped the simpler design:
 
-- [ ] Add a docs `next build` + typecheck job. Today a docs-only PR skips build/typecheck entirely (`packages` filter `:36,78-86`), and the filter's justifying comment (`:47-50` — "no app consumes @nexus_ds/react at runtime") is already false. This closes the blind spot the Phase 4 PR had to work around.
-- [ ] **Wire it into enforcement (Codex finding):** branch protection requires only the `CI Status` aggregator (`ci.yml:17-20`), and the aggregator's own contract comment says every required job must appear in its `needs:` list (`:534-549`). Add the docs job to `ci-status.needs`, and if the job is path-filtered, add a docs path output to the `changes` job. Without this, the docs job can fail while the PR stays green.
+- [x] Fold `apps/docs` into the shared turbo `build`/`typecheck` jobs: add `apps/**` to the `packages` filter and **delete** the `!apps/docs/**` exclusion (and the second `filter-apps` step that existed only for that negation). `apps/docs` is a package dir, so turbo's `--filter=...[origin/BASE]` selects it on docs-only changes — no dedicated job needed, and `apps/console` already worked this way.
+- [x] Root TS config (`tsconfig.base.json` / `tsconfig.json`) sits outside every package, so the filtered turbo run selects **zero tasks** for it. Added a `root_config` change-detection output routed to the **unfiltered** `build`/`typecheck` run (a bare `packages`-filter add would run the job but typecheck nothing — a false green).
+- [x] Enforcement: docs is covered by the already-required `Build` / `TypeScript Check` aggregator jobs, so no new `ci-status.needs` entry was needed — the dedicated-job wiring the original plan called for is moot.
 
 ### Task 5.2 — Component token-ownership lint + audit-and-fix
 


### PR DESCRIPTION
## Summary

- Phase 4 / PR B-ci only: adds a required docs build/typecheck CI job before B-docs.
- Adds docs path/dependency filters so docs CI runs for apps/docs, core/react/tailwind, and CI workflow changes.
- Wires the docs job into CI Status so branch protection catches docs failures.
- Includes no docs migration, provider work, deletion work, token/generator changes, or changeset.
- Unlocks B-docs as the next Phase 4 PR.

## GitHub Issue

N/A

## Test Plan

- [x] CI=true corepack pnpm --filter @nexus_ds/docs typecheck
- [x] CI=true corepack pnpm --filter @nexus_ds/docs build
- [x] CI=true corepack pnpm format:check
- [x] CI=true corepack pnpm lint
