### PR TITLE
feat(console): add color token atlas

### DIFF
--- a/apps/console/src/app/root-layout.tsx
+++ b/apps/console/src/app/root-layout.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { SidebarInset, SidebarProvider } from '@nexus_ds/react';
 import { Outlet } from '@tanstack/react-router';
 
+import { ColorDraftSync } from '../modules/design-system/color-atlas/color-draft-sync';
 import { AppSidebar } from '../shell/app-sidebar';
 import { CommandPalette } from '../shell/command-palette';
 import { Topbar } from '../shell/topbar';
@@ -48,6 +49,7 @@ export function RootLayout() {
         </div>
       </SidebarInset>
       <CommandPalette open={commandOpen} onOpenChange={setCommandOpen} />
+      <ColorDraftSync />
     </SidebarProvider>
   );
 }

--- a/apps/console/src/app/router.tsx
+++ b/apps/console/src/app/router.tsx
@@ -18,6 +18,7 @@ import { ContactDetailRoute } from '../modules/crm/contact-detail-route';
 import { ContactsRoute } from '../modules/crm/contacts-route';
 import { contactsSearchSchema } from '../modules/crm/contacts-search';
 import { AppearanceRoute } from '../modules/design-system/appearance-route';
+import { ColorAtlasRoute } from '../modules/design-system/color-atlas-route';
 import { FlowsRoute } from '../modules/design-system/flows-route';
 import { ReferenceRoute } from '../modules/design-system/reference-route';
 import { ScenesRoute } from '../modules/design-system/scenes-route';
@@ -76,6 +77,12 @@ const referenceRoute = createRoute({
   getParentRoute: () => appRoute,
   path: '/design/reference',
   component: ReferenceRoute,
+});
+
+const colorAtlasRoute = createRoute({
+  getParentRoute: () => appRoute,
+  path: '/design/color-atlas',
+  component: ColorAtlasRoute,
 });
 
 const scenesRoute = createRoute({
@@ -212,6 +219,7 @@ const routeTree = rootRoute.addChildren([
   appRoute.addChildren([
     indexRoute,
     referenceRoute,
+    colorAtlasRoute,
     scenesRoute,
     appearanceRoute,
     flowsRoute,

--- a/apps/console/src/modules/design-system/color-atlas-route.tsx
+++ b/apps/console/src/modules/design-system/color-atlas-route.tsx
@@ -1,0 +1,29 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@nexus_ds/react';
+
+import { PageHeader } from '../../components/page-header';
+
+import { DraftTab } from './color-atlas/draft-tab';
+import { InspectTab } from './color-atlas/inspect-tab';
+
+export function ColorAtlasRoute() {
+  return (
+    <div className="nx:mx-auto nx:max-w-5xl nx:space-y-6 nx:p-6">
+      <PageHeader
+        title="Color Token Atlas"
+        description="Inspect semantic color usage and preview local draft overrides across the Console."
+      />
+      <Tabs defaultValue="inspect" className="nx:space-y-6">
+        <TabsList>
+          <TabsTrigger value="inspect">Inspect</TabsTrigger>
+          <TabsTrigger value="draft">Draft Theme</TabsTrigger>
+        </TabsList>
+        <TabsContent value="inspect">
+          <InspectTab />
+        </TabsContent>
+        <TabsContent value="draft">
+          <DraftTab />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/console/src/modules/design-system/color-atlas/color-draft-store.ts
+++ b/apps/console/src/modules/design-system/color-atlas/color-draft-store.ts
@@ -1,0 +1,51 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+import {
+  type ColorDraftOverride,
+  type ColorDraftOverrides,
+  sanitizeOverrides,
+} from './color-draft';
+
+interface ColorDraftState {
+  overrides: ColorDraftOverrides;
+  setOverride: (token: string, override: ColorDraftOverride) => void;
+  removeOverride: (token: string) => void;
+  resetAll: () => void;
+}
+
+type PersistedColorDraftState = Pick<ColorDraftState, 'overrides'>;
+
+export const COLOR_DRAFT_STORAGE_KEY = 'nexus-console-color-draft';
+
+export const useColorDraftStore = create<ColorDraftState>()(
+  persist<ColorDraftState, [], [], PersistedColorDraftState>(
+    (set) => ({
+      overrides: {},
+      setOverride: (token, override) =>
+        set((state) => ({
+          overrides: { ...state.overrides, [token]: override },
+        })),
+      removeOverride: (token) =>
+        set((state) => {
+          const { [token]: _removed, ...overrides } = state.overrides;
+          return { overrides };
+        }),
+      resetAll: () => set({ overrides: {} }),
+    }),
+    {
+      name: COLOR_DRAFT_STORAGE_KEY,
+      partialize: (state) => ({ overrides: state.overrides }),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as
+          | Partial<PersistedColorDraftState>
+          | undefined;
+
+        return {
+          ...currentState,
+          overrides: sanitizeOverrides(persisted?.overrides),
+        };
+      },
+    }
+  )
+);

--- a/apps/console/src/modules/design-system/color-atlas/color-draft-sync.tsx
+++ b/apps/console/src/modules/design-system/color-atlas/color-draft-sync.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+
+import { Button } from '@nexus_ds/react';
+import { Link } from '@tanstack/react-router';
+
+import {
+  applyColorDraft,
+  type ColorDraftOverrides,
+  removeColorDraft,
+} from './color-draft';
+import { useColorDraftStore } from './color-draft-store';
+
+function draftModeSummary(overrides: ColorDraftOverrides): string {
+  const values = Object.values(overrides);
+  const hasLight = values.some(
+    (override) => override.mode === 'light' || override.mode === 'both'
+  );
+  const hasDark = values.some(
+    (override) => override.mode === 'dark' || override.mode === 'both'
+  );
+
+  if (hasLight && hasDark) return 'Light + dark draft';
+  if (hasDark) return 'Dark draft';
+  return 'Light draft';
+}
+
+export function ColorDraftSync() {
+  const overrides = useColorDraftStore((state) => state.overrides);
+  const resetAll = useColorDraftStore((state) => state.resetAll);
+  const count = Object.keys(overrides).length;
+  const modeSummary = draftModeSummary(overrides);
+
+  useEffect(() => {
+    applyColorDraft(overrides);
+
+    return removeColorDraft;
+  }, [overrides]);
+
+  if (count === 0) return null;
+
+  return (
+    <div className="nx:fixed nx:right-4 nx:bottom-4 nx:z-toast nx:flex nx:max-w-[calc(100vw-2rem)] nx:flex-wrap nx:items-center nx:gap-2 nx:rounded-md nx:border-default nx:border-border-default nx:bg-popover nx:px-3 nx:py-2 nx:text-popover-foreground nx:shadow-lg">
+      <span className="nx:typography-label-small">
+        {count} color {count === 1 ? 'override' : 'overrides'}
+      </span>
+      <span className="nx:typography-label-small nx:text-muted-foreground">
+        {modeSummary}
+      </span>
+      <Button asChild size="sm" variant="ghost">
+        <Link to="/design/color-atlas">Color Atlas</Link>
+      </Button>
+      <Button size="sm" variant="outline" onClick={resetAll}>
+        Reset
+      </Button>
+    </div>
+  );
+}

--- a/apps/console/src/modules/design-system/color-atlas/color-draft.test.ts
+++ b/apps/console/src/modules/design-system/color-atlas/color-draft.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyColorDraft,
+  buildDraftCss,
+  buildExportJson,
+  COLOR_DRAFT_STYLE_ATTRIBUTE,
+  primitiveValue,
+  removeColorDraft,
+  sanitizeOverrides,
+  shadesForFamily,
+  validateCustomColor,
+} from './color-draft';
+
+describe('validateCustomColor', () => {
+  const supportsColor = (value: string) =>
+    ['#f3f0ea', 'oklch(0.9 0.01 70)'].includes(value);
+
+  it('accepts trimmed CSS colors accepted by the injected predicate', () => {
+    expect(validateCustomColor('  #f3f0ea  ', supportsColor)).toBe('#f3f0ea');
+    expect(validateCustomColor('oklch(0.9 0.01 70)', supportsColor)).toBe(
+      'oklch(0.9 0.01 70)'
+    );
+  });
+
+  it('rejects empty, var(), url(), block, and unsupported values', () => {
+    expect(validateCustomColor('', supportsColor)).toBeNull();
+    expect(
+      validateCustomColor('var(--nx-color-red-500)', supportsColor)
+    ).toBeNull();
+    expect(
+      validateCustomColor('url(https://example.test)', supportsColor)
+    ).toBeNull();
+    expect(validateCustomColor('#fff; color: red', supportsColor)).toBeNull();
+    expect(validateCustomColor('/* nope */ #fff', supportsColor)).toBeNull();
+    expect(
+      validateCustomColor('definitely-not-a-color', supportsColor)
+    ).toBeNull();
+  });
+});
+
+describe('primitive helpers', () => {
+  it('includes surface-only 75 and 150 shade stops for neutral ramps', () => {
+    expect(shadesForFamily('stone')).toContain('75');
+    expect(shadesForFamily('stone')).toContain('150');
+    expect(shadesForFamily('red')).not.toContain('75');
+    expect(shadesForFamily('red')).not.toContain('150');
+  });
+
+  it('builds primitive CSS variable references', () => {
+    expect(primitiveValue('stone', '100')).toBe('var(--nx-color-stone-100)');
+  });
+});
+
+describe('draft serialization', () => {
+  it('builds no CSS for an empty draft', () => {
+    expect(buildDraftCss({})).toBe('');
+  });
+
+  it('builds light-mode draft CSS from sorted semantic overrides', () => {
+    expect(
+      buildDraftCss({
+        'nav-item-active': {
+          source: 'custom',
+          mode: 'light',
+          value: 'oklch(0.9 0.01 70)',
+        },
+        'background-hover': {
+          source: 'primitive',
+          mode: 'light',
+          value: 'var(--nx-color-stone-100)',
+          label: 'stone.100',
+        },
+      })
+    ).toBe(
+      [
+        'html:root {',
+        '  --nx-color-background-hover: var(--nx-color-stone-100);',
+        '  --nx-color-nav-item-active: oklch(0.9 0.01 70);',
+        '}',
+      ].join('\n')
+    );
+  });
+
+  it('builds dark and shared draft CSS from sorted semantic overrides', () => {
+    expect(
+      buildDraftCss({
+        'nav-item-active': {
+          source: 'custom',
+          mode: 'dark',
+          value: 'oklch(0.9 0.01 70)',
+        },
+        'background-hover': {
+          source: 'primitive',
+          mode: 'both',
+          value: 'var(--nx-color-stone-100)',
+          label: 'stone.100',
+        },
+      })
+    ).toBe(
+      [
+        'html:root {',
+        '  --nx-color-background-hover: var(--nx-color-stone-100);',
+        '}',
+        '',
+        'html:root.dark {',
+        '  --nx-color-background-hover: var(--nx-color-stone-100);',
+        '  --nx-color-nav-item-active: oklch(0.9 0.01 70);',
+        '}',
+      ].join('\n')
+    );
+  });
+
+  it('exports JSON with full CSS variable names grouped by target mode', () => {
+    expect(
+      buildExportJson({
+        'background-hover': {
+          source: 'primitive',
+          mode: 'both',
+          value: 'var(--nx-color-stone-100)',
+          label: 'stone.100',
+        },
+        'nav-item-active': {
+          source: 'custom',
+          mode: 'dark',
+          value: 'oklch(0.9 0.01 70)',
+        },
+      })
+    ).toBe(
+      JSON.stringify(
+        {
+          light: {
+            '--nx-color-background-hover': 'var(--nx-color-stone-100)',
+          },
+          dark: {
+            '--nx-color-background-hover': 'var(--nx-color-stone-100)',
+            '--nx-color-nav-item-active': 'oklch(0.9 0.01 70)',
+          },
+        },
+        null,
+        2
+      )
+    );
+  });
+});
+
+describe('sanitizeOverrides', () => {
+  const supportsColor = (value: string) => value === '#f3f0ea';
+
+  it('drops unknown tokens and malformed values', () => {
+    expect(
+      sanitizeOverrides(
+        {
+          'background-hover': {
+            source: 'primitive',
+            value: 'var(--nx-color-stone-100)',
+            label: 'stone.100',
+          },
+          'not-a-token': {
+            source: 'primitive',
+            value: 'var(--nx-color-stone-100)',
+          },
+          container: { source: 'custom', value: 'not-a-color' },
+          popover: { source: 'primitive', value: 'red' },
+        },
+        supportsColor
+      )
+    ).toEqual({
+      'background-hover': {
+        source: 'primitive',
+        mode: 'light',
+        value: 'var(--nx-color-stone-100)',
+        label: 'stone.100',
+      },
+    });
+  });
+
+  it('keeps supported custom colors', () => {
+    expect(
+      sanitizeOverrides(
+        {
+          'container-hover': { source: 'custom', value: '#f3f0ea' },
+        },
+        supportsColor
+      )
+    ).toEqual({
+      'container-hover': { source: 'custom', mode: 'light', value: '#f3f0ea' },
+    });
+  });
+
+  it('keeps explicit dark-mode targets', () => {
+    expect(
+      sanitizeOverrides(
+        {
+          'container-hover': {
+            source: 'custom',
+            mode: 'dark',
+            value: '#f3f0ea',
+          },
+        },
+        supportsColor
+      )
+    ).toEqual({
+      'container-hover': { source: 'custom', mode: 'dark', value: '#f3f0ea' },
+    });
+  });
+});
+
+describe('applyColorDraft', () => {
+  it('upserts exactly one style element and updates it in place', () => {
+    applyColorDraft({
+      'background-hover': {
+        source: 'primitive',
+        mode: 'light',
+        value: 'var(--nx-color-stone-100)',
+        label: 'stone.100',
+      },
+    });
+    applyColorDraft({
+      'container-hover': { source: 'custom', mode: 'dark', value: '#f3f0ea' },
+    });
+
+    const styles = document.head.querySelectorAll(
+      `style[${COLOR_DRAFT_STYLE_ATTRIBUTE}]`
+    );
+    expect(styles).toHaveLength(1);
+    expect(styles[0]?.textContent).toContain('--nx-color-container-hover');
+    expect(styles[0]?.textContent).toContain('html:root.dark');
+    expect(styles[0]?.textContent).not.toContain('--nx-color-background-hover');
+  });
+
+  it('removes the style element when the draft is empty', () => {
+    applyColorDraft({
+      'background-hover': {
+        source: 'primitive',
+        mode: 'light',
+        value: 'var(--nx-color-stone-100)',
+      },
+    });
+
+    applyColorDraft({});
+    expect(
+      document.head.querySelector(`style[${COLOR_DRAFT_STYLE_ATTRIBUTE}]`)
+    ).toBeNull();
+  });
+
+  it('removes the style element explicitly', () => {
+    applyColorDraft({
+      'background-hover': {
+        source: 'primitive',
+        mode: 'light',
+        value: 'var(--nx-color-stone-100)',
+      },
+    });
+
+    removeColorDraft();
+    expect(
+      document.head.querySelector(`style[${COLOR_DRAFT_STYLE_ATTRIBUTE}]`)
+    ).toBeNull();
+  });
+});

--- a/apps/console/src/modules/design-system/color-atlas/color-draft.ts
+++ b/apps/console/src/modules/design-system/color-atlas/color-draft.ts
@@ -1,0 +1,291 @@
+import { SEMANTIC_TOKEN_REGISTRY } from '@nexus_ds/core';
+
+export type ColorDraftSource = 'primitive' | 'custom';
+export type ColorDraftMode = 'light' | 'dark' | 'both';
+
+export interface ColorDraftOverride {
+  source: ColorDraftSource;
+  mode: ColorDraftMode;
+  value: string;
+  label?: string;
+}
+
+export type ColorDraftOverrides = Record<string, ColorDraftOverride>;
+
+export const COLOR_DRAFT_STYLE_ATTRIBUTE = 'data-nexus-color-draft';
+export const DEFAULT_COLOR_DRAFT_MODE: ColorDraftMode = 'light';
+
+export const PRIMITIVE_FAMILIES = [
+  'amber',
+  'blue',
+  'cyan',
+  'emerald',
+  'fuchsia',
+  'gray',
+  'green',
+  'indigo',
+  'lime',
+  'neutral',
+  'orange',
+  'pink',
+  'purple',
+  'red',
+  'rose',
+  'sky',
+  'slate',
+  'stone',
+  'teal',
+  'violet',
+  'yellow',
+  'zinc',
+] as const;
+
+export type PrimitiveFamily = (typeof PRIMITIVE_FAMILIES)[number];
+
+const BASE_SHADES = [
+  '50',
+  '100',
+  '200',
+  '300',
+  '400',
+  '500',
+  '600',
+  '700',
+  '800',
+  '900',
+  '950',
+] as const;
+
+const SURFACE_TONE_SHADES = [
+  '50',
+  '75',
+  '100',
+  '150',
+  '200',
+  '300',
+  '400',
+  '500',
+  '600',
+  '700',
+  '800',
+  '900',
+  '950',
+] as const;
+
+const SURFACE_TONE_FAMILIES = new Set<PrimitiveFamily>([
+  'gray',
+  'neutral',
+  'slate',
+  'stone',
+  'zinc',
+]);
+
+const TOKEN_NAMES = new Set(SEMANTIC_TOKEN_REGISTRY.map((token) => token.name));
+const UNSAFE_CUSTOM_COLOR_PARTS = ['var(', 'url(', ';', '{', '}', '/*'];
+const PRIMITIVE_VALUE_PATTERN =
+  /^var\(--nx-color-[a-z]+-(?:50|75|100|150|200|300|400|500|600|700|800|900|950)\)$/;
+
+export function isKnownToken(token: string): boolean {
+  return TOKEN_NAMES.has(token);
+}
+
+export function shadesForFamily(family: PrimitiveFamily): readonly string[] {
+  if (SURFACE_TONE_FAMILIES.has(family)) return SURFACE_TONE_SHADES;
+  return BASE_SHADES;
+}
+
+export function primitiveValue(family: PrimitiveFamily, shade: string): string {
+  return `var(--nx-color-${family}-${shade})`;
+}
+
+export function isColorDraftMode(value: unknown): value is ColorDraftMode {
+  return value === 'light' || value === 'dark' || value === 'both';
+}
+
+export function colorDraftModeLabel(mode: ColorDraftMode): string {
+  if (mode === 'both') return 'Light + dark';
+  if (mode === 'dark') return 'Dark';
+  return 'Light';
+}
+
+function defaultSupportsColor(value: string): boolean {
+  if (typeof CSS === 'undefined' || typeof CSS.supports !== 'function') {
+    return false;
+  }
+
+  return CSS.supports('color', value);
+}
+
+export function validateCustomColor(
+  input: string,
+  supportsColor: (value: string) => boolean = defaultSupportsColor
+): string | null {
+  const value = input.trim();
+  if (!value) return null;
+
+  const lowerValue = value.toLowerCase();
+  if (UNSAFE_CUSTOM_COLOR_PARTS.some((part) => lowerValue.includes(part))) {
+    return null;
+  }
+
+  if (!supportsColor(value)) return null;
+
+  return value;
+}
+
+function sanitizeOverride(
+  token: string,
+  value: unknown,
+  supportsColor: (value: string) => boolean
+): ColorDraftOverride | null {
+  if (!isKnownToken(token)) return null;
+  if (!value || typeof value !== 'object') return null;
+
+  const draft = value as Partial<ColorDraftOverride>;
+  if (draft.source !== 'primitive' && draft.source !== 'custom') return null;
+  if (typeof draft.value !== 'string') return null;
+  const mode = isColorDraftMode(draft.mode)
+    ? draft.mode
+    : DEFAULT_COLOR_DRAFT_MODE;
+
+  if (draft.source === 'primitive') {
+    if (!PRIMITIVE_VALUE_PATTERN.test(draft.value)) return null;
+
+    return {
+      source: 'primitive',
+      mode,
+      value: draft.value,
+      ...(typeof draft.label === 'string' ? { label: draft.label } : {}),
+    };
+  }
+
+  const customValue = validateCustomColor(draft.value, supportsColor);
+  if (!customValue) return null;
+
+  return {
+    source: 'custom',
+    mode,
+    value: customValue,
+    ...(typeof draft.label === 'string' ? { label: draft.label } : {}),
+  };
+}
+
+export function sanitizeOverrides(
+  input: unknown,
+  supportsColor: (value: string) => boolean = defaultSupportsColor
+): ColorDraftOverrides {
+  if (!input || typeof input !== 'object') return {};
+
+  const output: ColorDraftOverrides = {};
+
+  for (const [token, value] of Object.entries(input)) {
+    const sanitized = sanitizeOverride(token, value, supportsColor);
+    if (sanitized) output[token] = sanitized;
+  }
+
+  return output;
+}
+
+function sortedOverrides(overrides: ColorDraftOverrides) {
+  return Object.entries(overrides).sort(([a], [b]) => a.localeCompare(b));
+}
+
+export function buildDraftCss(overrides: ColorDraftOverrides): string {
+  const entries = sortedOverrides(overrides);
+  if (entries.length === 0) return '';
+
+  const lightDeclarations: string[] = [];
+  const darkDeclarations: string[] = [];
+
+  for (const [token, override] of entries) {
+    const declaration = `  --nx-color-${token}: ${override.value};`;
+
+    if (override.mode === 'light' || override.mode === 'both') {
+      lightDeclarations.push(declaration);
+    }
+
+    if (override.mode === 'dark' || override.mode === 'both') {
+      darkDeclarations.push(declaration);
+    }
+  }
+
+  return [
+    lightDeclarations.length > 0
+      ? `html:root {\n${lightDeclarations.join('\n')}\n}`
+      : '',
+    darkDeclarations.length > 0
+      ? `html:root.dark {\n${darkDeclarations.join('\n')}\n}`
+      : '',
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+export function buildExportJson(overrides: ColorDraftOverrides): string {
+  const light: Record<string, string> = {};
+  const dark: Record<string, string> = {};
+
+  for (const [token, override] of sortedOverrides(overrides)) {
+    const variableName = `--nx-color-${token}`;
+
+    if (override.mode === 'light' || override.mode === 'both') {
+      light[variableName] = override.value;
+    }
+
+    if (override.mode === 'dark' || override.mode === 'both') {
+      dark[variableName] = override.value;
+    }
+  }
+
+  const output = {
+    ...(Object.keys(light).length > 0 ? { light } : {}),
+    ...(Object.keys(dark).length > 0 ? { dark } : {}),
+  };
+
+  return JSON.stringify(output, null, 2);
+}
+
+export function buildExportSummary(overrides: ColorDraftOverrides): string {
+  const entries = sortedOverrides(overrides);
+  if (entries.length === 0) return 'No semantic color draft overrides.';
+
+  return entries
+    .map(([token, override]) => {
+      const sourceLabel =
+        override.source === 'primitive'
+          ? (override.label ?? override.value)
+          : 'custom CSS color';
+      return `${token} (${colorDraftModeLabel(override.mode)}) = ${
+        override.value
+      } (${sourceLabel})`;
+    })
+    .join('\n');
+}
+
+export function applyColorDraft(overrides: ColorDraftOverrides): void {
+  if (typeof document === 'undefined') return;
+
+  const css = buildDraftCss(overrides);
+  if (!css) {
+    removeColorDraft();
+    return;
+  }
+
+  const selector = `style[${COLOR_DRAFT_STYLE_ATTRIBUTE}]`;
+  const existing = document.head.querySelector<HTMLStyleElement>(selector);
+  const style = existing ?? document.createElement('style');
+
+  if (!existing) {
+    style.setAttribute(COLOR_DRAFT_STYLE_ATTRIBUTE, '');
+    document.head.appendChild(style);
+  }
+
+  style.textContent = css;
+}
+
+export function removeColorDraft(): void {
+  if (typeof document === 'undefined') return;
+
+  const selector = `style[${COLOR_DRAFT_STYLE_ATTRIBUTE}]`;
+  document.head.querySelector(selector)?.remove();
+}

--- a/apps/console/src/modules/design-system/color-atlas/component-token-matrix.test.ts
+++ b/apps/console/src/modules/design-system/color-atlas/component-token-matrix.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  COMPONENT_TOKEN_MATRIX,
+  filterMatrix,
+  matrixUnknownTokens,
+} from './component-token-matrix';
+
+describe('COMPONENT_TOKEN_MATRIX', () => {
+  it('uses only registered semantic token names', () => {
+    expect(matrixUnknownTokens()).toEqual([]);
+  });
+
+  it('keeps required fields populated', () => {
+    for (const entry of COMPONENT_TOKEN_MATRIX) {
+      expect(entry.component).not.toBe('');
+      expect(entry.part).not.toBe('');
+      expect(entry.state).not.toBe('');
+      expect(entry.tokens.length).toBeGreaterThan(0);
+      expect(entry.sourceFile).not.toBe('');
+      expect(entry.storybookCheck).not.toBe('');
+    }
+  });
+});
+
+describe('filterMatrix', () => {
+  it('returns all entries for an empty query', () => {
+    expect(filterMatrix(COMPONENT_TOKEN_MATRIX, '')).toHaveLength(
+      COMPONENT_TOKEN_MATRIX.length
+    );
+  });
+
+  it('matches query text case-insensitively', () => {
+    expect(filterMatrix(COMPONENT_TOKEN_MATRIX, 'SIDEBAR')).toEqual([
+      expect.objectContaining({ component: 'Sidebar' }),
+    ]);
+  });
+
+  it('returns no rows when nothing matches', () => {
+    expect(filterMatrix(COMPONENT_TOKEN_MATRIX, 'definitely-not-here')).toEqual(
+      []
+    );
+  });
+});

--- a/apps/console/src/modules/design-system/color-atlas/component-token-matrix.ts
+++ b/apps/console/src/modules/design-system/color-atlas/component-token-matrix.ts
@@ -1,0 +1,268 @@
+import { SEMANTIC_TOKEN_REGISTRY } from '@nexus_ds/core';
+
+export interface ComponentTokenMatrixEntry {
+  component: string;
+  part: string;
+  state: string;
+  tokens: readonly string[];
+  sourceFile: string;
+  storybookCheck: string;
+  note?: string;
+}
+
+export const COMPONENT_TOKEN_MATRIX = [
+  {
+    component: 'Card',
+    part: 'Root',
+    state: 'Rest',
+    tokens: ['container', 'container-foreground', 'border-default'],
+    sourceFile: 'packages/react/src/components/card/card.tsx',
+    storybookCheck: 'Card stories: compare root fill, text, and border.',
+  },
+  {
+    component: 'Button',
+    part: 'Primary variant',
+    state: 'Rest, hover, active, disabled',
+    tokens: [
+      'primary-background',
+      'primary-background-hover',
+      'primary-background-active',
+      'primary-foreground',
+      'primary-disabled',
+    ],
+    sourceFile: 'packages/react/src/components/button/button.tsx',
+    storybookCheck:
+      'Button stories: InteractionStateTokens verifies hover/active classes.',
+  },
+  {
+    component: 'Button',
+    part: 'Outline / dashed variants',
+    state: 'Rest, hover, active, disabled',
+    tokens: [
+      'container',
+      'container-hover',
+      'container-active',
+      'foreground',
+      'border-default',
+      'disabled',
+      'disabled-foreground',
+    ],
+    sourceFile: 'packages/react/src/components/button/button.tsx',
+    storybookCheck: 'Button stories: Outline and Dashed variants.',
+  },
+  {
+    component: 'Input',
+    part: 'Bordered field',
+    state: 'Rest, hover, focus, invalid, disabled',
+    tokens: [
+      'container',
+      'container-hover',
+      'foreground',
+      'muted-foreground',
+      'border-default',
+      'border-disabled',
+      'focus-default',
+      'focus-error',
+      'disabled',
+      'disabled-foreground',
+    ],
+    sourceFile: 'packages/react/src/components/input/input.tsx',
+    storybookCheck: 'Input stories: HoverToken and DisabledTokenSentinel.',
+  },
+  {
+    component: 'Input',
+    part: 'Borderless field',
+    state: 'Rest, hover',
+    tokens: ['control-background', 'control-background-hover', 'foreground'],
+    sourceFile: 'packages/react/src/components/input/input.tsx',
+    storybookCheck: 'Input stories: BorderlessBackgrounds.',
+  },
+  {
+    component: 'InputGroup',
+    part: 'Group frame',
+    state: 'Rest, hover, focus, invalid, disabled',
+    tokens: [
+      'container',
+      'container-hover',
+      'control-background',
+      'control-background-hover',
+      'border-default',
+      'border-disabled',
+      'focus-default',
+      'focus-error',
+      'disabled',
+      'disabled-foreground',
+    ],
+    sourceFile: 'packages/react/src/components/input-group/input-group.tsx',
+    storybookCheck:
+      'InputGroup stories: SurfaceTokens, BorderlessHover, HoverTokenSentinel.',
+  },
+  {
+    component: 'Table',
+    part: 'Rows and header',
+    state: 'Hover, selected, sticky header, striped rows',
+    tokens: [
+      'background-hover',
+      'control-background',
+      'control-background-hover',
+      'container',
+      'muted',
+      'muted-foreground',
+      'border-default-alpha',
+      'focus-default',
+    ],
+    sourceFile: 'packages/react/src/components/table/table.tsx',
+    storybookCheck: 'Table stories: HoverSelectedStriped and StickyHeader.',
+  },
+  {
+    component: 'DropdownMenu',
+    part: 'Content and item rows',
+    state: 'Open, focus, destructive, separator',
+    tokens: [
+      'popover-alpha',
+      'popover',
+      'popover-hover',
+      'popover-foreground',
+      'error-background',
+      'error-foreground',
+      'border-default-alpha',
+      'muted-foreground',
+    ],
+    sourceFile: 'packages/react/src/components/dropdown-menu/dropdown-menu.tsx',
+    storybookCheck: 'DropdownMenu stories: KeyboardNavigation and Destructive.',
+  },
+  {
+    component: 'Select',
+    part: 'Trigger and item rows',
+    state: 'Rest, hover, focus, checked item',
+    tokens: [
+      'container',
+      'container-hover',
+      'control-background',
+      'control-background-hover',
+      'popover-hover',
+      'popover-foreground',
+      'border-default',
+      'focus-default',
+    ],
+    sourceFile: 'packages/react/src/components/select/select.tsx',
+    storybookCheck: 'Select stories: variants and keyboard navigation.',
+  },
+  {
+    component: 'Popover',
+    part: 'Floating content',
+    state: 'Open',
+    tokens: [
+      'popover-alpha',
+      'popover',
+      'popover-foreground',
+      'border-default',
+    ],
+    sourceFile: 'packages/react/src/components/popover/popover.tsx',
+    storybookCheck: 'Popover stories: Default and Placement.',
+  },
+  {
+    component: 'NavigationMenu',
+    part: 'Trigger and flyout',
+    state: 'Rest, hover, open',
+    tokens: [
+      'background',
+      'background-hover',
+      'foreground',
+      'focus-default',
+      'popover-alpha',
+      'popover-foreground',
+    ],
+    sourceFile:
+      'packages/react/src/components/navigation-menu/navigation-menu.tsx',
+    storybookCheck: 'NavigationMenu stories: WithViewport and InlineContent.',
+  },
+  {
+    component: 'Menubar',
+    part: 'Bar, trigger, floating menu',
+    state: 'Rest, focus, open',
+    tokens: [
+      'container',
+      'container-hover',
+      'foreground',
+      'border-default',
+      'popover-alpha',
+      'popover-hover',
+      'popover-foreground',
+    ],
+    sourceFile: 'packages/react/src/components/menubar/menubar.tsx',
+    storybookCheck: 'Menubar stories: KeyboardNavigation and Submenus.',
+  },
+  {
+    component: 'Sidebar',
+    part: 'Rail and menu buttons',
+    state: 'Rest, hover, active, open',
+    tokens: [
+      'nav-background',
+      'nav-foreground',
+      'nav-muted-foreground',
+      'nav-item-hover',
+      'nav-item-active',
+      'nav-border',
+      'focus-default',
+    ],
+    sourceFile: 'packages/react/src/components/sidebar/sidebar.tsx',
+    storybookCheck:
+      'Sidebar stories: active menu item plus hover/open menu action states.',
+  },
+  {
+    component: 'Command',
+    part: 'Dialog content and command item',
+    state: 'Rest, selected, separator',
+    tokens: [
+      'popover',
+      'popover-hover',
+      'popover-foreground',
+      'border-default',
+      'border-active',
+      'border-default-alpha',
+      'muted-foreground',
+    ],
+    sourceFile: 'packages/react/src/components/command/command.tsx',
+    storybookCheck: 'Command stories: Dialog and ItemSelected.',
+  },
+] as const satisfies readonly ComponentTokenMatrixEntry[];
+
+const TOKEN_NAMES = new Set(SEMANTIC_TOKEN_REGISTRY.map((token) => token.name));
+
+export function matrixUnknownTokens(
+  entries: readonly ComponentTokenMatrixEntry[] = COMPONENT_TOKEN_MATRIX
+): string[] {
+  const unknown = new Set<string>();
+
+  for (const entry of entries) {
+    for (const token of entry.tokens) {
+      if (!TOKEN_NAMES.has(token)) unknown.add(token);
+    }
+  }
+
+  return [...unknown].sort();
+}
+
+export function filterMatrix(
+  entries: readonly ComponentTokenMatrixEntry[],
+  query: string
+): ComponentTokenMatrixEntry[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return [...entries];
+
+  return entries.filter((entry) =>
+    [
+      entry.component,
+      entry.part,
+      entry.state,
+      entry.sourceFile,
+      entry.storybookCheck,
+      entry.note ?? '',
+      ...entry.tokens,
+    ]
+      .join(' ')
+      .toLowerCase()
+      .includes(normalizedQuery)
+  );
+}

--- a/apps/console/src/modules/design-system/color-atlas/draft-tab.tsx
+++ b/apps/console/src/modules/design-system/color-atlas/draft-tab.tsx
@@ -1,0 +1,547 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import {
+  type NexusSurfaceTone,
+  SEMANTIC_TOKEN_REGISTRY,
+  type SemanticTokenMeta,
+} from '@nexus_ds/core';
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  NativeSelect,
+  NativeSelectOptGroup,
+  NativeSelectOption,
+  toast,
+  ToggleGroup,
+  ToggleGroupItem,
+} from '@nexus_ds/react';
+import {
+  type NexusResolvedAppearanceMode,
+  useNexusAppearance,
+} from '@nexus_ds/react/appearance';
+
+import {
+  buildDraftCss,
+  buildExportJson,
+  buildExportSummary,
+  type ColorDraftMode,
+  colorDraftModeLabel,
+  isColorDraftMode,
+  PRIMITIVE_FAMILIES,
+  type PrimitiveFamily,
+  primitiveValue,
+  shadesForFamily,
+  validateCustomColor,
+} from './color-draft';
+import { useColorDraftStore } from './color-draft-store';
+import {
+  COLOR_ATLAS_SURFACE_TOKENS,
+  DARK_SURFACE_LADDER,
+  formatAnchorLabel,
+  LIGHT_SURFACE_LADDER,
+} from './ladder-collisions';
+import { useResolvedTokenValues } from './use-resolved-token-values';
+
+type DraftSource = 'primitive' | 'custom';
+type ExportMode = 'json' | 'css' | 'summary';
+
+const DEFAULT_TOKEN = 'background-hover';
+const DEFAULT_FAMILY: PrimitiveFamily = 'stone';
+const LIGHT_DEFAULT_SHADE = '100';
+const DARK_DEFAULT_SHADE = '900';
+const DEFAULT_SHADE = LIGHT_DEFAULT_SHADE;
+const LIGHT_BIASED_SHADES = new Set(['50', '75', '100', '150', '200', '300']);
+const DARK_BIASED_SHADES = new Set(['700', '800', '900', '950']);
+const MODE_OPTIONS = [
+  'light',
+  'dark',
+  'both',
+] as const satisfies readonly ColorDraftMode[];
+const MODE_OPTION_LABELS: Record<ColorDraftMode, string> = {
+  light: 'Light',
+  dark: 'Dark',
+  both: 'Both',
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  alpha: 'Alpha',
+  border: 'Border',
+  brand: 'Brand',
+  chart: 'Chart',
+  focus: 'Focus',
+  status: 'Status',
+  surface: 'Surface',
+  text: 'Text',
+};
+
+function isPrimitiveFamily(value: string): value is PrimitiveFamily {
+  return PRIMITIVE_FAMILIES.includes(value as PrimitiveFamily);
+}
+
+function isAtlasSurfaceToken(
+  value: string
+): value is (typeof COLOR_ATLAS_SURFACE_TOKENS)[number] {
+  return (COLOR_ATLAS_SURFACE_TOKENS as readonly string[]).includes(value);
+}
+
+function currentToneLabel(
+  token: string,
+  resolvedMode: NexusResolvedAppearanceMode,
+  surfaceTone: NexusSurfaceTone
+): string | null {
+  if (!isAtlasSurfaceToken(token)) return null;
+
+  const ladder =
+    resolvedMode === 'dark' ? DARK_SURFACE_LADDER : LIGHT_SURFACE_LADDER;
+
+  return formatAnchorLabel(ladder[token], surfaceTone);
+}
+
+function defaultShadeForMode(mode: NexusResolvedAppearanceMode): string {
+  return mode === 'dark' ? DARK_DEFAULT_SHADE : LIGHT_DEFAULT_SHADE;
+}
+
+function shadeForModeChange(
+  mode: ColorDraftMode,
+  currentShade: string
+): string {
+  if (mode === 'dark' && LIGHT_BIASED_SHADES.has(currentShade)) {
+    return DARK_DEFAULT_SHADE;
+  }
+
+  if (mode === 'light' && DARK_BIASED_SHADES.has(currentShade)) {
+    return LIGHT_DEFAULT_SHADE;
+  }
+
+  return currentShade;
+}
+
+function resolveCssColorValue(value: string): string {
+  if (typeof window === 'undefined') return value;
+
+  const variableName = value.match(/^var\((--nx-color-[a-z0-9-]+)\)$/)?.[1];
+  if (!variableName) return value;
+
+  return (
+    window
+      .getComputedStyle(document.documentElement)
+      .getPropertyValue(variableName)
+      .trim() || value
+  );
+}
+
+function groupedTokens() {
+  return SEMANTIC_TOKEN_REGISTRY.reduce((groups, token) => {
+    const group = groups.get(token.category) ?? [];
+    group.push(token);
+    groups.set(token.category, group);
+    return groups;
+  }, new Map<string, SemanticTokenMeta[]>());
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card>
+      <CardHeader className="nx:pb-3">
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  );
+}
+
+function DraftSwatch({ value }: { value: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="nx:block nx:size-10 nx:shrink-0 nx:rounded-md nx:border-default nx:border-border-default"
+      style={{ backgroundColor: value }}
+    />
+  );
+}
+
+export function DraftTab() {
+  const { resolvedMode, state } = useNexusAppearance();
+  const tokenGroups = useMemo(groupedTokens, []);
+  const [token, setToken] = useState(DEFAULT_TOKEN);
+  const [source, setSource] = useState<DraftSource>('primitive');
+  const [mode, setMode] = useState<ColorDraftMode>(resolvedMode);
+  const [family, setFamily] = useState<PrimitiveFamily>(DEFAULT_FAMILY);
+  const [shade, setShade] = useState(() => defaultShadeForMode(resolvedMode));
+  const [customValue, setCustomValue] = useState('');
+  const [customError, setCustomError] = useState('');
+  const [exportMode, setExportMode] = useState<ExportMode>('json');
+  const [candidateResolvedValue, setCandidateResolvedValue] = useState('');
+  const selectedTokenNames = useMemo(() => [token], [token]);
+  const overrides = useColorDraftStore((state) => state.overrides);
+  const setOverride = useColorDraftStore((state) => state.setOverride);
+  const removeOverride = useColorDraftStore((state) => state.removeOverride);
+  const resetAll = useColorDraftStore((state) => state.resetAll);
+  const currentValue = useResolvedTokenValues(selectedTokenNames)[token] ?? '';
+  const currentLabel = currentToneLabel(token, resolvedMode, state.surfaceTone);
+  const activeOverrides = Object.entries(overrides).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+  const selectedMeta = SEMANTIC_TOKEN_REGISTRY.find(
+    (entry) => entry.name === token
+  );
+  const primitiveDraftValue = primitiveValue(family, shade);
+  const validCustomValue = validateCustomColor(customValue);
+  const candidateValue =
+    source === 'primitive'
+      ? primitiveDraftValue
+      : (validCustomValue ?? currentValue);
+  const candidateLabel =
+    source === 'primitive'
+      ? `${family}.${shade}`
+      : customValue || 'custom value';
+  const appearanceKey = JSON.stringify(state);
+  const exportText =
+    exportMode === 'json'
+      ? buildExportJson(overrides)
+      : exportMode === 'css'
+        ? buildDraftCss(overrides)
+        : buildExportSummary(overrides);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const frame = window.requestAnimationFrame(() => {
+      setCandidateResolvedValue(resolveCssColorValue(candidateValue));
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [appearanceKey, candidateValue]);
+
+  const handleFamilyChange = (value: string) => {
+    if (!isPrimitiveFamily(value)) return;
+
+    const nextShades = shadesForFamily(value);
+    setFamily(value);
+    if (!nextShades.includes(shade)) {
+      const fallbackShade =
+        mode === 'dark' ? DARK_DEFAULT_SHADE : LIGHT_DEFAULT_SHADE;
+      setShade(
+        nextShades.includes(fallbackShade)
+          ? fallbackShade
+          : (nextShades[0] ?? DEFAULT_SHADE)
+      );
+    }
+  };
+
+  const handleModeChange = (value: string) => {
+    if (!isColorDraftMode(value)) return;
+
+    setMode(value);
+    setShade((currentShade) => shadeForModeChange(value, currentShade));
+  };
+
+  const handleApply = () => {
+    if (source === 'primitive') {
+      setOverride(token, {
+        source: 'primitive',
+        mode,
+        value: primitiveDraftValue,
+        label: `${family}.${shade}`,
+      });
+      setCustomError('');
+      return;
+    }
+
+    const value = validateCustomColor(customValue);
+    if (!value) {
+      setCustomError('Enter a valid CSS color value.');
+      return;
+    }
+
+    setOverride(token, { source: 'custom', mode, value });
+    setCustomError('');
+  };
+
+  const handleCopy = () => {
+    if (!navigator.clipboard) {
+      toast.error('Clipboard is not available in this browser.');
+      return;
+    }
+
+    navigator.clipboard
+      .writeText(exportText)
+      .then(() => toast.success('Draft copied.'))
+      .catch(() => toast.error('Could not copy the draft.'));
+  };
+
+  return (
+    <div className="nx:space-y-6">
+      <Section title="Draft Override">
+        <div className="nx:grid nx:gap-4 nx:lg:grid-cols-[minmax(0,1fr)_18rem]">
+          <div className="nx:space-y-4">
+            <div className="nx:grid nx:gap-2">
+              <label
+                htmlFor="color-draft-token"
+                className="nx:typography-label-default"
+              >
+                Semantic token
+              </label>
+              <NativeSelect
+                id="color-draft-token"
+                value={token}
+                onChange={(event) => setToken(event.target.value)}
+              >
+                {[...tokenGroups.entries()].map(([category, tokens]) => (
+                  <NativeSelectOptGroup
+                    key={category}
+                    label={CATEGORY_LABELS[category] ?? category}
+                  >
+                    {tokens.map((entry) => (
+                      <NativeSelectOption key={entry.name} value={entry.name}>
+                        {entry.name}
+                      </NativeSelectOption>
+                    ))}
+                  </NativeSelectOptGroup>
+                ))}
+              </NativeSelect>
+              {selectedMeta?.description ? (
+                <p className="nx:text-muted-foreground">
+                  {selectedMeta.description}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="nx:grid nx:gap-2">
+              <span className="nx:typography-label-default">Source</span>
+              <ToggleGroup
+                type="single"
+                value={source}
+                onValueChange={(value) => {
+                  if (value === 'primitive' || value === 'custom') {
+                    setSource(value);
+                  }
+                }}
+                aria-label="Draft source"
+              >
+                <ToggleGroupItem value="primitive">Primitive</ToggleGroupItem>
+                <ToggleGroupItem value="custom">Custom</ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+
+            <div className="nx:grid nx:gap-2">
+              <span className="nx:typography-label-default">Theme</span>
+              <ToggleGroup
+                type="single"
+                value={mode}
+                onValueChange={handleModeChange}
+                aria-label="Draft theme"
+              >
+                {MODE_OPTIONS.map((draftMode) => (
+                  <ToggleGroupItem key={draftMode} value={draftMode}>
+                    {MODE_OPTION_LABELS[draftMode]}
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+            </div>
+
+            {source === 'primitive' ? (
+              <div className="nx:grid nx:gap-4 nx:md:grid-cols-2">
+                <div className="nx:grid nx:gap-2">
+                  <label
+                    htmlFor="color-draft-family"
+                    className="nx:typography-label-default"
+                  >
+                    Primitive family
+                  </label>
+                  <NativeSelect
+                    id="color-draft-family"
+                    value={family}
+                    onChange={(event) => handleFamilyChange(event.target.value)}
+                  >
+                    {PRIMITIVE_FAMILIES.map((primitiveFamily) => (
+                      <NativeSelectOption
+                        key={primitiveFamily}
+                        value={primitiveFamily}
+                      >
+                        {primitiveFamily}
+                      </NativeSelectOption>
+                    ))}
+                  </NativeSelect>
+                </div>
+                <div className="nx:grid nx:gap-2">
+                  <label
+                    htmlFor="color-draft-shade"
+                    className="nx:typography-label-default"
+                  >
+                    Shade
+                  </label>
+                  <NativeSelect
+                    id="color-draft-shade"
+                    value={shade}
+                    onChange={(event) => setShade(event.target.value)}
+                  >
+                    {shadesForFamily(family).map((primitiveShade) => (
+                      <NativeSelectOption
+                        key={primitiveShade}
+                        value={primitiveShade}
+                      >
+                        {primitiveShade}
+                      </NativeSelectOption>
+                    ))}
+                  </NativeSelect>
+                </div>
+              </div>
+            ) : (
+              <div className="nx:grid nx:gap-2">
+                <label
+                  htmlFor="color-draft-custom"
+                  className="nx:typography-label-default"
+                >
+                  Custom CSS color
+                </label>
+                <Input
+                  id="color-draft-custom"
+                  value={customValue}
+                  onChange={(event) => {
+                    setCustomValue(event.target.value);
+                    setCustomError('');
+                  }}
+                  placeholder="#f3f0ea or oklch(0.9 0.01 70)"
+                  aria-invalid={customError ? true : undefined}
+                />
+                {customError ? (
+                  <p className="nx:text-error-subtle-foreground">
+                    {customError}
+                  </p>
+                ) : null}
+              </div>
+            )}
+
+            <div className="nx:flex nx:flex-wrap nx:gap-2">
+              <Button onClick={handleApply}>Apply</Button>
+              <Button
+                variant="outline"
+                onClick={() => removeOverride(token)}
+                disabled={!overrides[token]}
+              >
+                Remove token
+              </Button>
+              <Button
+                variant="outline"
+                onClick={resetAll}
+                disabled={activeOverrides.length === 0}
+              >
+                Reset Draft
+              </Button>
+            </div>
+          </div>
+
+          <div className="nx:rounded-md nx:border-default nx:border-border-default nx:bg-muted nx:p-4">
+            <div className="nx:flex nx:items-start nx:gap-3">
+              <DraftSwatch value={`var(--nx-color-${token})`} />
+              <div className="nx:min-w-0 nx:space-y-1">
+                <p className="nx:typography-label-default">Current</p>
+                {currentLabel ? (
+                  <code className="nx:block nx:typography-code-inline nx:text-muted-foreground">
+                    {currentLabel}
+                  </code>
+                ) : null}
+                <code className="nx:block nx:break-all nx:typography-code-inline nx:text-muted-foreground">
+                  {currentValue || 'unresolved'}
+                </code>
+              </div>
+            </div>
+            <div className="nx:my-4 nx:h-px nx:bg-border-default-alpha" />
+            <div className="nx:flex nx:items-start nx:gap-3">
+              <DraftSwatch value={candidateValue} />
+              <div className="nx:min-w-0 nx:space-y-1">
+                <p className="nx:typography-label-default">Candidate</p>
+                <code className="nx:block nx:typography-code-inline nx:text-muted-foreground">
+                  {candidateLabel}
+                </code>
+                <code className="nx:block nx:break-all nx:typography-code-inline nx:text-muted-foreground">
+                  {candidateResolvedValue || candidateValue}
+                </code>
+                <span className="nx:typography-label-small nx:text-muted-foreground">
+                  {colorDraftModeLabel(mode)}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Section>
+
+      <Section title={`Active Overrides (${activeOverrides.length})`}>
+        {activeOverrides.length === 0 ? (
+          <p className="nx:text-muted-foreground">
+            No local semantic color overrides are active.
+          </p>
+        ) : (
+          <div className="nx:space-y-2">
+            {activeOverrides.map(([overrideToken, override]) => (
+              <div
+                key={overrideToken}
+                className="nx:flex nx:flex-wrap nx:items-center nx:gap-3 nx:rounded-md nx:border-default nx:border-border-default nx:px-3 nx:py-2"
+              >
+                <DraftSwatch value={override.value} />
+                <div className="nx:min-w-0 nx:flex-1">
+                  <p className="nx:typography-label-default">
+                    {overrideToken}{' '}
+                    <span className="nx:text-muted-foreground">
+                      ({colorDraftModeLabel(override.mode)})
+                    </span>
+                  </p>
+                  <code className="nx:typography-code-inline nx:text-muted-foreground">
+                    {override.label ?? override.value}
+                  </code>
+                </div>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => removeOverride(overrideToken)}
+                >
+                  Remove
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </Section>
+
+      <Section title="Export Draft">
+        <div className="nx:mb-3 nx:flex nx:flex-wrap nx:items-center nx:justify-between nx:gap-3">
+          <ToggleGroup
+            type="single"
+            value={exportMode}
+            onValueChange={(value) => {
+              if (value === 'json' || value === 'css' || value === 'summary') {
+                setExportMode(value);
+              }
+            }}
+            aria-label="Export format"
+          >
+            <ToggleGroupItem value="json">JSON</ToggleGroupItem>
+            <ToggleGroupItem value="css">CSS</ToggleGroupItem>
+            <ToggleGroupItem value="summary">Summary</ToggleGroupItem>
+          </ToggleGroup>
+          <Button
+            variant="outline"
+            onClick={handleCopy}
+            disabled={activeOverrides.length === 0}
+          >
+            Export Draft
+          </Button>
+        </div>
+        <pre className="nx:max-h-80 nx:overflow-auto nx:rounded-md nx:bg-muted nx:p-4 nx:typography-code-block nx:text-foreground">
+          {exportText}
+        </pre>
+      </Section>
+    </div>
+  );
+}

--- a/apps/console/src/modules/design-system/color-atlas/inspect-tab.tsx
+++ b/apps/console/src/modules/design-system/color-atlas/inspect-tab.tsx
@@ -1,0 +1,387 @@
+import { useMemo, useState } from 'react';
+
+import {
+  createNexusThemeContract,
+  deriveTheme,
+  type ShadeAnchor,
+  SURFACE_TOKENS,
+  type SurfaceToken,
+  type TokenMap,
+} from '@nexus_ds/core';
+import {
+  Badge,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+} from '@nexus_ds/react';
+import { useNexusAppearance } from '@nexus_ds/react/appearance';
+
+import { COMPONENT_TOKEN_MATRIX, filterMatrix } from './component-token-matrix';
+import {
+  collisionGroupFor,
+  COLOR_ATLAS_SURFACE_TOKENS,
+  DARK_SURFACE_LADDER,
+  formatAnchorLabel,
+  LIGHT_SURFACE_LADDER,
+} from './ladder-collisions';
+import { useResolvedTokenValues } from './use-resolved-token-values';
+
+type LadderMode = 'light' | 'dark';
+
+interface LadderValueRow {
+  key: string;
+  mode: LadderMode;
+  anchor: ShadeAnchor;
+  anchorLabel: string;
+  value: string;
+  tokens: SurfaceToken[];
+}
+
+function TokenSwatch({
+  token,
+  size = 'default',
+}: {
+  token: string;
+  size?: 'default' | 'small';
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      className={
+        size === 'small'
+          ? 'nx:block nx:size-3 nx:shrink-0 nx:rounded-sm nx:border-default nx:border-border-default'
+          : 'nx:block nx:size-8 nx:shrink-0 nx:rounded-md nx:border-default nx:border-border-default'
+      }
+      style={{ backgroundColor: `var(--nx-color-${token})` }}
+    />
+  );
+}
+
+function anchorKey(anchor: ShadeAnchor): string {
+  return JSON.stringify(anchor);
+}
+
+function anchorSortValue(anchor: ShadeAnchor): number {
+  if (anchor === 'base') return 0;
+  if (typeof anchor === 'number') return anchor;
+  return anchor.step;
+}
+
+function ladderRowsForMode({
+  mode,
+  ladder,
+  tokenMap,
+  surfaceTone,
+}: {
+  mode: LadderMode;
+  ladder: Record<SurfaceToken, ShadeAnchor>;
+  tokenMap: TokenMap;
+  surfaceTone: Parameters<typeof formatAnchorLabel>[1];
+}): LadderValueRow[] {
+  const groups = new Map<
+    string,
+    { anchor: ShadeAnchor; tokens: SurfaceToken[] }
+  >();
+
+  for (const token of SURFACE_TOKENS) {
+    const anchor = ladder[token];
+    const key = anchorKey(anchor);
+    const group = groups.get(key) ?? { anchor, tokens: [] };
+
+    group.tokens.push(token);
+    groups.set(key, group);
+  }
+
+  return [...groups.values()]
+    .map((group) => {
+      const representativeToken = group.tokens[0];
+
+      return {
+        key: `${mode}-${anchorKey(group.anchor)}`,
+        mode,
+        anchor: group.anchor,
+        anchorLabel: formatAnchorLabel(group.anchor, surfaceTone),
+        value: representativeToken
+          ? (tokenMap[`--nx-color-${representativeToken}`] ?? 'unresolved')
+          : 'unresolved',
+        tokens: group.tokens,
+      };
+    })
+    .sort((a, b) => anchorSortValue(a.anchor) - anchorSortValue(b.anchor));
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Card>
+      <CardHeader className="nx:pb-3">
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>{children}</CardContent>
+    </Card>
+  );
+}
+
+export function InspectTab() {
+  const { state } = useNexusAppearance();
+  const [query, setQuery] = useState('');
+  const values = useResolvedTokenValues(COLOR_ATLAS_SURFACE_TOKENS);
+  const derivedTheme = useMemo(
+    () => deriveTheme(createNexusThemeContract(state)),
+    [state]
+  );
+  const ladderValueRows = useMemo(
+    () => [
+      ...ladderRowsForMode({
+        mode: 'light',
+        ladder: LIGHT_SURFACE_LADDER,
+        tokenMap: derivedTheme.light,
+        surfaceTone: state.surfaceTone,
+      }),
+      ...ladderRowsForMode({
+        mode: 'dark',
+        ladder: DARK_SURFACE_LADDER,
+        tokenMap: derivedTheme.dark,
+        surfaceTone: state.surfaceTone,
+      }),
+    ],
+    [derivedTheme.dark, derivedTheme.light, state.surfaceTone]
+  );
+  const rows = filterMatrix(COMPONENT_TOKEN_MATRIX, query);
+
+  return (
+    <div className="nx:space-y-6">
+      <Section title="Light Surface Ladder">
+        <div className="nx:overflow-x-auto">
+          <table className="nx:w-full nx:min-w-[760px] nx:border-separate nx:border-spacing-0 nx:text-left">
+            <thead>
+              <tr className="nx:text-muted-foreground nx:typography-label-small">
+                <th className="nx:border-b-default nx:border-border-default nx:py-2 nx:pr-3">
+                  Token
+                </th>
+                <th className="nx:border-b-default nx:border-border-default nx:px-3 nx:py-2">
+                  Swatch
+                </th>
+                <th className="nx:border-b-default nx:border-border-default nx:px-3 nx:py-2">
+                  Resolved value
+                </th>
+                <th className="nx:border-b-default nx:border-border-default nx:px-3 nx:py-2">
+                  Light anchor
+                </th>
+                <th className="nx:border-b-default nx:border-border-default nx:px-3 nx:py-2">
+                  Dark anchor
+                </th>
+                <th className="nx:border-b-default nx:border-border-default nx:py-2 nx:pl-3">
+                  Overlap
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {COLOR_ATLAS_SURFACE_TOKENS.map((token) => {
+                const collisions = collisionGroupFor(
+                  token,
+                  LIGHT_SURFACE_LADDER
+                );
+
+                return (
+                  <tr key={token} className="nx:align-top">
+                    <td className="nx:border-b-default nx:border-border-default-alpha nx:py-3 nx:pr-3">
+                      <code className="nx:typography-code-inline">{token}</code>
+                    </td>
+                    <td className="nx:border-b-default nx:border-border-default-alpha nx:px-3 nx:py-3">
+                      <TokenSwatch token={token} />
+                    </td>
+                    <td className="nx:border-b-default nx:border-border-default-alpha nx:px-3 nx:py-3">
+                      <code className="nx:typography-code-inline nx:text-muted-foreground">
+                        {values[token] || 'unresolved'}
+                      </code>
+                    </td>
+                    <td className="nx:border-b-default nx:border-border-default-alpha nx:px-3 nx:py-3">
+                      {formatAnchorLabel(
+                        LIGHT_SURFACE_LADDER[token],
+                        state.surfaceTone
+                      )}
+                    </td>
+                    <td className="nx:border-b-default nx:border-border-default-alpha nx:px-3 nx:py-3">
+                      {formatAnchorLabel(DARK_SURFACE_LADDER[token])}
+                    </td>
+                    <td className="nx:border-b-default nx:border-border-default-alpha nx:py-3 nx:pl-3">
+                      {collisions.length > 0 ? (
+                        <div className="nx:flex nx:flex-wrap nx:gap-1">
+                          <Badge fill="light" variant="information">
+                            {collisions.length + 1} share anchor
+                          </Badge>
+                          {collisions.map((collision) => (
+                            <span
+                              key={collision}
+                              className="nx:rounded-sm nx:bg-muted nx:px-1.5 nx:py-0.5 nx:typography-code-inline"
+                            >
+                              {collision}
+                            </span>
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="nx:text-muted-foreground">Unique</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </Section>
+
+      <Section title="Ladder Values">
+        <div className="nx:overflow-x-auto">
+          <table className="nx:w-full nx:min-w-[840px] nx:border-separate nx:border-spacing-0 nx:text-left">
+            <thead>
+              <tr className="nx:text-muted-foreground nx:typography-label-small">
+                <th className="nx:border-b-default nx:border-border-default nx:py-2 nx:pr-3">
+                  Mode
+                </th>
+                <th className="nx:border-b-default nx:border-border-default nx:px-3 nx:py-2">
+                  Ladder
+                </th>
+                <th className="nx:border-b-default nx:border-border-default nx:px-3 nx:py-2">
+                  Value
+                </th>
+                <th className="nx:border-b-default nx:border-border-default nx:py-2 nx:pl-3">
+                  Semantic tokens
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {ladderValueRows.map((row) => (
+                <tr key={row.key} className="nx:align-top">
+                  <td className="nx:border-b-default nx:border-border-default-alpha nx:py-3 nx:pr-3">
+                    <Badge
+                      fill="light"
+                      variant={row.mode === 'dark' ? 'secondary' : 'default'}
+                    >
+                      {row.mode}
+                    </Badge>
+                  </td>
+                  <td className="nx:border-b-default nx:border-border-default-alpha nx:px-3 nx:py-3">
+                    <code className="nx:typography-code-inline">
+                      {row.anchorLabel}
+                    </code>
+                  </td>
+                  <td className="nx:border-b-default nx:border-border-default-alpha nx:px-3 nx:py-3">
+                    <div className="nx:flex nx:items-center nx:gap-2">
+                      <span
+                        aria-hidden="true"
+                        className="nx:block nx:size-5 nx:shrink-0 nx:rounded-sm nx:border-default nx:border-border-default"
+                        style={{ backgroundColor: row.value }}
+                      />
+                      <code className="nx:break-all nx:typography-code-inline nx:text-muted-foreground">
+                        {row.value}
+                      </code>
+                    </div>
+                  </td>
+                  <td className="nx:border-b-default nx:border-border-default-alpha nx:py-3 nx:pl-3">
+                    <div className="nx:flex nx:flex-wrap nx:gap-1">
+                      {row.tokens.map((token) => (
+                        <span
+                          key={token}
+                          className="nx:rounded-sm nx:bg-muted nx:px-1.5 nx:py-0.5 nx:typography-code-inline"
+                        >
+                          {token}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Section>
+
+      <Section title="Component Token Matrix">
+        <div className="nx:mb-4 nx:max-w-sm">
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Filter component, token, file…"
+            aria-label="Filter component token matrix"
+          />
+        </div>
+        <div className="nx:overflow-x-auto">
+          <table className="nx:w-full nx:min-w-[960px] nx:border-separate nx:border-spacing-0 nx:text-left">
+            <thead>
+              <tr className="nx:text-muted-foreground nx:typography-label-small">
+                <th className="nx:border-b-default nx:border-border-default nx:py-2 nx:pr-3">
+                  Component
+                </th>
+                <th className="nx:border-b-default nx:border-border-default nx:px-3 nx:py-2">
+                  Part
+                </th>
+                <th className="nx:border-b-default nx:border-border-default nx:px-3 nx:py-2">
+                  State
+                </th>
+                <th className="nx:border-b-default nx:border-border-default nx:px-3 nx:py-2">
+                  Semantic tokens
+                </th>
+                <th className="nx:border-b-default nx:border-border-default nx:px-3 nx:py-2">
+                  Source file
+                </th>
+                <th className="nx:border-b-default nx:border-border-default nx:py-2 nx:pl-3">
+                  Storybook check
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={`${row.component}-${row.part}-${row.state}`}>
+                  <td className="nx:border-b-default nx:border-border-default-alpha nx:py-3 nx:pr-3 nx:typography-label-default">
+                    {row.component}
+                  </td>
+                  <td className="nx:border-b-default nx:border-border-default-alpha nx:px-3 nx:py-3">
+                    {row.part}
+                  </td>
+                  <td className="nx:border-b-default nx:border-border-default-alpha nx:px-3 nx:py-3">
+                    {row.state}
+                  </td>
+                  <td className="nx:border-b-default nx:border-border-default-alpha nx:px-3 nx:py-3">
+                    <div className="nx:flex nx:flex-wrap nx:gap-1">
+                      {row.tokens.map((token) => (
+                        <span
+                          key={token}
+                          className="nx:inline-flex nx:items-center nx:gap-1 nx:rounded-sm nx:bg-muted nx:px-1.5 nx:py-0.5 nx:typography-code-inline"
+                        >
+                          <TokenSwatch token={token} size="small" />
+                          {token}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                  <td className="nx:border-b-default nx:border-border-default-alpha nx:px-3 nx:py-3">
+                    <code className="nx:typography-code-inline">
+                      {row.sourceFile}
+                    </code>
+                  </td>
+                  <td className="nx:border-b-default nx:border-border-default-alpha nx:py-3 nx:pl-3">
+                    {row.storybookCheck}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {rows.length === 0 ? (
+            <p className="nx:mt-4 nx:text-muted-foreground">
+              No component token rows match this filter.
+            </p>
+          ) : null}
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/apps/console/src/modules/design-system/color-atlas/ladder-collisions.test.ts
+++ b/apps/console/src/modules/design-system/color-atlas/ladder-collisions.test.ts
@@ -1,0 +1,49 @@
+import { LIGHT_SURFACE_LADDER, SURFACE_TOKENS } from '@nexus_ds/core';
+import { describe, expect, it } from 'vitest';
+
+import { collisionGroupFor, formatAnchorLabel } from './ladder-collisions';
+
+describe('formatAnchorLabel', () => {
+  it('formats base, shade, and dark-step anchors', () => {
+    expect(formatAnchorLabel('base')).toBe('base');
+    expect(formatAnchorLabel(150)).toBe('stone.150');
+    expect(formatAnchorLabel(50, 'slate')).toBe('slate.50');
+    expect(formatAnchorLabel({ step: 3.2 })).toBe('step 3.2');
+  });
+});
+
+describe('collisionGroupFor', () => {
+  it('derives collision siblings from the light ladder', () => {
+    expect(collisionGroupFor('background', LIGHT_SURFACE_LADDER)).toEqual([
+      'container',
+      'popover',
+    ]);
+    expect(collisionGroupFor('muted', LIGHT_SURFACE_LADDER)).toEqual([
+      'container-hover',
+      'nav-background',
+    ]);
+    expect(collisionGroupFor('container-active', LIGHT_SURFACE_LADDER)).toEqual(
+      ['popover-hover', 'popover-active', 'disabled']
+    );
+    expect(
+      collisionGroupFor('control-background', LIGHT_SURFACE_LADDER)
+    ).toEqual([
+      'background-active',
+      'nav-item-hover',
+      'nav-item-active',
+      'nav-border',
+    ]);
+  });
+
+  it('accounts for every surface token exactly once', () => {
+    expect(SURFACE_TOKENS).toHaveLength(18);
+    const singletonTokens = SURFACE_TOKENS.filter(
+      (token) => collisionGroupFor(token, LIGHT_SURFACE_LADDER).length === 0
+    );
+    expect(singletonTokens).toEqual([
+      'background-hover',
+      'control-background-hover',
+      'border-active',
+    ]);
+  });
+});

--- a/apps/console/src/modules/design-system/color-atlas/ladder-collisions.ts
+++ b/apps/console/src/modules/design-system/color-atlas/ladder-collisions.ts
@@ -1,0 +1,56 @@
+import {
+  DARK_SURFACE_LADDER,
+  LIGHT_SURFACE_LADDER,
+  type NexusSurfaceTone,
+  type ShadeAnchor,
+  SURFACE_TOKENS,
+  type SurfaceToken,
+} from '@nexus_ds/core';
+
+export const COLOR_ATLAS_SURFACE_TOKENS = [
+  'background',
+  'background-hover',
+  'container',
+  'container-hover',
+  'container-active',
+  'popover',
+  'popover-hover',
+  'popover-active',
+  'control-background',
+  'control-background-hover',
+  'nav-background',
+  'nav-item-hover',
+  'nav-item-active',
+  'nav-border',
+] as const satisfies readonly SurfaceToken[];
+
+export function formatAnchorLabel(
+  anchor: ShadeAnchor,
+  surfaceTone: NexusSurfaceTone = 'stone'
+): string {
+  if (anchor === 'base') return 'base';
+  if (typeof anchor === 'number') return `${surfaceTone}.${anchor}`;
+  return `step ${anchor.step}`;
+}
+
+function anchorKey(anchor: ShadeAnchor): string {
+  return JSON.stringify(anchor);
+}
+
+export function collisionGroupFor(
+  token: SurfaceToken,
+  ladder: Record<SurfaceToken, ShadeAnchor>
+): SurfaceToken[] {
+  const tokenKey = anchorKey(ladder[token]);
+
+  return SURFACE_TOKENS.filter(
+    (candidate) =>
+      candidate !== token && anchorKey(ladder[candidate]) === tokenKey
+  );
+}
+
+export function surfaceTokenCollisionCount(token: SurfaceToken): number {
+  return collisionGroupFor(token, LIGHT_SURFACE_LADDER).length;
+}
+
+export { DARK_SURFACE_LADDER, LIGHT_SURFACE_LADDER };

--- a/apps/console/src/modules/design-system/color-atlas/use-resolved-token-values.ts
+++ b/apps/console/src/modules/design-system/color-atlas/use-resolved-token-values.ts
@@ -1,0 +1,43 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { useNexusAppearance } from '@nexus_ds/react/appearance';
+
+import { useColorDraftStore } from './color-draft-store';
+
+export type ResolvedTokenValues = Record<string, string>;
+
+function overridesKey(overrides: Record<string, unknown>): string {
+  return JSON.stringify(overrides);
+}
+
+export function useResolvedTokenValues(
+  names: readonly string[]
+): ResolvedTokenValues {
+  const { resolvedMode, state } = useNexusAppearance();
+  const overrides = useColorDraftStore((draftState) => draftState.overrides);
+  const [values, setValues] = useState<ResolvedTokenValues>({});
+  const namesKey = names.join('|');
+  const appearanceKey = JSON.stringify(state);
+  const draftKey = useMemo(() => overridesKey(overrides), [overrides]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const tokenNames = namesKey ? namesKey.split('|') : [];
+    const frame = window.requestAnimationFrame(() => {
+      const computed = window.getComputedStyle(document.documentElement);
+      const nextValues = Object.fromEntries(
+        tokenNames.map((name) => [
+          name,
+          computed.getPropertyValue(`--nx-color-${name}`).trim(),
+        ])
+      );
+
+      setValues(nextValues);
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [appearanceKey, draftKey, namesKey, resolvedMode]);
+
+  return values;
+}

--- a/apps/console/src/shell/app-sidebar.tsx
+++ b/apps/console/src/shell/app-sidebar.tsx
@@ -19,6 +19,7 @@ import {
   SidebarSeparator,
 } from '@nexus_ds/react';
 import {
+  IconColorSwatch,
   IconComponents,
   IconLayoutGrid,
   IconLogout,
@@ -40,6 +41,7 @@ import { MODULE_ITEMS } from './modules';
 
 const DESIGN_ITEMS = [
   { label: 'Reference', to: '/design/reference', icon: IconComponents },
+  { label: 'Color Atlas', to: '/design/color-atlas', icon: IconColorSwatch },
   { label: 'Scenes', to: '/design/scenes', icon: IconLayoutGrid },
   { label: 'Appearance', to: '/design/appearance', icon: IconPalette },
   { label: 'Flows', to: '/design/flows', icon: IconRoute },

--- a/apps/console/src/shell/command-palette.tsx
+++ b/apps/console/src/shell/command-palette.tsx
@@ -12,6 +12,7 @@ import { useNexusAppearance } from '@nexus_ds/react/appearance';
 import {
   IconAddressBook,
   IconBriefcase,
+  IconColorSwatch,
   IconInbox,
   IconMoon,
   IconPalette,
@@ -243,6 +244,16 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         )}
 
         <CommandGroup heading="Actions">
+          <CommandItem
+            value="color-token-atlas"
+            keywords={['color', 'token', 'atlas', 'draft', 'swatch']}
+            onSelect={() =>
+              runCommand(() => navigate({ to: '/design/color-atlas' }))
+            }
+          >
+            <IconColorSwatch />
+            <span>Color Token Atlas</span>
+          </CommandItem>
           <CommandItem
             value="toggle-theme"
             keywords={['theme', 'dark', 'light', 'mode']}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,7 +18,12 @@ export { deriveTheme, themeToCss } from './lib/derive-theme';
 export type { NexusSurfaceTone } from './lib/palette';
 export { PALETTE_KEYS, TIER_THRESHOLDS } from './lib/palette';
 export { isColor } from './lib/perceptual-ramp';
-export type { SurfaceToken } from './lib/surface-ladder';
+export type { ShadeAnchor, SurfaceToken } from './lib/surface-ladder';
+export {
+  DARK_SURFACE_LADDER,
+  LIGHT_SURFACE_LADDER,
+  SURFACE_TOKENS,
+} from './lib/surface-ladder';
 export {
   SEMANTIC_TOKEN_REGISTRY,
   type SemanticTokenMeta,


### PR DESCRIPTION
## Summary

- Adds a Console Color Token Atlas at `/design/color-atlas` with Inspect and Draft Theme tabs.
- Shows the surface ladder, ladder anchor values, live resolved CSS values, swatches, anchor overlaps, and a curated component/state token matrix.
- Adds browser-local semantic color draft overrides backed by `localStorage`, applied Console-wide through a runtime style tag.
- Supports primitive semantic remaps, custom CSS colors, Light/Dark/Both draft targets, reset, and export as JSON/CSS/summary for engineering review.
- Shows the current surface tone anchor next to the raw OKLCH value so before/after comparisons read as labels like `stone.50` plus exact CSS.
- Keeps the change runtime-only: no token JSON, generated CSS, primitive ramp values, or committed draft values are mutated.

## GitHub Issue

Closes #629

## Test Plan

- [x] `corepack pnpm --filter @nexus_ds/console typecheck`
- [x] `corepack pnpm lint`
- [x] `corepack pnpm audit:browser-support`
- [x] `corepack pnpm --filter @nexus_ds/console build`
- [x] `corepack pnpm format:check`
- [x] `corepack pnpm exec vitest run --project=unit apps/console/src/modules/design-system/color-atlas`
- [x] Headless smoke: seed demo session and dark appearance, open `/design/color-atlas`, confirm Candidate defaults to `stone.900` with a dark resolved value, apply `background-hover = stone.900`, and verify the draft style contains `html:root.dark`.
- [x] Headless smoke: seed demo session, open `/design/color-atlas`, confirm Ladder Values renders light anchors like `stone.50`, dark anchors like `step 1.6`, resolved OKLCH values, and semantic token usage.
