### PR TITLE
fix(docs): publish Storybook and repair the dead footer links

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,73 @@
+name: Deploy Storybook
+
+# Publishes the static Storybook build to GitHub Pages
+# (https://nexuslabs-ai.github.io/nexus/), the URL the docs footer links to.
+# Standalone from ci.yml: this is a post-merge push:main workflow, not a PR
+# check, so it is not part of the `CI Status` branch-protection aggregator.
+# ci.yml still builds Storybook on PRs, which is where a broken build is caught.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/deploy-storybook.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # The AdjustContrast story imports @nexus_ds/core, which is consumed via
+      # its built dist/runtime entry (package.json exports). Build it so the
+      # Storybook production build can resolve the package.
+      - name: Build @nexus_ds/core
+        run: pnpm --filter @nexus_ds/core build
+
+      - name: Build Storybook
+        run: pnpm build-storybook
+
+      # `enablement` creates the Pages site on the first run, so publishing
+      # needs no manual repo-settings step.
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: packages/react/storybook-static
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Token-driven design system for product UI. Three layers compose into one consuma
 - **`@nexus_ds/tailwind`** — Tailwind CSS theme generated from the tokens. All utilities are namespaced with the `nx:` prefix.
 - **`@nexus_ds/react`** — React components built on Radix UI primitives and the Tailwind layer. Variants via CVA; data-attribute test surface; padding-based sizing.
 
-A console app exercises the tokens visually; Storybook hosts the component catalog and runs both visual docs and interaction tests against the real components.
+A console app exercises the tokens visually; Storybook hosts the component catalog and runs both visual docs and interaction tests against the real components. The catalog is published from `main` at **<https://nexuslabs-ai.github.io/nexus/>**.
 
 ## Prerequisites
 

--- a/apps/docs/app/_components/Footer.test.ts
+++ b/apps/docs/app/_components/Footer.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { FOOTER_LINKS } from './Footer';
+
+describe('FOOTER_LINKS', () => {
+  it('points every link at a reachable absolute URL', () => {
+    expect(FOOTER_LINKS.length).toBeGreaterThan(0);
+
+    for (const link of FOOTER_LINKS) {
+      expect(link.href).toMatch(/^https:\/\//);
+    }
+  });
+
+  it('links to the published Storybook', () => {
+    const storybook = FOOTER_LINKS.find((link) => link.label === 'Storybook');
+
+    expect(storybook?.href).toBe('https://nexuslabs-ai.github.io/nexus/');
+  });
+});

--- a/apps/docs/app/_components/Footer.tsx
+++ b/apps/docs/app/_components/Footer.tsx
@@ -1,0 +1,32 @@
+export const FOOTER_LINKS = [
+  { label: 'Storybook', href: 'https://nexuslabs-ai.github.io/nexus/' },
+  { label: 'GitHub', href: 'https://github.com/nexuslabs-ai/nexus' },
+];
+
+export function Footer() {
+  return (
+    <footer className="nx:border-t nx:border-border-default nx:mt-16">
+      <div className="nx:max-w-[1280px] nx:mx-auto nx:px-6 nx:py-8 nx:flex nx:flex-col nx:gap-4 nx:sm:flex-row nx:sm:items-center nx:sm:justify-between">
+        <div className="nx:flex nx:items-center nx:gap-3">
+          <span className="nx:font-semibold">Nexus</span>
+          <span className="nx:font-mono nx:text-[11px] nx:text-muted-foreground-subtle">
+            MIT · v0.0.1
+          </span>
+        </div>
+        <nav className="nx:flex nx:items-center nx:gap-5 nx:typography-label-default nx:text-muted-foreground">
+          {FOOTER_LINKS.map((link) => (
+            <a
+              key={link.label}
+              href={link.href}
+              target="_blank"
+              rel="noreferrer"
+              className="nx:rounded-sm nx:hover:text-foreground nx:transition-colors nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2"
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -2,6 +2,7 @@ import { NexusAppearanceProvider } from '@nexus_ds/react/appearance';
 import { NexusAppearanceScript } from '@nexus_ds/react/appearance/server';
 import type { Metadata } from 'next';
 
+import { Footer } from './_components/Footer';
 import { ThemePicker } from './_components/ThemePicker';
 import { TopNav } from './_components/TopNav';
 import {
@@ -10,12 +11,6 @@ import {
 } from './_lib/appearance-controls';
 
 import './globals.css';
-
-const FOOTER_LINKS = [
-  { label: 'Figma', href: '#' },
-  { label: 'Storybook', href: '#' },
-  { label: 'GitHub', href: 'https://github.com/nexuslabs-ai/nexus' },
-];
 
 export const metadata: Metadata = {
   title: 'Nexus Design System — Docs',
@@ -52,32 +47,7 @@ export default function RootLayout({
           <TopNav />
           <main>{children}</main>
           <ThemePicker />
-          <footer className="nx:border-t nx:border-border-default nx:mt-16">
-            <div className="nx:max-w-[1280px] nx:mx-auto nx:px-6 nx:py-8 nx:flex nx:flex-col nx:gap-4 nx:sm:flex-row nx:sm:items-center nx:sm:justify-between">
-              <div className="nx:flex nx:items-center nx:gap-3">
-                <span className="nx:font-semibold">Nexus</span>
-                <span className="nx:font-mono nx:text-[11px] nx:text-muted-foreground-subtle">
-                  MIT · v0.0.1
-                </span>
-              </div>
-              <nav className="nx:flex nx:items-center nx:gap-5 nx:typography-label-default nx:text-muted-foreground">
-                {FOOTER_LINKS.map((link) => {
-                  const isExternal = link.href.startsWith('http');
-                  return (
-                    <a
-                      key={link.label}
-                      href={link.href}
-                      target={isExternal ? '_blank' : undefined}
-                      rel={isExternal ? 'noreferrer' : undefined}
-                      className="nx:rounded-sm nx:hover:text-foreground nx:transition-colors nx:focus-visible:outline-2 nx:focus-visible:outline-focus-default nx:focus-visible:outline-offset-2"
-                    >
-                      {link.label}
-                    </a>
-                  );
-                })}
-              </nav>
-            </div>
-          </footer>
+          <Footer />
         </NexusAppearanceProvider>
       </body>
     </html>


### PR DESCRIPTION
## Summary

- Extracted the inline footer out of `apps/docs/app/layout.tsx` into `apps/docs/app/_components/Footer.tsx`, so the link table is importable and testable.
- **Storybook** link now points at the published build, `https://nexuslabs-ai.github.io/nexus/`.
- **Figma** link removed. I grepped the whole tree — the only `figma.com` references are `https://mcp.figma.com/mcp` MCP server endpoints in `.mcp.json`, i.e. tooling config, not a public design-library URL. There was nothing to point the link at, and per the issue a dead link is worse than no link.
- **GitHub** link was already live; left as-is.
- Added `.github/workflows/deploy-storybook.yml` — builds Storybook and deploys it to GitHub Pages on every push to `main`, so the published catalog tracks `main` rather than whenever someone last built by hand.
- Added `apps/docs/app/_components/Footer.test.ts` asserting every link is an absolute `https://` URL and that Storybook points at the published build.
- Noted the published catalog URL in `README.md`.

## GitHub Issue

Closes #678

## Notes for reviewers

**Why the deploy workflow is standalone rather than a job in `ci.yml`.** It is a post-merge `push: main` workflow, not a PR check, so folding it into `ci.yml` would drag it into the `CI Status` branch-protection aggregator and make Pages availability a merge gate. `ci.yml` already builds Storybook on PRs (`build-storybook`, `ci.yml:450`), which is where a broken build gets caught; this workflow only publishes what `main` already proved buildable. Its steps mirror that job exactly, including the `@nexus_ds/core` pre-build the `AdjustContrast` story needs.

**Pages is created by the workflow, not by hand.** `configure-pages` runs with `enablement: true`, so the first run provisions the site — no manual repo-settings step. The repo is public, so Pages is available. This does mean **the Storybook URL will 404 until this PR merges and that first run completes** — expected, and the reason the URL cannot be smoke-tested from the PR itself.

**Subpath hosting works without a `base` config.** Storybook's Vite production build emits relative asset paths — verified in the local build output, `index.html` and `iframe.html` reference `./assets/…`, `./sb-manager/…`, `./sb-addons/…` — so serving from `/nexus/` resolves correctly. `deploy-pages` also bypasses Jekyll, so no `.nojekyll` is needed.

**Trigger paths** are `packages/**`, `pnpm-lock.yaml`, and the workflow file, plus `workflow_dispatch`. The lockfile is included so a dependency bump that changes rendering still republishes.

**Known pre-existing issue, not touched here:** the Storybook static build also emits `index.d.ts`, `components/`, and `hooks/` into `storybook-static` (the react package's dts plugin running during the build). Harmless — extra files served alongside the catalog — and it predates this PR, affecting the existing `ci.yml` job identically. Flagging rather than fixing, since it is outside this issue's scope; happy to open a separate issue if you want it cleaned up.

## Test Plan

- [x] `pnpm build-storybook` succeeds locally — **899 stories across 70 components**.
- [x] Asset paths in `index.html` / `iframe.html` confirmed relative, so `/nexus/` subpath hosting resolves.
- [x] `Footer.test.ts` passes under the `unit` project (2 tests).
- [x] ESLint clean on all changed files; Prettier clean on all changed files.
- [x] No `href="#"` remains anywhere in `apps/`.
- [ ] After merge: confirm the first `Deploy Storybook` run provisions Pages and `https://nexuslabs-ai.github.io/nexus/` loads the current component set.
- [ ] After merge: confirm the docs footer Storybook link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)