### PR TITLE
chore(tokens): harden component token ownership audit

### DIFF
--- a/.claude/rules/components.md
+++ b/.claude/rules/components.md
@@ -52,7 +52,29 @@ All Tailwind utilities use the `nx:` prefix, and it comes BEFORE every modifier 
 
 ### Semantic Token Paths
 
-Use full semantic token paths, never incomplete or primitive ones: `nx:bg-primary-background` (not `nx:bg-primary`, not the primitive `nx:bg-blue-500`). There is no `accent` token in Nexus. See `packages/tailwind/nexus.css` for the available tokens.
+Use full semantic token paths, never incomplete or primitive ones: `nx:bg-primary-background` (not `nx:bg-primary`, not the primitive `nx:bg-blue-500`). There is no `accent` token in Nexus. See `SEMANTIC_TOKEN_REGISTRY` in `packages/core/src/lib/token-registry.ts` for the available semantic color tokens; `packages/tailwind/nexus.css` is generated from that surface.
+
+### Component Token Ownership
+
+Treat color family choice as part of the component contract. The class-ref
+audit enforces registry membership and bans direct primitive runtime color vars
+in component code; this ownership table is still a review-time rule because the
+script cannot know whether a `div` is acting as a card, a field surface, a
+popover, or app chrome.
+
+| Surface or role                                      | Owns these token families                                                                                     | Notes                                                                                                                              |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Page and app root                                    | `background`, `foreground`                                                                                    | Use for the document canvas and full-page app shells.                                                                              |
+| Cards, panels, field groups, raised content surfaces | `container`, `container-foreground`, `border-default`                                                         | Field separators and field-card surfaces mask or rest on `container`, not page `background`.                                       |
+| Native form controls and control internals           | `control-background`, `control-background-hover`, `control-thumb`                                             | Inputs, switches, and control wells use `control-*`; surrounding field layout uses `container` when it needs a surface.            |
+| Floating content and menu rows                       | `popover`, `popover-alpha`, `popover-hover`, `popover-active`, `popover-foreground`                           | Popover, DropdownMenu, ContextMenu, Select content, HoverCard, Menubar content, and NavigationMenu flyouts use the popover family. |
+| Modal scrims                                         | `overlay`                                                                                                     | Scrims/backdrops use `overlay`; the panel above them uses its own surface family.                                                  |
+| Sidebar and navigation rails                         | `nav-background`, `nav-foreground`, `nav-muted-foreground`, `nav-item-hover`, `nav-item-active`, `nav-border` | Use `nav-*` for persistent navigation chrome rather than borrowing page or container tokens.                                       |
+| Secondary or quiet page content                      | `muted`, `muted-foreground`, `muted-foreground-subtle`                                                        | Use for subdued inline areas, helper text, captions, and incidental fills.                                                         |
+| Brand and action states                              | `primary-*`, `secondary-*`                                                                                    | Use full paths such as `primary-background` or `secondary-subtle-foreground`; never stop at the family name.                       |
+| Status states                                        | `success-*`, `warning-*`, `error-*`, `information-*`, `border-*` status tokens                                | Match the status family to the user-facing state and pair fill/foreground/border roles deliberately.                               |
+| Keyboard focus                                       | `focus-default`, `focus-error`                                                                                | Keep focus color behind the stable focus token utilities.                                                                          |
+| Data visualization                                   | `chart-categorical-*`                                                                                         | Use only for chart marks, legends, and chart-specific swatches.                                                                    |
 
 ### Adaptive-by-Default Semantic Tokens
 

--- a/packages/core/scripts/audit-class-refs.js
+++ b/packages/core/scripts/audit-class-refs.js
@@ -1,41 +1,29 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
-const NEXUS_CSS = path.join(REPO_ROOT, 'packages', 'tailwind', 'nexus.css');
-const SOURCE_DIRS = [
+const TOKEN_REGISTRY = path.join(
+  REPO_ROOT,
+  'packages',
+  'core',
+  'src',
+  'lib',
+  'token-registry.ts'
+);
+const CLASS_SOURCE_DIRS = [
   path.join(REPO_ROOT, 'packages', 'react', 'src'),
   path.join(REPO_ROOT, 'apps'),
 ];
-
-// Prefixes whose value-slot we own as semantic tokens. Anything that starts
-// with one of these (after the utility prefix) must resolve to a --color-*
-// variable in the emitted CSS. Other class names — including Tailwind
-// built-ins like text-sm, border-2, bg-transparent — fall through this
-// allowlist and are not validated.
-const SEMANTIC_PREFIXES = [
-  'background',
-  'foreground',
-  'container',
-  'control',
-  'popover',
-  'muted',
-  'nav',
-  'primary',
-  'secondary',
-  'error',
-  'success',
-  'warning',
-  'information',
-  'border',
-  'overlay',
-  'disabled',
-  'focus',
-  'chart',
-  'accent', // not a real token in Nexus — surfaces the migration bug
+const COMPONENT_SOURCE_DIRS = [
+  path.join(REPO_ROOT, 'packages', 'react', 'src', 'components'),
 ];
+
+// Deleted/foreign shadcn-style families are not in the registry, but a class
+// using one is still trying to reach the semantic-token layer.
+const RETIRED_SEMANTIC_FAMILIES = ['accent'];
 
 // Utility prefixes that consume a color-like value (e.g., `nx:bg-X`, `nx:text-X`).
 const UTILITY_PREFIXES = [
@@ -50,20 +38,125 @@ const UTILITY_PREFIXES = [
   'divide',
 ];
 
-function loadEmittedColorNames() {
-  const css = fs.readFileSync(NEXUS_CSS, 'utf8');
-  const set = new Set();
-  for (const match of css.matchAll(/--color-([a-z0-9-]+):/g)) {
-    set.add(match[1]);
+function unwrapExpression(node) {
+  let current = node;
+  while (ts.isAsExpression(current)) {
+    current = current.expression;
   }
-  return set;
+  return current;
 }
 
-function isSemanticName(name) {
-  for (const prefix of SEMANTIC_PREFIXES) {
-    if (name === prefix || name.startsWith(`${prefix}-`)) return true;
+function readStringArray(node) {
+  const array = unwrapExpression(node);
+  if (!ts.isArrayLiteralExpression(array)) return null;
+
+  const values = [];
+  for (const element of array.elements) {
+    if (!ts.isStringLiteral(element)) return null;
+    values.push(element.text);
   }
-  return false;
+  return values;
+}
+
+function loadSemanticRegistryNames() {
+  const content = fs.readFileSync(TOKEN_REGISTRY, 'utf8');
+  const source = ts.createSourceFile(
+    TOKEN_REGISTRY,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+  const namedArrays = new Map();
+  let registryInitializer = null;
+
+  for (const statement of source.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || !declaration.initializer) {
+        continue;
+      }
+
+      const name = declaration.name.text;
+      if (name === 'SEMANTIC_TOKEN_REGISTRY') {
+        registryInitializer = unwrapExpression(declaration.initializer);
+        continue;
+      }
+
+      const values = readStringArray(declaration.initializer);
+      if (values) {
+        namedArrays.set(name, values);
+      }
+    }
+  }
+
+  if (
+    !registryInitializer ||
+    !ts.isArrayLiteralExpression(registryInitializer)
+  ) {
+    throw new Error(
+      'audit-class-refs: could not find SEMANTIC_TOKEN_REGISTRY array.'
+    );
+  }
+
+  const names = [];
+  for (const element of registryInitializer.elements) {
+    if (!ts.isSpreadElement(element)) {
+      throw new Error(
+        'audit-class-refs: SEMANTIC_TOKEN_REGISTRY must be composed from metas(...) spreads.'
+      );
+    }
+
+    const expression = element.expression;
+    if (
+      !ts.isCallExpression(expression) ||
+      !ts.isIdentifier(expression.expression) ||
+      expression.expression.text !== 'metas' ||
+      expression.arguments.length < 2
+    ) {
+      throw new Error(
+        'audit-class-refs: registry spreads must call metas(category, TOKEN_NAMES).'
+      );
+    }
+
+    const namesArg = expression.arguments[1];
+    if (!ts.isIdentifier(namesArg) || !namedArrays.has(namesArg.text)) {
+      throw new Error(
+        `audit-class-refs: could not resolve registry token array ${namesArg.getText(source)}.`
+      );
+    }
+
+    names.push(...namedArrays.get(namesArg.text));
+  }
+
+  return new Set(names);
+}
+
+function semanticFamily(name) {
+  return name.split('-')[0];
+}
+
+function semanticFamiliesFromRegistry(registryNames) {
+  const families = new Set(RETIRED_SEMANTIC_FAMILIES);
+  for (const name of registryNames) {
+    families.add(semanticFamily(name));
+  }
+  return families;
+}
+
+function isSemanticName(name, semanticFamilies) {
+  return semanticFamilies.has(semanticFamily(name));
+}
+
+function isAllowedRuntimeColorVar(name, registryNames) {
+  if (name.endsWith('-')) {
+    for (const registryName of registryNames) {
+      if (registryName.startsWith(name)) return true;
+    }
+  }
+
+  return registryNames.has(name);
 }
 
 function* walkSources(dir) {
@@ -99,16 +192,26 @@ function findClassRefs(content) {
   return hits;
 }
 
+function findRuntimeColorVarRefs(content) {
+  const hits = [];
+  for (const match of content.matchAll(/--nx-color-([a-z][a-z0-9-]*)/g)) {
+    hits.push({ name: match[1], offset: match.index });
+  }
+  return hits;
+}
+
 function lineOf(content, offset) {
   return content.slice(0, offset).split('\n').length;
 }
 
 function main() {
-  const known = loadEmittedColorNames();
-  const failures = [];
+  const known = loadSemanticRegistryNames();
+  const semanticFamilies = semanticFamiliesFromRegistry(known);
+  const unresolvedClassRefs = [];
+  const primitiveVarRefs = [];
   let scanned = 0;
 
-  for (const dir of SOURCE_DIRS) {
+  for (const dir of CLASS_SOURCE_DIRS) {
     for (const file of walkSources(dir)) {
       scanned += 1;
       const content = fs.readFileSync(file, 'utf8');
@@ -117,12 +220,12 @@ function main() {
         // Documentation placeholders like `nx:bg-chart-categorical-N` are not
         // real class refs; the regex stops before the uppercase placeholder.
         if (hit.name.endsWith('-')) continue;
-        if (!isSemanticName(hit.name)) continue;
+        if (!isSemanticName(hit.name, semanticFamilies)) continue;
         if (known.has(hit.name)) continue;
         const key = `${file}:${hit.name}`;
         if (seen.has(key)) continue;
         seen.add(key);
-        failures.push({
+        unresolvedClassRefs.push({
           file: path.relative(REPO_ROOT, file),
           line: lineOf(content, hit.offset),
           name: hit.name,
@@ -131,20 +234,54 @@ function main() {
     }
   }
 
-  if (failures.length === 0) {
+  for (const dir of COMPONENT_SOURCE_DIRS) {
+    for (const file of walkSources(dir)) {
+      const content = fs.readFileSync(file, 'utf8');
+      const seen = new Set();
+      for (const hit of findRuntimeColorVarRefs(content)) {
+        if (isAllowedRuntimeColorVar(hit.name, known)) {
+          continue;
+        }
+
+        const key = `${file}:${hit.name}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        primitiveVarRefs.push({
+          file: path.relative(REPO_ROOT, file),
+          line: lineOf(content, hit.offset),
+          name: hit.name,
+        });
+      }
+    }
+  }
+
+  if (unresolvedClassRefs.length === 0 && primitiveVarRefs.length === 0) {
     process.stdout.write(
-      `audit-class-refs: scanned ${scanned} files — all semantic color refs resolve.\n`
+      `audit-class-refs: scanned ${scanned} files — all semantic color refs resolve and component color vars are semantic.\n`
     );
     process.exit(0);
   }
 
-  process.stdout.write(
-    `audit-class-refs: scanned ${scanned} files — ${failures.length} unresolved semantic color ref(s):\n`
-  );
-  for (const f of failures) {
+  if (unresolvedClassRefs.length > 0) {
     process.stdout.write(
-      `  ${f.file}:${f.line}  nx:…-${f.name}  (no --color-${f.name} in nexus.css)\n`
+      `audit-class-refs: scanned ${scanned} files — ${unresolvedClassRefs.length} unresolved semantic color class ref(s):\n`
     );
+    for (const f of unresolvedClassRefs) {
+      process.stdout.write(
+        `  ${f.file}:${f.line}  nx:...-${f.name}  (not in SEMANTIC_TOKEN_REGISTRY)\n`
+      );
+    }
+  }
+
+  if (primitiveVarRefs.length > 0) {
+    process.stdout.write(
+      `audit-class-refs: found ${primitiveVarRefs.length} primitive/unknown component color var ref(s):\n`
+    );
+    for (const f of primitiveVarRefs) {
+      process.stdout.write(
+        `  ${f.file}:${f.line}  --nx-color-${f.name}  (component code must use semantic color vars)\n`
+      );
+    }
   }
   process.exit(1);
 }

--- a/packages/core/scripts/audit-class-refs.js
+++ b/packages/core/scripts/audit-class-refs.js
@@ -1,25 +1,25 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import ts from 'typescript';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
-const TOKEN_REGISTRY = path.join(
-  REPO_ROOT,
-  'packages',
-  'core',
-  'src',
-  'lib',
-  'token-registry.ts'
-);
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+const RUNTIME_ENTRY = path.join(PACKAGE_ROOT, 'dist', 'runtime', 'index.js');
 const CLASS_SOURCE_DIRS = [
   path.join(REPO_ROOT, 'packages', 'react', 'src'),
   path.join(REPO_ROOT, 'apps'),
 ];
-const COMPONENT_SOURCE_DIRS = [
-  path.join(REPO_ROOT, 'packages', 'react', 'src', 'components'),
-];
+// The primitive/unknown `--nx-color-*` ban applies only to component code:
+// apps are consumers (free to reach for primitives) and non-component
+// `react/src` is internal plumbing. Components are the public surface.
+const COMPONENTS_DIR = path.join(
+  REPO_ROOT,
+  'packages',
+  'react',
+  'src',
+  'components'
+);
 
 // Deleted/foreign shadcn-style families are not in the registry, but a class
 // using one is still trying to reach the semantic-token layer.
@@ -38,99 +38,15 @@ const UTILITY_PREFIXES = [
   'divide',
 ];
 
-function unwrapExpression(node) {
-  let current = node;
-  while (ts.isAsExpression(current)) {
-    current = current.expression;
-  }
-  return current;
-}
-
-function readStringArray(node) {
-  const array = unwrapExpression(node);
-  if (!ts.isArrayLiteralExpression(array)) return null;
-
-  const values = [];
-  for (const element of array.elements) {
-    if (!ts.isStringLiteral(element)) return null;
-    values.push(element.text);
-  }
-  return values;
-}
-
-function loadSemanticRegistryNames() {
-  const content = fs.readFileSync(TOKEN_REGISTRY, 'utf8');
-  const source = ts.createSourceFile(
-    TOKEN_REGISTRY,
-    content,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS
-  );
-  const namedArrays = new Map();
-  let registryInitializer = null;
-
-  for (const statement of source.statements) {
-    if (!ts.isVariableStatement(statement)) continue;
-
-    for (const declaration of statement.declarationList.declarations) {
-      if (!ts.isIdentifier(declaration.name) || !declaration.initializer) {
-        continue;
-      }
-
-      const name = declaration.name.text;
-      if (name === 'SEMANTIC_TOKEN_REGISTRY') {
-        registryInitializer = unwrapExpression(declaration.initializer);
-        continue;
-      }
-
-      const values = readStringArray(declaration.initializer);
-      if (values) {
-        namedArrays.set(name, values);
-      }
-    }
-  }
-
-  if (
-    !registryInitializer ||
-    !ts.isArrayLiteralExpression(registryInitializer)
-  ) {
+async function loadSemanticRegistryNames() {
+  const runtime = await import(pathToFileURL(RUNTIME_ENTRY).href);
+  const registry = runtime.SEMANTIC_TOKEN_REGISTRY;
+  if (!Array.isArray(registry)) {
     throw new Error(
-      'audit-class-refs: could not find SEMANTIC_TOKEN_REGISTRY array.'
+      'audit-class-refs: @nexus_ds/core dist is missing SEMANTIC_TOKEN_REGISTRY — run `pnpm --filter @nexus_ds/core build` first.'
     );
   }
-
-  const names = [];
-  for (const element of registryInitializer.elements) {
-    if (!ts.isSpreadElement(element)) {
-      throw new Error(
-        'audit-class-refs: SEMANTIC_TOKEN_REGISTRY must be composed from metas(...) spreads.'
-      );
-    }
-
-    const expression = element.expression;
-    if (
-      !ts.isCallExpression(expression) ||
-      !ts.isIdentifier(expression.expression) ||
-      expression.expression.text !== 'metas' ||
-      expression.arguments.length < 2
-    ) {
-      throw new Error(
-        'audit-class-refs: registry spreads must call metas(category, TOKEN_NAMES).'
-      );
-    }
-
-    const namesArg = expression.arguments[1];
-    if (!ts.isIdentifier(namesArg) || !namedArrays.has(namesArg.text)) {
-      throw new Error(
-        `audit-class-refs: could not resolve registry token array ${namesArg.getText(source)}.`
-      );
-    }
-
-    names.push(...namedArrays.get(namesArg.text));
-  }
-
-  return new Set(names);
+  return new Set(registry.map((token) => token.name));
 }
 
 function semanticFamily(name) {
@@ -204,8 +120,8 @@ function lineOf(content, offset) {
   return content.slice(0, offset).split('\n').length;
 }
 
-function main() {
-  const known = loadSemanticRegistryNames();
+async function main() {
+  const known = await loadSemanticRegistryNames();
   const semanticFamilies = semanticFamiliesFromRegistry(known);
   const unresolvedClassRefs = [];
   const primitiveVarRefs = [];
@@ -215,7 +131,8 @@ function main() {
     for (const file of walkSources(dir)) {
       scanned += 1;
       const content = fs.readFileSync(file, 'utf8');
-      const seen = new Set();
+
+      const seenClassRefs = new Set();
       for (const hit of findClassRefs(content)) {
         // Documentation placeholders like `nx:bg-chart-categorical-N` are not
         // real class refs; the regex stops before the uppercase placeholder.
@@ -223,29 +140,24 @@ function main() {
         if (!isSemanticName(hit.name, semanticFamilies)) continue;
         if (known.has(hit.name)) continue;
         const key = `${file}:${hit.name}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
+        if (seenClassRefs.has(key)) continue;
+        seenClassRefs.add(key);
         unresolvedClassRefs.push({
           file: path.relative(REPO_ROOT, file),
           line: lineOf(content, hit.offset),
           name: hit.name,
         });
       }
-    }
-  }
 
-  for (const dir of COMPONENT_SOURCE_DIRS) {
-    for (const file of walkSources(dir)) {
-      const content = fs.readFileSync(file, 'utf8');
-      const seen = new Set();
+      // Component code must reach color only through semantic runtime vars.
+      if (!file.startsWith(`${COMPONENTS_DIR}${path.sep}`)) continue;
+
+      const seenVarRefs = new Set();
       for (const hit of findRuntimeColorVarRefs(content)) {
-        if (isAllowedRuntimeColorVar(hit.name, known)) {
-          continue;
-        }
-
+        if (isAllowedRuntimeColorVar(hit.name, known)) continue;
         const key = `${file}:${hit.name}`;
-        if (seen.has(key)) continue;
-        seen.add(key);
+        if (seenVarRefs.has(key)) continue;
+        seenVarRefs.add(key);
         primitiveVarRefs.push({
           file: path.relative(REPO_ROOT, file),
           line: lineOf(content, hit.offset),
@@ -286,4 +198,9 @@ function main() {
   process.exit(1);
 }
 
-main();
+main().catch((error) => {
+  process.stderr.write(
+    `${error instanceof Error ? error.message : String(error)}\n`
+  );
+  process.exit(1);
+});

--- a/packages/react/src/components/field/Field.stories.tsx
+++ b/packages/react/src/components/field/Field.stories.tsx
@@ -168,17 +168,19 @@ export const MultipleErrors: Story = {
 // A divider between groups of fields, with centered content.
 export const WithSeparator: Story = {
   render: () => (
-    <FieldGroup className="nx:w-80">
-      <Field>
-        <FieldLabel htmlFor="field-sep-email">Email</FieldLabel>
-        <Input id="field-sep-email" type="email" />
-      </Field>
-      <FieldSeparator>OR</FieldSeparator>
-      <Field>
-        <FieldLabel htmlFor="field-sep-phone">Phone</FieldLabel>
-        <Input id="field-sep-phone" type="tel" />
-      </Field>
-    </FieldGroup>
+    <div className="nx:w-80 nx:rounded-lg nx:border nx:border-border-default nx:bg-container nx:p-6">
+      <FieldGroup>
+        <Field>
+          <FieldLabel htmlFor="field-sep-email">Email</FieldLabel>
+          <Input id="field-sep-email" type="email" />
+        </Field>
+        <FieldSeparator>OR</FieldSeparator>
+        <Field>
+          <FieldLabel htmlFor="field-sep-phone">Phone</FieldLabel>
+          <Input id="field-sep-phone" type="tel" />
+        </Field>
+      </FieldGroup>
+    </div>
   ),
 };
 
@@ -357,19 +359,25 @@ export const Disabled: Story = {
 // collisions across the generated cells.
 export const AllVariants: Story = {
   render: () => (
-    <FieldSet className="nx:w-80">
-      <FieldLegend variant="legend">Account</FieldLegend>
-      <Field>
-        <FieldLabel>Email</FieldLabel>
-        <Input type="email" aria-label="Email" placeholder="you@example.com" />
-        <FieldDescription>We never share it.</FieldDescription>
-      </Field>
-      <FieldSeparator>OR</FieldSeparator>
-      <Field data-invalid="true">
-        <FieldLabel>Username</FieldLabel>
-        <Input aria-label="Username" aria-invalid />
-        <FieldError errors={[{ message: 'That username is taken.' }]} />
-      </Field>
-    </FieldSet>
+    <div className="nx:w-80 nx:rounded-lg nx:border nx:border-border-default nx:bg-container nx:p-6">
+      <FieldSet>
+        <FieldLegend variant="legend">Account</FieldLegend>
+        <Field>
+          <FieldLabel>Email</FieldLabel>
+          <Input
+            type="email"
+            aria-label="Email"
+            placeholder="you@example.com"
+          />
+          <FieldDescription>We never share it.</FieldDescription>
+        </Field>
+        <FieldSeparator>OR</FieldSeparator>
+        <Field data-invalid="true">
+          <FieldLabel>Username</FieldLabel>
+          <Input aria-label="Username" aria-invalid />
+          <FieldError errors={[{ message: 'That username is taken.' }]} />
+        </Field>
+      </FieldSet>
+    </div>
   ),
 };

--- a/packages/react/src/components/field/field.tsx
+++ b/packages/react/src/components/field/field.tsx
@@ -302,7 +302,7 @@ function FieldSeparator({
       {children && (
         <span
           data-slot="field-separator-content"
-          className="nx:relative nx:mx-auto nx:block nx:w-fit nx:bg-background nx:px-2 nx:text-muted-foreground"
+          className="nx:relative nx:mx-auto nx:block nx:w-fit nx:bg-container nx:px-2 nx:text-muted-foreground"
         >
           {children}
         </span>


### PR DESCRIPTION
## Summary

- Phase 5 post-cutover hardening only; Task 5.1 already shipped in PR #646.
- Phase 4 B-del (#648) is merged, so the legacy static/modular token pipeline is already deleted and this PR does not reintroduce it.
- Retargets `audit-class-refs` from generated `nexus.css` to `SEMANTIC_TOKEN_REGISTRY`.
- Bans direct primitive or unknown `--nx-color-*` runtime variable usage in component code.
- Fixes the discovered field-surface token drift by moving `FieldSeparator` content from page `background` to `container`.
- Documents component token ownership guidance in `.claude/rules/components.md`.

## GitHub Issue

N/A - Phase 5 plan follow-up.

## Test Plan

- [x] `CI=true corepack pnpm --filter @nexus_ds/core audit:class-refs`
- [x] `CI=true corepack pnpm --filter @nexus_ds/core build`
- [x] `CI=true corepack pnpm --filter @nexus_ds/react build`
- [x] `CI=true corepack pnpm test:unit`
- [x] `CI=true corepack pnpm test:storybook`
- [x] `CI=true corepack pnpm build-storybook`
- [x] `CI=true corepack pnpm format:check`
- [x] `CI=true corepack pnpm lint`
- [x] `CI=true corepack pnpm lint-staged`
