### PR TITLE
refactor(core): retire pre-single-source-engine token cruft

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,10 +16,6 @@ examples
 
 # Auto-generated CSS — produced by @nexus_ds/core token pipeline; do not reformat
 packages/tailwind/*.css
-apps/console/src/styles/*.css
-
-# Generated Storybook base-variant stories — produced by generate-base-variants.mjs
-packages/react/src/components/__generated__/
 
 # Untracked git worktree copies under .claude (full-repo clones, not part of the tree)
 .claude/worktrees/

--- a/apps/docs/app/_lib/appearance-controls.test.ts
+++ b/apps/docs/app/_lib/appearance-controls.test.ts
@@ -47,7 +47,7 @@ describe('docs appearance controls', () => {
       .forEach((node) => node.remove());
   });
 
-  it('defaults docs to provider system mode with the previous static mode values', () => {
+  it('defaults docs to provider system mode with the documented default values', () => {
     expect(DOCS_APPEARANCE_DEFAULT_STATE).toMatchObject({
       ...DEFAULT_NEXUS_APPEARANCE,
       mode: 'system',
@@ -59,7 +59,7 @@ describe('docs appearance controls', () => {
     });
   });
 
-  it('maps the old docs controls onto provider state fields', () => {
+  it('maps the docs controls onto provider state fields', () => {
     const state: NexusAppearanceState = {
       ...DOCS_APPEARANCE_DEFAULT_STATE,
       mode: 'light',

--- a/docs/superpowers/plans/2026-07-09-single-source-token-engine.md
+++ b/docs/superpowers/plans/2026-07-09-single-source-token-engine.md
@@ -1,5 +1,8 @@
 # Single-Source Token Engine — Execution Plan
 
+> **Completed — merged via #641–#649.** This plan executed as written; it is the
+> architecture record for the single-source engine, not pending work.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 >
 > **Design rationale + council review:** `.claude/plans/issue-a-review-council-encapsulated-peacock.md` (v3). This document is the executable companion — how, in what order, with what gates.

--- a/docs/superpowers/plans/2026-07-09-split-light-dark-contrast.md
+++ b/docs/superpowers/plans/2026-07-09-split-light-dark-contrast.md
@@ -1,5 +1,11 @@
 # Split Light & Dark Contrast Controls — Implementation Plan
 
+> **Historical — superseded.** Preserved as the design/rationale record. This
+> plan shipped as Phase 0 of the single-source token engine migration (#641);
+> the parity oracles and `tokens:modular` step it references were later deleted
+> in that migration (#641–#649). Read it as the decision record for the
+> light/dark contrast split, not as current infrastructure.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Replace the single global `contrast: number` appearance knob with two independent scalars — `lightContrast` and `darkContrast` — so the dark theme's surface separation can be tuned without moving the light theme.

--- a/docs/superpowers/specs/2026-07-07-model2-light-surface-foundation.md
+++ b/docs/superpowers/specs/2026-07-07-model2-light-surface-foundation.md
@@ -1,8 +1,10 @@
 # Model 2 Light Surface Hierarchy — Foundation + adoption slice
 
-> **Status:** in progress. Stone static-token slice landed in `104909ee8`. This
-> doc specs the Foundation work plus the first component-adoption slice now
-> included in PR #626.
+> **Historical — superseded.** Preserved as the design/rationale record. The
+> static-token slice this spec builds on was removed by the single-source token
+> engine migration (#641–#649), and the Model 2 light-surface direction was
+> subsequently revised. Read it as a decision record, not as current
+> infrastructure or the shipped surface model.
 
 ## Why this exists
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -225,8 +225,8 @@ export default tseslint.config(
   // Nexus: enforce documented component rules as lint — nx: class conventions
   // (ported from the former lint-nx-prefix Claude hook), composition over
   // render props, and handler extraction. Scoped to component-bearing source
-  // (React package + apps). Hand-written stories are linted too; only the
-  // gitignored __generated__ base-variant stories are excluded (global ignore).
+  // (React package + apps). Hand-written stories are linted too; any
+  // `__generated__` output stays excluded via the global ignore.
   {
     files: ['packages/react/src/**/*.{ts,tsx}', 'apps/**/*.{ts,tsx}'],
     ...nexusComponentConfig(),

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:unit": "vitest run --project=unit",
-    "typecheck:dist": "pnpm --filter @nexus_ds/core typecheck:dist-core && node scripts/typecheck-tailwind-dist.mjs",
+    "typecheck:dist": "pnpm --filter @nexus_ds/core typecheck:dist && node scripts/typecheck-tailwind-dist.mjs",
     "test:storybook": "vitest run --project=storybook",
     "test:storybook:watch": "vitest --project=storybook",
     "test:storybook:ui": "vitest --project=storybook --ui",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -77,7 +77,7 @@ All tokens follow the [Design Tokens Community Group](https://tr.designtokens.or
 **Primitives** (`tokens/primitives/`)
 
 - Context-independent base values
-- Color, radius, border-width, shadow, typography, focus, motion
+- Color, radius, border-width, shadow, typography, motion
 - Output: CSS variables with the `--nx-*` prefix
 - Example: `--nx-color-gray-950`, `--nx-radius-md`
 - Motion primitives also promote named Tailwind utilities such as `nx:duration-fast` and `nx:ease-enter`: durations are emitted as explicit `@utility` rules, while easing uses Tailwind's `@theme` namespace. Existing Tailwind numeric duration/ease defaults remain available until the repo-wide migration lands.
@@ -85,9 +85,9 @@ All tokens follow the [Design Tokens Community Group](https://tr.designtokens.or
 **Semantic** (`tokens/semantic/`)
 
 - Contextual meanings that reference primitives (and per-mode direct values for spacing)
-- Light and dark theme variants for color; per-mode files for spacing
-- Output: Tailwind v4 `@theme` block + per-mode `[data-density="X"]` blocks
-- Example: `--color-background: var(--nx-color-white-base)`, `--nx-spacing-4: 16px`
+- Semantic **color** is engine-derived (`deriveTheme`), not authored here; `tokens/semantic/` now holds only spacing, breakpoints, focus offset, and z-index
+- Output: Tailwind v4 `@theme` block (semantic color via `@theme inline`, accepting runtime `--nx-color-*` overrides) + per-mode `[data-density="X"]` blocks
+- Example: `--color-background: var(--nx-color-background, oklch(1 0 0))` (engine color floor), `--nx-spacing-4: 16px`
 
 > **Spacing is two-tier, not three.** Unlike color/radius/shadow/typography, spacing has no `--nx-size-*` primitive layer — `semantic/spacing-{mode}.json` files carry direct px values, and the build emits per-mode `[data-density="X"]` blocks plus role utilities (`nx:p-container`, `nx:gap-layout-section`, …). Mode swap is runtime via the `data-density` attribute on `<html>`.
 
@@ -104,22 +104,19 @@ Generated global CSS sets the native browser UI policy alongside the tokens: `:r
 
 ## Reference Resolution
 
-Semantic tokens use DTCG reference syntax:
-
-```json
-{
-  "background": {
-    "$value": "{white.base}",
-    "$type": "color"
-  }
-}
-```
-
-This resolves to CSS:
+Semantic **color** is produced by the engine (`deriveTheme`), not authored as
+JSON. The build bakes each derived value into `nexus.css` as a `@theme inline`
+fallback that still accepts a runtime override:
 
 ```css
---color-background: var(--nx-color-white-base);
+--color-background: var(--nx-color-background, oklch(1 0 0));
 ```
+
+The `--color-*` name is the Tailwind v4 `@theme` key that generates the utility
+(`nx:bg-background`); the `--nx-color-*` fallback is the runtime override the
+appearance provider injects. Non-color families (spacing, radius, shadow,
+borderwidth, …) still use DTCG `{reference}` syntax, resolved to `var(--nx-*)`
+at build time.
 
 ## Build Process
 
@@ -147,7 +144,7 @@ When multi-platform support is needed, tools like Style Dictionary can be added 
 
 ## Adding New Tokens
 
-1. Edit token files in `tokens/`
-2. Follow DTCG format with `$value`, `$type`, `$description`
-3. Run `make tokens` to regenerate CSS
-4. Tokens automatically copied to React package
+- **Color** is engine-owned: edit the derivation in `src/lib/surface-ladder.ts` / `src/lib/derive-theme.ts` (color primitives live in `tokens/primitives/color.json`).
+- **Non-color** (spacing, radius, shadow, borderwidth, motion, typography): edit the DTCG token files in `tokens/` (`$value`, `$type`, `$description`).
+
+Then run `make tokens` (or `pnpm build:tailwind`) to regenerate CSS; the output is copied into the `@nexus_ds/tailwind` package.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,6 @@
     "build": "tsup",
     "typecheck": "tsc --noEmit",
     "typecheck:dist": "node scripts/typecheck-runtime-dist.mjs",
-    "typecheck:dist-core": "node scripts/typecheck-runtime-dist.mjs",
     "build:tailwind": "node scripts/generate-tailwind-package.js --base=stone --borderwidth=normal --radius=square --shadow=quiet --motion=snappy --spacingDefault=default",
     "audit:runtime-exports": "node scripts/audit-runtime-exports.mjs",
     "audit:contrast": "cd ../.. && vitest run --project=unit packages/core/src/lib/derive-theme.test.ts -t \"legibility invariant\"",

--- a/packages/core/scripts/__tests__/generate-tailwind-package.test.js
+++ b/packages/core/scripts/__tests__/generate-tailwind-package.test.js
@@ -276,15 +276,12 @@ describe('generateTailwindPackage', () => {
     expect(variablesCSS).toMatch(/^:root \{/m);
   });
 
-  it('emits focus error primitive but no default focus primitive or geometry in :root', () => {
+  it('emits no focus color primitive in :root (focus is engine-derived)', () => {
     const rootBlock = extractBlock(variablesCSS, ':root');
     expect(rootBlock).toMatch(/--nx-shadow-2xs-layer-1-x: 0px;/);
-    expect(rootBlock).not.toMatch(/--nx-focus-color-default:/);
-    expect(rootBlock).toMatch(
-      /--nx-focus-color-error:\s*var\(--nx-color-red-600\);/
-    );
-    // Focus is an outline ring; default focus follows primary accent, and the old
-    // geometry primitives were dropped.
+    // Focus is an outline ring driven entirely by the engine (--color-focus-*);
+    // no --nx-focus-color-* or geometry primitives are emitted.
+    expect(rootBlock).not.toMatch(/--nx-focus-color-/);
     expect(rootBlock).not.toMatch(/--nx-focus-geometry-/);
   });
 
@@ -507,17 +504,14 @@ describe('generateTailwindPackage', () => {
   });
 
   // The .dark block must contain only dark tokens whose value diverges from
-  // their `:root` counterpart by cssName. Error focus lives in the focus
-  // primitive category and supplies the focus divergence.
+  // their `:root` counterpart by cssName.
   // Default elevation shadows now also carry dark-only color tuning; geometry
   // stays shared, so only the diverging shadow colour leaves should appear.
   it('.dark block contains only tokens that diverge from :root by value', () => {
     const darkBlock = extractBlock(variablesCSS, '.dark');
 
-    expect(darkBlock).not.toMatch(/--nx-focus-color-default:/);
-    expect(darkBlock).toMatch(
-      /--nx-focus-color-error:\s*var\(--nx-color-red-300\);/
-    );
+    // Focus color is engine-derived (no --nx-focus-color-* primitive emitted).
+    expect(darkBlock).not.toMatch(/--nx-focus-color-/);
     expect(darkBlock).toMatch(/--nx-shadow-2xs-layer-1-color:/);
     expect(darkBlock).toMatch(/--nx-shadow-sm-layer-1-color:/);
 

--- a/packages/core/scripts/__tests__/utils.test.js
+++ b/packages/core/scripts/__tests__/utils.test.js
@@ -5,7 +5,6 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   collectBreakpointsTokens,
-  collectSemanticColorTokensVarRef,
   collectSpacingTokens,
   collectZIndexTokens,
   DEFAULT_CONFIG,
@@ -19,7 +18,6 @@ import {
   isReference,
   parseArgs,
   partitionThemedModes,
-  pathToCssVar,
   resolveReference,
   resolveValue,
   splitSpacingTokens,
@@ -146,30 +144,6 @@ describe('utils', () => {
       expect(extractRefPath('{2xs.layer-1.x}')).toBe('2xs.layer-1.x');
       expect(extractRefPath('{focus.default.color}')).toBe(
         'focus.default.color'
-      );
-    });
-  });
-
-  describe('pathToCssVar', () => {
-    it('joins path array with hyphens', () => {
-      expect(pathToCssVar(['blue', '500'])).toBe('blue-500');
-      expect(pathToCssVar(['size', '6xl'])).toBe('size-6xl');
-    });
-
-    it('adds prefix when provided', () => {
-      expect(pathToCssVar(['background'], 'color')).toBe('color-background');
-      expect(pathToCssVar(['primary', 'background-hover'], 'color')).toBe(
-        'color-primary-background-hover'
-      );
-    });
-
-    it('handles single-element paths', () => {
-      expect(pathToCssVar(['background'])).toBe('background');
-    });
-
-    it('handles deeply nested paths', () => {
-      expect(pathToCssVar(['focus', 'default', 'color'])).toBe(
-        'focus-default-color'
       );
     });
   });
@@ -703,45 +677,6 @@ describe('utils', () => {
         fs.writeFileSync(path.join(dir, 'focus.json'), JSON.stringify({}));
         const result = discoverSemantics(dir);
         expect(result.perModeFiles).toEqual({});
-      } finally {
-        fs.rmSync(dir, { recursive: true, force: true });
-      }
-    });
-  });
-
-  describe('collectSemanticColorTokensVarRef', () => {
-    it('preserves primitive references and maps semantic references to color aliases', () => {
-      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nexus-sem-test-'));
-      try {
-        fs.writeFileSync(
-          path.join(dir, 'focus.json'),
-          JSON.stringify({
-            focus: {
-              default: {
-                $value: '{primary.subtle-foreground}',
-                $type: 'color',
-              },
-              error: { $value: '{focus.color.error}', $type: 'color' },
-            },
-          })
-        );
-
-        const primitiveMap = new Map([
-          ['focus.color.error', { cssName: 'nx-focus-color-error' }],
-        ]);
-
-        expect(
-          collectSemanticColorTokensVarRef(dir, 'focus.json', primitiveMap)
-        ).toEqual([
-          {
-            cssName: 'color-focus-default',
-            value: 'var(--color-primary-subtle-foreground)',
-          },
-          {
-            cssName: 'color-focus-error',
-            value: 'var(--nx-focus-color-error)',
-          },
-        ]);
       } finally {
         fs.rmSync(dir, { recursive: true, force: true });
       }

--- a/packages/core/scripts/generate-tailwind-package.js
+++ b/packages/core/scripts/generate-tailwind-package.js
@@ -730,7 +730,6 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
       'radius',
       'borderwidth',
       'motion',
-      'focus',
       'brandColor',
       'spacingDefault',
     ],

--- a/packages/core/scripts/generate-tailwind-package.js
+++ b/packages/core/scripts/generate-tailwind-package.js
@@ -650,10 +650,8 @@ export async function generateTailwindPackage(
     log.success(`Generated ${borderWidth.count} border width utilities`);
   }
 
-  const borderColorAliases = generateBorderColorAliasUtilitiesCSS(
-    lightSemanticTokens,
-    { runtimeFallback: true }
-  );
+  const borderColorAliases =
+    generateBorderColorAliasUtilitiesCSS(lightSemanticTokens);
   if (borderColorAliases.css) {
     writeDistFile('border-color-aliases.css', borderColorAliases.css);
     log.success(

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -284,17 +284,15 @@ export function discoverPrimitives(primitivesDir) {
 }
 
 /**
- * Discover all semantic token themes and standalone files from file system.
- * Detects:
- * - Themed files: {type}-{mode}-{light|dark}.json pattern
- * - Standalone files: {name}.json (no light/dark suffix)
+ * Discover semantic token files from the file system, partitioning
+ * spacing-mode files (spacing-{mode}.json) into perModeFiles from plain
+ * standalone files ({name}.json).
  *
  * @param {string} semanticDir - Path to semantic directory
- * @returns {object} { themed: { type: { mode: { light, dark } } }, standalone: string[], perModeFiles: { category: { mode: filename } } }
+ * @returns {object} { standalone: string[], perModeFiles: { category: { mode: filename } } }
  */
 export function discoverSemantics(semanticDir) {
   const result = {
-    themed: {},
     standalone: [],
     // Bucket for per-mode semantic categories. Keyed by category so a future
     // per-mode category (e.g. per-mode color shading) lands as a sibling key
@@ -309,8 +307,6 @@ export function discoverSemantics(semanticDir) {
 
   const files = fs.readdirSync(semanticDir).filter((f) => f.endsWith('.json'));
 
-  // Pattern for themed files: {type}-{mode}-{light|dark}.json
-  const themedPattern = /^(.+)-(.+)-(light|dark)\.json$/;
   // Pattern for spacing-mode files: spacing-{mode}.json. Their values are
   // direct px (no `{N}` refs) and emit per-mode `[data-density="X"]` blocks via
   // `collectSpacingTokens` — they intentionally bypass the generic
@@ -329,21 +325,8 @@ export function discoverSemantics(semanticDir) {
       continue;
     }
 
-    const match = file.match(themedPattern);
-    if (match) {
-      const [, type, mode, variant] = match;
-
-      if (!result.themed[type]) {
-        result.themed[type] = {};
-      }
-      if (!result.themed[type][mode]) {
-        result.themed[type][mode] = {};
-      }
-      result.themed[type][mode][variant] = file;
-    } else {
-      // Standalone file (no light/dark suffix, not a spacing mode)
-      result.standalone.push(file);
-    }
+    // Standalone file (not a spacing mode)
+    result.standalone.push(file);
   }
 
   return result;
@@ -351,7 +334,7 @@ export function discoverSemantics(semanticDir) {
 
 /**
  * Group {base}-light / {base}-dark mode names into pairs; pass others through unchanged.
- * Used by both bundled and modular generators to recognize themed primitive categories.
+ * Used by the generator to recognize themed primitive categories.
  *
  * @param {string[]} modes - List of mode names (e.g., ['vega-light', 'vega-dark', 'lyra'])
  * @returns {{ themed: Record<string, { light: string, dark: string }>, plain: string[] }}
@@ -810,10 +793,7 @@ function getBorderColorAliasName(cssName) {
  * @param {object[]} tokens - Array of semantic color tokens with cssName property (e.g., "color-border-default")
  * @returns {{ css: string, count: number }} Generated CSS and utility count
  */
-export function generateBorderColorAliasUtilitiesCSS(
-  tokens,
-  { runtimeFallback = false } = {}
-) {
+export function generateBorderColorAliasUtilitiesCSS(tokens) {
   const borderColorTokens = (tokens ?? [])
     .map((token) => ({ token, name: getBorderColorAliasName(token.cssName) }))
     .filter(({ name }) => name !== null)
@@ -831,9 +811,7 @@ export function generateBorderColorAliasUtilitiesCSS(
 
   for (const { token, name } of borderColorTokens) {
     css += `@utility border-color-${name} {\n`;
-    const value = runtimeFallback
-      ? `var(--nx-${token.cssName}, ${token.value})`
-      : `var(--${token.cssName})`;
+    const value = `var(--nx-${token.cssName}, ${token.value})`;
     css += `  border-color: ${value};\n`;
     css += `}\n\n`;
   }

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -134,17 +134,6 @@ export function extractTokens(obj, currentPath = [], result = []) {
 }
 
 /**
- * Convert token path to CSS variable name
- * @param {string[]} tokenPath - Token path array
- * @param {string|null} prefix - Optional prefix (e.g., 'color' for semantic colors)
- * @returns {string} CSS variable name (without --)
- */
-export function pathToCssVar(tokenPath, prefix = null) {
-  const cssName = tokenPath.join('-');
-  return prefix ? `${prefix}-${cssName}` : cssName;
-}
-
-/**
  * Convert token path to CSS variable name with optional nx- prefix
  * Used for generating prefixed CSS variables for @nexus_ds/tailwind package
  * @param {string[]} tokenPath - Token path array
@@ -408,38 +397,6 @@ export function partitionThemedModes(modes) {
 export function filterDivergentDark(lightTokens, darkTokens) {
   const lightByName = new Map(lightTokens.map((t) => [t.cssName, t.value]));
   return darkTokens.filter((t) => lightByName.get(t.cssName) !== t.value);
-}
-
-/**
- * Process a semantic token file and resolve references
- * @param {string} filePath - Full path to semantic file
- * @param {Map} primitiveMap - Primitive map for reference resolution
- * @returns {object[]} Array of { cssName, value, type }
- */
-export function processSemanticTokens(filePath, primitiveMap) {
-  if (!fs.existsSync(filePath)) {
-    throw new Error(`Semantic file missing: ${filePath}`);
-  }
-
-  const tokenData = readTokenFile(filePath);
-  const extracted = extractTokens(tokenData);
-  const tokens = [];
-
-  for (const token of extracted) {
-    // Add 'nx-color' prefix for color tokens (to match Tailwind prefix(nx) output)
-    // No prefix for dimensions (spacing)
-    const prefix = token.type === 'color' ? 'nx-color' : null;
-    const cssName = pathToCssVar(token.path, prefix);
-    const cssValue = resolveValue(
-      token.value,
-      primitiveMap,
-      token.type,
-      token.path
-    );
-    tokens.push({ cssName, value: cssValue, type: token.type });
-  }
-
-  return tokens;
 }
 
 /**
@@ -1731,61 +1688,6 @@ export function collectShadowTokens(tokensDir, primitiveMap) {
 }
 
 /**
- * Collect semantic color tokens from a file with var() references
- * Used for static theming where colors reference --nx-* primitives
- *
- * @param {string} semanticDir - Path to semantic directory
- * @param {string} fileName - Semantic token file name
- * @param {Map} primitiveMap - Map of primitive token values (used for var reference generation)
- * @returns {object[]} Array of { cssName, value }
- */
-export function collectSemanticColorTokensVarRef(
-  semanticDir,
-  fileName,
-  primitiveMap
-) {
-  const filePath = path.join(semanticDir, fileName);
-  if (!fs.existsSync(filePath)) {
-    throw new Error(`Semantic color file missing: ${filePath}`);
-  }
-
-  const tokenData = readTokenFile(filePath);
-  const tokens = [];
-
-  function extractPaths(obj, pathParts = []) {
-    for (const [key, value] of Object.entries(obj)) {
-      if (key.startsWith('$')) continue;
-
-      const currentPath = [...pathParts, key];
-
-      if (value.$value !== undefined && value.$type === 'color') {
-        const cssName = `color-${currentPath.join('-')}`;
-        let resolvedValue = value.$value;
-
-        if (isReference(resolvedValue)) {
-          const refPath = resolvedValue.slice(1, -1);
-          const primitiveInfo = primitiveMap.get(refPath);
-          if (primitiveInfo) {
-            resolvedValue = `var(--${primitiveInfo.cssName})`;
-          } else {
-            resolvedValue = `var(--color-${refPath.replace(/\./g, '-')})`;
-          }
-        } else {
-          resolvedValue = formatTokenValue(resolvedValue, 'color', currentPath);
-        }
-
-        tokens.push({ cssName, value: resolvedValue });
-      } else if (typeof value === 'object' && !Array.isArray(value)) {
-        extractPaths(value, currentPath);
-      }
-    }
-  }
-
-  extractPaths(tokenData);
-  return tokens;
-}
-
-/**
  * Files in `semanticFiles.standalone` that own a dedicated dimension collector.
  * Callers iterating standalone files for the generic `collectSemanticDimensionTokens`
  * scan MUST skip these to avoid duplicate emission of the same `--*` variable
@@ -1806,8 +1708,7 @@ export const FILES_WITH_DEDICATED_DIMENSION_COLLECTORS = new Set([
 /**
  * Collect literal-valued `$type: dimension` leaves from a token file and
  * emit them with the path as the CSS-variable name — e.g. `focus.offset` →
- * `--focus-offset`. Mirrors `collectSemanticColorTokensVarRef` but for
- * dimensions, and skips the `color-` prefix so the path drives the variable
+ * `--focus-offset`. Skips the `color-` prefix so the path drives the variable
  * name directly.
  *
  * Filter behavior:

--- a/packages/core/scripts/utils.js
+++ b/packages/core/scripts/utils.js
@@ -225,7 +225,6 @@ export const DEFAULT_CONFIG = {
   radius: 'square',
   borderwidth: 'normal',
   motion: 'snappy',
-  focus: 'default',
   // see CANONICAL_SPACING_DEFAULT_MODE — controls :root cascade only (all 6 modes ship)
   spacingDefault: 'default',
 };
@@ -438,9 +437,8 @@ export const log = {
 /**
  * Format a shadow property value as a var() reference or literal.
  * References are resolved through the primitive map so the var name matches
- * the actual primitive cssName (e.g. `{color.error}` → `var(--nx-focus-color-error)`
- * when the focus primitive provides it). This means shadow property references
- * can point to any primitive category, not just `--nx-shadow-*`.
+ * the actual primitive cssName. This means shadow property references can
+ * point to any primitive category, not just `--nx-shadow-*`.
  */
 function formatShadowPropertyAsVar(value, primitiveMap) {
   if (isReference(value)) {

--- a/packages/core/src/lib/appearance-model.test.ts
+++ b/packages/core/src/lib/appearance-model.test.ts
@@ -355,7 +355,7 @@ describe('createNexusThemeContract', () => {
       });
     });
 
-    it('does NOT migrate the legacy scalar `contrast` key — resets to defaults', () => {
+    it('does NOT migrate a pre-split scalar `contrast` key — resets to defaults', () => {
       const result = sanitizeNexusAppearance({
         mode: 'light',
         brandColor: '#0a0a0a',

--- a/packages/core/src/lib/appearance-snapshot.test.ts
+++ b/packages/core/src/lib/appearance-snapshot.test.ts
@@ -119,7 +119,7 @@ describe('NexusAppearanceSnapshot', () => {
     expect(snapshot.prefsCss).toBe(prefsCss());
   });
 
-  it('does not treat a raw Phase B state object as a snapshot payload', () => {
+  it('does not treat a raw (unversioned) state object as a snapshot payload', () => {
     const snapshot = sanitizeNexusAppearanceSnapshot({
       ...DEFAULT_NEXUS_APPEARANCE,
       mode: 'dark',

--- a/packages/core/src/lib/surface-ladder.test.ts
+++ b/packages/core/src/lib/surface-ladder.test.ts
@@ -7,7 +7,7 @@ import {
   type SurfaceSteps,
 } from './surface-ladder';
 
-const LEGACY_LIGHT_SURFACE_STEPS = {
+const EXPECTED_LIGHT_SURFACE_STEPS = {
   background: 0,
   'background-hover': -0.27,
   'background-active': -1.38,
@@ -28,7 +28,7 @@ const LEGACY_LIGHT_SURFACE_STEPS = {
   'border-active': -6.07,
 } satisfies SurfaceSteps;
 
-const LEGACY_DARK_SURFACE_STEPS = {
+const EXPECTED_DARK_SURFACE_STEPS = {
   background: 0,
   'background-hover': 1.6,
   'background-active': 1.6,
@@ -56,11 +56,11 @@ function expectStepsToMatch(actual: SurfaceSteps, expected: SurfaceSteps) {
 }
 
 describe('surface ladder', () => {
-  it('keeps the light shade anchors on the legacy surface steps', () => {
-    expectStepsToMatch(LIGHT_SURFACE_STEPS, LEGACY_LIGHT_SURFACE_STEPS);
+  it('keeps the light surface steps at their expected shade anchors', () => {
+    expectStepsToMatch(LIGHT_SURFACE_STEPS, EXPECTED_LIGHT_SURFACE_STEPS);
   });
 
-  it('keeps the dark ladder step-preserved until dark shell adjudication', () => {
-    expectStepsToMatch(DARK_SURFACE_STEPS, LEGACY_DARK_SURFACE_STEPS);
+  it('keeps the dark ladder at its expected raw steps', () => {
+    expectStepsToMatch(DARK_SURFACE_STEPS, EXPECTED_DARK_SURFACE_STEPS);
   });
 });

--- a/packages/core/src/lib/surface-ladder.ts
+++ b/packages/core/src/lib/surface-ladder.ts
@@ -130,7 +130,7 @@ export const LIGHT_SURFACE_LADDER = {
 } as const satisfies Record<SurfaceToken, ShadeAnchor>;
 
 // Current dark surfaces are bg-seed-relative and do not sit on shared shade
-// gridlines across tones, so Phase 1 preserves them as raw steps.
+// gridlines across tones, so the dark ladder keeps them as raw steps.
 export const DARK_SURFACE_LADDER = {
   background: 'base',
   'background-hover': { step: 1.6 },

--- a/packages/core/tokens/primitives/focus/focus-default-dark.json
+++ b/packages/core/tokens/primitives/focus/focus-default-dark.json
@@ -1,8 +1,0 @@
-{
-  "color": {
-    "error": {
-      "$value": "{red.300}",
-      "$type": "color"
-    }
-  }
-}

--- a/packages/core/tokens/primitives/focus/focus-default-light.json
+++ b/packages/core/tokens/primitives/focus/focus-default-light.json
@@ -1,8 +1,0 @@
-{
-  "color": {
-    "error": {
-      "$value": "{red.600}",
-      "$type": "color"
-    }
-  }
-}

--- a/packages/tailwind/variables.css
+++ b/packages/tailwind/variables.css
@@ -340,9 +340,6 @@
   --nx-color-black-a900: oklch(0.1448 0 0 / 0.9098);
   --nx-color-black-a950: oklch(0.1448 0 0 / 0.9569);
 
-  /* focus (default) */
-  --nx-focus-color-error: var(--nx-color-red-600);
-
   /* motion (snappy) */
   --nx-motion-duration-0: 0ms;
   --nx-motion-duration-faster: 100ms;
@@ -490,9 +487,6 @@
 }
 
 .dark {
-  /* focus (default dark) */
-  --nx-focus-color-error: var(--nx-color-red-300);
-
   /* shadow (quiet dark) */
   --nx-shadow-2xs-layer-1-color: oklch(0 0 0 / 0.051);
   --nx-shadow-xs-layer-1-color: oklch(0 0 0 / 0.051);


### PR DESCRIPTION
## Summary

Post-migration cleanup after the single-source token engine landed (#641–#649): `deriveTheme` is now the only producer of semantic color, so this removes the dead scaffolding, bridge branches, and stale references the fast migration left behind. Generated `packages/tailwind/*.css` stays byte-identical except C1 (below).

- **B1** `bd65ff5` — delete the dead static-JSON semantic-color reader chain (`processSemanticTokens`, `collectSemanticColorTokensVarRef`, non-prefixed `pathToCssVar`) — 0 callers. Shared helpers (`resolveValue` / `resolveReference` / `pathToCssVarPrefixed`) preserved.
- **B2+B3+B4** `7da69a8` — drop the `runtimeFallback` dead branch (sole caller always passes `true`), the always-empty `discoverSemantics` `themed` bucket, and a stale "modular generators" comment.
- **C1** `3c31243` — remove the dead focus **color primitive** axis (`tokens/primitives/focus/`). It fed only `--nx-focus-color-error`, which has **zero consumers** — error focus is engine-derived (`--color-focus-error`). Only output change: `variables.css` loses those 2 dead declarations.
- **D** `6bd50f2` — align `packages/core/README.md` with the engine (color is derived, not static JSON); add "Historical — superseded" headers to two completed plan/spec docs.
- **E** `d9be077` — rename `LEGACY_* → EXPECTED_*` and drop migration-phase naming ("Phase 1/B", "old", "legacy") from surviving tests/comments.
- **F** `6828cd9` — remove two orphaned `.prettierignore` entries + a stale eslint comment (targets deleted in #545 / #560).
- **typecheck:dist** `60b3181` — collapse the duplicate `typecheck:dist` / `typecheck:dist-core` core scripts (identical commands) into one canonical `typecheck:dist`; CI (`ci.yml:285`) and root `package.json` now both call it.

Load-bearing items that *looked* like cruft were verified and kept: the `--color-*` `@theme inline` layer, the live `chart-categorical` engine axis, dimension-only `focus.json`, and the four color oracles + `semantic-shape` guard.

## GitHub Issue

Follow-up cleanup to the single-source token engine epic (#641–#649). No separate tracking issue.

## Test Plan

- [x] `pnpm test:unit` — 704 passed (incl. `audit:contrast` legibility invariant)
- [x] `pnpm test:storybook` — 814 passed
- [x] `pnpm build-storybook` — passed
- [x] `cd apps/docs && pnpm build` — passed
- [x] `pnpm --filter @nexus_ds/core audit:colorblind` — 0 findings
- [x] `pnpm --filter @nexus_ds/core audit:runtime-exports` — clean
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm format:check` — passed
- [x] `typecheck:dist` — both CI-direct (`pnpm --filter @nexus_ds/core typecheck:dist`) and root-composed (`pnpm typecheck:dist`) paths verified green
- [x] Regenerate CSS → whole-tree diff empty (C1's −6 focus lines committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)